### PR TITLE
Enrich sample data for previews

### DIFF
--- a/Sources/Scout/UI/Chart/ChartPoint.swift
+++ b/Sources/Scout/UI/Chart/ChartPoint.swift
@@ -53,9 +53,9 @@ extension [ChartPoint<Int>] {
 
     static var sample: Self {
         let end = Date()
-        return (1...30).compactMap { i in
-            Calendar.utc.date(byAdding: .day, value: -i, to: end).map {
-                ChartPoint(date: $0, count: .random(in: 0...10))
+        return (0..<168).compactMap { i in
+            Calendar.utc.date(byAdding: .hour, value: -i, to: end).map {
+                ChartPoint(date: $0, count: .random(in: 0...20))
             }
         }
         .sorted()

--- a/Sources/Scout/UI/Database/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/DefaultDatabase.swift
@@ -9,7 +9,16 @@ import CloudKit
 
 struct DefaultDatabase: AppDatabase {
     func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
-        RecordChunk(records: Event.sampleRecords, cursor: nil)
+        let records: [CKRecord]
+
+        switch query.recordType {
+        case "DateIntMatrix":
+            records = Self.sampleMatrixRecords
+        default:
+            records = Event.sampleRecords
+        }
+
+        return RecordChunk(records: records, cursor: nil)
     }
 
     func readMore(from cursor: CKQueryOperation.Cursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
@@ -18,5 +27,30 @@ struct DefaultDatabase: AppDatabase {
 
     func lookup(id: CKRecord.ID) async throws -> CKRecord {
         Event.sampleRecords.randomElement()!
+    }
+
+    // MARK: - Sample Matrix Records
+
+    private static var sampleMatrixRecords: [CKRecord] {
+        let calendar = Calendar.utc
+        let today = Date().startOfDay
+
+        return (-52...0).compactMap { weekOffset in
+            guard let weekStart = calendar.date(byAdding: .weekOfYear, value: weekOffset, to: today) else {
+                return nil
+            }
+
+            let record = CKRecord(recordType: "DateIntMatrix")
+            record["date"] = weekStart
+            record["name"] = "event_name"
+
+            for day in 1...7 {
+                for hour in stride(from: 8, through: 20, by: 2) {
+                    record["cell_\(day)_\(String(format: "%02d", hour))"] = Int.random(in: 1...15)
+                }
+            }
+
+            return record
+        }
     }
 }


### PR DESCRIPTION
- Add hourly chart points (168 hours) instead of daily (30 days) for richer MetricsView previews
- Add DateIntMatrix sample records to DefaultDatabase for EventView Stats section
- Route queries by record type in DefaultDatabase read method