### PR TITLE
Refactor startOfDay usage for Date

### DIFF
--- a/Sources/Scout/Core/Activity/ActivityPeriod.swift
+++ b/Sources/Scout/Core/Activity/ActivityPeriod.swift
@@ -13,9 +13,7 @@ enum ActivityPeriod: String, Identifiable, CaseIterable, Equatable {
     case monthly = "m"
 
     var id: Self { self }
-}
 
-extension ActivityPeriod {
     var title: String {
         switch self {
         case .daily:
@@ -32,5 +30,6 @@ extension ActivityPeriod: ChartTimeScale {
     var horizonDate: Date { today }
 
     var rangeComponent: Calendar.Component { .month }
+
     var pointComponent: Calendar.Component { .day }
 }

--- a/Sources/Scout/UI/Chart/ChartTimeScale.swift
+++ b/Sources/Scout/UI/Chart/ChartTimeScale.swift
@@ -48,7 +48,7 @@ protocol ChartTimeScale: Identifiable, Hashable {
 extension ChartTimeScale {
 
     var today: Date {
-        Calendar.utc.startOfDay(for: Date())
+        Date().startOfDay
     }
 
     var initialRange: Range<Date> {

--- a/Sources/Scout/UI/Utilities/Calendar+Range.swift
+++ b/Sources/Scout/UI/Utilities/Calendar+Range.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Calendar {
     var defaultRange: ClosedRange<Date> {
-        let today = startOfDay(for: Date())
+        let today = Date().startOfDay
         let yearAgo = today.addingYear(-1).addingWeek(-1)
         let tomorrow = today.addingDay()
         return yearAgo...tomorrow


### PR DESCRIPTION
Replaced Calendar.utc.startOfDay(for: Date()) with Date().startOfDay for improved readability and consistency in ChartTimeScale and Calendar+Range extensions.