### PR TITLE
Add unit tests for core Scout components

### DIFF
--- a/Tests/ScoutTests/Core/Activity/ActivityPeriodTests.swift
+++ b/Tests/ScoutTests/Core/Activity/ActivityPeriodTests.swift
@@ -1,0 +1,67 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct ActivityPeriodTests {
+
+    // MARK: - Raw Values
+
+    @Test("Raw values encode correctly")
+    func rawValues() {
+        #expect(ActivityPeriod.daily.rawValue == "d")
+        #expect(ActivityPeriod.weekly.rawValue == "w")
+        #expect(ActivityPeriod.monthly.rawValue == "m")
+    }
+
+    @Test("Init from raw value")
+    func initFromRawValue() {
+        #expect(ActivityPeriod(rawValue: "d") == .daily)
+        #expect(ActivityPeriod(rawValue: "w") == .weekly)
+        #expect(ActivityPeriod(rawValue: "m") == .monthly)
+        #expect(ActivityPeriod(rawValue: "x") == nil)
+    }
+
+    // MARK: - Titles
+
+    @Test("Titles are human-readable")
+    func titles() {
+        #expect(ActivityPeriod.daily.title == "Daily")
+        #expect(ActivityPeriod.weekly.title == "Weekly")
+        #expect(ActivityPeriod.monthly.title == "Monthly")
+    }
+
+    // MARK: - Spread Components
+
+    @Test("Daily spread component is day")
+    func dailySpread() {
+        #expect(ActivityPeriod.daily.spreadComponent == .day)
+    }
+
+    @Test("Weekly spread component is weekOfYear")
+    func weeklySpread() {
+        #expect(ActivityPeriod.weekly.spreadComponent == .weekOfYear)
+    }
+
+    @Test("Monthly spread component is month")
+    func monthlySpread() {
+        #expect(ActivityPeriod.monthly.spreadComponent == .month)
+    }
+
+    // MARK: - CaseIterable
+
+    @Test("All cases are present")
+    func allCases() {
+        #expect(ActivityPeriod.allCases.count == 3)
+        #expect(ActivityPeriod.allCases.contains(.daily))
+        #expect(ActivityPeriod.allCases.contains(.weekly))
+        #expect(ActivityPeriod.allCases.contains(.monthly))
+    }
+}

--- a/Tests/ScoutTests/Core/Cell/CombiningTests.swift
+++ b/Tests/ScoutTests/Core/Cell/CombiningTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Testing
+
+@testable import Scout
+
+struct CombiningTests {
+
+    // MARK: - mergeDuplicates
+
+    @Test("Merge duplicates combines matching cells")
+    func mergeDuplicates() {
+        let cells = [
+            GridCell(row: 1, column: 2, value: 3),
+            GridCell(row: 1, column: 2, value: 4),
+            GridCell(row: 3, column: 4, value: 5),
+        ]
+
+        let merged = cells.mergeDuplicates()
+
+        #expect(merged.count == 2)
+        #expect(merged[0] == GridCell(row: 1, column: 2, value: 7))
+        #expect(merged[1] == GridCell(row: 3, column: 4, value: 5))
+    }
+
+    @Test("Merge duplicates with no duplicates")
+    func mergeDuplicatesNoDuplicates() {
+        let cells = [
+            GridCell(row: 1, column: 1, value: 1),
+            GridCell(row: 2, column: 2, value: 2),
+            GridCell(row: 3, column: 3, value: 3),
+        ]
+
+        let merged = cells.mergeDuplicates()
+
+        #expect(merged.count == 3)
+    }
+
+    @Test("Merge duplicates with all duplicates")
+    func mergeDuplicatesAllSame() {
+        let cells = [
+            GridCell(row: 0, column: 0, value: 1),
+            GridCell(row: 0, column: 0, value: 2),
+            GridCell(row: 0, column: 0, value: 3),
+        ]
+
+        let merged = cells.mergeDuplicates()
+
+        #expect(merged.count == 1)
+        #expect(merged[0] == GridCell(row: 0, column: 0, value: 6))
+    }
+
+    @Test("Merge duplicates on empty array")
+    func mergeDuplicatesEmpty() {
+        let cells: [GridCell<Int>] = []
+        let merged = cells.mergeDuplicates()
+        #expect(merged.isEmpty)
+    }
+
+    @Test("Merge duplicates preserves order of first occurrence")
+    func mergeDuplicatesOrder() {
+        let cells = [
+            GridCell(row: 2, column: 0, value: 10),
+            GridCell(row: 1, column: 0, value: 5),
+            GridCell(row: 2, column: 0, value: 20),
+        ]
+
+        let merged = cells.mergeDuplicates()
+
+        #expect(merged.count == 2)
+        #expect(merged[0] == GridCell(row: 2, column: 0, value: 30))
+        #expect(merged[1] == GridCell(row: 1, column: 0, value: 5))
+    }
+}

--- a/Tests/ScoutTests/Core/Cell/PeriodCellTests.swift
+++ b/Tests/ScoutTests/Core/Cell/PeriodCellTests.swift
@@ -1,0 +1,97 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Testing
+
+@testable import Scout
+
+struct PeriodCellTests {
+
+    // MARK: - Key Generation
+
+    @Test("Key encodes period and day")
+    func keyGeneration() {
+        let cell = PeriodCell<Int>(period: .daily, day: 0, value: 5)
+        #expect(cell.key == "cell_d_01")
+    }
+
+    @Test("Key uses leading zero for single-digit days")
+    func keyLeadingZero() {
+        let cell = PeriodCell<Int>(period: .weekly, day: 8, value: 1)
+        #expect(cell.key == "cell_w_09")
+    }
+
+    @Test("Key encodes monthly period")
+    func keyMonthly() {
+        let cell = PeriodCell<Int>(period: .monthly, day: 11, value: 1)
+        #expect(cell.key == "cell_m_12")
+    }
+
+    // MARK: - Key Parsing
+
+    @Test("Init from key parses correctly")
+    func initFromKey() {
+        let cell = PeriodCell<Int>(key: "cell_d_05", value: 10)
+        #expect(cell.period == .daily)
+        #expect(cell.day == 4)
+        #expect(cell.value == 10)
+    }
+
+    @Test("Init from key parses weekly")
+    func initFromKeyWeekly() {
+        let cell = PeriodCell<Int>(key: "cell_w_01", value: 3)
+        #expect(cell.period == .weekly)
+        #expect(cell.day == 0)
+        #expect(cell.value == 3)
+    }
+
+    // MARK: - Round-trip
+
+    @Test("Key round-trips through init")
+    func keyRoundTrip() {
+        let original = PeriodCell<Int>(period: .monthly, day: 6, value: 42)
+        let restored = PeriodCell<Int>(key: original.key, value: original.value)
+
+        #expect(restored.period == original.period)
+        #expect(restored.day == original.day)
+        #expect(restored.value == original.value)
+    }
+
+    // MARK: - Combining
+
+    @Test("Addition combines values")
+    func addition() {
+        let a = PeriodCell<Int>(period: .daily, day: 3, value: 10)
+        let b = PeriodCell<Int>(period: .daily, day: 3, value: 7)
+        let c = a + b
+
+        #expect(c.period == .daily)
+        #expect(c.day == 3)
+        #expect(c.value == 17)
+    }
+
+    @Test("isDuplicate matches same period and day")
+    func isDuplicate() {
+        let a = PeriodCell<Int>(period: .weekly, day: 2, value: 1)
+        let b = PeriodCell<Int>(period: .weekly, day: 2, value: 9)
+        #expect(a.isDuplicate(of: b))
+    }
+
+    @Test("isDuplicate rejects different period")
+    func isDuplicateDifferentPeriod() {
+        let a = PeriodCell<Int>(period: .daily, day: 2, value: 1)
+        let b = PeriodCell<Int>(period: .weekly, day: 2, value: 1)
+        #expect(!a.isDuplicate(of: b))
+    }
+
+    @Test("isDuplicate rejects different day")
+    func isDuplicateDifferentDay() {
+        let a = PeriodCell<Int>(period: .daily, day: 1, value: 1)
+        let b = PeriodCell<Int>(period: .daily, day: 2, value: 1)
+        #expect(!a.isDuplicate(of: b))
+    }
+}

--- a/Tests/ScoutTests/Core/Database/RecordChunkTests.swift
+++ b/Tests/ScoutTests/Core/Database/RecordChunkTests.swift
@@ -1,0 +1,52 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Testing
+
+@testable import Scout
+
+struct RecordChunkTests {
+
+    @Test("Addition concatenates records")
+    func addition() {
+        let r1 = CKRecord(recordType: "A")
+        let r2 = CKRecord(recordType: "B")
+        let r3 = CKRecord(recordType: "C")
+
+        let a = RecordChunk(records: [r1], cursor: nil)
+        let b = RecordChunk(records: [r2, r3], cursor: nil)
+        let c = a + b
+
+        #expect(c.records.count == 3)
+        #expect(c.records[0].recordType == "A")
+        #expect(c.records[1].recordType == "B")
+        #expect(c.records[2].recordType == "C")
+    }
+
+    @Test("Addition takes cursor from right-hand side")
+    func additionCursor() {
+        let a = RecordChunk(records: [], cursor: nil)
+        let b = RecordChunk(records: [], cursor: nil)
+        let c = a + b
+
+        #expect(c.cursor == nil)
+    }
+
+    @Test("Plus-equals mutates in place")
+    func plusEquals() {
+        let r1 = CKRecord(recordType: "X")
+        let r2 = CKRecord(recordType: "Y")
+
+        var chunk = RecordChunk(records: [r1], cursor: nil)
+        chunk += RecordChunk(records: [r2], cursor: nil)
+
+        #expect(chunk.records.count == 2)
+        #expect(chunk.records[0].recordType == "X")
+        #expect(chunk.records[1].recordType == "Y")
+    }
+}

--- a/Tests/ScoutTests/Core/Utilities/UserDefaultsUUIDTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/UserDefaultsUUIDTests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct UserDefaultsUUIDTests {
+    let defaults: UserDefaults
+    let prefix: String
+
+    init() {
+        prefix = UUID().uuidString
+        defaults = UserDefaults(suiteName: "UserDefaultsUUIDTests_\(prefix)")!
+    }
+
+    @Test("UUID round-trips through UserDefaults")
+    func roundTrip() {
+        let uuid = UUID()
+        defaults.set(uuid, forKey: "\(prefix)_rt")
+        let result = defaults.uuid(forKey: "\(prefix)_rt")
+        #expect(result == uuid)
+    }
+
+    @Test("Returns nil for missing key")
+    func missingKey() {
+        let result = defaults.uuid(forKey: "\(prefix)_missing")
+        #expect(result == nil)
+    }
+
+    @Test("Returns nil for non-UUID string")
+    func invalidString() {
+        defaults.set("not-a-uuid", forKey: "\(prefix)_bad")
+        let result = defaults.uuid(forKey: "\(prefix)_bad")
+        #expect(result == nil)
+    }
+
+    @Test("Overwrites previous value")
+    func overwrite() {
+        let first = UUID()
+        let second = UUID()
+        let key = "\(prefix)_overwrite"
+
+        defaults.set(first, forKey: key)
+        defaults.set(second, forKey: key)
+
+        #expect(defaults.uuid(forKey: key) == second)
+    }
+}


### PR DESCRIPTION
Add new unit tests under Tests/ScoutTests to validate core behavior: ActivityPeriod (raw values, titles, calendar components, CaseIterable), GridCell combining (mergeDuplicates), PeriodCell key generation/parsing, addition and duplicate detection, RecordChunk concatenation and mutation, and UserDefaults UUID storage/retrieval. Tests import the Testing framework and @testable import Scout to exercise expected encoding, parsing, and combining logic across these utilities and data types.