### PR TITLE
Move ParamProvider.Item to separate file

### DIFF
--- a/Sources/Scout/UI/Event/Param/ParamProvider.Item.swift
+++ b/Sources/Scout/UI/Event/Param/ParamProvider.Item.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension ParamProvider {
+    struct Item: Identifiable, Comparable, Hashable, CustomStringConvertible {
+        let id = UUID()
+        let key: String
+        let value: String
+
+        static func fromData(_ data: Data) throws -> [Item] {
+            try JSONDecoder().decode([String: String].self, from: data).map(Item.init)
+        }
+
+        static func < (lhs: Item, rhs: Item) -> Bool {
+            lhs.key < rhs.key
+        }
+
+        var description: String {
+            "\(key): \(value)"
+        }
+    }
+}

--- a/Sources/Scout/UI/Event/Param/ParamProvider.swift
+++ b/Sources/Scout/UI/Event/Param/ParamProvider.swift
@@ -10,7 +10,7 @@ import CloudKit
 class ParamProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[Item]>?
 
-    let recordID: CKRecord.ID
+    private let recordID: CKRecord.ID
 
     init(recordID: CKRecord.ID) {
         self.recordID = recordID
@@ -21,25 +21,5 @@ class ParamProvider: ObservableObject, Provider {
             .record(for: recordID)["params"]
             .map(Item.fromData)?
             .sorted() ?? []
-    }
-}
-
-extension ParamProvider {
-    struct Item: Identifiable, Comparable, Hashable, CustomStringConvertible {
-        static func < (lhs: Item, rhs: Item) -> Bool {
-            lhs.key < rhs.key
-        }
-
-        let id = UUID()
-        let key: String
-        let value: String
-
-        fileprivate static func fromData(_ data: Data) throws -> [Item] {
-            try JSONDecoder().decode([String: String].self, from: data).map(Item.init)
-        }
-
-        var description: String {
-            "\(key): \(value)"
-        }
     }
 }


### PR DESCRIPTION
Moved the Item struct from ParamProvider.swift to a new ParamProvider.Item.swift file for better code organization. Also changed recordID property in ParamProvider to private for improved encapsulation.