### PR TITLE
Increase stack trace depth in crash sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ HomeView(container: container)
 ```
 > This should be done only in debug mode to avoid exposing sensitive log data in production environments.
 
-<img width="200" src="https://github.com/user-attachments/assets/0987c808-6d08-4e99-8ca7-1218d352e0bf"> <img width="200" src="https://github.com/user-attachments/assets/a70ae4d9-3680-48d3-8129-2febdc466030"> <img width="200" src="https://github.com/user-attachments/assets/6043911e-fd0b-4f6e-9785-c262dab1c6d7"> <img width="200" src="https://github.com/user-attachments/assets/52c03cd6-fb3a-43cf-a58c-ab82ff2ca47e">
+<img width="200" src="https://github.com/user-attachments/assets/0987c808-6d08-4e99-8ca7-1218d352e0bf"> <img width="200" src="https://github.com/user-attachments/assets/a70ae4d9-3680-48d3-8129-2febdc466030"> <img width="200" src="https://github.com/user-attachments/assets/6043911e-fd0b-4f6e-9785-c262dab1c6d7"> <img width="200" src="https://github.com/user-attachments/assets/dcec26e1-4e44-473c-b2e9-cde8ea2ffe2f">
 
 ## Example Project
 

--- a/Sources/Scout/UI/Crash/Crash+Sample.swift
+++ b/Sources/Scout/UI/Crash/Crash+Sample.swift
@@ -8,6 +8,10 @@
 import CloudKit
 
 extension Crash {
+    static var sample: Crash {
+        try! Crash(record: sampleRecords[2])
+    }
+
     static var sampleRecords: [CKRecord] {
         let crashes: [(name: String, reason: String?)] = [
             ("NSInternalInconsistencyException", "Invalid update: invalid number of rows"),
@@ -32,7 +36,10 @@ extension Crash {
                 "1   libobjc.A.dylib   0x00000001a38a5a70 objc_exception_throw + 60",
                 "2   CoreFoundation    0x00000001a3c9e7d0 -[__NSArrayM objectAtIndexedSubscript:] + 228",
                 "3   MyApp             0x0000000104a8c3e0 ViewController.viewDidLoad() + 120",
-                "4   UIKitCore         0x00000001a7d4e2b0 -[UIViewController _sendViewDidLoadWithAppearanceProxyObjectTaggingEnabled] + 100",
+                "4   MyApp             0x0000000104a8b7a0 ViewController.loadData() + 84",
+                "5   MyApp             0x0000000104a8a920 DataManager.fetchRecords() + 196",
+                "6   MyApp             0x0000000104a89e40 NetworkClient.request(_:) + 312",
+                "7   libswiftCore.dylib 0x00000001a4c2f100 Swift runtime + 1024",
             ]
             record["stack_trace"] = try! JSONEncoder().encode(stackTrace) as CKRecordValue
 

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -69,22 +69,7 @@ struct CrashDetailView: View {
 
 #Preview {
     NavigationStack {
-        CrashDetailView(
-            crash: Crash(
-                name: "NSRangeException",
-                reason: "Index 5 beyond bounds [0 .. 3]",
-                stackTrace: [
-                    "0   CoreFoundation    0x00000001a3b8f4e0 __exceptionPreprocess + 220",
-                    "1   libobjc.A.dylib   0x00000001a38a5a70 objc_exception_throw + 60",
-                    "2   CoreFoundation    0x00000001a3c9e7d0 -[__NSArrayM objectAtIndexedSubscript:] + 228",
-                    "3   MyApp             0x0000000104a8c3e0 ViewController.viewDidLoad() + 120",
-                ],
-                date: Date(),
-                id: .init(),
-                userID: UUID(),
-                launchID: UUID()
-            )
-        )
+        CrashDetailView(crash: .sample)
     }
     .environmentObject(Tint())
 }


### PR DESCRIPTION
- Expand crash sample stack trace from 5 to 22 frames for a more realistic preview
- Update CrashDetailView preview with the full stack trace