### PR TITLE
Refactor ExportError for improved error handling

### DIFF
--- a/Sources/Scout/Core/Telemetry/Telemetry.Export.swift
+++ b/Sources/Scout/Core/Telemetry/Telemetry.Export.swift
@@ -5,6 +5,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import Foundation
+
 extension Telemetry {
     enum Export: String, CaseIterable {
         case counter = "counter"
@@ -16,10 +18,10 @@ extension Telemetry {
         case timer = "timer"
     }
 
-    enum ExportError: Error, CustomStringConvertible {
+    enum ExportError: LocalizedError {
         case invalidName
 
-        var description: String {
+        var errorDescription: String? {
             "Invalid telemetry name. Expected one of: "
                 + Export.allCases.map(\.rawValue).joined(separator: ", ")
         }

--- a/Tests/ScoutTests/Core/Telemetry/TelemetryExportTests.swift
+++ b/Tests/ScoutTests/Core/Telemetry/TelemetryExportTests.swift
@@ -171,7 +171,7 @@ struct TelemetryExportTests {
     @Test("Error description contains names")
     func errorDescriptionContainsNames() {
         let error = Telemetry.ExportError.invalidName
-        let description = error.description
+        let description = error.localizedDescription
         #expect(description.contains("counter"))
         #expect(description.contains("floating_counter"))
         #expect(description.contains("meter_set"))


### PR DESCRIPTION
Refactor the `ExportError` to conform to `LocalizedError`, enhancing error handling capabilities by providing a more user-friendly error description.