### PR TITLE
Rename Calendar.UTC to Calendar.utc throughout codebase

### DIFF
--- a/Sources/Scout/Core/Activity/UserActivity.swift
+++ b/Sources/Scout/Core/Activity/UserActivity.swift
@@ -39,7 +39,7 @@ final class UserActivity: SyncableObject, Syncable {
         }
         return PeriodCell(
             period: period,
-            day: Calendar.UTC.dateComponents([.day], from: month, to: day).day ?? 0,
+            day: Calendar.utc.dateComponents([.day], from: month, to: day).day ?? 0,
             value: Int(self[keyPath: period.countField])
         )
     }

--- a/Sources/Scout/Core/Utilities/Array+Grouping.swift
+++ b/Sources/Scout/Core/Utilities/Array+Grouping.swift
@@ -14,8 +14,8 @@ extension Array {
         }
         .reduce(into: [:]) { result, pair in
             if let key = pair.key {
-                let week = Calendar.UTC.component(.weekday, from: key)
-                let hour = Calendar.UTC.component(.hour, from: key)
+                let week = Calendar.utc.component(.weekday, from: key)
+                let hour = Calendar.utc.component(.hour, from: key)
                 let components = ["cell", String(week), String(format: "%02d", hour)]
                 let joined = components.joined(separator: "_")
 

--- a/Sources/Scout/Core/Utilities/Calendar+UTC.swift
+++ b/Sources/Scout/Core/Utilities/Calendar+UTC.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Calendar {
-    static var UTC: Calendar {
+    static var utc: Calendar {
         var calendar = Calendar(identifier: .iso8601)
         calendar.firstWeekday = 1
         calendar.timeZone = TimeZone(identifier: "UTC")!

--- a/Sources/Scout/Core/Utilities/Date+Start.swift
+++ b/Sources/Scout/Core/Utilities/Date+Start.swift
@@ -9,18 +9,18 @@ import Foundation
 
 extension Date {
     var startOfHour: Date {
-        Calendar.UTC.dateComponents([.calendar, .year, .month, .day, .hour], from: self).date!
+        Calendar.utc.dateComponents([.calendar, .year, .month, .day, .hour], from: self).date!
     }
 
     var startOfDay: Date {
-        Calendar.UTC.dateComponents([.calendar, .year, .month, .day], from: self).date!
+        Calendar.utc.dateComponents([.calendar, .year, .month, .day], from: self).date!
     }
 
     var startOfWeek: Date {
-        Calendar.UTC.dateComponents([.calendar, .yearForWeekOfYear, .weekOfYear], from: self).date!
+        Calendar.utc.dateComponents([.calendar, .yearForWeekOfYear, .weekOfYear], from: self).date!
     }
 
     var startOfMonth: Date {
-        Calendar.UTC.dateComponents([.calendar, .year, .month], from: self).date!
+        Calendar.utc.dateComponents([.calendar, .year, .month], from: self).date!
     }
 }

--- a/Sources/Scout/UI/Chart/ChartTimeScale.swift
+++ b/Sources/Scout/UI/Chart/ChartTimeScale.swift
@@ -48,7 +48,7 @@ protocol ChartTimeScale: Identifiable, Hashable {
 extension ChartTimeScale {
 
     var today: Date {
-        Calendar.UTC.startOfDay(for: Date())
+        Calendar.utc.startOfDay(for: Date())
     }
 
     var initialRange: Range<Date> {

--- a/Sources/Scout/UI/Utilities/Date+Add.swift
+++ b/Sources/Scout/UI/Utilities/Date+Add.swift
@@ -9,27 +9,27 @@ import Foundation
 
 extension Date {
     func adding(_ component: Calendar.Component, value: Int = 1) -> Date {
-        Calendar.UTC.date(byAdding: component, value: value, to: self)!
+        Calendar.utc.date(byAdding: component, value: value, to: self)!
     }
 
     func addingDay(_ value: Int = 1) -> Date {
-        Calendar.UTC.date(byAdding: .day, value: value, to: self)!
+        Calendar.utc.date(byAdding: .day, value: value, to: self)!
     }
 
     func addingHour(_ value: Int = 1) -> Date {
-        Calendar.UTC.date(byAdding: .hour, value: value, to: self)!
+        Calendar.utc.date(byAdding: .hour, value: value, to: self)!
     }
 
     func addingWeek(_ value: Int = 1) -> Date {
-        Calendar.UTC.date(byAdding: .weekOfYear, value: value, to: self)!
+        Calendar.utc.date(byAdding: .weekOfYear, value: value, to: self)!
     }
 
     func addingMonth(_ value: Int = 1) -> Date {
-        Calendar.UTC.date(byAdding: .month, value: value, to: self)!
+        Calendar.utc.date(byAdding: .month, value: value, to: self)!
     }
 
     func addingYear(_ value: Int = 1) -> Date {
-        Calendar.UTC.date(byAdding: .year, value: value, to: self)!
+        Calendar.utc.date(byAdding: .year, value: value, to: self)!
     }
 }
 

--- a/Tests/ScoutTests/Core/Utilities/DateStartTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/DateStartTests.swift
@@ -23,12 +23,12 @@ struct DateStartTests {
             minute: 9,
             second: 11
         )
-        date = Calendar.UTC.date(from: components)!
+        date = Calendar.utc.date(from: components)!
     }
 
     @Test("Start of an hour") func startOfHour() {
         let hour = date.startOfHour
-        let components = Calendar.UTC.dateComponents(set, from: hour)
+        let components = Calendar.utc.dateComponents(set, from: hour)
 
         #expect(components.year == 2030)
         #expect(components.month == 3)
@@ -40,7 +40,7 @@ struct DateStartTests {
 
     @Test("Start of a day") func startOfDay() {
         let day = date.startOfDay
-        let components = Calendar.UTC.dateComponents(set, from: day)
+        let components = Calendar.utc.dateComponents(set, from: day)
 
         #expect(components.year == 2030)
         #expect(components.month == 3)
@@ -52,7 +52,7 @@ struct DateStartTests {
 
     @Test("Start of a week") func startOfWeek() {
         let week = date.startOfWeek
-        let components = Calendar.UTC.dateComponents(set, from: week)
+        let components = Calendar.utc.dateComponents(set, from: week)
 
         #expect(components.year == 2030)
         #expect(components.month == 3)
@@ -64,7 +64,7 @@ struct DateStartTests {
 
     @Test("Start of a month") func startOfMonth() {
         let month = date.startOfMonth
-        let components = Calendar.UTC.dateComponents(set, from: month)
+        let components = Calendar.utc.dateComponents(set, from: month)
 
         #expect(components.year == 2030)
         #expect(components.month == 3)

--- a/Tests/ScoutTests/Utilities/Date+Init.swift
+++ b/Tests/ScoutTests/Utilities/Date+Init.swift
@@ -12,7 +12,7 @@ import Foundation
 extension Date {
     init(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0, second: Int = 0) {
         var components = DateComponents()
-        components.calendar = Calendar.UTC
+        components.calendar = .utc
         components.timeZone = TimeZone(secondsFromGMT: 0)
         components.year = year
         components.month = month


### PR DESCRIPTION
Updated all references from Calendar.UTC to Calendar.utc for consistency with Swift naming conventions. This change affects date calculations and utilities across multiple files.