### PR TITLE
Refine MetricsValued associatedtype constraint

### DIFF
--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -10,11 +10,11 @@ import CoreData
 
 @objc(MetricsObject)
 class MetricsObject: TrackedObject {
-    static func group<T: MetricsObject & MetricsValued>(in context: NSManagedObjectContext) throws -> [T]? {
+    static func group<T: MetricsValued>(in context: NSManagedObjectContext) throws -> [T]? {
         try batch(in: context, matching: [\.name, \.telemetry, \.week])
     }
 
-    static func matrix<T: MetricsObject & MetricsValued>(of batch: [T]) throws(MatrixSyncError) -> Matrix<T.Cell> {
+    static func matrix<T: MetricsValued>(of batch: [T]) throws(MatrixSyncError) -> Matrix<T.Cell> {
         guard let name = batch.first?.name else {
             throw .missingProperty("name")
         }

--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -10,11 +10,11 @@ import CoreData
 
 @objc(MetricsObject)
 class MetricsObject: TrackedObject {
-    static func group<T: MetricsObject & Syncable>(in context: NSManagedObjectContext) throws -> [T]? {
+    static func group<T: MetricsObject & MetricsValued>(in context: NSManagedObjectContext) throws -> [T]? {
         try batch(in: context, matching: [\.name, \.telemetry, \.week])
     }
 
-    static func matrix<T: MetricsObject & Syncable>(of batch: [T]) throws(MatrixSyncError) -> Matrix<T.Cell> {
+    static func matrix<T: MetricsObject & MetricsValued>(of batch: [T]) throws(MatrixSyncError) -> Matrix<T.Cell> {
         guard let name = batch.first?.name else {
             throw .missingProperty("name")
         }

--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -33,7 +33,7 @@ class MetricsObject: TrackedObject {
         )
     }
 
-    static func parse<T: MetricsValued>(of batch: [T]) -> [T.Cell] where T.Cell.Scalar == T.Value {
+    static func parse<T: MetricsValued>(of batch: [T]) -> [T.Cell] {
         batch.grouped(by: \.hour).mapValues { items in
             items.reduce(.zero) { $0 + $1.value }
         }

--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -25,7 +25,7 @@ class MetricsObject: TrackedObject {
             throw .missingProperty("week")
         }
         return Matrix(
-            recordType: T.Cell.Scalar.recordName,
+            recordType: T.Value.recordName,
             date: week,
             name: name,
             category: telemetry,

--- a/Sources/Scout/Core/Metrics/MetricsValued.swift
+++ b/Sources/Scout/Core/Metrics/MetricsValued.swift
@@ -8,7 +8,7 @@
 import CoreData
 
 protocol MetricsValued: Syncable {
-    associatedtype Value
+    associatedtype Value where Cell.Scalar == Value
     var value: Value { get set }
     init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?)
 }

--- a/Sources/Scout/Core/Metrics/MetricsValued.swift
+++ b/Sources/Scout/Core/Metrics/MetricsValued.swift
@@ -7,7 +7,7 @@
 
 import CoreData
 
-protocol MetricsValued: Syncable {
+protocol MetricsValued: MetricsObject & Syncable {
     associatedtype Value where Cell.Scalar == Value
     var value: Value { get set }
     init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?)


### PR DESCRIPTION
Updated the MetricsValued protocol to constrain Value to match Cell.Scalar, and removed redundant constraint from MetricsObject.parse. This improves type safety and clarity in metrics aggregation.