### PR TITLE
Add separate build step to CI workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,6 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Build
+        run: |
+          xcodebuild \
+            -scheme Scout \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            build
+
       - name: Run unit tests
         run: |
           xcodebuild \


### PR DESCRIPTION
- Add a dedicated build step before tests so compilation errors are clearly separated from test failures in GitHub Actions UI