### PR TITLE
Move SyncCoordinator extension to Syncable.swift

### DIFF
--- a/Sources/Scout/Core/Sync/SyncCoordinator.swift
+++ b/Sources/Scout/Core/Sync/SyncCoordinator.swift
@@ -30,11 +30,3 @@ struct SyncCoordinator<T: CellProtocol & Combining & Sendable> {
         }
     }
 }
-
-extension SyncCoordinator {
-    init<V: Syncable>(database: Database, maxRetry: Int, batch: [V]) throws where V.Cell == T {
-        self.database = database
-        self.maxRetry = maxRetry
-        self.matrix = try V.matrix(of: batch)
-    }
-}

--- a/Sources/Scout/Core/Sync/Syncable.swift
+++ b/Sources/Scout/Core/Sync/Syncable.swift
@@ -16,6 +16,14 @@ protocol Syncable: SyncableObject {
     static func parse(of batch: [Self]) -> [Cell]
 }
 
+extension SyncCoordinator {
+    init<V: Syncable>(database: Database, maxRetry: Int, batch: [V]) throws where V.Cell == T {
+        self.database = database
+        self.maxRetry = maxRetry
+        self.matrix = try V.matrix(of: batch)
+    }
+}
+
 enum SyncableError: LocalizedError {
     case missingProperty(String)
 


### PR DESCRIPTION
Relocated the SyncCoordinator extension with the generic initializer from SyncCoordinator.swift to Syncable.swift for better organization and separation of concerns.