### PR TITLE
Change Syncable protocol to inherit from SyncableObject

### DIFF
--- a/Sources/Scout/Core/Sync/Syncable.swift
+++ b/Sources/Scout/Core/Sync/Syncable.swift
@@ -10,14 +10,12 @@ import CoreData
 
 typealias SyncValue = MatrixValue & CKRecordValueProtocol & AdditiveArithmetic & Sendable & Hashable
 
-protocol Syncable: NSManagedObject {
+protocol Syncable: SyncableObject {
     associatedtype Cell: CellProtocol & Combining & Sendable
 
     static func group(in context: NSManagedObjectContext) throws -> [Self]?
     static func matrix(of batch: [Self]) throws(SyncableError) -> Matrix<Cell>
     static func parse(of batch: [Self]) -> [Cell]
-
-    var isSynced: Bool { get set }
 }
 
 enum SyncableError: LocalizedError {


### PR DESCRIPTION
Updated the Syncable protocol to inherit from SyncableObject instead of NSManagedObject. Also removed the isSynced property requirement from the protocol.