### PR TITLE
Add DoubleMetricsObject and rename IntMetricsObject

### DIFF
--- a/Sources/Scout/Core/Metrics/DoubleMetricsObject.swift
+++ b/Sources/Scout/Core/Metrics/DoubleMetricsObject.swift
@@ -1,24 +1,17 @@
+//
 // Copyright 2025 Mikhail Kasianov
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CoreData
+import Foundation
 
+@objc(DoubleMetricsObject)
 final class DoubleMetricsObject: MetricsObject, Syncable {
     static func parse(of batch: [DoubleMetricsObject]) -> [Cell<Double>] {
         batch.grouped(by: \.hour).mapValues { items in
             items.reduce(0) { $0 + $1.doubleValue }
-        }
-        .map(Cell.init)
-    }
-}
-
-final class IntMetricsObject: MetricsObject, Syncable {
-    static func parse(of batch: [IntMetricsObject]) -> [Cell<Int>] {
-        batch.grouped(by: \.hour).mapValues { items in
-            items.reduce(0) { $0 + Int($1.intValue) }
         }
         .map(Cell.init)
     }

--- a/Sources/Scout/Core/Metrics/IntMetricsObject.swift
+++ b/Sources/Scout/Core/Metrics/IntMetricsObject.swift
@@ -1,0 +1,17 @@
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+@objc(IntMetricsObject)
+final class IntMetricsObject: MetricsObject, Syncable {
+    static func parse(of batch: [IntMetricsObject]) -> [Cell<Int>] {
+        batch.grouped(by: \.hour).mapValues { items in
+            items.reduce(0) { $0 + Int($1.intValue) }
+        }
+        .map(Cell.init)
+    }
+}


### PR DESCRIPTION
Introduces DoubleMetricsObject for handling double metric values and moves IntMetricsObject to its own file, renaming it from MetricsObject+Syncable.swift. This refactor separates double and integer metric logic for better clarity and maintainability.