### PR TITLE
Refactor switch cases to use shorthand syntax

### DIFF
--- a/Sources/Scout/Core/Activity/ActivityPeriod.swift
+++ b/Sources/Scout/Core/Activity/ActivityPeriod.swift
@@ -17,22 +17,22 @@ enum ActivityPeriod: String, Identifiable, CaseIterable {
     var title: String {
         switch self {
         case .daily:
-            return "Daily"
+            "Daily"
         case .weekly:
-            return "Weekly"
+            "Weekly"
         case .monthly:
-            return "Monthly"
+            "Monthly"
         }
     }
 
     var countField: ReferenceWritableKeyPath<UserActivity, Int32> {
         switch self {
         case .daily:
-            return \.dayCount
+            \.dayCount
         case .weekly:
-            return \.weekCount
+            \.weekCount
         case .monthly:
-            return \.monthCount
+            \.monthCount
         }
     }
 }
@@ -41,11 +41,11 @@ extension ActivityPeriod {
     var spreadComponent: Calendar.Component {
         switch self {
         case .daily:
-            return .day
+            .day
         case .weekly:
-            return .weekOfYear
+            .weekOfYear
         case .monthly:
-            return .month
+            .month
         }
     }
 }

--- a/Sources/Scout/UI/Event/Event.swift
+++ b/Sources/Scout/UI/Event/Event.swift
@@ -39,13 +39,13 @@ extension Event {
 
     init(record: CKRecord) throws {
         name = record["name"] ?? ""
-        level = record["level"].flatMap { EventLevel(rawValue: $0) }
+        level = record["level"].flatMap(EventLevel.init)
         date = record["date"]
         paramCount = record["param_count"]
-        uuid = record["uuid"].flatMap { UUID(uuidString: $0) }
+        uuid = record["uuid"].flatMap(UUID.init)
         id = record.recordID
-        userID = record["user_id"].flatMap { UUID(uuidString: $0) }
-        sessionID = record["session_id"].flatMap { UUID(uuidString: $0) }
+        userID = record["user_id"].flatMap(UUID.init)
+        sessionID = record["session_id"].flatMap(UUID.init)
     }
 }
 

--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -46,9 +46,9 @@ extension EventView {
 
         var seeAll: (() -> Void)? {
             if let _ = param.data, count > 3 {
-                return { isParamPresented = true }
+                { isParamPresented = true }
             } else {
-                return nil
+                nil
             }
         }
     }


### PR DESCRIPTION
Simplifies switch case returns in ActivityPeriod, Event, and EventView.Sections by removing explicit return statements and using Swift's shorthand syntax. This improves code readability and conciseness without changing functionality.