### PR TITLE
Update actions/checkout from v4 to v5

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Prepare simulator
         run: |


### PR DESCRIPTION
- Fix Node.js 20 deprecation warning in CI by upgrading to actions/checkout@v5