### PR TITLE
Download iOS simulator runtime if unavailable

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Prepare simulator
+        run: |
+          if ! xcrun simctl list devices available | grep -q "iPhone"; then
+            xcodebuild -downloadPlatform iOS
+          fi
+
       - name: Build
         run: |
           xcodebuild \


### PR DESCRIPTION
- CI fails because the `macos-15` runner sometimes has no iOS simulator runtime installed
- Add a `Prepare simulator` step that downloads the iOS platform when no iPhone simulator is available