### PR TITLE
Use build-for-testing and test-without-building

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,7 +29,7 @@ jobs:
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=iPhone 16' \
-            build
+            build-for-testing
 
       - name: Run unit tests
         run: |
@@ -37,4 +37,4 @@ jobs:
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=iPhone 16' \
             -enableCodeCoverage YES \
-            test
+            test-without-building


### PR DESCRIPTION
- Replace `build` + `test` with `build-for-testing` + `test-without-building` to avoid compiling the project twice