### PR TITLE
Move SyncCoordinator batch init to its own extension

### DIFF
--- a/Sources/Scout/Core/Sync/SyncCoordinator.swift
+++ b/Sources/Scout/Core/Sync/SyncCoordinator.swift
@@ -7,12 +7,21 @@
 
 import CloudKit
 
-@MainActor
-struct SyncCoordinator<T: CellProtocol> {
+@MainActor struct SyncCoordinator<T: CellProtocol> {
     let database: Database
     let maxRetry: Int
     let matrix: Matrix<T>
+}
 
+extension SyncCoordinator {
+    init<V: Syncable>(database: Database, maxRetry: Int, batch: [V]) throws where V.Cell == T {
+        self.database = database
+        self.maxRetry = maxRetry
+        self.matrix = try V.matrix(of: batch)
+    }
+}
+
+extension SyncCoordinator {
     func upload() async throws {
         if let existing = try await matrix.lookupExisting(in: database) {
             try await upload(snapshot: matrix + existing)

--- a/Sources/Scout/Core/Sync/Syncable.swift
+++ b/Sources/Scout/Core/Sync/Syncable.swift
@@ -16,20 +16,12 @@ protocol Syncable: SyncableObject {
     static func parse(of batch: [Self]) -> [Cell]
 }
 
-extension SyncCoordinator {
-    init<V: Syncable>(database: Database, maxRetry: Int, batch: [V]) throws where V.Cell == T {
-        self.database = database
-        self.maxRetry = maxRetry
-        self.matrix = try V.matrix(of: batch)
-    }
-}
-
 enum MatrixSyncError: LocalizedError {
     case missingProperty(String)
 
     var errorDescription: String? {
         switch self {
-        case let .missingProperty(property):
+        case .missingProperty(let property):
             return "Missing property: \(property). Cannot group objects."
         }
     }


### PR DESCRIPTION
Relocated the initializer for SyncCoordinator with batch processing from Syncable.swift to a dedicated extension in SyncCoordinator.swift for better organization and separation of concerns. Also made a minor syntax update in MatrixSyncError.