### PR TITLE
Refactor CompleteError to use implicit returns

### DIFF
--- a/Sources/Scout/Core/Monitor/SessionObject+Monitor.swift
+++ b/Sources/Scout/Core/Monitor/SessionObject+Monitor.swift
@@ -43,20 +43,20 @@ extension SessionObject {
         var errorDescription: String? {
             switch self {
             case .sessionNotFound:
-                return "Session not found"
+                "Session not found"
             case .alreadyCompleted(let date):
-                return "Session already completed on \(date)"
+                "Session already completed on \(date)"
             }
         }
 
         static func == (lhs: CompleteError, rhs: CompleteError) -> Bool {
             switch (lhs, rhs) {
             case (.sessionNotFound, .sessionNotFound):
-                return true
+                true
             case (.alreadyCompleted, .alreadyCompleted):
-                return true
+                true
             default:
-                return false
+                false
             }
         }
     }


### PR DESCRIPTION
Simplified the CompleteError enum by removing explicit return statements in single-expression cases for errorDescription and equality operator implementations.