### PR TITLE
Enhance Core Data error handling and store management

### DIFF
--- a/Sources/Scout/Core/Storage/Persistence+Load.swift
+++ b/Sources/Scout/Core/Storage/Persistence+Load.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension NSPersistentContainer {
+    func loadPersistentStores() throws {
+        var captured: Error?
+        loadPersistentStores { _, error in
+            captured = error
+        }
+        if let captured {
+            throw captured
+        }
+    }
+}

--- a/Sources/Scout/Core/Storage/Persistence+Rebuild.swift
+++ b/Sources/Scout/Core/Storage/Persistence+Rebuild.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Logging
+
+private let logger = Logger(label: "Scout.CoreData")
+
+extension NSPersistentContainer {
+    func rebuildStore() {
+        do {
+            try rebuildStoreThrowing()
+            logger.info("Core Data store wiped and recreated due to model incompatibility.")
+        } catch {
+            fatalError("Failed to wipe Core Data store: \(error)")
+        }
+    }
+
+    func rebuildStoreThrowing() throws {
+        viewContext.reset()
+
+        if let store = persistentStoreCoordinator.persistentStores.first, let url = store.url {
+            try persistentStoreCoordinator.remove(store)
+            try persistentStoreCoordinator.destroyPersistentStore(
+                at: url,
+                ofType: NSSQLiteStoreType
+            )
+        } else if let url = persistentStoreDescriptions.first?.url {
+            try persistentStoreCoordinator.destroyPersistentStore(
+                at: url,
+                ofType: NSSQLiteStoreType
+            )
+        }
+
+        try loadPersistentStores()
+    }
+}

--- a/Sources/Scout/Core/Storage/Persistence.swift
+++ b/Sources/Scout/Core/Storage/Persistence.swift
@@ -10,11 +10,12 @@ import CoreData
 let persistentContainer: NSPersistentContainer = {
     let container = NSPersistentContainer.newContainer(named: "Scout")
 
-    container.loadPersistentStores { _, error in
-        if let error {
-            print("Error loading Core Data store: \(error.localizedDescription)")
-        }
+    do {
+        try container.loadPersistentStores()
+    } catch {
+        print("Error loading Core Data store: \(error.localizedDescription)")
     }
+
     return container
 }()
 

--- a/Sources/Scout/Core/Storage/Persistence.swift
+++ b/Sources/Scout/Core/Storage/Persistence.swift
@@ -6,14 +6,25 @@
 // https://opensource.org/licenses/MIT.
 
 import CoreData
+import Logging
+
+private let incompatibleCodes = [
+    NSPersistentStoreIncompatibleVersionHashError,
+    NSMigrationError,
+    NSMigrationMissingSourceModelError,
+]
 
 let persistentContainer: NSPersistentContainer = {
     let container = NSPersistentContainer.newContainer(named: "Scout")
 
     do {
         try container.loadPersistentStores()
-    } catch {
-        print("Error loading Core Data store: \(error.localizedDescription)")
+    } catch let error as NSError {
+        if error.domain == NSCocoaErrorDomain && incompatibleCodes.contains(error.code) {
+            container.rebuildStore()
+        } else {
+            fatalError("Error loading Core Data store: \(error) | \(error.userInfo)")
+        }
     }
 
     return container


### PR DESCRIPTION
Introduce extensions for NSPersistentContainer to simplify loading and rebuilding persistent stores, improving error handling and clarity during Core Data stack setup. Handle specific incompatibility errors by triggering a store rebuild, while logging detailed error information for better diagnostics.