### PR TITLE
Rename queryRange to defaultRange in Calendar extension

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -17,7 +17,7 @@ class ActivityProvider: ObservableObject {
 
 extension ActivityProvider: Provider {
     func fetch(in database: DatabaseController) async {
-        let range = Calendar(identifier: .iso8601).queryRange
+        let range = Calendar(identifier: .iso8601).defaultRange
 
         do {
             let records = try await database.allRecords(

--- a/Sources/Scout/UI/Event/Stat/StatProvider.swift
+++ b/Sources/Scout/UI/Event/Stat/StatProvider.swift
@@ -22,7 +22,7 @@ class StatProvider: ObservableObject {
 
 extension StatProvider: Provider {
     func fetch(in database: DatabaseController) async {
-        let range = Calendar(identifier: .iso8601).queryRange
+        let range = Calendar(identifier: .iso8601).defaultRange
 
         do {
             let records = try await database.allRecords(

--- a/Sources/Scout/UI/Utilities/Calendar+Range.swift
+++ b/Sources/Scout/UI/Utilities/Calendar+Range.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Calendar {
-    var queryRange: ClosedRange<Date> {
+    var defaultRange: ClosedRange<Date> {
         let today = startOfDay(for: Date())
         let yearAgo = today.addingYear(-1).addingWeek(-1)
         let tomorrow = today.addingDay()


### PR DESCRIPTION
Refactored Calendar extension property from queryRange to defaultRange for clarity. Updated all provider classes to use the new property name and renamed the utility file accordingly.