### PR TITLE
Remove unused CloudKit imports

### DIFF
--- a/Sources/Scout/Core/Listener/NotificationListener.swift
+++ b/Sources/Scout/Core/Listener/NotificationListener.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import CoreData
 import UIKit
 

--- a/Sources/Scout/Core/Log/LogHandler.swift
+++ b/Sources/Scout/Core/Log/LogHandler.swift
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
+import Foundation
 import Logging
 
 struct CKLogHandler: LogHandler {

--- a/Sources/Scout/UI/Home/StatView.swift
+++ b/Sources/Scout/UI/Home/StatView.swift
@@ -6,7 +6,6 @@
 // https://opensource.org/licenses/MIT.
 
 import Charts
-import CloudKit
 import SwiftUI
 
 struct StatView: View {


### PR DESCRIPTION
- Remove unused `import CloudKit` from StatView, NotificationListener, and LogHandler
- Add `import Foundation` to LogHandler for `Date` usage