### PR TITLE
Add summary property to CellProtocol array

### DIFF
--- a/Sources/Scout/Core/Cell/CellProtocol.swift
+++ b/Sources/Scout/Core/Cell/CellProtocol.swift
@@ -15,3 +15,15 @@ protocol CellProtocol {
 
     init(key: String, value: Scalar) throws
 }
+
+extension Array where Element: CellProtocol {
+    var summary: String {
+        if isEmpty {
+            return "[]"
+        }
+        let items = map { cell in
+            "\(cell.key)=\(String(describing: cell.value))"
+        }
+        return "[\(items.joined(separator: ", "))]"
+    }
+}

--- a/Sources/Scout/Core/Matrix/Matrix.swift
+++ b/Sources/Scout/Core/Matrix/Matrix.swift
@@ -60,17 +60,7 @@ extension Matrix: CustomDebugStringConvertible {
           name: \(name),
           category: \(category ?? "nil"),
           id: \(recordID.recordName),
-          cells: \(cellsSummary))
+          cells: \(cells.summary)
         """
-    }
-
-    private var cellsSummary: String {
-        if cells.isEmpty {
-            return "[]"
-        }
-        let items = cells.map { cell in
-            "\(cell.key)=\(String(describing: cell.value))"
-        }
-        return "[\(items.joined(separator: ", "))]"
     }
 }


### PR DESCRIPTION
Introduces an Array extension for CellProtocol elements, providing a summary property for concise string representation. Refactors Matrix debug description to use this new summary property, removing redundant code.