### PR TITLE
Fix missing return in Double extension

### DIFF
--- a/Sources/Scout/UI/Metrics/MetricsFormatters.swift
+++ b/Sources/Scout/UI/Metrics/MetricsFormatters.swift
@@ -41,7 +41,7 @@ extension Double {
 
         switch self {
         case 0:
-            "0.0"
+            return "0.0"
         case ..<0.01:
             formatter.minimumFractionDigits = 3
             formatter.maximumFractionDigits = 3


### PR DESCRIPTION
Added a missing 'return' statement for the case when Double is 0 in the string formatting extension, ensuring correct value is returned.