### PR TITLE
Remove MetricsObject constraint from MatrixValue

### DIFF
--- a/Sources/Scout/Core/Matrix/MatrixValue.swift
+++ b/Sources/Scout/Core/Matrix/MatrixValue.swift
@@ -9,7 +9,7 @@ import CoreData
 import CloudKit
 
 protocol MatrixValue: CKRecordValueProtocol & AdditiveArithmetic & Sendable & Hashable {
-    associatedtype Object: MetricsObject & MetricsValued where Object.Value == Self
+    associatedtype Object: MetricsValued where Object.Value == Self
     static var recordName: String { get }
 }
 


### PR DESCRIPTION
The associatedtype Object in the MatrixValue protocol no longer requires conformance to MetricsObject, simplifying the protocol requirements.