### PR TITLE
Remove usedWithSwiftData flag from Core Data model

### DIFF
--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="CrashObject" representedClassName="CrashObject" parentEntity="NamedObject" syncable="YES" codeGenerationType="category">
         <attribute name="crashID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="reason" optional="YES" attributeType="String"/>


### PR DESCRIPTION
- Remove `usedWithSwiftData` attribute from the Core Data model
- The entity hierarchy uses inheritance and abstract entities, which are not supported by SwiftData
- Eliminates 14 build warnings