### PR TITLE
Move eventID attribute from TrackedObject to EventObject

### DIFF
--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24295.2" systemVersion="25A5349a" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24295.2" systemVersion="25A5351b" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="DateObject" representedClassName="DateObject" isAbstract="YES" syncable="YES" codeGenerationType="class">
         <attribute name="datePrimitive" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="day" attributeType="Date" usesScalarValueType="NO"/>
@@ -11,6 +11,7 @@
         <attribute name="doubleValue" attributeType="Double" usesScalarValueType="YES"/>
     </entity>
     <entity name="EventObject" representedClassName="EventObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="category">
+        <attribute name="eventID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="level" attributeType="String"/>
         <attribute name="paramCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="params" optional="YES" attributeType="Binary"/>
@@ -33,7 +34,6 @@
         <attribute name="isSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
     </entity>
     <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="class">
-        <attribute name="eventID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
     </entity>
     <entity name="UserActivity" representedClassName="UserActivity" parentEntity="SyncableObject" syncable="YES" codeGenerationType="category">


### PR DESCRIPTION
The eventID attribute was removed from the abstract TrackedObject entity and added to the EventObject entity. This change clarifies the data model by associating eventID specifically with EventObject instances.