### PR TITLE
Fix date calculation in ChartSeries and use UTC calendar

### DIFF
--- a/Sources/Scout/UI/Chart/ChartSeries.swift
+++ b/Sources/Scout/UI/Chart/ChartSeries.swift
@@ -30,7 +30,8 @@ extension Collection where Element: ChartSeries {
         var date = range.upperBound
 
         while date > range.lowerBound {
-            let newDate = date.adding(component, value: -1)
+            let i = -result.count - 1
+            let newDate = range.upperBound.adding(component, value: i)
             let points = filter {
                 newDate..<date ~= $0.date
             }

--- a/Sources/Scout/UI/Chart/ChartTimeScale.swift
+++ b/Sources/Scout/UI/Chart/ChartTimeScale.swift
@@ -48,7 +48,7 @@ protocol ChartTimeScale: Identifiable, Hashable {
 extension ChartTimeScale {
 
     var today: Date {
-        Calendar(identifier: .iso8601).startOfDay(for: Date())
+        Calendar.UTC.startOfDay(for: Date())
     }
 
     var initialRange: Range<Date> {


### PR DESCRIPTION
Corrects the date calculation logic in ChartSeries by adjusting how newDate is computed in the loop. Updates ChartTimeScale to use Calendar.UTC instead of ISO8601 for determining today's date.