### PR TITLE
Refactor providers to use unified result type

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityRow.swift
+++ b/Sources/Scout/UI/Activity/ActivityRow.swift
@@ -17,7 +17,7 @@ struct ActivityRow: View {
             Text(period.title)
             Spacer()
 
-            let count = activity.data?
+            let count = try? activity.result?.get()
                 .points(on: period)
                 .bucket(on: period)
                 .max()?

--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -21,7 +21,11 @@ struct ActivityView: View {
         VStack(spacing: 0) {
             PeriodPicker(extent: $extent, periods: ActivityPeriod.allCases)
 
-            if let data = activity.data {
+            switch activity.result {
+            case nil:
+                ProgressView().tint(nil).frame(maxHeight: .infinity)
+
+            case .success(let data):
                 RangeControl(extent: $extent)
 
                 List {
@@ -33,8 +37,9 @@ struct ActivityView: View {
                 }
                 .listStyle(.plain)
                 .scrollDisabled(true)
-            } else {
-                ProgressView().tint(nil).frame(maxHeight: .infinity)
+
+            case .failure(let error):
+                EmptyView()
             }
         }
         .navigationTitle("Active Users")

--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -28,12 +28,12 @@ extension EventView {
                 await param.fetchIfNeeded(in: database)
             }
             .navigationDestination(isPresented: $isParamPresented) {
-                if let items = param.data {
+                if let items = try? param.result?.get() {
                     ParamList(items: items)
                 }
             }
 
-            if let items = param.data {
+            if let items = try? param.result?.get() {
                 ForEach(items.prefix(3)) { item in
                     ParamRow(item: item)
                 }
@@ -45,7 +45,7 @@ extension EventView {
         }
 
         var seeAll: (() -> Void)? {
-            if let _ = param.data, count > 3 {
+            if let _ = try? param.result?.get(), count > 3 {
                 { isParamPresented = true }
             } else {
                 nil

--- a/Sources/Scout/UI/Event/Param/ParamProvider.swift
+++ b/Sources/Scout/UI/Event/Param/ParamProvider.swift
@@ -7,28 +7,20 @@
 
 import CloudKit
 
-@MainActor
-class ParamProvider: ObservableObject {
-    let recordID: CKRecord.ID
+class ParamProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<[Item]>?
 
-    @Published var data: [Item]?
+    let recordID: CKRecord.ID
 
     init(recordID: CKRecord.ID) {
         self.recordID = recordID
     }
-}
 
-extension ParamProvider: Provider {
-    func fetch(in database: DatabaseController) async {
-        do {
-            data = try await database
-                .record(for: recordID)["params"]
-                .map(Item.fromData)?
-                .sorted()
-        } catch {
-            print(error.localizedDescription)
-            data = nil
-        }
+    func fetch(in database: DatabaseController) async throws -> ResultType {
+        try await database
+            .record(for: recordID)["params"]
+            .map(Item.fromData)?
+            .sorted() ?? []
     }
 }
 

--- a/Sources/Scout/UI/Event/Stat/StatRow.swift
+++ b/Sources/Scout/UI/Event/Stat/StatRow.swift
@@ -21,7 +21,10 @@ struct StatRow: View {
                 Text(period.title)
                 Spacer()
 
-                let count = stat.data?.bucket(on: period).total
+                let count = try? stat.result?.get()
+                    .flatMap(\.points)
+                    .bucket(on: period).total
+
                 RedactedText(count: count)
             }
             .foregroundColor(config.color)

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -15,12 +15,15 @@ struct MetricsContent<T: ChartNumeric>: View {
     @EnvironmentObject var database: DatabaseController
 
     var body: some View {
-        if let data = metrics.data {
-            list(groups: data.pointGroups())
-        } else {
+        switch metrics.result {
+        case nil:
             ProgressView().frame(maxHeight: .infinity).task {
                 await metrics.fetchIfNeeded(in: database)
             }
+        case .success(let data):
+            list(groups: data.pointGroups())
+        case .failure(let error):
+            EmptyView()
         }
     }
 

--- a/Sources/Scout/UI/Utilities/Provider.swift
+++ b/Sources/Scout/UI/Utilities/Provider.swift
@@ -5,23 +5,35 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-@MainActor protocol Provider: AnyObject {
-    associatedtype DataType
+@MainActor
+protocol Provider: AnyObject {
+    associatedtype ResultType
 
-    var data: DataType? { set get }
+    var result: ProviderResult<ResultType>? { get set }
 
-    func fetch(in database: DatabaseController) async
+    func fetch(in database: DatabaseController) async throws -> ResultType
 }
+
+typealias ProviderResult<T> = Result<T, Error>
 
 extension Provider {
     func fetchAgain(in database: DatabaseController) async {
-        data = nil
-        await fetch(in: database)
+        result = nil
+        result = await resolve(in: database)
     }
 
     func fetchIfNeeded(in database: DatabaseController) async {
-        if data == nil {
-            await fetch(in: database)
+        guard result == nil else { return }
+        result = await resolve(in: database)
+    }
+}
+
+extension Provider {
+    private func resolve(in database: DatabaseController) async -> ProviderResult<ResultType> {
+        do {
+            return .success(try await fetch(in: database))
+        } catch {
+            return .failure(error)
         }
     }
 }


### PR DESCRIPTION
Replaces individual data properties in provider classes with a unified `ProviderResult` type to standardize error handling and loading states. Updates all relevant UI components to use the new result property and refactors fetch logic to return results via async/await. This improves consistency and error management across Activity, Stat, Param, and Metrics providers.