### PR TITLE
Pin runner image to macos-15

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 20
 
     steps:


### PR DESCRIPTION
- Replace `macos-latest` with `macos-15` to prevent unexpected breakage when the latest alias moves to a newer major macOS version