### PR TITLE
Add SwiftUI preview for ChartView (Month period)

### DIFF
--- a/Sources/Scout/UI/Chart/ChartPoint.swift
+++ b/Sources/Scout/UI/Chart/ChartPoint.swift
@@ -57,3 +57,15 @@ extension ChartPoint: CustomStringConvertible {
         "\(date): \(count)"
     }
 }
+
+extension [ChartPoint] {
+    static let sample: [ChartPoint] = {
+        let cal = Calendar(identifier: .iso8601)
+        let end = Date()
+        return (1...30).compactMap { i in
+            cal.date(byAdding: .day, value: -i, to: end).map {
+                ChartPoint(date: $0, count: Int.random(in: 0...10))
+            }
+        }.sorted()
+    }()
+}

--- a/Sources/Scout/UI/Chart/ChartView.swift
+++ b/Sources/Scout/UI/Chart/ChartView.swift
@@ -47,3 +47,24 @@ extension StatModel {
         }
     }
 }
+
+#Preview("ChartView – Month") {
+    let model = StatModel(period: Period.month)
+
+    let cal = Calendar(identifier: .iso8601)
+    let end = model.range.upperBound
+    let points: [ChartPoint] = (1...30).compactMap { i in
+        cal.date(byAdding: .day, value: -i, to: end).map {
+            ChartPoint(date: $0, count: Int.random(in: 0...10))
+        }
+    }.sorted()
+
+    return VStack(alignment: .leading, spacing: 24) {
+        Text("With Data").font(.headline)
+        ChartView(points: points, model: model)
+
+        Text("Empty State").font(.headline)
+        ChartView(points: [], model: model)
+    }
+    .padding()
+}

--- a/Sources/Scout/UI/Chart/ChartView.swift
+++ b/Sources/Scout/UI/Chart/ChartView.swift
@@ -51,17 +51,9 @@ extension StatModel {
 #Preview("ChartView – Month") {
     let model = StatModel(period: Period.month)
 
-    let cal = Calendar(identifier: .iso8601)
-    let end = model.range.upperBound
-    let points: [ChartPoint] = (1...30).compactMap { i in
-        cal.date(byAdding: .day, value: -i, to: end).map {
-            ChartPoint(date: $0, count: Int.random(in: 0...10))
-        }
-    }.sorted()
-
-    return VStack(alignment: .leading, spacing: 24) {
+    VStack(alignment: .leading, spacing: 24) {
         Text("With Data").font(.headline)
-        ChartView(points: points, model: model)
+        ChartView(points: .sample, model: model)
 
         Text("Empty State").font(.headline)
         ChartView(points: [], model: model)


### PR DESCRIPTION
Introduces a #Preview for ChartView using StatModel with a month period. The preview displays both a populated chart and an empty state for easier UI development and testing.