### PR TITLE
Update key path syntax in batch tests

### DIFF
--- a/Tests/ScoutTests/Core/Sync/SyncableObjectBatchTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncableObjectBatchTests.swift
@@ -28,7 +28,7 @@ struct SyncableObjectBatchTests {
 
         let batch = try #require(try EventObject.batch(
             in: context,
-            matching: [\EventObject.name, \EventObject.week]
+            matching: [\.name, \.week]
         ))
 
         #expect(Set(batch.map(\.name)).count == 1)
@@ -41,7 +41,7 @@ struct SyncableObjectBatchTests {
 
         let batch = try EventObject.batch(
             in: context,
-            matching: [\EventObject.name]
+            matching: [\.name]
         )
 
         #expect(batch == nil)
@@ -54,10 +54,10 @@ struct SyncableObjectBatchTests {
         let event = EventObject.stub(name: "EventC", date: week, synced: false, in: context)
         try context.save()
 
-        let batch = try EventObject.batch(
+        let batch = try #require(try EventObject.batch(
             in: context,
-            matching: [\EventObject.name, \EventObject.week]
-        )
+            matching: [\.name, \.week]
+        ))
 
         #expect(batch?.count == 1)
         #expect(batch?.first === event)

--- a/Tests/ScoutTests/Core/Sync/SyncableObjectBatchTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncableObjectBatchTests.swift
@@ -26,9 +26,9 @@ struct SyncableObjectBatchTests {
 
         try context.save()
 
-        let batch = try #require(try EventObject.batch(
+        let batch = try #require(try SyncableObject.batch(
             in: context,
-            matching: [\.name, \.week]
+            matching: [\EventObject.name, \.week]
         ))
 
         #expect(Set(batch.map(\.name)).count == 1)
@@ -39,9 +39,9 @@ struct SyncableObjectBatchTests {
         EventObject.stub(name: "EventA", synced: true, in: context)
         try context.save()
 
-        let batch = try EventObject.batch(
+        let batch = try SyncableObject.batch(
             in: context,
-            matching: [\.name]
+            matching: [\EventObject.name]
         )
 
         #expect(batch == nil)
@@ -54,12 +54,12 @@ struct SyncableObjectBatchTests {
         let event = EventObject.stub(name: "EventC", date: week, synced: false, in: context)
         try context.save()
 
-        let batch = try #require(try EventObject.batch(
+        let batch = try #require(try SyncableObject.batch(
             in: context,
-            matching: [\.name, \.week]
+            matching: [\EventObject.name, \.week]
         ))
 
-        #expect(batch?.count == 1)
-        #expect(batch?.first === event)
+        #expect(batch.count == 1)
+        #expect(batch.first === event)
     }
 }


### PR DESCRIPTION
Replaces explicit type key paths (e.g., \EventObject.name) with shorthand key paths (e.g., \.name) in SyncableObjectBatchTests for improved Swift syntax consistency.