### PR TITLE
Fix Event level initialization from CKRecord

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,6 +29,6 @@ jobs:
           set -o pipefail && \
           xcodebuild \
             -scheme $SCHEME_NAME \
-            -destination 'platform=iOS Simulator,name=Any iOS Simulator Device' \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
             -enableCodeCoverage YES \
             test | xcpretty

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,11 +24,11 @@ jobs:
         run: |
           sudo gem install xcpretty
 
-      - name: Run unit tests (iPhone 16 Pro, latest iOS)
+      - name: Run unit tests (iOS Simulator)
         run: |
           set -o pipefail && \
           xcodebuild \
             -scheme $SCHEME_NAME \
-            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
+            -destination 'platform=iOS Simulator,name=Any iOS Simulator Device' \
             -enableCodeCoverage YES \
             test | xcpretty

--- a/Sources/Scout/UI/Event/Event.swift
+++ b/Sources/Scout/UI/Event/Event.swift
@@ -37,7 +37,7 @@ extension Event {
 
     init(record: CKRecord) throws {
         name = record["name"] ?? ""
-        level = record["level"].flatMap(Level.init)
+        level = record["level"].flatMap { Level(rawValue: $0) }
         date = record["date"]
         paramCount = record["param_count"]
         uuid = record["uuid"].flatMap(UUID.init)


### PR DESCRIPTION
Replaces Level.init with Level(rawValue:) when initializing the level property from a CKRecord. This ensures the correct enum case is used based on the raw value.