### PR TITLE
Refactor model inheritance and ID assignment

### DIFF
--- a/Sources/Scout/Core/Activity/UserActivity.Provider.swift
+++ b/Sources/Scout/Core/Activity/UserActivity.Provider.swift
@@ -55,6 +55,7 @@ extension UserActivity.Provider {
         let entity = NSEntityDescription.entity(forEntityName: "UserActivity", in: context)!
         let activity = UserActivity(entity: entity, insertInto: context)
 
+        activity.userActivityID = UUID()
         activity.date = date
         activity.period = period.rawValue
 

--- a/Sources/Scout/Core/Activity/UserActivity.swift
+++ b/Sources/Scout/Core/Activity/UserActivity.swift
@@ -8,7 +8,7 @@
 import CoreData
 
 @objc(UserActivity)
-final class UserActivity: DateObject, Syncable {
+final class UserActivity: IDObject, Syncable {
     static func group(in context: NSManagedObjectContext) throws -> SyncGroup<UserActivity>? {
         let seedReq = NSFetchRequest<UserActivity>(entityName: "UserActivity")
         seedReq.predicate = NSPredicate(format: "isSynced == false")

--- a/Sources/Scout/Core/Log/Log.swift
+++ b/Sources/Scout/Core/Log/Log.swift
@@ -19,6 +19,7 @@ func log(
     let entity = NSEntityDescription.entity(forEntityName: "EventObject", in: context)!
     let event = EventObject(entity: entity, insertInto: context)
 
+    event.eventID = UUID()
     event.date = date
     event.level = level.rawValue
     event.name = name

--- a/Sources/Scout/Core/Monitor/IDs.swift
+++ b/Sources/Scout/Core/Monitor/IDs.swift
@@ -48,8 +48,8 @@ extension UserDefaults {
 extension IDObject {
     public override func awakeFromInsert() {
         super.awakeFromInsert()
-        setPrimitiveValue(UUID(), forKey: #keyPath(SessionObject.sessionID))
-        setPrimitiveValue(IDs.user, forKey: #keyPath(SessionObject.userID))
-        setPrimitiveValue(IDs.launch, forKey: #keyPath(SessionObject.launchID))
+        setPrimitiveValue(UUID(), forKey: #keyPath(IDObject.sessionID))
+        setPrimitiveValue(IDs.user, forKey: #keyPath(IDObject.userID))
+        setPrimitiveValue(IDs.launch, forKey: #keyPath(IDObject.launchID))
     }
 }

--- a/Sources/Scout/Core/Monitor/IDs.swift
+++ b/Sources/Scout/Core/Monitor/IDs.swift
@@ -45,7 +45,7 @@ extension UserDefaults {
     }
 }
 
-extension SessionObject {
+extension IDObject {
     public override func awakeFromInsert() {
         super.awakeFromInsert()
         setPrimitiveValue(UUID(), forKey: #keyPath(SessionObject.sessionID))
@@ -58,9 +58,6 @@ extension EventObject {
     public override func awakeFromInsert() {
         super.awakeFromInsert()
         setPrimitiveValue(UUID(), forKey: #keyPath(EventObject.eventID))
-        setPrimitiveValue(IDs.session, forKey: #keyPath(EventObject.sessionID))
-        setPrimitiveValue(IDs.user, forKey: #keyPath(EventObject.userID))
-        setPrimitiveValue(IDs.launch, forKey: #keyPath(EventObject.launchID))
     }
 }
 
@@ -68,8 +65,5 @@ extension UserActivity {
     public override func awakeFromInsert() {
         super.awakeFromInsert()
         setPrimitiveValue(UUID(), forKey: #keyPath(UserActivity.userActivityID))
-        setPrimitiveValue(IDs.session, forKey: #keyPath(UserActivity.sessionID))
-        setPrimitiveValue(IDs.user, forKey: #keyPath(UserActivity.userID))
-        setPrimitiveValue(IDs.launch, forKey: #keyPath(UserActivity.launchID))
     }
 }

--- a/Sources/Scout/Core/Monitor/IDs.swift
+++ b/Sources/Scout/Core/Monitor/IDs.swift
@@ -53,17 +53,3 @@ extension IDObject {
         setPrimitiveValue(IDs.launch, forKey: #keyPath(SessionObject.launchID))
     }
 }
-
-extension EventObject {
-    public override func awakeFromInsert() {
-        super.awakeFromInsert()
-        setPrimitiveValue(UUID(), forKey: #keyPath(EventObject.eventID))
-    }
-}
-
-extension UserActivity {
-    public override func awakeFromInsert() {
-        super.awakeFromInsert()
-        setPrimitiveValue(UUID(), forKey: #keyPath(UserActivity.userActivityID))
-    }
-}

--- a/Sources/Scout/Core/Monitor/SessionObject.swift
+++ b/Sources/Scout/Core/Monitor/SessionObject.swift
@@ -8,7 +8,7 @@
 import CoreData
 
 @objc(SessionObject)
-final class SessionObject: DateObject, Syncable {
+final class SessionObject: IDObject, Syncable {
     static func group(in context: NSManagedObjectContext) throws -> SyncGroup<SessionObject>? {
         let seedReq = NSFetchRequest<SessionObject>(entityName: "SessionObject")
         seedReq.predicate = NSPredicate(format: "isSynced == false")

--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -15,36 +15,32 @@
         <attribute name="paramCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="params" optional="YES" attributeType="Binary"/>
     </entity>
+    <entity name="IDObject" representedClassName="IDObject" isAbstract="YES" parentEntity="DateObject" syncable="YES" codeGenerationType="class">
+        <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="sessionID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="userID" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
     <entity name="IntMetricsObject" representedClassName="IntMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="category">
         <attribute name="intValue" attributeType="Integer 64" usesScalarValueType="YES"/>
     </entity>
     <entity name="MetricsObject" representedClassName="MetricsObject" isAbstract="YES" parentEntity="TrackedObject" syncable="YES" codeGenerationType="class">
         <attribute name="telemetry" attributeType="String"/>
     </entity>
-    <entity name="SessionObject" representedClassName="SessionObject" parentEntity="DateObject" syncable="YES" codeGenerationType="category">
+    <entity name="SessionObject" representedClassName="SessionObject" parentEntity="IDObject" syncable="YES" codeGenerationType="category">
         <attribute name="endDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="isSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="sessionID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="userID" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
-    <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="DateObject" syncable="YES" codeGenerationType="class">
+    <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="IDObject" syncable="YES" codeGenerationType="class">
         <attribute name="eventID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="sessionID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="userID" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
-    <entity name="UserActivity" representedClassName="UserActivity" parentEntity="DateObject" syncable="YES" codeGenerationType="category">
+    <entity name="UserActivity" representedClassName="UserActivity" parentEntity="IDObject" syncable="YES" codeGenerationType="category">
         <attribute name="dayCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="isSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="monthCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="period" attributeType="String"/>
-        <attribute name="sessionID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="userActivityID" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="userID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="weekCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
 </model>

--- a/Tests/ScoutTests/Core/Log/LogTest.swift
+++ b/Tests/ScoutTests/Core/Log/LogTest.swift
@@ -38,7 +38,6 @@ import Testing
     #expect(event.week == date.startOfWeek)
     #expect(event.eventID != nil)
     #expect(event.userID == IDs.user)
-    #expect(event.sessionID == IDs.session)
     #expect(event.paramCount == 1)
 
     let paramData = try #require(event.params)

--- a/Tests/ScoutTests/Core/Sync/SyncDriverTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncDriverTests.swift
@@ -49,6 +49,7 @@ class SyncDriverTests {
 private func createEvent(name: String, in context: NSManagedObjectContext, level: EventLevel = .info) {
     let entity = NSEntityDescription.entity(forEntityName: "EventObject", in: context)!
     let event = EventObject(entity: entity, insertInto: context)
+    event.eventID = UUID()
     event.name = name
     event.date = Date()
     event.level = level.rawValue

--- a/Tests/ScoutTests/Stubs/UserActivity+Stub.swift
+++ b/Tests/ScoutTests/Stubs/UserActivity+Stub.swift
@@ -21,6 +21,7 @@ extension UserActivity {
         let entity = NSEntityDescription.entity(forEntityName: "UserActivity", in: context)!
         let activity = UserActivity(entity: entity, insertInto: context)
 
+        activity.userActivityID = UUID()
         activity.month = month
         activity.day = day
         activity.period = period.rawValue


### PR DESCRIPTION
Refactor the inheritance structure to use an abstract `IDObject` base class for `UserActivity`, `SessionObject`, and `TrackedObject`. Remove automatic ID assignments in object extensions and assign UUIDs explicitly during object creation to enhance clarity and control over ID generation. This improves code organization and centralizes ID-related properties.