### PR TITLE
Skip CI for non-code changes

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -3,8 +3,18 @@ name: Swift
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'Sources/**'
+      - 'Tests/**'
+      - 'Package.swift'
+      - '.github/workflows/swift.yml'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'Sources/**'
+      - 'Tests/**'
+      - 'Package.swift'
+      - '.github/workflows/swift.yml'
 
 concurrency:
   group: ios-tests-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
- Add path filters to push and pull_request triggers
- CI runs only when Sources/, Tests/, Package.swift, or the workflow itself changes
- Changes to README, LICENSE, docs, etc. no longer trigger builds