### PR TITLE
Refactor to use MatrixValue instead of SyncValue

### DIFF
--- a/Sources/Scout/Core/Cell/Cell.swift
+++ b/Sources/Scout/Core/Cell/Cell.swift
@@ -7,7 +7,7 @@
 
 import CloudKit
 
-struct Cell<T: SyncValue>: Hashable {
+struct Cell<T: MatrixValue>: Hashable {
     let row: Int
     let column: Int
     let value: T

--- a/Sources/Scout/Core/Cell/PeriodCell.swift
+++ b/Sources/Scout/Core/Cell/PeriodCell.swift
@@ -7,7 +7,7 @@
 
 import CloudKit
 
-struct PeriodCell<T: SyncValue> {
+struct PeriodCell<T: MatrixValue> {
     let period: ActivityPeriod
     let day: Int
     let value: T

--- a/Sources/Scout/Core/Matrix/MatrixValue.swift
+++ b/Sources/Scout/Core/Matrix/MatrixValue.swift
@@ -6,8 +6,9 @@
 // https://opensource.org/licenses/MIT.
 
 import CoreData
+import CloudKit
 
-protocol MatrixValue: Sendable {
+protocol MatrixValue: CKRecordValueProtocol & AdditiveArithmetic & Sendable & Hashable {
     associatedtype Object: MetricsObject
 
     static var recordName: String { get }

--- a/Sources/Scout/Core/Sync/Syncable.swift
+++ b/Sources/Scout/Core/Sync/Syncable.swift
@@ -8,8 +8,6 @@
 import CloudKit
 import CoreData
 
-typealias SyncValue = MatrixValue & CKRecordValueProtocol & AdditiveArithmetic & Sendable & Hashable
-
 protocol Syncable: SyncableObject {
     associatedtype Cell: CellProtocol & Combining & Sendable
 


### PR DESCRIPTION
Updated Cell and PeriodCell generics to require MatrixValue instead of SyncValue. MatrixValue protocol now inherits required protocols directly, and the SyncValue typealias was removed. This simplifies type constraints and clarifies protocol usage.