### PR TITLE
Rename ChartPoint array 'count' to 'total'

### DIFF
--- a/Sources/Scout/UI/Chart/ChartPoint.swift
+++ b/Sources/Scout/UI/Chart/ChartPoint.swift
@@ -24,6 +24,8 @@ struct ChartPoint: Identifiable {
     }
 }
 
+// MARK: - Operators
+
 extension ChartPoint: Comparable {
     static func < (lhs: ChartPoint, rhs: ChartPoint) -> Bool {
         lhs.date < rhs.date
@@ -46,8 +48,10 @@ extension ChartPoint {
     }
 }
 
+// MARK: -
+
 extension [ChartPoint] {
-    var count: Int {
+    var total: Int {
         map(\.count).reduce(0, +)
     }
 }

--- a/Sources/Scout/UI/Chart/ChartView.swift
+++ b/Sources/Scout/UI/Chart/ChartView.swift
@@ -27,7 +27,7 @@ struct ChartView<T: ChartCompatible>: View {
             }
         }
         .chartBackground { proxy in
-            if points.count == 0 {
+            if points.total == 0 {
                 Placeholder(text: "No results")
             }
         }

--- a/Sources/Scout/UI/Event/Stat/StatRow.swift
+++ b/Sources/Scout/UI/Event/Stat/StatRow.swift
@@ -22,7 +22,7 @@ struct StatRow: View {
                 Spacer()
 
                 let model = StatModel(period: period)
-                let count = model.points(from: stat.data)?.count
+                let count = model.points(from: stat.data)?.total
 
                 RedactedText(count: count)
             }

--- a/Sources/Scout/UI/Event/Stat/StatView.swift
+++ b/Sources/Scout/UI/Event/Stat/StatView.swift
@@ -43,7 +43,7 @@ struct StatView: View {
                         .listRowSeparator(config.showList ? .visible : .hidden, edges: .bottom)
 
                     if config.showList {
-                        total(count: points.count)
+                        total(count: points.total)
                     }
                 }
                 .listStyle(.plain)


### PR DESCRIPTION
Replaces the 'count' computed property in [ChartPoint] with 'total' for clarity. Updates all usages in ChartView, RawPointData, StatRow, and StatView to reference 'total' instead of 'count'.
