### PR TITLE
Remove 'throws' from CellProtocol and PeriodCell initializers

### DIFF
--- a/Sources/Scout/Core/Cell/CellProtocol.swift
+++ b/Sources/Scout/Core/Cell/CellProtocol.swift
@@ -13,7 +13,7 @@ protocol CellProtocol: Combining, Sendable {
     var key: String { get }
     var value: Scalar { get }
 
-    init(key: String, value: Scalar) throws
+    init(key: String, value: Scalar)
 }
 
 extension Array where Element: CellProtocol {

--- a/Sources/Scout/Core/Cell/PeriodCell.swift
+++ b/Sources/Scout/Core/Cell/PeriodCell.swift
@@ -18,7 +18,7 @@ extension PeriodCell: CellProtocol {
         "cell_\(period.rawValue)_\(String(format: "%02d", day + 1))"
     }
 
-    init(key: String, value: T) throws {
+    init(key: String, value: T) {
         let parts = key.components(separatedBy: "_")
 
         guard parts.count == 3 else {


### PR DESCRIPTION
The initializers in CellProtocol and PeriodCell no longer throw errors. This simplifies their usage and removes the need for error handling when initializing these types.