### PR TITLE
Add Scout.xctestplan and update .gitignore

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -33,7 +33,6 @@ jobs:
           set -o pipefail && \
           xcodebuild \
             -scheme $SCHEME_NAME \
-            -arch 'x86_64' \
-            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
+            -destination 'platform=iOS Simulator,arch:x86_64,OS=latest,name=iPhone 16 Pro' \
             -enableCodeCoverage YES \
             test | xcpretty

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -33,6 +33,7 @@ jobs:
           set -o pipefail && \
           xcodebuild \
             -scheme $SCHEME_NAME \
+            -arch 'x86_64' \
             -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
             -enableCodeCoverage YES \
             test | xcpretty

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.build
 /Packages
 xcuserdata/
-.swiftpm/
+/.swiftpm/*
+!.swiftpm/Scout.xctestplan
 Package.resolved

--- a/.swiftpm/Scout.xctestplan
+++ b/.swiftpm/Scout.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "B1F1F7E4-D813-4F3C-8DE6-037A274BA883",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "performanceAntipatternCheckerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "ScoutTests",
+        "name" : "ScoutTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/.swiftpm/Scout.xctestplan
+++ b/.swiftpm/Scout.xctestplan
@@ -13,6 +13,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:",
         "identifier" : "ScoutTests",


### PR DESCRIPTION
Added .swiftpm/Scout.xctestplan to support test planning. Updated .gitignore to ignore all files in .swiftpm except Scout.xctestplan, ensuring the test plan is tracked in version control.