### PR TITLE
Refactor error handling to use MonitorError enum

### DIFF
--- a/Sources/Scout/Core/Listener/MonitorError.swift
+++ b/Sources/Scout/Core/Listener/MonitorError.swift
@@ -1,0 +1,33 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+enum MonitorError: LocalizedError, Equatable {
+    case notFound
+    case alreadyCompleted(Date)
+
+    var errorDescription: String? {
+        switch self {
+        case .notFound:
+            "\(type(of: self)) not found in the context"
+        case .alreadyCompleted(let date):
+            "\(type(of: self)) already completed on \(date)"
+        }
+    }
+
+    static func == (lhs: MonitorError, rhs: MonitorError) -> Bool {
+        switch (lhs, rhs) {
+        case (.notFound, .notFound):
+            true
+        case (.alreadyCompleted, .alreadyCompleted):
+            true
+        default:
+            false
+        }
+    }
+}

--- a/Sources/Scout/Core/Session/SessionObject+Monitor.swift
+++ b/Sources/Scout/Core/Session/SessionObject+Monitor.swift
@@ -22,42 +22,14 @@ extension SessionObject: Monitor {
         request.fetchLimit = 1
 
         guard let session = try context.fetch(request).first else {
-            throw CompleteError.sessionNotFound
+            throw MonitorError.notFound
         }
-
         if let endDate = session.endDate {
-            throw CompleteError.alreadyCompleted(endDate)
+            throw MonitorError.alreadyCompleted(endDate)
         }
 
         let date = Date()
         session.endDate = date
         try context.save()
-    }
-}
-
-extension SessionObject {
-    enum CompleteError: LocalizedError, Equatable {
-        case sessionNotFound
-        case alreadyCompleted(Date)
-
-        var errorDescription: String? {
-            switch self {
-            case .sessionNotFound:
-                "Session not found"
-            case .alreadyCompleted(let date):
-                "Session already completed on \(date)"
-            }
-        }
-
-        static func == (lhs: CompleteError, rhs: CompleteError) -> Bool {
-            switch (lhs, rhs) {
-            case (.sessionNotFound, .sessionNotFound):
-                true
-            case (.alreadyCompleted, .alreadyCompleted):
-                true
-            default:
-                false
-            }
-        }
     }
 }


### PR DESCRIPTION
Introduces a new MonitorError enum for error handling in monitor-related operations, replacing the previous CompleteError. Updates SessionObject+Monitor.swift to use MonitorError for improved clarity and consistency.