### PR TITLE
Refactor database protocols and extract RecordLookup

### DIFF
--- a/Sources/Scout/UI/Database/AppDatabase.swift
+++ b/Sources/Scout/UI/Database/AppDatabase.swift
@@ -8,22 +8,12 @@
 import CloudKit
 import SwiftUI
 
-/// AppDatabase is a UI-oriented facade over the core database used in Scout.
-/// It provides a simplified interface tailored for SwiftUI integration while
-/// delegating actual data operations to the underlying database layer.
+/// AppDatabase defines the read-only database surface used by the UI.
+/// It abstracts record lookup and query operations for use in SwiftUI
+/// and is intended for dependency injection via the environment.
 ///
-typealias AppDatabase = Database & RecordLookup & Sendable
-
-protocol RecordLookup {
-    func lookup(id: CKRecord.ID) async throws -> CKRecord
-}
+typealias AppDatabase = RecordLookup & RecordReader & Sendable
 
 extension EnvironmentValues {
     @Entry var database: AppDatabase = DefaultDatabase()
-}
-
-extension CKDatabase: RecordLookup {
-    func lookup(id: CKRecord.ID) async throws -> CKRecord {
-        try await record(for: id)
-    }
 }

--- a/Sources/Scout/UI/Database/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/DefaultDatabase.swift
@@ -8,14 +8,6 @@
 import CloudKit
 
 struct DefaultDatabase: AppDatabase {
-    func write(record: CKRecord) async throws {
-
-    }
-
-    func write(records: [CKRecord]) async throws {
-
-    }
-
     func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
         RecordChunk(records: Event.sampleRecords, cursor: nil)
     }

--- a/Sources/Scout/UI/Database/RecordLookup.swift
+++ b/Sources/Scout/UI/Database/RecordLookup.swift
@@ -1,0 +1,18 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+protocol RecordLookup {
+    func lookup(id: CKRecord.ID) async throws -> CKRecord
+}
+
+extension CKDatabase: RecordLookup {
+    func lookup(id: CKRecord.ID) async throws -> CKRecord {
+        try await record(for: id)
+    }
+}


### PR DESCRIPTION
Moved the RecordLookup protocol and its CKDatabase extension to a new file for better separation of concerns. Updated AppDatabase typealias to use RecordLookup and RecordReader, and removed write methods from DefaultDatabase to clarify its read-only interface.