### PR TITLE
Refactor MetricsValued protocol and MatrixValue extension

### DIFF
--- a/Sources/Scout/Core/Matrix/MatrixValue+Object.swift
+++ b/Sources/Scout/Core/Matrix/MatrixValue+Object.swift
@@ -11,7 +11,7 @@ extension MatrixValue {
     func toObject(in context: NSManagedObjectContext) -> Object {
         let entityName = String(describing: Object.self)
         let entity = NSEntityDescription.entity(forEntityName: entityName, in: context)!
-        var object = NSManagedObject(entity: entity, insertInto: context) as! Object
+        let object = NSManagedObject(entity: entity, insertInto: context) as! Object
         object.value = self
         return object
     }

--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -33,7 +33,7 @@ class MetricsObject: TrackedObject {
         )
     }
 
-    static func parse<T: MetricsObject & Syncable & MetricsValued>(of batch: [T]) -> [T.Cell] where T.Cell.Scalar == T.Value {
+    static func parse<T: Syncable & MetricsValued>(of batch: [T]) -> [T.Cell] where T.Cell.Scalar == T.Value {
         batch.grouped(by: \.hour).mapValues { items in
             items.reduce(.zero) { $0 + $1.value }
         }

--- a/Sources/Scout/Core/Metrics/MetricsValued.swift
+++ b/Sources/Scout/Core/Metrics/MetricsValued.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol MetricsValued {
+protocol MetricsValued: MetricsObject {
     associatedtype Value: MatrixValue
     var value: Value { get set }
 }


### PR DESCRIPTION
MetricsValued now inherits from MetricsObject for improved type safety and consistency. Minor variable declaration cleanup in MatrixValue+Object.swift for clarity.