### PR TITLE
Refactor generics to require only CellProtocol

### DIFF
--- a/Sources/Scout/Core/Cell/CellProtocol.swift
+++ b/Sources/Scout/Core/Cell/CellProtocol.swift
@@ -7,7 +7,7 @@
 
 import CloudKit
 
-protocol CellProtocol {
+protocol CellProtocol: Combining, Sendable {
     associatedtype Scalar: MatrixValue & CKRecordValueProtocol
 
     var key: String { get }

--- a/Sources/Scout/Core/Matrix/Matrix.swift
+++ b/Sources/Scout/Core/Matrix/Matrix.swift
@@ -7,7 +7,7 @@
 
 import CloudKit
 
-struct Matrix<T: CellProtocol & Combining & Sendable> {
+struct Matrix<T: CellProtocol> {
     let recordType: String
     let date: Date
     let name: String

--- a/Sources/Scout/Core/Sync/SyncCoordinator.swift
+++ b/Sources/Scout/Core/Sync/SyncCoordinator.swift
@@ -8,7 +8,7 @@
 import CloudKit
 
 @MainActor
-struct SyncCoordinator<T: CellProtocol & Combining & Sendable> {
+struct SyncCoordinator<T: CellProtocol> {
     let database: Database
     let maxRetry: Int
     let matrix: Matrix<T>

--- a/Sources/Scout/Core/Sync/Syncable.swift
+++ b/Sources/Scout/Core/Sync/Syncable.swift
@@ -9,7 +9,7 @@ import CloudKit
 import CoreData
 
 protocol Syncable: SyncableObject {
-    associatedtype Cell: CellProtocol & Combining & Sendable
+    associatedtype Cell: CellProtocol
 
     static func group(in context: NSManagedObjectContext) throws -> [Self]?
     static func matrix(of batch: [Self]) throws(SyncableError) -> Matrix<Cell>


### PR DESCRIPTION
Removed redundant Combining and Sendable constraints from Matrix, SyncCoordinator, and Syncable generics. CellProtocol now directly inherits from Combining and Sendable, simplifying type requirements and improving code clarity.