### PR TITLE
Remove xcpretty for Swift Testing support

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,4 +19,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run unit tests
-        run: swift test
+        run: |
+          xcodebuild \
+            -scheme Scout \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -enableCodeCoverage YES \
+            test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,25 +10,13 @@ concurrency:
   group: ios-tests-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  SCHEME_NAME: Scout
-
 jobs:
-  ios-tests:
+  tests:
     runs-on: macos-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install xcpretty
-        run: |
-          sudo gem install xcpretty
-
-      - name: Run unit tests (iOS Simulator)
-        run: |
-          set -o pipefail && \
-          xcodebuild \
-            -scheme $SCHEME_NAME \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
-            -enableCodeCoverage YES \
-            test | xcpretty
+      - name: Run unit tests
+        run: swift test


### PR DESCRIPTION
- Remove `xcpretty` which does not understand Swift Testing output and silently filtered out all `@Test`/`@Suite` results, showing only 1 of 100+ tests
- Add `timeout-minutes: 20` to guard against hanging test runs