### PR TITLE
Rename parameter 'block' to 'work' in Dispatcher

### DIFF
--- a/Sources/Scout/Core/Dispatcher/Dispatcher.swift
+++ b/Sources/Scout/Core/Dispatcher/Dispatcher.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol Dispatcher {
-    func perform(_ block: @escaping Work) async throws
+    func perform(_ work: @escaping Work) async throws
 }
 
 extension Dispatcher {
@@ -16,13 +16,13 @@ extension Dispatcher {
 }
 
 extension Dispatcher {
-    func performEnsuringBackground(_ block: @escaping Work) async throws {
+    func performEnsuringBackground(_ work: @escaping Work) async throws {
         try await perform { @MainActor in
             let task = UIApplication.shared.beginBackgroundTask()
 
             defer { UIApplication.shared.endBackgroundTask(task) }
 
-            try await block()
+            try await work()
         }
     }
 }

--- a/Sources/Scout/Core/Dispatcher/QueueDispatcher.swift
+++ b/Sources/Scout/Core/Dispatcher/QueueDispatcher.swift
@@ -9,8 +9,8 @@ actor QueueDispatcher: Dispatcher {
     private var queue: [Work] = []
     private var isRunning = false
 
-    func perform(_ block: @escaping Work) async throws {
-        queue.append(block)
+    func perform(_ work: @escaping Work) async throws {
+        queue.append(work)
 
         guard !isRunning else { return }
 


### PR DESCRIPTION
Updated the parameter name from 'block' to 'work' in Dispatcher protocol and related methods for improved clarity and consistency.