### PR TITLE
Switch Core Data codegen to Manual/None

### DIFF
--- a/Sources/Scout/Core/Activity/UserActivity.swift
+++ b/Sources/Scout/Core/Activity/UserActivity.swift
@@ -10,6 +10,17 @@ import CoreData
 
 @objc(UserActivity)
 final class UserActivity: SyncableObject, Syncable {
+
+    @NSManaged var dayCount: Int32
+    @NSManaged var monthCount: Int32
+    @NSManaged var period: String?
+    @NSManaged var userActivityID: UUID?
+    @NSManaged var weekCount: Int32
+
+    @nonobjc class func fetchRequest() -> NSFetchRequest<UserActivity> {
+        NSFetchRequest<UserActivity>(entityName: "UserActivity")
+    }
+
     static func group(in context: NSManagedObjectContext) throws -> [UserActivity]? {
         try batch(in: context, matching: [\.month])
     }

--- a/Sources/Scout/Core/Activity/UserActivity.swift
+++ b/Sources/Scout/Core/Activity/UserActivity.swift
@@ -17,10 +17,6 @@ final class UserActivity: SyncableObject, Syncable {
     @NSManaged var userActivityID: UUID?
     @NSManaged var weekCount: Int32
 
-    @nonobjc class func fetchRequest() -> NSFetchRequest<UserActivity> {
-        NSFetchRequest<UserActivity>(entityName: "UserActivity")
-    }
-
     static func group(in context: NSManagedObjectContext) throws -> [UserActivity]? {
         try batch(in: context, matching: [\.month])
     }

--- a/Sources/Scout/Core/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Crash/CrashObject.swift
@@ -10,6 +10,15 @@ import CoreData
 
 @objc(CrashObject)
 final class CrashObject: NamedObject, Syncable, MatrixBatch {
+
+    @NSManaged var crashID: UUID?
+    @NSManaged var reason: String?
+    @NSManaged var stackTrace: Data?
+
+    @nonobjc class func fetchRequest() -> NSFetchRequest<CrashObject> {
+        NSFetchRequest<CrashObject>(entityName: "CrashObject")
+    }
+
     static func group(in context: NSManagedObjectContext) throws -> [CrashObject]? {
         try batch(in: context, matching: [\.name, \.week])
     }

--- a/Sources/Scout/Core/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Crash/CrashObject.swift
@@ -15,10 +15,6 @@ final class CrashObject: NamedObject, Syncable, MatrixBatch {
     @NSManaged var reason: String?
     @NSManaged var stackTrace: Data?
 
-    @nonobjc class func fetchRequest() -> NSFetchRequest<CrashObject> {
-        NSFetchRequest<CrashObject>(entityName: "CrashObject")
-    }
-
     static func group(in context: NSManagedObjectContext) throws -> [CrashObject]? {
         try batch(in: context, matching: [\.name, \.week])
     }

--- a/Sources/Scout/Core/ID/IDObject.swift
+++ b/Sources/Scout/Core/ID/IDObject.swift
@@ -5,10 +5,19 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import Foundation
+import CoreData
 
 @objc(IDObject)
 class IDObject: DateObject {
+
+    @NSManaged var launchID: UUID?
+    @NSManaged var sessionID: UUID?
+    @NSManaged var userID: UUID?
+
+    @nonobjc class func fetchRequest() -> NSFetchRequest<IDObject> {
+        NSFetchRequest<IDObject>(entityName: "IDObject")
+    }
+
     override func awakeFromInsert() {
         super.awakeFromInsert()
         setPrimitiveValue(UUID(), forKey: #keyPath(IDObject.sessionID))

--- a/Sources/Scout/Core/ID/IDObject.swift
+++ b/Sources/Scout/Core/ID/IDObject.swift
@@ -14,10 +14,6 @@ class IDObject: DateObject {
     @NSManaged var sessionID: UUID?
     @NSManaged var userID: UUID?
 
-    @nonobjc class func fetchRequest() -> NSFetchRequest<IDObject> {
-        NSFetchRequest<IDObject>(entityName: "IDObject")
-    }
-
     override func awakeFromInsert() {
         super.awakeFromInsert()
         setPrimitiveValue(UUID(), forKey: #keyPath(IDObject.sessionID))

--- a/Sources/Scout/Core/ID/IDs.swift
+++ b/Sources/Scout/Core/ID/IDs.swift
@@ -11,7 +11,7 @@ import Foundation
 enum IDs {
     static var session: UUID? {
         let context = persistentContainer.viewContext
-        let request: NSFetchRequest<SessionObject> = SessionObject.fetchRequest()
+        let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
         request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
         request.predicate = NSPredicate(format: "launchID == %@", launch as CVarArg)
         request.fetchLimit = 1

--- a/Sources/Scout/Core/Log/EventObject.swift
+++ b/Sources/Scout/Core/Log/EventObject.swift
@@ -16,10 +16,6 @@ final class EventObject: NamedObject, Syncable, MatrixBatch {
     @NSManaged var paramCount: Int64
     @NSManaged var params: Data?
 
-    @nonobjc class func fetchRequest() -> NSFetchRequest<EventObject> {
-        NSFetchRequest<EventObject>(entityName: "EventObject")
-    }
-
     static func group(in context: NSManagedObjectContext) throws -> [EventObject]? {
         try batch(in: context, matching: [\.name, \.week])
     }

--- a/Sources/Scout/Core/Log/EventObject.swift
+++ b/Sources/Scout/Core/Log/EventObject.swift
@@ -10,6 +10,16 @@ import CoreData
 
 @objc(EventObject)
 final class EventObject: NamedObject, Syncable, MatrixBatch {
+
+    @NSManaged var eventID: UUID?
+    @NSManaged var level: String?
+    @NSManaged var paramCount: Int64
+    @NSManaged var params: Data?
+
+    @nonobjc class func fetchRequest() -> NSFetchRequest<EventObject> {
+        NSFetchRequest<EventObject>(entityName: "EventObject")
+    }
+
     static func group(in context: NSManagedObjectContext) throws -> [EventObject]? {
         try batch(in: context, matching: [\.name, \.week])
     }

--- a/Sources/Scout/Core/Matrix/NamedObject.swift
+++ b/Sources/Scout/Core/Matrix/NamedObject.swift
@@ -9,6 +9,13 @@ import CoreData
 
 @objc(NamedObject)
 class NamedObject: SyncableObject {
+
+    @NSManaged var name: String?
+
+    @nonobjc class func fetchRequest() -> NSFetchRequest<NamedObject> {
+        NSFetchRequest<NamedObject>(entityName: "NamedObject")
+    }
+
     static func matrix(of batch: [NamedObject]) throws(MatrixPropertyError) -> GridMatrix<Int> {
         guard let name = batch.first?.name else {
             throw .init("name")

--- a/Sources/Scout/Core/Matrix/NamedObject.swift
+++ b/Sources/Scout/Core/Matrix/NamedObject.swift
@@ -12,10 +12,6 @@ class NamedObject: SyncableObject {
 
     @NSManaged var name: String?
 
-    @nonobjc class func fetchRequest() -> NSFetchRequest<NamedObject> {
-        NSFetchRequest<NamedObject>(entityName: "NamedObject")
-    }
-
     static func matrix(of batch: [NamedObject]) throws(MatrixPropertyError) -> GridMatrix<Int> {
         guard let name = batch.first?.name else {
             throw .init("name")

--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -10,6 +10,14 @@ import CoreData
 
 @objc(MetricsObject)
 class MetricsObject: SyncableObject {
+
+    @NSManaged var name: String?
+    @NSManaged var telemetry: String?
+
+    @nonobjc class func fetchRequest() -> NSFetchRequest<MetricsObject> {
+        NSFetchRequest<MetricsObject>(entityName: "MetricsObject")
+    }
+
     static func group<T: MetricsValued>(in context: NSManagedObjectContext) throws -> [T]? {
         try batch(in: context, matching: [\.name, \.telemetry, \.week])
     }

--- a/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Metrics/MetricsObject+Group.swift
@@ -14,10 +14,6 @@ class MetricsObject: SyncableObject {
     @NSManaged var name: String?
     @NSManaged var telemetry: String?
 
-    @nonobjc class func fetchRequest() -> NSFetchRequest<MetricsObject> {
-        NSFetchRequest<MetricsObject>(entityName: "MetricsObject")
-    }
-
     static func group<T: MetricsValued>(in context: NSManagedObjectContext) throws -> [T]? {
         try batch(in: context, matching: [\.name, \.telemetry, \.week])
     }

--- a/Sources/Scout/Core/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Session/SessionObject.swift
@@ -13,10 +13,6 @@ final class SessionObject: SyncableObject, Syncable {
 
     @NSManaged var endDate: Date?
 
-    @nonobjc class func fetchRequest() -> NSFetchRequest<SessionObject> {
-        NSFetchRequest<SessionObject>(entityName: "SessionObject")
-    }
-
     static func group(in context: NSManagedObjectContext) throws -> [SessionObject]? {
         try batch(in: context, matching: [\.week])
     }

--- a/Sources/Scout/Core/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Session/SessionObject.swift
@@ -10,6 +10,13 @@ import CoreData
 
 @objc(SessionObject)
 final class SessionObject: SyncableObject, Syncable {
+
+    @NSManaged var endDate: Date?
+
+    @nonobjc class func fetchRequest() -> NSFetchRequest<SessionObject> {
+        NSFetchRequest<SessionObject>(entityName: "SessionObject")
+    }
+
     static func group(in context: NSManagedObjectContext) throws -> [SessionObject]? {
         try batch(in: context, matching: [\.week])
     }

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -16,10 +16,6 @@ class SyncableObject: IDObject {
 
     @NSManaged var isSynced: Bool
 
-    @nonobjc class func fetchRequest() -> NSFetchRequest<SyncableObject> {
-        NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
-    }
-
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {
         let entityName = String(describing: T.self)
 

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -13,6 +13,13 @@ protocol Syncable: SyncableObject {
 
 @objc(SyncableObject)
 class SyncableObject: IDObject {
+
+    @NSManaged var isSynced: Bool
+
+    @nonobjc class func fetchRequest() -> NSFetchRequest<SyncableObject> {
+        NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
+    }
+
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {
         let entityName = String(describing: T.self)
 

--- a/Sources/Scout/Core/Utilities/DateObject.swift
+++ b/Sources/Scout/Core/Utilities/DateObject.swift
@@ -8,7 +8,18 @@
 import CoreData
 
 @objc(DateObject)
-class DateObject: NSManagedObject {
+class DateObject: NSManagedObject, Identifiable {
+
+    @NSManaged var datePrimitive: Date?
+    @NSManaged var day: Date?
+    @NSManaged var hour: Date?
+    @NSManaged var month: Date?
+    @NSManaged var week: Date?
+
+    @nonobjc class func fetchRequest() -> NSFetchRequest<DateObject> {
+        NSFetchRequest<DateObject>(entityName: "DateObject")
+    }
+
     var date: Date? {
         get {
             datePrimitive

--- a/Sources/Scout/Core/Utilities/DateObject.swift
+++ b/Sources/Scout/Core/Utilities/DateObject.swift
@@ -16,10 +16,6 @@ class DateObject: NSManagedObject, Identifiable {
     @NSManaged var month: Date?
     @NSManaged var week: Date?
 
-    @nonobjc class func fetchRequest() -> NSFetchRequest<DateObject> {
-        NSFetchRequest<DateObject>(entityName: "DateObject")
-    }
-
     var date: Date? {
         get {
             datePrimitive

--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="CrashObject" representedClassName="CrashObject" parentEntity="NamedObject" syncable="YES" codeGenerationType="category">
+    <entity name="CrashObject" representedClassName="CrashObject" parentEntity="NamedObject" syncable="YES" codeGenerationType="none">
         <attribute name="crashID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="reason" optional="YES" attributeType="String"/>
         <attribute name="stackTrace" optional="YES" attributeType="Binary"/>
     </entity>
-    <entity name="DateObject" representedClassName="DateObject" isAbstract="YES" syncable="YES" codeGenerationType="category">
+    <entity name="DateObject" representedClassName="DateObject" isAbstract="YES" syncable="YES" codeGenerationType="none">
         <attribute name="datePrimitive" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="day" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="hour" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="month" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="week" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
-    <entity name="DoubleMetricsObject" representedClassName="DoubleMetricsObject" parentEntity="MetricsObject" syncable="YES">
+    <entity name="DoubleMetricsObject" representedClassName="DoubleMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="none">
         <attribute name="value" attributeType="Double" usesScalarValueType="YES"/>
     </entity>
-    <entity name="EventObject" representedClassName="EventObject" parentEntity="NamedObject" syncable="YES" codeGenerationType="category">
+    <entity name="EventObject" representedClassName="EventObject" parentEntity="NamedObject" syncable="YES" codeGenerationType="none">
         <attribute name="eventID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="level" attributeType="String"/>
         <attribute name="paramCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="params" optional="YES" attributeType="Binary"/>
     </entity>
-    <entity name="IDObject" representedClassName="IDObject" isAbstract="YES" parentEntity="DateObject" syncable="YES" codeGenerationType="category">
+    <entity name="IDObject" representedClassName="IDObject" isAbstract="YES" parentEntity="DateObject" syncable="YES" codeGenerationType="none">
         <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="sessionID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="userID" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
-    <entity name="IntMetricsObject" representedClassName="IntMetricsObject" parentEntity="MetricsObject" syncable="YES">
+    <entity name="IntMetricsObject" representedClassName="IntMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="none">
         <attribute name="value" attributeType="Integer 64" usesScalarValueType="YES"/>
     </entity>
-    <entity name="MetricsObject" representedClassName="MetricsObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="category">
+    <entity name="MetricsObject" representedClassName="MetricsObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
         <attribute name="name" attributeType="String"/>
         <attribute name="telemetry" attributeType="String"/>
     </entity>
-    <entity name="NamedObject" representedClassName="NamedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="category">
+    <entity name="NamedObject" representedClassName="NamedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
         <attribute name="name" attributeType="String"/>
     </entity>
-    <entity name="SessionObject" representedClassName="SessionObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="category">
+    <entity name="SessionObject" representedClassName="SessionObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
-    <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="IDObject" syncable="YES" codeGenerationType="category">
+    <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="IDObject" syncable="YES" codeGenerationType="none">
         <attribute name="isSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
     </entity>
-    <entity name="UserActivity" representedClassName="UserActivity" parentEntity="SyncableObject" syncable="YES" codeGenerationType="category">
+    <entity name="UserActivity" representedClassName="UserActivity" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
         <attribute name="dayCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="monthCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="period" attributeType="String"/>

--- a/Tests/ScoutTests/Core/Log/LogTest.swift
+++ b/Tests/ScoutTests/Core/Log/LogTest.swift
@@ -25,7 +25,7 @@ import Testing
         context: context
     )
 
-    let fetchRequest: NSFetchRequest<EventObject> = EventObject.fetchRequest()
+    let fetchRequest: NSFetchRequest<EventObject> = NSFetchRequest<EventObject>(entityName: "EventObject")
     let events = try context.fetch(fetchRequest)
 
     #expect(events.count == 1)
@@ -55,7 +55,7 @@ import Testing
 
     try log("Array Event", level: .info, metadata: metadata, date: Date(), context: context)
 
-    let events = try context.fetch(EventObject.fetchRequest())
+    let events = try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject"))
     let paramData = try #require(events.first?.params)
     let params = try JSONDecoder().decode([String: String].self, from: paramData)
 
@@ -71,7 +71,7 @@ import Testing
 
     try log("Dict Event", level: .info, metadata: metadata, date: Date(), context: context)
 
-    let events = try context.fetch(EventObject.fetchRequest())
+    let events = try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject"))
     let paramData = try #require(events.first?.params)
     let params = try JSONDecoder().decode([String: String].self, from: paramData)
 
@@ -89,7 +89,7 @@ import Testing
 
     try log("Mixed Event", level: .info, metadata: metadata, date: Date(), context: context)
 
-    let events = try context.fetch(EventObject.fetchRequest())
+    let events = try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject"))
     let paramData = try #require(events.first?.params)
     let params = try JSONDecoder().decode([String: String].self, from: paramData)
 


### PR DESCRIPTION
- Move @NSManaged property declarations from Xcode-generated extensions into hand-written source files
- Set codeGenerationType to none for all entities in the data model
- Use NSFetchRequest(entityName:) directly instead of generated fetchRequest() methods
- Removes dependency on Xcode codegen, making the package buildable via swift build
- Eliminates Public import of CoreData warnings from generated code