### PR TITLE
Remove CKRecordValueProtocol constraint from Scalar

### DIFF
--- a/Sources/Scout/Core/Cell/CellProtocol.swift
+++ b/Sources/Scout/Core/Cell/CellProtocol.swift
@@ -8,7 +8,7 @@
 import CloudKit
 
 protocol CellProtocol: Combining, Sendable {
-    associatedtype Scalar: MatrixValue & CKRecordValueProtocol
+    associatedtype Scalar: MatrixValue
 
     var key: String { get }
     var value: Scalar { get }


### PR DESCRIPTION
The Scalar associated type in CellProtocol no longer requires conformance to CKRecordValueProtocol, only to MatrixValue. This change may be in preparation for broader usage or to decouple from CloudKit-specific types.