### PR TITLE
Refactor Dispatcher and rename block types for clarity

### DIFF
--- a/Sources/Scout/Core/Dispatcher/Dispatcher.swift
+++ b/Sources/Scout/Core/Dispatcher/Dispatcher.swift
@@ -8,13 +8,15 @@
 import UIKit
 
 protocol Dispatcher {
-    func perform(_ block: @escaping DispatchBlock) async throws
+    func perform(_ block: @escaping Block) async throws
 }
 
-typealias DispatchBlock = @Sendable () async throws -> Void
+extension Dispatcher {
+    typealias Block = @Sendable () async throws -> Void
+}
 
 extension Dispatcher {
-    func performEnsuringBackground(_ block: @escaping DispatchBlock) async throws {
+    func performEnsuringBackground(_ block: @escaping Block) async throws {
         try await perform { @MainActor in
             let task = UIApplication.shared.beginBackgroundTask()
 

--- a/Sources/Scout/Core/Dispatcher/Dispatcher.swift
+++ b/Sources/Scout/Core/Dispatcher/Dispatcher.swift
@@ -8,15 +8,15 @@
 import UIKit
 
 protocol Dispatcher {
-    func perform(_ block: @escaping Block) async throws
+    func perform(_ block: @escaping Work) async throws
 }
 
 extension Dispatcher {
-    typealias Block = @Sendable () async throws -> Void
+    typealias Work = @Sendable () async throws -> Void
 }
 
 extension Dispatcher {
-    func performEnsuringBackground(_ block: @escaping Block) async throws {
+    func performEnsuringBackground(_ block: @escaping Work) async throws {
         try await perform { @MainActor in
             let task = UIApplication.shared.beginBackgroundTask()
 

--- a/Sources/Scout/Core/Dispatcher/QueueDispatcher.swift
+++ b/Sources/Scout/Core/Dispatcher/QueueDispatcher.swift
@@ -6,10 +6,10 @@
 // https://opensource.org/licenses/MIT.
 
 actor QueueDispatcher: Dispatcher {
-    private var queue: [DispatchBlock] = []
+    private var queue: [Block] = []
     private var isRunning = false
 
-    func perform(_ block: @escaping DispatchBlock) async throws {
+    func perform(_ block: @escaping Block) async throws {
         queue.append(block)
 
         guard !isRunning else { return }

--- a/Sources/Scout/Core/Dispatcher/QueueDispatcher.swift
+++ b/Sources/Scout/Core/Dispatcher/QueueDispatcher.swift
@@ -6,10 +6,10 @@
 // https://opensource.org/licenses/MIT.
 
 actor QueueDispatcher: Dispatcher {
-    private var queue: [Block] = []
+    private var queue: [Work] = []
     private var isRunning = false
 
-    func perform(_ block: @escaping Block) async throws {
+    func perform(_ block: @escaping Work) async throws {
         queue.append(block)
 
         guard !isRunning else { return }


### PR DESCRIPTION
Refactor the DispatchBlock type to Block within the Dispatcher extension for better encapsulation and rename it to Work for improved clarity and consistency across the protocol and its implementations.