### PR TITLE
Disable Claude Code attribution in commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 xcuserdata/
 .swiftpm/
 Package.resolved
+.claude/settings.local.json


### PR DESCRIPTION
- Add `.claude/settings.json` with empty `attribution` fields to suppress the auto-generated footer in commits and PR descriptions