### PR TITLE
Specify list row separator edges in StatView

### DIFF
--- a/Sources/Scout/UI/StatView.swift
+++ b/Sources/Scout/UI/StatView.swift
@@ -40,7 +40,7 @@ struct StatView: View {
                 List {
                     ChartView(points: points, model: model)
                         .foregroundStyle(config.color)
-                        .listRowSeparator(config.showList ? .visible : .hidden)
+                        .listRowSeparator(config.showList ? .visible : .hidden, edges: .bottom)
 
                     if config.showList {
                         total(count: points.count)


### PR DESCRIPTION
Updated the list row separator in StatView to explicitly set the edges to .bottom when configuring visibility. This provides more precise control over separator appearance in the list.