### PR TITLE
Remove unused 'now' constant in SyncGroupTests

### DIFF
--- a/Tests/ScoutTests/Core/Sync/SyncGroupTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncGroupTests.swift
@@ -25,7 +25,7 @@ struct SyncGroupTests {
         group = SyncGroup<EventObject>(
             matrix: Matrix(
                 recordType: "DateIntMatrix",
-                date: now,
+                date: Date(),
                 name: "group_name",
                 cells: EventObject.parse(of: batch)
             ),
@@ -34,5 +34,3 @@ struct SyncGroupTests {
         )
     }
 }
-
-private let now = Date()


### PR DESCRIPTION
Replaces usage of the 'now' constant with direct Date() initialization and removes the unused 'now' declaration from SyncGroupTests.swift.