### PR TITLE
Refactor Core Data store rebuild logic

### DIFF
--- a/Sources/Scout/Core/Persistence/Persistence+Load.swift
+++ b/Sources/Scout/Core/Persistence/Persistence+Load.swift
@@ -8,7 +8,7 @@
 import CoreData
 
 extension NSPersistentContainer {
-    func loadStores() throws {
+    func loadStore() throws {
         var captured: Error?
         loadPersistentStores { _, error in
             captured = error

--- a/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
+++ b/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
@@ -14,7 +14,7 @@ extension NSPersistentContainer {
     func rebuildStore() {
         do {
             try destroyStore()
-            try loadStores()
+            try loadStore()
             logger.info("Core Data store wiped and recreated due to model incompatibility.")
         } catch {
             fatalError("Failed to wipe Core Data store: \(error)")

--- a/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
+++ b/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
@@ -13,14 +13,15 @@ private let logger = Logger(label: "Scout.CoreData")
 extension NSPersistentContainer {
     func rebuildStore() {
         do {
-            try rebuildStoreThrowing()
+            try destroyStore()
+            try loadStores()
             logger.info("Core Data store wiped and recreated due to model incompatibility.")
         } catch {
             fatalError("Failed to wipe Core Data store: \(error)")
         }
     }
 
-    func rebuildStoreThrowing() throws {
+    func destroyStore() throws {
         viewContext.reset()
 
         if let store = persistentStoreCoordinator.persistentStores.first, let url = store.url {
@@ -35,7 +36,5 @@ extension NSPersistentContainer {
                 ofType: NSSQLiteStoreType
             )
         }
-
-        try loadStores()
     }
 }

--- a/Sources/Scout/Core/Persistence/Persistence.swift
+++ b/Sources/Scout/Core/Persistence/Persistence.swift
@@ -17,7 +17,7 @@ let persistentContainer: NSPersistentContainer = {
     let container = NSPersistentContainer.newContainer(named: "Scout")
 
     do {
-        try container.loadStores()
+        try container.loadStore()
     } catch let error as NSError {
         if error.domain == NSCocoaErrorDomain && incompatibleCodes.contains(error.code) {
             container.rebuildStore()

--- a/Tests/ScoutTests/Core/Persistence/PersistenceLoadTests.swift
+++ b/Tests/ScoutTests/Core/Persistence/PersistenceLoadTests.swift
@@ -10,7 +10,7 @@ import Testing
 
 @testable import Scout
 
-@Suite("NSPersistentContainer.loadStores()")
+@Suite("NSPersistentContainer.loadStore()")
 struct PersistenceLoadTests {
     let model = NSManagedObjectModel.stub()
 
@@ -23,7 +23,7 @@ struct PersistenceLoadTests {
         container.persistentStoreDescriptions = [description]
 
         // This should not throw
-        try container.loadStores()
+        try container.loadStore()
     }
 
     @Test("loadStores throws when loadPersistentStores reports an error")
@@ -37,8 +37,8 @@ struct PersistenceLoadTests {
         )
 
         do {
-            try container.loadStores()
-            Issue.record("Expected loadStores() to throw, but it did not.")
+            try container.loadStore()
+            Issue.record("Expected loadStore() to throw, but it did not.")
         } catch {
             // Ensure we surface the same error we injected
             let nsError = error as NSError


### PR DESCRIPTION
Split the rebuildStore logic into separate destroyStore and loadStores steps. The rebuildStore method now calls destroyStore and then loadStores, improving clarity and separation of concerns.