### PR TITLE
Add crash browsing UI and data models

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ HomeView(container: container)
 ```
 > This should be done only in debug mode to avoid exposing sensitive log data in production environments.
 
-| | | |
-| ------------- | ------------- | ------------- |
-| ![](https://github.com/user-attachments/assets/a7cf7126-d995-4fa8-a148-20670b1260f6)  | ![](https://github.com/user-attachments/assets/c84c0051-5dea-4669-9bd1-bc9bb9f7d321)  | ![](https://github.com/user-attachments/assets/2e88e5c2-11ef-4fa5-bdb1-9217ca8d869a)  |
+<img width="200" src="https://github.com/user-attachments/assets/a7cf7126-d995-4fa8-a148-20670b1260f6"> <img width="200" src="https://github.com/user-attachments/assets/c84c0051-5dea-4669-9bd1-bc9bb9f7d321"> <img width="200" src="https://github.com/user-attachments/assets/2e88e5c2-11ef-4fa5-bdb1-9217ca8d869a"> <img width="200" src="https://github.com/user-attachments/assets/52c03cd6-fb3a-43cf-a58c-ab82ff2ca47e">
 
 ## Example Project
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ HomeView(container: container)
 ```
 > This should be done only in debug mode to avoid exposing sensitive log data in production environments.
 
-<img width="200" src="https://github.com/user-attachments/assets/a7cf7126-d995-4fa8-a148-20670b1260f6"> <img width="200" src="https://github.com/user-attachments/assets/c84c0051-5dea-4669-9bd1-bc9bb9f7d321"> <img width="200" src="https://github.com/user-attachments/assets/2e88e5c2-11ef-4fa5-bdb1-9217ca8d869a"> <img width="200" src="https://github.com/user-attachments/assets/52c03cd6-fb3a-43cf-a58c-ab82ff2ca47e">
+<img width="200" src="https://github.com/user-attachments/assets/0987c808-6d08-4e99-8ca7-1218d352e0bf"> <img width="200" src="https://github.com/user-attachments/assets/a70ae4d9-3680-48d3-8129-2febdc466030"> <img width="200" src="https://github.com/user-attachments/assets/6043911e-fd0b-4f6e-9785-c262dab1c6d7"> <img width="200" src="https://github.com/user-attachments/assets/52c03cd6-fb3a-43cf-a58c-ab82ff2ca47e">
 
 ## Example Project
 

--- a/Sources/Scout/UI/Controls/UTCDateFormatter.swift
+++ b/Sources/Scout/UI/Controls/UTCDateFormatter.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+/// A shared UTC date formatter used across detail views.
+let utcDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "dd.MM.y, HH:mm"
+    return formatter
+}()

--- a/Sources/Scout/UI/Crash/Crash+Sample.swift
+++ b/Sources/Scout/UI/Crash/Crash+Sample.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+extension Crash {
+    static var sampleRecords: [CKRecord] {
+        let crashes: [(name: String, reason: String?)] = [
+            ("NSInternalInconsistencyException", "Invalid update: invalid number of rows"),
+            ("SIGSEGV", nil),
+            ("NSRangeException", "Index 5 beyond bounds [0 .. 3]"),
+            ("EXC_BAD_ACCESS", "Attempted to dereference garbage pointer"),
+            ("NSInvalidArgumentException", "Unrecognized selector sent to instance"),
+            ("SIGABRT", "Abort trap 6"),
+        ]
+
+        return crashes.enumerated().map { index, crash in
+            let record = CKRecord(recordType: "Crash", recordID: CKRecord.ID())
+            record["name"] = crash.name
+            record["reason"] = crash.reason
+            record["date"] = Date().addingTimeInterval(TimeInterval(-index * 7200))
+            record["uuid"] = UUID().uuidString
+            record["user_id"] = UUID().uuidString
+            record["launch_id"] = UUID().uuidString
+
+            let stackTrace = [
+                "0   CoreFoundation    0x00000001a3b8f4e0 __exceptionPreprocess + 220",
+                "1   libobjc.A.dylib   0x00000001a38a5a70 objc_exception_throw + 60",
+                "2   CoreFoundation    0x00000001a3c9e7d0 -[__NSArrayM objectAtIndexedSubscript:] + 228",
+                "3   MyApp             0x0000000104a8c3e0 ViewController.viewDidLoad() + 120",
+                "4   UIKitCore         0x00000001a7d4e2b0 -[UIViewController _sendViewDidLoadWithAppearanceProxyObjectTaggingEnabled] + 100",
+            ]
+            record["stack_trace"] = try! JSONEncoder().encode(stackTrace) as CKRecordValue
+
+            return record
+        }
+    }
+}

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -1,0 +1,90 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct CrashDetailView: View {
+    let crash: Crash
+
+    @EnvironmentObject var tint: Tint
+
+    var body: some View {
+        List {
+            headerSection
+
+//            if let reason = crash.reason {
+//                reasonSection(reason)
+//            }
+
+            if !crash.stackTrace.isEmpty {
+                stackTraceSection
+            }
+        }
+        .onAppear {
+            tint.value = .red
+        }
+        .onDisappear {
+            tint.value = nil
+        }
+        .listStyle(.plain)
+        .toolbarBackground(Color.red.opacity(0.12), for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .navigationTitle(crash.name)
+    }
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let date = crash.date {
+                Text(utcDateFormatter.string(from: date) + " UTC")
+                    .font(.system(size: 16))
+                    .monospaced()
+            }
+
+            if let reason = crash.reason {
+                Text("REASON:   ").fontWeight(.bold)
+                + Text(reason).fontWeight(.bold).foregroundColor(.red)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var stackTraceSection: some View {
+        Header(title: "Stack Trace")
+
+        ForEach(Array(crash.stackTrace.enumerated()), id: \.offset) { _, frame in
+            Text(frame)
+                .font(.system(size: 12))
+                .monospaced()
+                .lineLimit(2)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    NavigationStack {
+        CrashDetailView(
+            crash: Crash(
+                name: "NSRangeException",
+                reason: "Index 5 beyond bounds [0 .. 3]",
+                stackTrace: [
+                    "0   CoreFoundation    0x00000001a3b8f4e0 __exceptionPreprocess + 220",
+                    "1   libobjc.A.dylib   0x00000001a38a5a70 objc_exception_throw + 60",
+                    "2   CoreFoundation    0x00000001a3c9e7d0 -[__NSArrayM objectAtIndexedSubscript:] + 228",
+                    "3   MyApp             0x0000000104a8c3e0 ViewController.viewDidLoad() + 120",
+                ],
+                date: Date(),
+                id: .init(),
+                userID: UUID(),
+                launchID: UUID()
+            )
+        )
+    }
+    .environmentObject(Tint())
+}

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -1,0 +1,84 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import SwiftUI
+
+struct CrashListView: View {
+    @Environment(\.database) var database
+    @StateObject private var provider = CrashProvider()
+
+    var body: some View {
+        Group {
+            if let crashes = provider.crashes {
+                if crashes.isEmpty {
+                    Placeholder(text: "No crashes").frame(maxHeight: .infinity)
+                } else {
+                    List {
+                        ForEach(crashes, content: row)
+
+                        if let cursor = provider.cursor {
+                            ProgressView()
+                                .task {
+                                    await provider.fetchMore(cursor: cursor, in: database)
+                                }
+                                .id(UUID())
+                                .frame(height: 72)
+                                .frame(maxWidth: .infinity)
+                                .listRowSeparator(.hidden, edges: .bottom)
+                        }
+                    }
+                    .listStyle(.plain)
+                    .animation(nil, value: UUID())
+                }
+            } else {
+                ProgressView().frame(maxHeight: .infinity)
+            }
+        }
+        .navigationTitle("Crashes")
+        .task {
+            await provider.fetch(in: database)
+        }
+    }
+
+    private func row(for crash: Crash) -> some View {
+        ZStack {
+            HStack(spacing: 12) {
+                Text(crash.name)
+                    .font(.system(size: 17))
+                    .lineLimit(1)
+                    .monospaced()
+
+                Spacer()
+
+                if let date = crash.date {
+                    Text(date, style: .relative)
+                        .font(.system(size: 15))
+                        .foregroundStyle(Color.gray)
+                }
+            }
+
+            NavigationLink {
+                CrashDetailView(crash: crash)
+            } label: {
+                EmptyView()
+            }
+            .opacity(0)
+        }
+        .alignmentGuide(.listRowSeparatorTrailing) { dimension in
+            dimension[.trailing]
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    NavigationStack {
+        CrashListView()
+    }
+}

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import SwiftUI
+
+@MainActor
+class CrashProvider: ObservableObject {
+    @Published var crashes: [Crash]?
+    @Published var cursor: CKQueryOperation.Cursor?
+
+    func fetch(in database: AppDatabase) async {
+        do {
+            let query = CKQuery(recordType: "Crash", predicate: Self.predicate)
+            query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+
+            let results = try await database.read(
+                matching: query,
+                fields: Crash.desiredKeys
+            )
+
+            self.cursor = results.cursor
+            self.crashes = try results.records.map(Crash.init)
+        } catch {
+            self.crashes = []
+        }
+    }
+
+    func fetchMore(cursor: CKQueryOperation.Cursor, in database: AppDatabase) async {
+        do {
+            let results = try await database.readMore(
+                from: cursor,
+                fields: nil
+            )
+
+            self.cursor = results.cursor
+            self.crashes?.append(contentsOf: try results.records.map(Crash.init))
+        } catch {
+            // Keep existing data on pagination failure
+        }
+    }
+
+    private static var predicate: NSPredicate {
+        let dateRange = Calendar.utc.defaultRange
+
+        return NSPredicate(
+            format: "date >= %@ AND date < %@",
+            dateRange.lowerBound as NSDate,
+            dateRange.upperBound as NSDate
+        )
+    }
+}

--- a/Sources/Scout/UI/Crash/CrashRecord.swift
+++ b/Sources/Scout/UI/Crash/CrashRecord.swift
@@ -1,0 +1,51 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+struct Crash: Identifiable {
+    let name: String
+    let reason: String?
+    let stackTrace: [String]
+    let date: Date?
+    let id: CKRecord.ID
+    let userID: UUID?
+    let launchID: UUID?
+}
+
+extension Crash {
+    static let desiredKeys = [
+        "name",
+        "reason",
+        "stack_trace",
+        "date",
+        "uuid",
+        "user_id",
+        "launch_id",
+    ]
+}
+
+extension Crash {
+    init(results: (CKRecord.ID, Result<CKRecord, Error>)) throws {
+        try self.init(record: results.1.get())
+    }
+
+    init(record: CKRecord) throws {
+        name = record["name"] ?? ""
+        reason = record["reason"]
+        date = record["date"]
+        id = record.recordID
+        userID = record["user_id"].flatMap(UUID.init)
+        launchID = record["launch_id"].flatMap(UUID.init)
+
+        if let data = record["stack_trace"] as? Data, let decoded = try? JSONDecoder().decode([String].self, from: data) {
+            stackTrace = decoded
+        } else {
+            stackTrace = []
+        }
+    }
+}

--- a/Sources/Scout/UI/Database/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/DefaultDatabase.swift
@@ -9,7 +9,11 @@ import CloudKit
 
 struct DefaultDatabase: AppDatabase {
     func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
-        RecordChunk(records: Event.sampleRecords, cursor: nil)
+        let records = query.recordType == "Crash"
+            ? Crash.sampleRecords
+            : Event.sampleRecords
+
+        return RecordChunk(records: records, cursor: nil)
     }
 
     func readMore(from cursor: CKQueryOperation.Cursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {

--- a/Sources/Scout/UI/Database/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/DefaultDatabase.swift
@@ -9,16 +9,9 @@ import CloudKit
 
 struct DefaultDatabase: AppDatabase {
     func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
-        let records: [CKRecord]
-
-        switch query.recordType {
-        case "Crash":
-            records = Crash.sampleRecords
-        case "DateIntMatrix":
-            records = Self.sampleMatrixRecords
-        default:
-            records = Event.sampleRecords
-        }
+        let records = query.recordType == "Crash"
+            ? Crash.sampleRecords
+            : Event.sampleRecords
 
         return RecordChunk(records: records, cursor: nil)
     }
@@ -29,30 +22,5 @@ struct DefaultDatabase: AppDatabase {
 
     func lookup(id: CKRecord.ID) async throws -> CKRecord {
         Event.sampleRecords.randomElement()!
-    }
-
-    // MARK: - Sample Matrix Records
-
-    private static var sampleMatrixRecords: [CKRecord] {
-        let calendar = Calendar.utc
-        let today = Date().startOfDay
-
-        return (-52...0).compactMap { weekOffset in
-            guard let weekStart = calendar.date(byAdding: .weekOfYear, value: weekOffset, to: today) else {
-                return nil
-            }
-
-            let record = CKRecord(recordType: "DateIntMatrix")
-            record["date"] = weekStart
-            record["name"] = "event_name"
-
-            for day in 1...7 {
-                let count = Int.random(in: 1...10)
-                let hour = Int.random(in: 8...18)
-                record["cell_\(day)_\(String(format: "%02d", hour))"] = count
-            }
-
-            return record
-        }
     }
 }

--- a/Sources/Scout/UI/Database/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/DefaultDatabase.swift
@@ -9,9 +9,16 @@ import CloudKit
 
 struct DefaultDatabase: AppDatabase {
     func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
-        let records = query.recordType == "Crash"
-            ? Crash.sampleRecords
-            : Event.sampleRecords
+        let records: [CKRecord]
+
+        switch query.recordType {
+        case "Crash":
+            records = Crash.sampleRecords
+        case "DateIntMatrix":
+            records = Self.sampleMatrixRecords
+        default:
+            records = Event.sampleRecords
+        }
 
         return RecordChunk(records: records, cursor: nil)
     }
@@ -22,5 +29,30 @@ struct DefaultDatabase: AppDatabase {
 
     func lookup(id: CKRecord.ID) async throws -> CKRecord {
         Event.sampleRecords.randomElement()!
+    }
+
+    // MARK: - Sample Matrix Records
+
+    private static var sampleMatrixRecords: [CKRecord] {
+        let calendar = Calendar.utc
+        let today = Date().startOfDay
+
+        return (-52...0).compactMap { weekOffset in
+            guard let weekStart = calendar.date(byAdding: .weekOfYear, value: weekOffset, to: today) else {
+                return nil
+            }
+
+            let record = CKRecord(recordType: "DateIntMatrix")
+            record["date"] = weekStart
+            record["name"] = "event_name"
+
+            for day in 1...7 {
+                let count = Int.random(in: 1...10)
+                let hour = Int.random(in: 8...18)
+                record["cell_\(day)_\(String(format: "%02d", hour))"] = count
+            }
+
+            return record
+        }
     }
 }

--- a/Sources/Scout/UI/Event/EventView.swift
+++ b/Sources/Scout/UI/Event/EventView.swift
@@ -45,20 +45,13 @@ struct EventView: View {
 // MARK: - Header
 
 extension EventView {
-    static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "dd.MM.y, HH:mm"
-        return formatter
-    }()
-
     struct EventHeader: View {
         let event: Event
 
         var body: some View {
             VStack(alignment: .leading) {
                 if let date = event.date {
-                    Text(dateFormatter.string(from: date) + " UTC")
+                    Text(utcDateFormatter.string(from: date) + " UTC")
                         .font(.system(size: 16))
                         .monospaced()
                 }

--- a/Sources/Scout/UI/Home/HomeView.Sections.swift
+++ b/Sources/Scout/UI/Home/HomeView.Sections.swift
@@ -75,4 +75,18 @@ extension HomeView {
             }
         }
     }
+
+    struct CrashSection: View {
+        var body: some View {
+            Header(title: "Crashes")
+
+            Row {
+                Text("All Crashes")
+                Spacer()
+            } destination: {
+                CrashListView()
+            }
+            .foregroundStyle(.red)
+        }
+    }
 }

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -24,6 +24,7 @@ public struct HomeView: View {
                 LogSection()
                 ActivitySection()
                 SessionSection()
+                CrashSection()
             }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {


### PR DESCRIPTION
- Add CrashListView with paginated loading and CrashDetailView with stack trace display
- Add Crash model, CrashProvider for CloudKit queries, and sample data for previews
- Add CrashSection to HomeView for navigating to the crash list
- Extract shared UTC date formatter into a reusable utility