### PR TITLE
Remove unnecessary try from cell mapping

### DIFF
--- a/Sources/Scout/Core/Matrix/Matrix+CKPersistable.swift
+++ b/Sources/Scout/Core/Matrix/Matrix+CKPersistable.swift
@@ -32,7 +32,7 @@ extension Matrix: CKPersistable {
             throw MapError.invalidCells
         }
 
-        self.cells = try cellDict.map(T.init)
+        self.cells = cellDict.map(T.init)
     }
 
     var toRecord: CKRecord {


### PR DESCRIPTION
Eliminated the use of 'try' when mapping cellDict to cells in Matrix+CKPersistable, as T.init no longer throws. This simplifies the initialization logic.