### PR TITLE
Add CloudKit schema verification on startup

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+struct SchemaError: LocalizedError {
+    let recordTypes: [String]
+
+    var errorDescription: String? {
+        let list = recordTypes.joined(separator: ", ")
+        return "CloudKit schema is outdated. Missing record types: \(list). Run upload-schema.sh to fix."
+    }
+}
+
+private let schemaRecordTypes = [
+    "Event", "Session", "Crash",
+    "DateIntMatrix", "DateDoubleMatrix", "PeriodMatrix",
+]
+
+extension CKContainer {
+
+    /// Queries each record type to verify the CloudKit schema is up to date.
+    /// Throws a `SchemaError` if any record types have schema issues.
+    ///
+    func verifySchema() async throws {
+        guard let status = try? await accountStatus(), status == .available else {
+            return
+        }
+
+        var invalid: [String] = []
+
+        for recordType in schemaRecordTypes {
+            let query = CKQuery(recordType: recordType, predicate: NSPredicate(value: true))
+
+            do {
+                _ = try await publicCloudDatabase.records(matching: query, resultsLimit: 1)
+            } catch let error as CKError where error.isSchemaError {
+                print("[Scout] Schema error for '\(recordType)': \(error.localizedDescription)")
+                invalid.append(recordType)
+            }
+        }
+
+        if !invalid.isEmpty {
+            let containerID = containerIdentifier ?? "<container-id>"
+
+            print("[Scout] Upload the schema to your CloudKit container using: ./upload-schema.sh <team-id> \(containerID)")
+            print("[Scout] For details, see INSTALLATION.md")
+
+            throw SchemaError(recordTypes: invalid)
+        }
+    }
+}

--- a/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2025 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+extension CKError {
+
+    /// Returns `true` when the error indicates the CloudKit schema
+    /// is missing or outdated (e.g. unknown record type, missing indexes).
+    var isSchemaError: Bool {
+        switch code {
+        case .invalidArguments, .serverRejectedRequest:
+            let message = localizedDescription.lowercased()
+            return message.contains("record type")
+                || message.contains("field")
+                || message.contains("not marked queryable")
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -37,4 +37,6 @@ public func setup(container: CKContainer) async throws {
     SyncController.shared.container = container
     LoggingSystem.bootstrap(CKLogHandler.init)
     MetricsSystem.bootstrap(TelemetryFactory())
+
+    try await container.verifySchema()
 }

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -12,6 +12,7 @@ public struct HomeView: View {
     let container: CKContainer
 
     @StateObject private var tint = Tint()
+    @State private var schemaError: SchemaError?
     @Environment(\.dismiss) var dismiss
 
     public init(container: CKContainer) {
@@ -20,11 +21,21 @@ public struct HomeView: View {
 
     public var body: some View {
         NavigationStack {
-            List {
-                LogSection()
-                ActivitySection()
-                SessionSection()
-                CrashSection()
+            Group {
+                if let schemaError {
+                    ErrorView(
+                        error: schemaError,
+                        retry: { Task { await self.verify() } }
+                    )
+                } else {
+                    List {
+                        LogSection()
+                        ActivitySection()
+                        SessionSection()
+                        CrashSection()
+                    }
+                    .listStyle(.plain)
+                }
             }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -33,11 +44,32 @@ public struct HomeView: View {
                     }
                 }
             }
-            .listStyle(.plain)
             .navigationBarTitle("Home")
+        }
+        .task {
+            await verify()
         }
         .tint(tint.value)
         .environmentObject(tint)
         .environment(\.database, container.publicCloudDatabase)
     }
+
+    private func verify() async {
+        do {
+            try await container.verifySchema()
+            schemaError = nil
+        } catch let error as SchemaError {
+            schemaError = error
+        } catch {
+            // Ignore other errors (network, auth, etc.)
+        }
+    }
 }
+
+#Preview("Schema Error") {
+    ErrorView(
+        error: SchemaError(recordTypes: ["Crash", "PeriodMatrix"]),
+        retry: {}
+    )
+}
+

--- a/Tests/ScoutTests/Core/Bootstrap/SchemaErrorTests.swift
+++ b/Tests/ScoutTests/Core/Bootstrap/SchemaErrorTests.swift
@@ -1,0 +1,82 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Testing
+
+@testable import Scout
+
+@Suite("CKError.isSchemaError")
+struct SchemaErrorTests {
+
+    // MARK: - Matching codes with schema messages
+
+    @Test("invalidArguments with 'record type' message")
+    func invalidArgumentsRecordType() {
+        let error = makeCKError(code: .invalidArguments, message: "Invalid record type 'Foo'")
+        #expect(error.isSchemaError)
+    }
+
+    @Test("invalidArguments with 'field' message")
+    func invalidArgumentsField() {
+        let error = makeCKError(code: .invalidArguments, message: "Unknown field 'bar'")
+        #expect(error.isSchemaError)
+    }
+
+    @Test("serverRejectedRequest with 'not marked queryable' message")
+    func serverRejectedQueryable() {
+        let error = makeCKError(code: .serverRejectedRequest, message: "Field is not marked queryable")
+        #expect(error.isSchemaError)
+    }
+
+    // MARK: - Matching codes without schema messages
+
+    @Test("invalidArguments with unrelated message")
+    func invalidArgumentsUnrelated() {
+        let error = makeCKError(code: .invalidArguments, message: "Bad predicate format")
+        #expect(!error.isSchemaError)
+    }
+
+    @Test("serverRejectedRequest with unrelated message")
+    func serverRejectedUnrelated() {
+        let error = makeCKError(code: .serverRejectedRequest, message: "Rate limit exceeded")
+        #expect(!error.isSchemaError)
+    }
+
+    // MARK: - Non-matching codes
+
+    @Test("networkFailure is not a schema error")
+    func networkFailure() {
+        let error = makeCKError(code: .networkFailure, message: "record type should not match")
+        #expect(!error.isSchemaError)
+    }
+
+    @Test("networkUnavailable is not a schema error")
+    func networkUnavailable() {
+        let error = makeCKError(code: .networkUnavailable, message: "field should not match")
+        #expect(!error.isSchemaError)
+    }
+
+    // MARK: - Case insensitivity
+
+    @Test("message matching is case-insensitive")
+    func caseInsensitive() {
+        let error = makeCKError(code: .invalidArguments, message: "Unknown RECORD TYPE 'Foo'")
+        #expect(error.isSchemaError)
+    }
+
+    // MARK: - Helper
+
+    private func makeCKError(code: CKError.Code, message: String) -> CKError {
+        let nsError = NSError(
+            domain: CKErrorDomain,
+            code: code.rawValue,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+        return CKError(_nsError: nsError)
+    }
+}


### PR DESCRIPTION
Verify that required record types exist in the CloudKit container during setup and in HomeView, showing an error screen with retry when the schema is outdated.