### PR TITLE
Refactor error handling in PersistenceLoadTests

### DIFF
--- a/Tests/ScoutTests/Core/Persistence/PersistenceLoadTests.swift
+++ b/Tests/ScoutTests/Core/Persistence/PersistenceLoadTests.swift
@@ -39,11 +39,9 @@ struct PersistenceLoadTests {
         do {
             try container.loadStore()
             Issue.record("Expected loadStore() to throw, but it did not.")
-        } catch {
-            // Ensure we surface the same error we injected
-            let nsError = error as NSError
-            #expect(nsError.domain == expectedError.domain)
-            #expect(nsError.code == expectedError.code)
+        } catch let error as NSError {
+            #expect(error.domain == expectedError.domain)
+            #expect(error.code == expectedError.code)
         }
     }
 }


### PR DESCRIPTION
Simplified the catch block to directly cast the error as NSError, improving clarity and ensuring type safety when comparing error domain and code.