### PR TITLE
Add details to RunnerError in CKDatabase extension

### DIFF
--- a/Sources/Scout/Core/Database/CKDatabase+Runner.swift
+++ b/Sources/Scout/Core/Database/CKDatabase+Runner.swift
@@ -23,5 +23,8 @@ extension CKDatabase {
 
     struct RunnerError: LocalizedError {
         let errorDescription: String? = "The operation was aborted because the remaining background time is insufficient."
+        let failureReason: String? = "Not enough background time remaining."
+        let helpAnchor: String? = "https://developer.apple.com/documentation/uikit/uiapplication/backgroundtimeremaining"
+        let recoveringSuggestion: String? = "Try again later."
     }
 }


### PR DESCRIPTION
Expanded RunnerError to include failureReason, helpAnchor, and recoveringSuggestion for improved error context and guidance.