### PR TITLE
Fix day offset in PeriodCell initializer

### DIFF
--- a/Sources/Scout/Core/Cell/PeriodCell.swift
+++ b/Sources/Scout/Core/Cell/PeriodCell.swift
@@ -33,7 +33,7 @@ extension PeriodCell: CellProtocol {
             fatalError("Invalid day")
         }
 
-        self.init(period: period, day: day, value: value)
+        self.init(period: period, day: day - 1, value: value)
     }
 }
 


### PR DESCRIPTION
Adjusts the day parameter by subtracting 1 before initializing PeriodCell to ensure correct day mapping.