### PR TITLE
Implement array and dictionary metadata conversion

### DIFF
--- a/Sources/Scout/Core/Log/Log.swift
+++ b/Sources/Scout/Core/Log/Log.swift
@@ -36,16 +36,16 @@ extension Logger.MetadataValue {
     fileprivate var stringValue: String? {
         switch self {
         case .string(let string):
-            return string
+            string
         case .stringConvertible(let convertible):
-            return convertible.description
+            convertible.description
         case .array(let array):
-            return array.compactMap(\.stringValue).joined(separator: ", ")
+            array.compactMap(\.stringValue).joined(separator: ", ")
         case .dictionary(let dictionary):
-            let pairs = dictionary.compactMapValues(\.stringValue)
+            dictionary.compactMapValues(\.stringValue)
                 .sorted(by: { $0.key < $1.key })
                 .map { "\($0.key): \($0.value)" }
-            return pairs.joined(separator: ", ")
+                .joined(separator: ", ")
         }
     }
 }

--- a/Sources/Scout/Core/Log/Log.swift
+++ b/Sources/Scout/Core/Log/Log.swift
@@ -39,10 +39,13 @@ extension Logger.MetadataValue {
             return string
         case .stringConvertible(let convertible):
             return convertible.description
-        case .array:
-            return nil  // TODO: Implement array conversion
-        case .dictionary:
-            return nil  // TODO: Implement dictionary conversion
+        case .array(let array):
+            return array.compactMap(\.stringValue).joined(separator: ", ")
+        case .dictionary(let dictionary):
+            let pairs = dictionary.compactMapValues(\.stringValue)
+                .sorted(by: { $0.key < $1.key })
+                .map { "\($0.key): \($0.value)" }
+            return pairs.joined(separator: ", ")
         }
     }
 }

--- a/Tests/ScoutTests/Core/Log/LogTest.swift
+++ b/Tests/ScoutTests/Core/Log/LogTest.swift
@@ -45,3 +45,56 @@ import Testing
 
     #expect(params["key"] == "value")
 }
+
+@MainActor
+@Test("Logging an event with array metadata") func testLogArrayMetadata() throws {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let metadata: Logger.Metadata = [
+        "tags": .array([.string("a"), .string("b"), .string("c")])
+    ]
+
+    try log("Array Event", level: .info, metadata: metadata, date: Date(), context: context)
+
+    let events = try context.fetch(EventObject.fetchRequest())
+    let paramData = try #require(events.first?.params)
+    let params = try JSONDecoder().decode([String: String].self, from: paramData)
+
+    #expect(params["tags"] == "a, b, c")
+}
+
+@MainActor
+@Test("Logging an event with dictionary metadata") func testLogDictionaryMetadata() throws {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let metadata: Logger.Metadata = [
+        "user": .dictionary(["name": .string("Alice"), "role": .string("admin")])
+    ]
+
+    try log("Dict Event", level: .info, metadata: metadata, date: Date(), context: context)
+
+    let events = try context.fetch(EventObject.fetchRequest())
+    let paramData = try #require(events.first?.params)
+    let params = try JSONDecoder().decode([String: String].self, from: paramData)
+
+    #expect(params["user"] == "name: Alice, role: admin")
+}
+
+@MainActor
+@Test("Logging an event with nested metadata") func testLogNestedMetadata() throws {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let metadata: Logger.Metadata = [
+        "simple": .string("value"),
+        "list": .array([.string("x"), .stringConvertible(42)]),
+        "map": .dictionary(["key": .string("val")]),
+    ]
+
+    try log("Mixed Event", level: .info, metadata: metadata, date: Date(), context: context)
+
+    let events = try context.fetch(EventObject.fetchRequest())
+    let paramData = try #require(events.first?.params)
+    let params = try JSONDecoder().decode([String: String].self, from: paramData)
+
+    #expect(params["simple"] == "value")
+    #expect(params["list"] == "x, 42")
+    #expect(params["map"] == "key: val")
+    #expect(events.first?.paramCount == 3)
+}


### PR DESCRIPTION
- Convert array metadata values to comma-separated strings (e.g. `"a, b, c"`)
- Convert dictionary metadata values to sorted key-value pairs (e.g. `"name: Alice, role: admin"`)
- Previously both types were silently dropped, losing metadata with complex values
- Add tests for array, dictionary, and mixed metadata scenarios