### PR TITLE
Refactor MetricsView to accept ChartExtent state

### DIFF
--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -26,8 +26,14 @@ struct MetricsContent<T: ChartNumeric>: View {
                     Row {
                         row(group: group)
                     } destination: {
+                        @State var extent = ChartExtent(period: period)
+
                         if let named = groups.named(group.name) {
-                            MetricsView(group: named, formatter: formatter, period: period)
+                            MetricsView(
+                                group: named,
+                                formatter: formatter,
+                                extent: extent
+                            )
                         }
                     }
                 }
@@ -35,7 +41,7 @@ struct MetricsContent<T: ChartNumeric>: View {
             }
         }
         .task {
-            await metrics.fetchIfNeeded(in: database)
+            await metrics.fetchAgain(in: database)
         }
     }
 

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -12,13 +12,7 @@ struct MetricsView<T: ChartNumeric>: View {
     let group: PointGroup<T>
     let formatter: KeyPath<T, String>
 
-    @State private var extent: ChartExtent<Period>
-
-    init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period) {
-        self.group = group
-        self.formatter = formatter
-        self._extent = State(wrappedValue: ChartExtent(period: period))
-    }
+    @State var extent: ChartExtent<Period>
 
     var body: some View {
         Picker("Period", selection: $extent.period) {
@@ -59,7 +53,7 @@ struct MetricsView<T: ChartNumeric>: View {
         MetricsView(
             group: .init(name: "Group", points: .sample),
             formatter: \.plain,
-            period: .yesterday
+            extent: ChartExtent(period: .yesterday)
         )
     }
 }


### PR DESCRIPTION
Changed MetricsView to receive an @State ChartExtent via its initializer instead of constructing it internally. Updated MetricsContent to manage ChartExtent state and pass it to MetricsView. Also replaced metrics.fetchIfNeeded with metrics.fetchAgain for data fetching.