### PR TITLE
Refactor Metrics initialization and usage

### DIFF
--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -32,13 +32,11 @@ struct MetricsContent<T: ChartNumeric>: View {
                     Row {
                         row(group: group)
                     } destination: {
-                        @State var extent = ChartExtent(period: period)
-
                         if let named = groups.named(group.name) {
                             MetricsView(
                                 group: named,
                                 formatter: formatter,
-                                extent: extent
+                                period: period
                             )
                         }
                     }

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -11,8 +11,14 @@ struct MetricsContent<T: ChartNumeric>: View {
     let period: Period
     let formatter: KeyPath<T, String>
 
-    @ObservedObject var metrics: MetricsProvider<T>
+    @StateObject var metrics: MetricsProvider<T>
     @EnvironmentObject var database: DatabaseController
+
+    init(period: Period, formatter: KeyPath<T, String>, telemetry: Telemetry.Export) {
+        self.period = period
+        self.formatter = formatter
+        self._metrics = StateObject(wrappedValue: MetricsProvider(telemetry: telemetry))
+    }
 
     var body: some View {
         ProviderView(provider: metrics) { data in
@@ -41,7 +47,7 @@ struct MetricsContent<T: ChartNumeric>: View {
             }
         }
         .task {
-            await metrics.fetchAgain(in: database)
+            await metrics.fetchIfNeeded(in: database)
         }
     }
 

--- a/Sources/Scout/UI/Metrics/MetricsList.swift
+++ b/Sources/Scout/UI/Metrics/MetricsList.swift
@@ -19,10 +19,6 @@ struct MetricsList: View {
     @State private var period: Period = .today
     @State private var scope: Scope = .int
 
-    @StateObject private var counter = MetricsProvider<Int>(telemetry: .counter)
-    @StateObject private var floating = MetricsProvider<Double>(telemetry: .floatingCounter)
-    @StateObject private var timer = MetricsProvider<TimeInterval>(telemetry: .timer)
-
     var body: some View {
         Picker("Period", selection: $period) {
             ForEach(Period.all) { period in
@@ -45,20 +41,20 @@ struct MetricsList: View {
         case .int:
             MetricsContent(
                 period: period,
-                formatter: \.plain,
-                metrics: counter
+                formatter: \Int.plain,
+                telemetry: .counter
             )
         case .double:
             MetricsContent(
                 period: period,
-                formatter: \.decimal,
-                metrics: floating
+                formatter: \Double.decimal,
+                telemetry: .floatingCounter
             )
         case .timer:
             MetricsContent(
                 period: period,
-                formatter: \.duration,
-                metrics: timer
+                formatter: \TimeInterval.duration,
+                telemetry: .timer
             )
         }
     }

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -14,6 +14,12 @@ struct MetricsView<T: ChartNumeric>: View {
 
     @State var extent: ChartExtent<Period>
 
+    init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period) {
+        self.group = group
+        self.formatter = formatter
+        self._extent = State(wrappedValue: ChartExtent(period: period))
+    }
+
     var body: some View {
         Picker("Period", selection: $extent.period) {
             ForEach(Period.all) { period in
@@ -53,7 +59,7 @@ struct MetricsView<T: ChartNumeric>: View {
         MetricsView(
             group: .init(name: "Group", points: .sample),
             formatter: \.plain,
-            extent: ChartExtent(period: .yesterday)
+            period: .yesterday
         )
     }
 }


### PR DESCRIPTION
Improve state management in MetricsContent by using @StateObject for metrics and streamline MetricsView initialization by accepting a period parameter instead of ChartExtent. This enhances code clarity and reduces redundancy in MetricsList.