### PR TITLE
Rename loadPersistentStores to loadStores

### DIFF
--- a/Sources/Scout/Core/Persistence/Persistence+Load.swift
+++ b/Sources/Scout/Core/Persistence/Persistence+Load.swift
@@ -8,7 +8,7 @@
 import CoreData
 
 extension NSPersistentContainer {
-    func loadPersistentStores() throws {
+    func loadStores() throws {
         var captured: Error?
         loadPersistentStores { _, error in
             captured = error

--- a/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
+++ b/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
@@ -36,6 +36,6 @@ extension NSPersistentContainer {
             )
         }
 
-        try loadPersistentStores()
+        try loadStores()
     }
 }

--- a/Sources/Scout/Core/Persistence/Persistence.swift
+++ b/Sources/Scout/Core/Persistence/Persistence.swift
@@ -17,7 +17,7 @@ let persistentContainer: NSPersistentContainer = {
     let container = NSPersistentContainer.newContainer(named: "Scout")
 
     do {
-        try container.loadPersistentStores()
+        try container.loadStores()
     } catch let error as NSError {
         if error.domain == NSCocoaErrorDomain && incompatibleCodes.contains(error.code) {
             container.rebuildStore()


### PR DESCRIPTION
Refactored NSPersistentContainer extension method from loadPersistentStores() to loadStores() for improved clarity and consistency. Updated all usages accordingly.