### PR TITLE
Rename Value to Scalar in CellProtocol and related types

### DIFF
--- a/Sources/Scout/Core/Matrix/CellProtocol.swift
+++ b/Sources/Scout/Core/Matrix/CellProtocol.swift
@@ -8,10 +8,16 @@
 import CloudKit
 
 protocol CellProtocol {
-    associatedtype Value: MatrixValue & CKRecordValueProtocol
+    associatedtype Scalar: MatrixValue & CKRecordValueProtocol
 
     var key: String { get }
-    var value: Value { get }
+    var value: Scalar { get }
 
-    init(key: String, value: Value) throws
+    init(key: String, value: Scalar) throws
+}
+
+// Backward compatibility
+extension CellProtocol {
+    @available(*, deprecated, renamed: "Scalar")
+    typealias Value = Scalar
 }

--- a/Sources/Scout/Core/Matrix/Matrix.swift
+++ b/Sources/Scout/Core/Matrix/Matrix.swift
@@ -68,7 +68,7 @@ extension Matrix: CKInitializable {
         guard cellDict.count > 0 else {
             throw MapError.missingCells
         }
-        guard let cellDict = cellDict as? [String: T.Value] else {
+        guard let cellDict = cellDict as? [String: T.Scalar] else {
             throw MapError.invalidCells
         }
 
@@ -78,7 +78,7 @@ extension Matrix: CKInitializable {
 
 extension Matrix: CKRepresentable {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: T.Value.recordName, recordID: recordID)
+        let record = CKRecord(recordType: T.Scalar.recordName, recordID: recordID)
         record["date"] = date
         record["name"] = name
         for cell in cells {

--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -18,7 +18,7 @@ extension MetricsObject {
             return nil
         }
         return SyncGroup(
-            recordType: T.Value.Value.recordName,
+            recordType: T.Cell.Scalar.recordName,
             name: "\(name)_\(telemetry)",
             date: week,
             representables: nil,

--- a/Sources/Scout/Core/Sync/SyncGroup.swift
+++ b/Sources/Scout/Core/Sync/SyncGroup.swift
@@ -17,7 +17,7 @@ struct SyncGroup<T: Syncable>: @unchecked Sendable {
 }
 
 extension SyncGroup {
-    func newMatrix() -> Matrix<T.Value> {
+    func newMatrix() -> Matrix<T.Cell> {
         Matrix(
             date: date,
             name: name,
@@ -26,7 +26,7 @@ extension SyncGroup {
         )
     }
 
-    func matrix(in database: Database) async throws -> Matrix<T.Value> {
+    func matrix(in database: Database) async throws -> Matrix<T.Cell> {
         let name = NSPredicate(format: "name == %@", name)
         let date = NSPredicate(format: "date == %@", date as NSDate)
         let predicate = NSCompoundPredicate(type: .and, subpredicates: [name, date])

--- a/Sources/Scout/Core/Sync/Syncable.swift
+++ b/Sources/Scout/Core/Sync/Syncable.swift
@@ -11,12 +11,18 @@ import CoreData
 typealias SyncValue = MatrixValue & CKRecordValueProtocol & AdditiveArithmetic & Sendable & Hashable
 
 protocol Syncable: NSManagedObject {
-    associatedtype Value: CellProtocol & Combining & Sendable
+    associatedtype Cell: CellProtocol & Combining & Sendable
 
     static func group(in context: NSManagedObjectContext) throws -> SyncGroup<Self>?
-    static func parse(of batch: [Self]) -> [Value]
+    static func parse(of batch: [Self]) -> [Cell]
 
     var isSynced: Bool { get set }
+}
+
+// Backward compatibility
+extension Syncable {
+    @available(*, deprecated, renamed: "Cell")
+    typealias Value = Cell
 }
 
 enum SyncableError: Error {


### PR DESCRIPTION
Refactors CellProtocol to use 'Scalar' instead of 'Value' for the associated type, and updates all related usages in Matrix, MetricsObject+Group, SyncGroup, and Syncable. Adds typealias for backward compatibility to minimize migration issues.