### PR TITLE
Add retry support to ErrorView and ProviderView

### DIFF
--- a/Sources/Scout/UI/Provider/ErrorView.swift
+++ b/Sources/Scout/UI/Provider/ErrorView.swift
@@ -9,9 +9,12 @@ import SwiftUI
 
 struct ErrorView: View {
     let error: Error
+    let retry: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 16) {
+            Spacer()
+
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 48))
                 .foregroundColor(.yellow)
@@ -21,20 +24,39 @@ struct ErrorView: View {
                 .bold()
 
             Text(error.localizedDescription)
+                .font(.body)
                 .multilineTextAlignment(.center)
+
+            if let retry {
+                Button(action: retry) {
+                    Text("Retry")
+                        .bold()
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 100, style: .continuous))
+                }
+                .padding(8)
+            }
+
+            Spacer()
         }
+        .lineSpacing(4)
         .padding()
     }
 }
 
 #Preview("ErrorView") {
+    let errorText =
+        "This is a sample error message that is intentionally made very long to test how the \(ErrorView.self) handles multiline text display. It should properly wrap and be readable without any issues."
+
     ErrorView(
         error: NSError(
             domain: "",
             code: 0,
-            userInfo: [
-                NSLocalizedDescriptionKey: "This is a sample error message to demonstrate the \(ErrorView.self)."
-            ]
-        )
+            userInfo: [NSLocalizedDescriptionKey: errorText]
+        ),
+        retry: {}
     )
 }

--- a/Sources/Scout/UI/Provider/ProviderView.swift
+++ b/Sources/Scout/UI/Provider/ProviderView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ProviderView<P: Provider, Content: View>: View {
+    @EnvironmentObject var database: DatabaseController
     @ObservedObject var provider: P
 
     @ViewBuilder let content: (P.Output) -> Content
@@ -19,7 +20,11 @@ struct ProviderView<P: Provider, Content: View>: View {
         case .success(let data):
             content(data)
         case .failure(let error):
-            ErrorView(error: error)
+            ErrorView(error: error, retry: fetch)
         }
+    }
+
+    private func fetch() {
+        Task { await provider.fetchAgain(in: database) }
     }
 }


### PR DESCRIPTION
ErrorView now accepts an optional retry callback and displays a Retry button when provided. ProviderView passes a fetch retry action to ErrorView on failure, allowing users to retry failed operations. Also improved ErrorView layout and multiline error handling.