### PR TITLE
Enable SyncCoordinator retry and fallback tests

### DIFF
--- a/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
@@ -37,19 +37,19 @@ struct SyncCoordinatorTests {
         #expect(database.records.filter { $0.recordType == "DateIntMatrix" }.count == 1)
     }
 
-    @Test("Upload retries and merges on serverRecordChanged error", .disabled())
+    @Test("Upload retries and merges on serverRecordChanged error")
     func testUploadServerRecordChangedMerges() async throws {
-        database.errors.append(createMergeError())
+        database.writeErrors.append(createMergeError())
 
         try await coordinator.upload()
 
         #expect(database.records.filter { $0.recordType == "DateIntMatrix" }.count == 1)
     }
 
-    @Test("Upload falls back to newMatrix after max retries", .disabled())
+    @Test("Upload falls back to newMatrix after max retries")
     func testUploadMaxRetryFallback() async throws {
         for _ in 0..<(coordinator.maxRetry + 1) {
-            database.errors.append(createMergeError())
+            database.writeErrors.append(createMergeError())
         }
         try await coordinator.upload()
 

--- a/Tests/ScoutTests/Transient/InMemoryDatabase.swift
+++ b/Tests/ScoutTests/Transient/InMemoryDatabase.swift
@@ -12,9 +12,10 @@ import CloudKit
 final class InMemoryDatabase: Database {
     var records: [CKRecord] = []
     var errors: [Error] = []
+    var writeErrors: [Error] = []
 
     func write(record: CKRecord) async throws {
-        if let error = errors.popLast() {
+        if let error = writeErrors.popLast() ?? errors.popLast() {
             throw error
         } else {
             records.append(record)
@@ -22,7 +23,7 @@ final class InMemoryDatabase: Database {
     }
 
     func write(records: [CKRecord]) async throws {
-        if let error = errors.popLast() {
+        if let error = writeErrors.popLast() ?? errors.popLast() {
             throw error
         } else {
             self.records += records


### PR DESCRIPTION
## Summary
- Re-enable two disabled tests in `SyncCoordinatorTests`: retry-merge and max-retry fallback
- Add `writeErrors` array to `InMemoryDatabase` so injected errors are only consumed by `write` calls, not `read` calls in `lookupExisting`