### PR TITLE
Rename Cell to GridCell throughout codebase

### DIFF
--- a/Sources/Scout/Core/Cell/GridCell.swift
+++ b/Sources/Scout/Core/Cell/GridCell.swift
@@ -7,13 +7,13 @@
 
 import CloudKit
 
-struct Cell<T: MatrixValue>: Hashable {
+struct GridCell<T: MatrixValue>: Hashable {
     let row: Int
     let column: Int
     let value: T
 }
 
-extension Cell: CellProtocol {
+extension GridCell: CellProtocol {
     var key: String {
         "cell_\(row)_\(String(format: "%02d", column))"
     }
@@ -37,8 +37,8 @@ extension Cell: CellProtocol {
     }
 }
 
-extension Cell: Combining {
-    func isDuplicate(of other: Cell<T>) -> Bool {
+extension GridCell: Combining {
+    func isDuplicate(of other: GridCell<T>) -> Bool {
         row == other.row && column == other.column
     }
 
@@ -46,7 +46,7 @@ extension Cell: Combining {
         assert(lhs.row == rhs.row, "Row indices must match")
         assert(lhs.column == rhs.column, "Column indices must match")
 
-        return Cell(
+        return GridCell(
             row: lhs.row,
             column: lhs.column,
             value: lhs.value + rhs.value
@@ -54,8 +54,8 @@ extension Cell: Combining {
     }
 }
 
-extension Cell: Comparable {
-    static func < (lhs: Cell<T>, rhs: Cell<T>) -> Bool {
+extension GridCell: Comparable {
+    static func < (lhs: GridCell<T>, rhs: GridCell<T>) -> Bool {
         if lhs.row == rhs.row {
             return lhs.column < rhs.column
         } else {
@@ -64,7 +64,7 @@ extension Cell: Comparable {
     }
 }
 
-extension Cell: CustomStringConvertible {
+extension GridCell: CustomStringConvertible {
     var description: String {
         "Cell(row: \(row), column: \(column), value: \(value))"
     }

--- a/Sources/Scout/Core/Log/EventObject.swift
+++ b/Sources/Scout/Core/Log/EventObject.swift
@@ -14,7 +14,7 @@ final class EventObject: TrackedObject, Syncable {
         try batch(in: context, matching: [\.name, \.week])
     }
 
-    static func matrix(of batch: [EventObject]) throws(MatrixSyncError) -> Matrix<Cell<Int>> {
+    static func matrix(of batch: [EventObject]) throws(MatrixSyncError) -> Matrix<GridCell<Int>> {
         guard let name = batch.first?.name else {
             throw .missingProperty("name")
         }
@@ -29,7 +29,7 @@ final class EventObject: TrackedObject, Syncable {
         )
     }
 
-    static func parse(of batch: [EventObject]) -> [Cell<Int>] {
+    static func parse(of batch: [EventObject]) -> [GridCell<Int>] {
         batch.grouped(by: \.hour).mapValues(\.count).map(Cell.init)
     }
 }

--- a/Sources/Scout/Core/Metrics/DoubleMetricsObject.swift
+++ b/Sources/Scout/Core/Metrics/DoubleMetricsObject.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @objc(DoubleMetricsObject)
 final class DoubleMetricsObject: MetricsObject, Syncable {
-    static func parse(of batch: [DoubleMetricsObject]) -> [Cell<Double>] {
+    static func parse(of batch: [DoubleMetricsObject]) -> [GridCell<Double>] {
         batch.grouped(by: \.hour).mapValues { items in
             items.reduce(0) { $0 + $1.doubleValue }
         }

--- a/Sources/Scout/Core/Metrics/IntMetricsObject.swift
+++ b/Sources/Scout/Core/Metrics/IntMetricsObject.swift
@@ -8,7 +8,7 @@ import CoreData
 
 @objc(IntMetricsObject)
 final class IntMetricsObject: MetricsObject, Syncable {
-    static func parse(of batch: [IntMetricsObject]) -> [Cell<Int>] {
+    static func parse(of batch: [IntMetricsObject]) -> [GridCell<Int>] {
         batch.grouped(by: \.hour).mapValues { items in
             items.reduce(0) { $0 + Int($1.intValue) }
         }

--- a/Sources/Scout/Core/Monitor/SessionObject.swift
+++ b/Sources/Scout/Core/Monitor/SessionObject.swift
@@ -14,7 +14,7 @@ final class SessionObject: SyncableObject, Syncable {
         try batch(in: context, matching: [\.week])
     }
 
-    static func matrix(of batch: [SessionObject]) throws(MatrixSyncError) -> Matrix<Cell<Int>> {
+    static func matrix(of batch: [SessionObject]) throws(MatrixSyncError) -> Matrix<GridCell<Int>> {
         guard let week = batch.first?.week else {
             throw .missingProperty("week")
         }
@@ -26,7 +26,7 @@ final class SessionObject: SyncableObject, Syncable {
         )
     }
 
-    static func parse(of batch: [SessionObject]) -> [Cell<Int>] {
+    static func parse(of batch: [SessionObject]) -> [GridCell<Int>] {
         batch.grouped(by: \.date).mapValues(\.count).map(Cell.init)
     }
 }

--- a/Sources/Scout/UI/Chart/ChartPoint.swift
+++ b/Sources/Scout/UI/Chart/ChartPoint.swift
@@ -14,7 +14,7 @@ struct ChartPoint: Identifiable {
     let date: Date
     let count: Int
 
-    static func fromIntMatrix(_ matrix: Matrix<Cell<Int>>) -> [ChartPoint] {
+    static func fromIntMatrix(_ matrix: Matrix<GridCell<Int>>) -> [ChartPoint] {
         matrix.cells.map { cell in
             ChartPoint(
                 date: matrix.date.addingDay(cell.row - 1).addingHour(cell.column),

--- a/Sources/Scout/UI/Event/Stat/StatProvider.swift
+++ b/Sources/Scout/UI/Event/Stat/StatProvider.swift
@@ -30,7 +30,7 @@ extension StatProvider: Provider {
                 desiredKeys: nil
             )
 
-            let rawPoints = try records.map(Matrix<Cell<Int>>.init)
+            let rawPoints = try records.map(Matrix<GridCell<Int>>.init)
                 .mergeDuplicates()
                 .flatMap(ChartPoint.fromIntMatrix)
 

--- a/Tests/ScoutTests/Core/Cell/GridCellTest.swift
+++ b/Tests/ScoutTests/Core/Cell/GridCellTest.swift
@@ -9,10 +9,10 @@ import Testing
 
 @testable import Scout
 
-@Test("Cell addition") func testCellAddition() {
-    let a = Cell(row: 1, column: 2, value: 3)
-    let b = Cell(row: 1, column: 2, value: 4)
+@Test("GridCell addition") func testCellAddition() {
+    let a = GridCell(row: 1, column: 2, value: 3)
+    let b = GridCell(row: 1, column: 2, value: 4)
     let c = a + b
 
-    #expect(c == Cell(row: 1, column: 2, value: 7))
+    #expect(c == GridCell(row: 1, column: 2, value: 7))
 }

--- a/Tests/ScoutTests/Core/Log/EventObjectTests.swift
+++ b/Tests/ScoutTests/Core/Log/EventObjectTests.swift
@@ -16,7 +16,7 @@ struct EventObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
     let date = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
 
-    @Test("parse(of:) produces correct Cell<Int> counts by hour")
+    @Test("parse(of:) produces correct GridCell<Int> counts by hour")
     func testParseOf() throws {
         let batch: [EventObject] = [
             .stub(name: "name", date: date, in: context),

--- a/Tests/ScoutTests/Core/Matrix/MatrixLookupTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/MatrixLookupTests.swift
@@ -19,7 +19,7 @@ struct MatrixLookupTests {
     func testNoMatches() async throws {
         database.records = [CKRecord.matrixStub(name: "other", date: Date().addingTimeInterval(-3600))]
 
-        let matrix = Matrix<Cell<Int>>(
+        let matrix = Matrix<GridCell<Int>>(
             recordType: "DateIntMatrix",
             date: Date(),
             name: "target",
@@ -36,7 +36,7 @@ struct MatrixLookupTests {
         let match = CKRecord.matrixStub(name: "target", date: date)
         database.records = [match]
 
-        let query = Matrix<Cell<Int>>(
+        let query = Matrix<GridCell<Int>>(
             recordType: "DateIntMatrix",
             date: date,
             name: "target",
@@ -44,7 +44,7 @@ struct MatrixLookupTests {
         )
 
         let existing = try #require(try await query.lookupExisting(in: database))
-        let parsed = try Matrix<Cell<Int>>(record: match)
+        let parsed = try Matrix<GridCell<Int>>(record: match)
 
         #expect(existing.recordType == "DateIntMatrix")
         #expect(existing.name == "target")

--- a/Tests/ScoutTests/Core/Matrix/MatrixTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/MatrixTests.swift
@@ -21,10 +21,10 @@ struct MatrixTests {
         record["cell_0_0"] = 1
         record["cell_0_1"] = 2
 
-        let matrix = try Matrix<Cell<Int>>(record: record)
+        let matrix = try Matrix<GridCell<Int>>(record: record)
         let expectedCells = [
-            Cell(row: 0, column: 0, value: 1),
-            Cell(row: 0, column: 1, value: 2),
+            GridCell(row: 0, column: 0, value: 1),
+            GridCell(row: 0, column: 1, value: 2),
         ]
 
         #expect(Set(matrix.cells) == Set(expectedCells))
@@ -36,13 +36,13 @@ struct MatrixTests {
             recordType: "DateIntMatrix",
             date: date,
             name: "Test Matrix",
-            cells: [Cell(row: 0, column: 0, value: 1)]
+            cells: [GridCell(row: 0, column: 0, value: 1)]
         )
         let matrix2 = Matrix(
             recordType: "DateIntMatrix",
             date: date,
             name: "Test Matrix",
-            cells: [Cell(row: 0, column: 0, value: 2)]
+            cells: [GridCell(row: 0, column: 0, value: 2)]
         )
 
         matrix1 += matrix2
@@ -52,8 +52,8 @@ struct MatrixTests {
     }
 
     @Test("Matrix cell addition") func testMatrixCellAddition() {
-        var cell1 = Cell(row: 0, column: 0, value: 1)
-        let cell2 = Cell(row: 0, column: 0, value: 2)
+        var cell1 = GridCell(row: 0, column: 0, value: 1)
+        let cell2 = GridCell(row: 0, column: 0, value: 2)
 
         cell1 += cell2
 
@@ -68,7 +68,7 @@ struct MatrixTests {
             name: "Test Matrix",
             category: "A",
             recordID: CKRecord.ID(recordName: "1"),
-            cells: [Cell(row: 0, column: 0, value: 1)]
+            cells: [GridCell(row: 0, column: 0, value: 1)]
         )
         let matrix2 = Matrix(
             recordType: "DateIntMatrix",
@@ -76,7 +76,7 @@ struct MatrixTests {
             name: "Test Matrix",
             category: "A",
             recordID: CKRecord.ID(recordName: "2"),
-            cells: [Cell(row: 0, column: 0, value: 2)]
+            cells: [GridCell(row: 0, column: 0, value: 2)]
         )
 
         let merged = [matrix1, matrix2].mergeDuplicates()
@@ -87,8 +87,8 @@ struct MatrixTests {
     }
 
     @Test("Merge duplicate cells") func testMergeDuplicateCells() {
-        let cell1 = Cell(row: 0, column: 0, value: 1)
-        let cell2 = Cell(row: 0, column: 0, value: 2)
+        let cell1 = GridCell(row: 0, column: 0, value: 1)
+        let cell2 = GridCell(row: 0, column: 0, value: 2)
 
         let merged = [cell1, cell2].mergeDuplicates()
 

--- a/Tests/ScoutTests/Core/Monitor/SessionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Monitor/SessionObjectTests.swift
@@ -16,7 +16,7 @@ struct SessionObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
     let week = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
 
-    @Test("parse(of:) produces correct Cell<Int> counts by date")
+    @Test("parse(of:) produces correct GridCell<Int> counts by date")
     func testParseOf() throws {
         let batch: [SessionObject] = [
             .stub(date: week, synced: false, in: context),
@@ -27,8 +27,8 @@ struct SessionObjectTests {
         let cells = SessionObject.parse(of: batch)
 
         #expect(cells.sorted() == [
-            Cell(row: 1, column: 0, value: 2),
-            Cell(row: 1, column: 1, value: 1),
+            GridCell(row: 1, column: 0, value: 2),
+            GridCell(row: 1, column: 1, value: 1),
         ])
     }
 }

--- a/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
@@ -16,7 +16,7 @@ import Testing
 struct SyncCoordinatorTests {
     let database = InMemoryDatabase()
     let context = NSManagedObjectContext.inMemoryContext()
-    let coordinator: SyncCoordinator<Cell<Int>>
+    let coordinator: SyncCoordinator<GridCell<Int>>
 
     init() {
         coordinator = SyncCoordinator(

--- a/Tests/ScoutTests/UI/ChartPointTests.swift
+++ b/Tests/ScoutTests/UI/ChartPointTests.swift
@@ -19,8 +19,8 @@ struct ChartPointTests {
             date: date,
             name: "Test",
             cells: [
-                Cell(row: 2, column: 0, value: 5),
-                Cell(row: 1, column: 1, value: 10),
+                GridCell(row: 2, column: 0, value: 5),
+                GridCell(row: 1, column: 1, value: 10),
             ])
 
         let points = ChartPoint.fromIntMatrix(matrix)


### PR DESCRIPTION
Refactored the Cell struct to GridCell and updated all references in source and test files to improve clarity and consistency. This includes renaming files, types, function signatures, and test cases that previously used Cell.