### PR TITLE
Refactor provider pattern and add ProviderView

### DIFF
--- a/Sources/Scout/Core/Matrix/MatrixBatch.swift
+++ b/Sources/Scout/Core/Matrix/MatrixBatch.swift
@@ -22,6 +22,6 @@ struct MatrixPropertyError: LocalizedError {
     let errorDescription: String?
 
     init(_ property: String) {
-        self.errorDescription = "Missing property: \(property). Cannot group objects."
+        errorDescription = "Missing property: \(property). Cannot group objects."
     }
 }

--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -11,7 +11,7 @@ import SwiftUI
 class ActivityProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[ActivityMatrix]>?
 
-    func fetch(in database: DatabaseController) async throws -> ResultType {
+    func fetch(in database: DatabaseController) async throws -> Output {
         try await database
             .allRecords(matching: query, desiredKeys: nil)
             .map(ActivityMatrix.init)

--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -21,11 +21,7 @@ struct ActivityView: View {
         VStack(spacing: 0) {
             PeriodPicker(extent: $extent, periods: ActivityPeriod.allCases)
 
-            switch activity.result {
-            case nil:
-                ProgressView().tint(nil).frame(maxHeight: .infinity)
-
-            case .success(let data):
+            ProviderView(provider: activity) { data in
                 RangeControl(extent: $extent)
 
                 List {
@@ -37,9 +33,6 @@ struct ActivityView: View {
                 }
                 .listStyle(.plain)
                 .scrollDisabled(true)
-
-            case .failure(let error):
-                EmptyView()
             }
         }
         .navigationTitle("Active Users")

--- a/Sources/Scout/UI/Event/Param/ParamProvider.swift
+++ b/Sources/Scout/UI/Event/Param/ParamProvider.swift
@@ -16,7 +16,7 @@ class ParamProvider: ObservableObject, Provider {
         self.recordID = recordID
     }
 
-    func fetch(in database: DatabaseController) async throws -> ResultType {
+    func fetch(in database: DatabaseController) async throws -> Output {
         try await database
             .record(for: recordID)["params"]
             .map(Item.fromData)?

--- a/Sources/Scout/UI/Event/Stat/StatProvider.swift
+++ b/Sources/Scout/UI/Event/Stat/StatProvider.swift
@@ -18,7 +18,7 @@ class StatProvider: ObservableObject, Provider {
         self.periods = periods
     }
 
-    func fetch(in database: DatabaseController) async throws -> ResultType {
+    func fetch(in database: DatabaseController) async throws -> Output {
         try await database
             .allRecords(matching: query, desiredKeys: nil)
             .map(GridMatrix.init)

--- a/Sources/Scout/UI/Event/Stat/StatRow.swift
+++ b/Sources/Scout/UI/Event/Stat/StatRow.swift
@@ -23,7 +23,8 @@ struct StatRow: View {
 
                 let count = try? stat.result?.get()
                     .flatMap(\.points)
-                    .bucket(on: period).total
+                    .bucket(on: period)
+                    .total
 
                 RedactedText(count: count)
             }

--- a/Sources/Scout/UI/Event/Stat/StatView.swift
+++ b/Sources/Scout/UI/Event/Stat/StatView.swift
@@ -32,10 +32,7 @@ struct StatView: View {
         VStack(spacing: 0) {
             PeriodPicker(extent: $extent, periods: stat.periods)
 
-            switch stat.result {
-            case nil:
-                ProgressView().tint(nil).frame(maxHeight: .infinity)
-            case .success(let data):
+            ProviderView(provider: stat) { data in
                 RangeControl(extent: $extent)
 
                 List {
@@ -52,9 +49,6 @@ struct StatView: View {
                 }
                 .listStyle(.plain)
                 .scrollDisabled(true)
-
-            case .failure(let error):
-                EmptyView()
             }
         }
         .navigationTitle(config.title)

--- a/Sources/Scout/UI/Metrics/MetricsProvider.swift
+++ b/Sources/Scout/UI/Metrics/MetricsProvider.swift
@@ -17,7 +17,7 @@ class MetricsProvider<T: ChartNumeric>: ObservableObject, Provider {
         self.telemetry = telemetry
     }
 
-    func fetch(in database: DatabaseController) async throws -> ResultType {
+    func fetch(in database: DatabaseController) async throws -> Output {
         try await database
             .allRecords(matching: query, desiredKeys: nil)
             .map(GridMatrix.init)

--- a/Sources/Scout/UI/Provider/Provider.swift
+++ b/Sources/Scout/UI/Provider/Provider.swift
@@ -5,13 +5,15 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import SwiftUI
+
 @MainActor
-protocol Provider: AnyObject {
-    associatedtype ResultType
+protocol Provider: ObservableObject {
+    associatedtype Output
 
-    var result: ProviderResult<ResultType>? { get set }
+    var result: ProviderResult<Output>? { get set }
 
-    func fetch(in database: DatabaseController) async throws -> ResultType
+    func fetch(in database: DatabaseController) async throws -> Output
 }
 
 typealias ProviderResult<T> = Result<T, Error>
@@ -29,7 +31,7 @@ extension Provider {
 }
 
 extension Provider {
-    private func resolve(in database: DatabaseController) async -> ProviderResult<ResultType> {
+    private func resolve(in database: DatabaseController) async -> ProviderResult<Output> {
         do {
             return .success(try await fetch(in: database))
         } catch {

--- a/Sources/Scout/UI/Provider/ProviderView.swift
+++ b/Sources/Scout/UI/Provider/ProviderView.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct ProviderView<P: Provider, Content: View>: View {
+    @ObservedObject var provider: P
+
+    @ViewBuilder let content: (P.Output) -> Content
+
+    var body: some View {
+        switch provider.result {
+        case nil:
+            ProgressView().frame(maxHeight: .infinity).tint(nil)
+        case .success(let data):
+            content(data)
+        case .failure(let error):
+            EmptyView()
+        }
+    }
+}


### PR DESCRIPTION
Unified the Provider protocol and its usage by renaming ResultType to Output and moving it to a dedicated Provider directory. Replaced manual result handling in views with a reusable ProviderView component for consistent loading, success, and error states. Updated all provider implementations and affected views to use the new pattern for improved code clarity and maintainability.