### PR TITLE
Refactor MatrixValue and MetricsValued protocols

### DIFF
--- a/Sources/Scout/Core/Matrix/MatrixValue+Object.swift
+++ b/Sources/Scout/Core/Matrix/MatrixValue+Object.swift
@@ -1,0 +1,18 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension MatrixValue {
+    func toObject(in context: NSManagedObjectContext) -> Object {
+        let entityName = String(describing: Object.self)
+        let entity = NSEntityDescription.entity(forEntityName: entityName, in: context)!
+        var object = NSManagedObject(entity: entity, insertInto: context) as! Object
+        object.value = self
+        return object
+    }
+}

--- a/Sources/Scout/Core/Matrix/MatrixValue.swift
+++ b/Sources/Scout/Core/Matrix/MatrixValue.swift
@@ -22,13 +22,3 @@ extension Double: MatrixValue {
     typealias Object = DoubleMetricsObject
     static let recordName = "DateDoubleMatrix"
 }
-
-extension MatrixValue {
-    func toObject(in context: NSManagedObjectContext) -> Object {
-        let entityName = String(describing: Object.self)
-        let entity = NSEntityDescription.entity(forEntityName: entityName, in: context)!
-        var object = MetricsObject(entity: entity, insertInto: context) as! Object
-        object.value = self
-        return object
-    }
-}

--- a/Sources/Scout/Core/Matrix/MatrixValue.swift
+++ b/Sources/Scout/Core/Matrix/MatrixValue.swift
@@ -9,29 +9,25 @@ import CoreData
 import CloudKit
 
 protocol MatrixValue: CKRecordValueProtocol & AdditiveArithmetic & Sendable & Hashable {
-    associatedtype Object: MetricsObject
-
+    associatedtype Object: MetricsObject & MetricsValued where Object.Value == Self
     static var recordName: String { get }
-    func toObject(in context: NSManagedObjectContext) -> Object
 }
 
 extension Int: MatrixValue {
+    typealias Object = IntMetricsObject
     static let recordName = "DateIntMatrix"
-
-    func toObject(in context: NSManagedObjectContext) -> IntMetricsObject {
-        let entity = NSEntityDescription.entity(forEntityName: "IntMetricsObject", in: context)!
-        let object = IntMetricsObject(entity: entity, insertInto: context)
-        object.value = self
-        return object
-    }
 }
 
 extension Double: MatrixValue {
+    typealias Object = DoubleMetricsObject
     static let recordName = "DateDoubleMatrix"
+}
 
-    func toObject(in context: NSManagedObjectContext) -> DoubleMetricsObject {
-        let entity = NSEntityDescription.entity(forEntityName: "DoubleMetricsObject", in: context)!
-        let object = DoubleMetricsObject(entity: entity, insertInto: context)
+extension MatrixValue {
+    func toObject(in context: NSManagedObjectContext) -> Object {
+        let entityName = String(describing: Object.self)
+        let entity = NSEntityDescription.entity(forEntityName: entityName, in: context)!
+        var object = MetricsObject(entity: entity, insertInto: context) as! Object
         object.value = self
         return object
     }

--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -33,7 +33,7 @@ class MetricsObject: TrackedObject {
         )
     }
 
-    static func parse<T: MetricsObject & MetricsValued>(of batch: [T]) -> [T.Cell] {
+    static func parse<T: MetricsObject & Syncable & MetricsValued>(of batch: [T]) -> [T.Cell] where T.Cell.Scalar == T.Value {
         batch.grouped(by: \.hour).mapValues { items in
             items.reduce(.zero) { $0 + $1.value }
         }

--- a/Sources/Scout/Core/Metrics/MetricsValued.swift
+++ b/Sources/Scout/Core/Metrics/MetricsValued.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-protocol MetricsValued: Syncable {
-    associatedtype Value: MatrixValue where Cell == GridCell<Value>
+protocol MetricsValued {
+    associatedtype Value: MatrixValue
     var value: Value { get set }
 }
 

--- a/Sources/Scout/Core/Metrics/MetricsValued.swift
+++ b/Sources/Scout/Core/Metrics/MetricsValued.swift
@@ -13,11 +13,13 @@ protocol MetricsValued: Syncable {
 }
 
 @objc(DoubleMetricsObject)
-final class DoubleMetricsObject: MetricsObject, MetricsValued {
+final class DoubleMetricsObject: MetricsObject, MetricsValued, Syncable {
+    typealias Cell = GridCell<Double>
     @NSManaged var value: Double
 }
 
 @objc(IntMetricsObject)
-final class IntMetricsObject: MetricsObject, MetricsValued {
+final class IntMetricsObject: MetricsObject, MetricsValued, Syncable {
+    typealias Cell = GridCell<Int>
     @NSManaged var value: Int
 }


### PR DESCRIPTION
Simplified MatrixValue by moving toObject implementation to a protocol extension and updating associatedtype constraints. Added typealias Cell to DoubleMetricsObject and IntMetricsObject, and conformed both to Syncable. This improves type safety and code reuse.