### PR TITLE
Refactor TelemetryFactory method signatures

### DIFF
--- a/Sources/Scout/Core/Telemetry/TelemetryFactory.swift
+++ b/Sources/Scout/Core/Telemetry/TelemetryFactory.swift
@@ -9,40 +9,24 @@ import Foundation
 import Metrics
 
 struct TelemetryFactory: MetricsFactory {
-    func makeCounter(
-        label: String,
-        dimensions: [(String, String)]
-    ) -> CounterHandler {
-        return CKTelemetryHandler(label: label, dimensions: dimensions)
+    func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
+        CKTelemetryHandler(label: label, dimensions: dimensions)
     }
 
-    func makeFloatingPointCounter(
-        label: String,
-        dimensions: [(String, String)]
-    ) -> FloatingPointCounterHandler {
-        return CKTelemetryHandler(label: label, dimensions: dimensions)
+    func makeFloatingPointCounter(label: String, dimensions: [(String, String)]) -> FloatingPointCounterHandler {
+        CKTelemetryHandler(label: label, dimensions: dimensions)
     }
 
-    func makeMeter(
-        label: String,
-        dimensions: [(String, String)]
-    ) -> MeterHandler {
-        return CKTelemetryHandler.Idle()
+    func makeMeter(label: String,dimensions: [(String, String)]) -> MeterHandler {
+        CKTelemetryHandler.Idle()
     }
 
-    func makeRecorder(
-        label: String,
-        dimensions: [(String, String)],
-        aggregate: Bool
-    ) -> RecorderHandler {
-        return CKTelemetryHandler.Idle()
+    func makeRecorder(label: String,dimensions: [(String, String)],aggregate: Bool) -> RecorderHandler {
+        CKTelemetryHandler.Idle()
     }
 
-    func makeTimer(
-        label: String,
-        dimensions: [(String, String)]
-    ) -> TimerHandler {
-        return CKTelemetryHandler(label: label, dimensions: dimensions)
+    func makeTimer(label: String,dimensions: [(String, String)]) -> TimerHandler {
+        CKTelemetryHandler(label: label, dimensions: dimensions)
     }
 
     func destroyCounter(_ handler: CounterHandler) {}


### PR DESCRIPTION
Simplified method signatures in TelemetryFactory by removing unnecessary line breaks and 'return' statements. This improves code readability and consistency.