### PR TITLE
Refactor CloudKit protocols and add CKPersistable

### DIFF
--- a/Sources/Scout/Core/Matrix/Matrix+CKPersistable.swift
+++ b/Sources/Scout/Core/Matrix/Matrix+CKPersistable.swift
@@ -7,10 +7,6 @@
 
 import CloudKit
 
-protocol CKInitializable {
-    init(record: CKRecord) throws
-}
-
 extension Matrix: CKInitializable {
     init(record: CKRecord) throws {
         guard let date = record["date"] as? Date else {

--- a/Sources/Scout/Core/Sync/CKPersistable.swift
+++ b/Sources/Scout/Core/Sync/CKPersistable.swift
@@ -1,0 +1,18 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+typealias CKPersistable = CKInitializable & CKRepresentable
+
+protocol CKInitializable {
+    init(record: CKRecord) throws
+}
+
+protocol CKRepresentable {
+    var toRecord: CKRecord { get }
+}

--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -8,10 +8,6 @@
 import CloudKit
 import CoreData
 
-protocol CKRepresentable {
-    var toRecord: CKRecord { get }
-}
-
 struct SyncEngine: @unchecked Sendable {
     let database: Database
     let context: NSManagedObjectContext


### PR DESCRIPTION
Moved CKInitializable and CKRepresentable protocols to a new CKPersistable.swift file and introduced a CKPersistable typealias. Updated Matrix extension and SyncEngine to use the new protocol structure for improved code organization and clarity.