### PR TITLE
Refactor background task handling in Dispatcher

### DIFF
--- a/Sources/Scout/Core/Dispatcher/Dispatcher.swift
+++ b/Sources/Scout/Core/Dispatcher/Dispatcher.swift
@@ -15,14 +15,10 @@ typealias DispatchBlock = @Sendable () async throws -> Void
 
 extension Dispatcher {
     func performEnsuringBackground(_ block: @escaping DispatchBlock) async throws {
-        try await perform {
-            let task = await UIApplication.shared.beginBackgroundTask()
+        try await perform { @MainActor in
+            let task = UIApplication.shared.beginBackgroundTask()
 
-            defer {
-                Task {
-                    await UIApplication.shared.endBackgroundTask(task)
-                }
-            }
+            defer { UIApplication.shared.endBackgroundTask(task) }
 
             try await block()
         }


### PR DESCRIPTION
Simplifies background task management by removing unnecessary async calls and ensuring execution on the main actor. The defer block now directly ends the background task without spawning a new Task.