### PR TITLE
Remove Matrix extension initializer for MatrixBatch

### DIFF
--- a/Sources/Scout/Core/Matrix/MatrixBatch.swift
+++ b/Sources/Scout/Core/Matrix/MatrixBatch.swift
@@ -12,12 +12,6 @@ protocol MatrixBatch {
     static func matrix(of batch: [Self]) throws(MatrixPropertyError) -> Matrix<Cell>
 }
 
-extension Matrix {
-    init<V: MatrixBatch>(of batch: [V]) throws where V.Cell == T {
-        self = try V.matrix(of: batch)
-    }
-}
-
 struct MatrixPropertyError: LocalizedError {
     let errorDescription: String?
 

--- a/Sources/Scout/Core/Sync/SyncCoordinator.swift
+++ b/Sources/Scout/Core/Sync/SyncCoordinator.swift
@@ -17,7 +17,7 @@ extension SyncCoordinator {
     init<V: MatrixBatch>(database: Database, maxRetry: Int, batch: [V]) throws where V.Cell == T {
         self.database = database
         self.maxRetry = maxRetry
-        self.matrix = try Matrix(of: batch)
+        self.matrix = try V.matrix(of: batch)
     }
 }
 


### PR DESCRIPTION
Deleted the Matrix extension that provided an initializer for MatrixBatch types and updated SyncCoordinator to use V.matrix(of:) directly. This simplifies the code by removing the extra initializer indirection.