### PR TITLE
Add tests and stubs for NSPersistentContainer.loadStores

### DIFF
--- a/Tests/ScoutTests/Core/Persistence/PersistenceLoadTests.swift
+++ b/Tests/ScoutTests/Core/Persistence/PersistenceLoadTests.swift
@@ -1,0 +1,49 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@Suite("NSPersistentContainer.loadStores()")
+struct PersistenceLoadTests {
+    let model = NSManagedObjectModel.stub()
+
+    @Test("loadStores succeeds with an in-memory store")
+    func loadStoresSucceeds() throws {
+        let container = NSPersistentContainer(name: "TestModel", managedObjectModel: model)
+
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+
+        // This should not throw
+        try container.loadStores()
+    }
+
+    @Test("loadStores throws when loadPersistentStores reports an error")
+    func loadStoresThrowsInjectedError() throws {
+        let expectedError = NSError(domain: "TestError", code: 42)
+
+        let container = InMemoryContainer(
+            name: "TestModel",
+            managedObjectModel: model,
+            injectedError: expectedError
+        )
+
+        do {
+            try container.loadStores()
+            Issue.record("Expected loadStores() to throw, but it did not.")
+        } catch {
+            // Ensure we surface the same error we injected
+            let nsError = error as NSError
+            #expect(nsError.domain == expectedError.domain)
+            #expect(nsError.code == expectedError.code)
+        }
+    }
+}

--- a/Tests/ScoutTests/Stubs/NSManagedObjectModel+Stub.swift
+++ b/Tests/ScoutTests/Stubs/NSManagedObjectModel+Stub.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension NSManagedObjectModel {
+    static func stub() -> NSManagedObjectModel {
+        // Build a minimal model with a single entity so the container is valid.
+        let model = NSManagedObjectModel()
+
+        let entity = NSEntityDescription()
+        entity.name = "Dummy"
+        entity.managedObjectClassName = "NSManagedObject"
+
+        let attribute = NSAttributeDescription()
+        attribute.name = "id"
+        attribute.attributeType = .stringAttributeType
+        attribute.isOptional = false
+
+        entity.properties = [attribute]
+        model.entities = [entity]
+
+        return model
+    }
+}

--- a/Tests/ScoutTests/Transient/InMemoryContainer.swift
+++ b/Tests/ScoutTests/Transient/InMemoryContainer.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+final class InMemoryContainer: NSPersistentContainer, @unchecked Sendable {
+    private let injectedError: Error
+
+    init(name: String, managedObjectModel model: NSManagedObjectModel, injectedError: Error) {
+        self.injectedError = injectedError
+        super.init(name: name, managedObjectModel: model)
+
+        // Provide a store description so super doesn't try to auto-create one.
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        self.persistentStoreDescriptions = [description]
+    }
+
+    override func loadPersistentStores(completionHandler block: @escaping (NSPersistentStoreDescription, Error?) -> Void) {
+        // Call completion with the injected error to simulate a failure.
+        let description = persistentStoreDescriptions.first ?? NSPersistentStoreDescription()
+        block(description, injectedError)
+    }
+}


### PR DESCRIPTION
Introduces PersistenceLoadTests to verify NSPersistentContainer.loadStores behavior, including success and error scenarios. Adds NSManagedObjectModel.stub for creating minimal models and InMemoryContainer to simulate error injection during store loading.