### PR TITLE
Refactor UserActivity to use 'cell' instead of 'matrix'

### DIFF
--- a/Sources/Scout/Core/Activity/UserActivity.swift
+++ b/Sources/Scout/Core/Activity/UserActivity.swift
@@ -27,10 +27,10 @@ final class UserActivity: SyncableObject, Syncable {
     }
 
     static func parse(of batch: [UserActivity]) -> [PeriodCell<Int>] {
-        batch.compactMap(\.matrix).mergeDuplicates()
+        batch.compactMap(\.cell).mergeDuplicates()
     }
 
-    private var matrix: PeriodCell<Int>? {
+    private var cell: PeriodCell<Int>? {
         guard let month, let day else {
             return nil
         }


### PR DESCRIPTION
Renamed the 'matrix' property to 'cell' in UserActivity and updated references in the parse method for clarity and consistency.