### PR TITLE
Add recovery suggestion to SetupError

### DIFF
--- a/Sources/Scout/Core/Monitor/NotificationListener.swift
+++ b/Sources/Scout/Core/Monitor/NotificationListener.swift
@@ -12,6 +12,7 @@ import UIKit
 class NotificationListener {
     struct SetupError: LocalizedError {
         let errorDescription: String? = "NotificationListener is already setup"
+        let recoverySuggestion: String? = "Review the code to ensure setup is called only once"
     }
 
     typealias Action = @Sendable () async throws -> Void


### PR DESCRIPTION
Added a recoverySuggestion property to the SetupError struct in NotificationListener to provide guidance when setup is called more than once.