### PR TITLE
Remove redundant public access modifiers

### DIFF
--- a/Sources/Scout/Core/ID/IDObject.swift
+++ b/Sources/Scout/Core/ID/IDObject.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @objc(IDObject)
 class IDObject: DateObject {
-    public override func awakeFromInsert() {
+    override func awakeFromInsert() {
         super.awakeFromInsert()
         setPrimitiveValue(UUID(), forKey: #keyPath(IDObject.sessionID))
         setPrimitiveValue(IDs.user, forKey: #keyPath(IDObject.userID))

--- a/Sources/Scout/Core/Telemetry/Telemetry.swift
+++ b/Sources/Scout/Core/Telemetry/Telemetry.swift
@@ -9,11 +9,11 @@
 /// but is reserved for future telemetry expansion and metrics export.
 /// Keeping it now helps establish a consistent data format (see Telemetry.Export)
 /// and simplifies integration in upcoming releases.
-public enum Telemetry {
+enum Telemetry {
     case counter(Int)
     case floatingCounter(Double)
 
-    public enum Meter {
+    enum Meter {
         case set(Double)
         case increment(Double)
         case decrement(Double)


### PR DESCRIPTION
Removed unnecessary 'public' access modifiers from IDObject and Telemetry enums to simplify code and restrict visibility to within the module. This helps clarify intended usage and maintain encapsulation.