### PR TITLE
Add Equatable and Comparable to Matrix and CellProtocol

### DIFF
--- a/Sources/Scout/Core/Cell/CellProtocol.swift
+++ b/Sources/Scout/Core/Cell/CellProtocol.swift
@@ -7,7 +7,7 @@
 
 import CloudKit
 
-protocol CellProtocol: Combining, Sendable {
+protocol CellProtocol: Combining, Sendable, Equatable {
     associatedtype Scalar: MatrixValue
 
     var key: String { get }

--- a/Sources/Scout/Core/Matrix/Matrix.swift
+++ b/Sources/Scout/Core/Matrix/Matrix.swift
@@ -36,6 +36,31 @@ extension Matrix: Combining {
     }
 }
 
+extension Matrix: Equatable {
+    static func == (lhs: Matrix<T>, rhs: Matrix<T>) -> Bool {
+        lhs.recordType == rhs.recordType
+            && lhs.date == rhs.date
+            && lhs.name == rhs.name
+            && lhs.category == rhs.category
+            && lhs.cells == rhs.cells
+    }
+}
+
+extension Matrix: Comparable {
+    static func < (lhs: Matrix<T>, rhs: Matrix<T>) -> Bool {
+        if lhs.date != rhs.date {
+            return lhs.date < rhs.date
+        }
+        if lhs.name != rhs.name {
+            return lhs.name < rhs.name
+        }
+        if lhs.category != rhs.category {
+            return (lhs.category ?? "") < (rhs.category ?? "")
+        }
+        return lhs.recordType < rhs.recordType
+    }
+}
+
 extension Matrix: CustomStringConvertible {
     var description: String {
         """


### PR DESCRIPTION
CellProtocol now conforms to Equatable. Matrix now conforms to Equatable and Comparable, with custom implementations for equality and ordering based on its properties. This enables direct comparison and sorting of Matrix and CellProtocol instances.