### PR TITLE
Add category handling to CKPersistable and lookupExisting methods

### DIFF
--- a/Sources/Scout/Core/Matrix/Matrix+CKPersistable.swift
+++ b/Sources/Scout/Core/Matrix/Matrix+CKPersistable.swift
@@ -39,6 +39,7 @@ extension Matrix: CKPersistable {
         let record = CKRecord(recordType: recordType, recordID: recordID)
         record["date"] = date
         record["name"] = name
+        record["category"] = category
         for cell in cells {
             record[cell.key] = cell.value
         }

--- a/Sources/Scout/Core/Matrix/Matrix+Lookup.swift
+++ b/Sources/Scout/Core/Matrix/Matrix+Lookup.swift
@@ -11,7 +11,8 @@ extension Matrix {
     func lookupExisting(in database: Database) async throws -> Self? {
         let name = NSPredicate(format: "name == %@", name)
         let date = NSPredicate(format: "date == %@", date as NSDate)
-        let predicate = NSCompoundPredicate(type: .and, subpredicates: [name, date])
+        let category = NSPredicate(format: "category == %@", category ?? NSNull())
+        let predicate = NSCompoundPredicate(type: .and, subpredicates: [name, date, category])
         let query = CKQuery(recordType: recordType, predicate: predicate)
 
         let matrices = try await database.allRecords(matching: query, desiredKeys: nil)


### PR DESCRIPTION
Introduce category support in the CKPersistable extension and enhance the lookupExisting method to include category in the query predicate.