### PR TITLE
Fix RunnerError to conform to LocalizedError

### DIFF
--- a/Sources/Scout/Core/Database/CKDatabase+Runner.swift
+++ b/Sources/Scout/Core/Database/CKDatabase+Runner.swift
@@ -22,6 +22,6 @@ extension CKDatabase {
     }
 
     struct RunnerError: LocalizedError {
-        let errorDescription = "The operation was aborted because the remaining background time is insufficient."
+        let errorDescription: String? = "The operation was aborted because the remaining background time is insufficient."
     }
 }


### PR DESCRIPTION
Changed RunnerError's errorDescription property to be optional, matching the LocalizedError protocol requirements.