### PR TITLE
Rename SyncableError to MatrixSyncError in matrix methods

### DIFF
--- a/Sources/Scout/Core/Activity/UserActivity.swift
+++ b/Sources/Scout/Core/Activity/UserActivity.swift
@@ -14,7 +14,7 @@ final class UserActivity: SyncableObject, Syncable {
          try batch(in: context, matching: [\.month])
     }
 
-    static func matrix(of batch: [UserActivity]) throws(SyncableError) -> Matrix<PeriodCell<Int>> {
+    static func matrix(of batch: [UserActivity]) throws(MatrixSyncError) -> Matrix<PeriodCell<Int>> {
         guard let month = batch.first?.month else {
             throw .missingProperty("month")
         }

--- a/Sources/Scout/Core/Log/EventObject.swift
+++ b/Sources/Scout/Core/Log/EventObject.swift
@@ -14,7 +14,7 @@ final class EventObject: TrackedObject, Syncable {
         try batch(in: context, matching: [\.name, \.week])
     }
 
-    static func matrix(of batch: [EventObject]) throws(SyncableError) -> Matrix<Cell<Int>> {
+    static func matrix(of batch: [EventObject]) throws(MatrixSyncError) -> Matrix<Cell<Int>> {
         guard let name = batch.first?.name else {
             throw .missingProperty("name")
         }

--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -14,7 +14,7 @@ class MetricsObject: TrackedObject {
         try batch(in: context, matching: [\.name, \.telemetry, \.week])
     }
 
-    static func matrix<T: MetricsObject & Syncable>(of batch: [T]) throws(SyncableError) -> Matrix<T.Cell> {
+    static func matrix<T: MetricsObject & Syncable>(of batch: [T]) throws(MatrixSyncError) -> Matrix<T.Cell> {
         guard let name = batch.first?.name else {
             throw .missingProperty("name")
         }

--- a/Sources/Scout/Core/Monitor/SessionObject.swift
+++ b/Sources/Scout/Core/Monitor/SessionObject.swift
@@ -14,7 +14,7 @@ final class SessionObject: SyncableObject, Syncable {
         try batch(in: context, matching: [\.week])
     }
 
-    static func matrix(of batch: [SessionObject]) throws(SyncableError) -> Matrix<Cell<Int>> {
+    static func matrix(of batch: [SessionObject]) throws(MatrixSyncError) -> Matrix<Cell<Int>> {
         guard let week = batch.first?.week else {
             throw .missingProperty("week")
         }

--- a/Sources/Scout/Core/Sync/Syncable.swift
+++ b/Sources/Scout/Core/Sync/Syncable.swift
@@ -12,7 +12,7 @@ protocol Syncable: SyncableObject {
     associatedtype Cell: CellProtocol & Combining & Sendable
 
     static func group(in context: NSManagedObjectContext) throws -> [Self]?
-    static func matrix(of batch: [Self]) throws(SyncableError) -> Matrix<Cell>
+    static func matrix(of batch: [Self]) throws(MatrixSyncError) -> Matrix<Cell>
     static func parse(of batch: [Self]) -> [Cell]
 }
 
@@ -24,7 +24,7 @@ extension SyncCoordinator {
     }
 }
 
-enum SyncableError: LocalizedError {
+enum MatrixSyncError: LocalizedError {
     case missingProperty(String)
 
     var errorDescription: String? {


### PR DESCRIPTION
Replaces the SyncableError error type with MatrixSyncError in all matrix-related methods and updates the error enum name accordingly. This change clarifies error handling specific to matrix operations.