### PR TITLE
Extract QueryProvider base class from duplicate providers

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -6,31 +6,23 @@
 // https://opensource.org/licenses/MIT.
 
 import CloudKit
-import SwiftUI
 
-class ActivityProvider: ObservableObject, Provider {
-    @Published var result: ProviderResult<[ActivityMatrix]>?
+class ActivityProvider: QueryProvider<ActivityMatrix> {
+    init() {
+        super.init {
+            let dateRange = Calendar.utc.defaultRange
 
-    func fetch(in database: AppDatabase) async throws -> Output {
-        try await database
-            .readAll(matching: query, fields: nil)
-            .map(ActivityMatrix.init)
-            .mergeDuplicates()
-    }
+            let predicate = NSPredicate(
+                format: "date >= %@ AND date < %@ AND name == %@",
+                dateRange.lowerBound as NSDate,
+                dateRange.upperBound as NSDate,
+                "ActiveUser"
+            )
 
-    private var query: CKQuery {
-        let dateRange = Calendar.utc.defaultRange
-
-        let predicate = NSPredicate(
-            format: "date >= %@ AND date < %@ AND name == %@",
-            dateRange.lowerBound as NSDate,
-            dateRange.upperBound as NSDate,
-            "ActiveUser"
-        )
-
-        return CKQuery(
-            recordType: "PeriodMatrix",
-            predicate: predicate
-        )
+            return CKQuery(
+                recordType: "PeriodMatrix",
+                predicate: predicate
+            )
+        }
     }
 }

--- a/Sources/Scout/UI/Home/StatProvider.swift
+++ b/Sources/Scout/UI/Home/StatProvider.swift
@@ -7,36 +7,27 @@
 
 import CloudKit
 
-class StatProvider: ObservableObject, Provider {
-    @Published var result: ProviderResult<[GridMatrix<Int>]>?
-
+class StatProvider: QueryProvider<GridMatrix<Int>> {
     let eventName: String
     let periods: [Period]
 
     init(eventName: String, periods: [Period]) {
         self.eventName = eventName
         self.periods = periods
-    }
 
-    func fetch(in database: AppDatabase) async throws -> Output {
-        try await database
-            .readAll(matching: query, fields: nil)
-            .map(GridMatrix.init)
-            .mergeDuplicates()
-    }
+        super.init {
+            let dateRange = Calendar.utc.defaultRange
 
-    private var query: CKQuery {
-        let dateRange = Calendar.utc.defaultRange
+            let predicate = NSPredicate(
+                format: "date >= %@ AND name == %@",
+                dateRange.lowerBound as NSDate,
+                eventName
+            )
 
-        let predicate = NSPredicate(
-            format: "date >= %@ AND name == %@",
-            dateRange.lowerBound as NSDate,
-            eventName
-        )
-
-        return CKQuery(
-            recordType: "DateIntMatrix",
-            predicate: predicate
-        )
+            return CKQuery(
+                recordType: "DateIntMatrix",
+                predicate: predicate
+            )
+        }
     }
 }

--- a/Sources/Scout/UI/Metrics/MetricsProvider.swift
+++ b/Sources/Scout/UI/Metrics/MetricsProvider.swift
@@ -6,37 +6,23 @@
 // https://opensource.org/licenses/MIT.
 
 import CloudKit
-import SwiftUI
 
-class MetricsProvider<T: ChartNumeric>: ObservableObject, Provider {
-    @Published var result: ProviderResult<[GridMatrix<T>]>?
-
-    private let telemetry: Telemetry.Export
-
+class MetricsProvider<T: ChartNumeric>: QueryProvider<GridMatrix<T>> {
     init(telemetry: Telemetry.Export) {
-        self.telemetry = telemetry
-    }
+        super.init {
+            let dateRange = Calendar.utc.defaultRange
 
-    func fetch(in database: AppDatabase) async throws -> Output {
-        try await database
-            .readAll(matching: query, fields: nil)
-            .map(GridMatrix.init)
-            .mergeDuplicates()
-    }
+            let predicate = NSPredicate(
+                format: "date >= %@ AND date < %@ AND category == %@",
+                dateRange.lowerBound as NSDate,
+                dateRange.upperBound as NSDate,
+                telemetry.rawValue
+            )
 
-    private var query: CKQuery {
-        let dateRange = Calendar.utc.defaultRange
-
-        let predicate = NSPredicate(
-            format: "date >= %@ AND date < %@ AND category == %@",
-            dateRange.lowerBound as NSDate,
-            dateRange.upperBound as NSDate,
-            telemetry.rawValue
-        )
-
-        return CKQuery(
-            recordType: T.recordName,
-            predicate: predicate
-        )
+            return CKQuery(
+                recordType: T.recordName,
+                predicate: predicate
+            )
+        }
     }
 }

--- a/Sources/Scout/UI/Provider/QueryProvider.swift
+++ b/Sources/Scout/UI/Provider/QueryProvider.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+class QueryProvider<T: Combining & CKInitializable>: ObservableObject, Provider {
+    @Published var result: ProviderResult<[T]>?
+
+    private let queryBuilder: () -> CKQuery
+
+    init(query: @escaping @autoclosure () -> CKQuery) {
+        self.queryBuilder = query
+    }
+
+    init(query: @escaping () -> CKQuery) {
+        self.queryBuilder = query
+    }
+
+    func fetch(in database: AppDatabase) async throws -> [T] {
+        try await database
+            .readAll(matching: queryBuilder(), fields: nil)
+            .map { try T(record: $0) }
+            .mergeDuplicates()
+    }
+}


### PR DESCRIPTION
- Deduplicate the shared `readAll`/`map`/`mergeDuplicates` pattern into a generic `QueryProvider<T>` base class
- Simplify `ActivityProvider`, `StatProvider`, and `MetricsProvider` to pass a query-building closure instead of overriding a computed property
- Remove `fatalError` in favor of compile-time safety via required init parameter