### PR TITLE
Refactor providers to use common Provider protocol

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -13,14 +13,10 @@ typealias PeriodMatrix = Matrix<PeriodCell<Int>>
 @MainActor
 class ActivityProvider: ObservableObject {
     @Published var data: ChartData<ActivityPeriod>?
+}
 
-    func fetchIfNeeded(in database: DatabaseController) async {
-        if data == nil {
-            await fetch(in: database)
-        }
-    }
-
-    private func fetch(in database: DatabaseController) async {
+extension ActivityProvider: Provider {
+    func fetch(in database: DatabaseController) async {
         let range = Calendar(identifier: .iso8601).queryRange
 
         do {

--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -28,12 +28,12 @@ extension EventView {
                 await param.fetchIfNeeded(in: database)
             }
             .navigationDestination(isPresented: $isParamPresented) {
-                if let items = param.items {
+                if let items = param.data {
                     ParamList(items: items)
                 }
             }
 
-            if let items = param.items {
+            if let items = param.data {
                 ForEach(items.prefix(3)) { item in
                     ParamRow(item: item)
                 }
@@ -45,7 +45,7 @@ extension EventView {
         }
 
         var seeAll: (() -> Void)? {
-            if let _ = param.items, count > 3 {
+            if let _ = param.data, count > 3 {
                 return { isParamPresented = true }
             } else {
                 return nil

--- a/Sources/Scout/UI/Event/Param/ParamProvider.swift
+++ b/Sources/Scout/UI/Event/Param/ParamProvider.swift
@@ -11,15 +11,23 @@ import CloudKit
 class ParamProvider: ObservableObject {
     let recordID: CKRecord.ID
 
-    @Published var items: [Item]?
+    @Published var data: [Item]?
 
     init(recordID: CKRecord.ID) {
         self.recordID = recordID
     }
+}
 
-    func fetchIfNeeded(in database: DatabaseController) async {
-        if items == nil {
-            await fetch(in: database)
+extension ParamProvider: Provider {
+    func fetch(in database: DatabaseController) async {
+        do {
+            data = try await database
+                .record(for: recordID)["params"]
+                .map(Item.fromData)?
+                .sorted()
+        } catch {
+            print(error.localizedDescription)
+            data = nil
         }
     }
 }
@@ -40,20 +48,6 @@ extension ParamProvider {
 
         var description: String {
             "\(key): \(value)"
-        }
-    }
-}
-
-extension ParamProvider {
-    fileprivate func fetch(in database: DatabaseController) async {
-        do {
-            items = try await database
-                .record(for: recordID)["params"]
-                .map(Item.fromData)?
-                .sorted()
-        } catch {
-            print(error.localizedDescription)
-            items = nil
         }
     }
 }

--- a/Sources/Scout/UI/Event/Stat/StatProvider.swift
+++ b/Sources/Scout/UI/Event/Stat/StatProvider.swift
@@ -18,16 +18,10 @@ class StatProvider: ObservableObject {
         self.eventName = eventName
         self.periods = periods
     }
-
-    func fetchIfNeeded(in database: DatabaseController) async {
-        if data == nil {
-            await fetch(in: database)
-        }
-    }
 }
 
-extension StatProvider {
-    private func fetch(in database: DatabaseController) async {
+extension StatProvider: Provider {
+    func fetch(in database: DatabaseController) async {
         let range = Calendar(identifier: .iso8601).queryRange
 
         do {

--- a/Sources/Scout/UI/Utilities/Provider.swift
+++ b/Sources/Scout/UI/Utilities/Provider.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+@MainActor
+protocol Provider {
+    associatedtype DataType
+
+    var data: DataType? { get }
+
+    func fetch(in database: DatabaseController) async
+}
+
+extension Provider {
+    func fetchIfNeeded(in database: DatabaseController) async {
+        if data == nil {
+            await fetch(in: database)
+        }
+    }
+}


### PR DESCRIPTION
Introduced a generic Provider protocol to unify data fetching logic across ActivityProvider, ParamProvider, and StatProvider. Replaced individual fetchIfNeeded and fetch methods with protocol conformance and moved shared logic to the protocol extension. Updated references from items to data in ParamProvider and related UI code for consistency.