### PR TITLE
Refactor persistent store destruction logic for clarity and brevity

### DIFF
--- a/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
+++ b/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
@@ -26,15 +26,9 @@ extension NSPersistentContainer {
 
         if let store = persistentStoreCoordinator.persistentStores.first, let url = store.url {
             try persistentStoreCoordinator.remove(store)
-            try persistentStoreCoordinator.destroyPersistentStore(
-                at: url,
-                ofType: NSSQLiteStoreType
-            )
+            try persistentStoreCoordinator.destroyPersistentStore(at: url, ofType: NSSQLiteStoreType)
         } else if let url = persistentStoreDescriptions.first?.url {
-            try persistentStoreCoordinator.destroyPersistentStore(
-                at: url,
-                ofType: NSSQLiteStoreType
-            )
+            try persistentStoreCoordinator.destroyPersistentStore(at: url, ofType: NSSQLiteStoreType)
         }
     }
 }

--- a/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
+++ b/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
@@ -26,9 +26,15 @@ extension NSPersistentContainer {
 
         if let store = persistentStoreCoordinator.persistentStores.first, let url = store.url {
             try persistentStoreCoordinator.remove(store)
-            try persistentStoreCoordinator.destroyPersistentStore(at: url, ofType: NSSQLiteStoreType)
+            try persistentStoreCoordinator.destroyStore(at: url)
         } else if let url = persistentStoreDescriptions.first?.url {
-            try persistentStoreCoordinator.destroyPersistentStore(at: url, ofType: NSSQLiteStoreType)
+            try persistentStoreCoordinator.destroyStore(at: url)
         }
+    }
+}
+
+extension NSPersistentStoreCoordinator {
+    fileprivate func destroyStore(at url: URL) throws {
+        try destroyPersistentStore(at: url, ofType: NSSQLiteStoreType)
     }
 }

--- a/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
+++ b/Sources/Scout/Core/Persistence/Persistence+Rebuild.swift
@@ -26,15 +26,15 @@ extension NSPersistentContainer {
 
         if let store = persistentStoreCoordinator.persistentStores.first, let url = store.url {
             try persistentStoreCoordinator.remove(store)
-            try persistentStoreCoordinator.destroyStore(at: url)
+            try persistentStoreCoordinator.destroySQLite(at: url)
         } else if let url = persistentStoreDescriptions.first?.url {
-            try persistentStoreCoordinator.destroyStore(at: url)
+            try persistentStoreCoordinator.destroySQLite(at: url)
         }
     }
 }
 
 extension NSPersistentStoreCoordinator {
-    fileprivate func destroyStore(at url: URL) throws {
+    fileprivate func destroySQLite(at url: URL) throws {
         try destroyPersistentStore(at: url, ofType: NSSQLiteStoreType)
     }
 }


### PR DESCRIPTION
Consolidate and streamline the destruction of persistent stores by moving the logic into a dedicated method, enhancing code readability and reuse.