### PR TITLE
Reorder Calendar.utc property assignments

### DIFF
--- a/Sources/Scout/Core/Utilities/Calendar+UTC.swift
+++ b/Sources/Scout/Core/Utilities/Calendar+UTC.swift
@@ -10,8 +10,8 @@ import Foundation
 extension Calendar {
     static var utc: Calendar {
         var calendar = Calendar(identifier: .iso8601)
-        calendar.firstWeekday = 1
         calendar.timeZone = TimeZone(identifier: "UTC")!
+        calendar.firstWeekday = 1
         return calendar
     }
 }


### PR DESCRIPTION
- Set timeZone before firstWeekday in Calendar.utc for clarity