### PR TITLE
Optimize CI workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -36,5 +36,4 @@ jobs:
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=iPhone 16' \
-            -enableCodeCoverage YES \
             test-without-building

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,27 +13,30 @@ concurrency:
 jobs:
   tests:
     runs-on: macos-15
-    timeout-minutes: 20
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v5
 
       - name: Prepare simulator
         run: |
-          if ! xcrun simctl list devices available | grep -q "iPhone"; then
+          DEVICE_NAME="iPhone 16"
+          if ! xcrun simctl list devices available | grep -q "$DEVICE_NAME"; then
             xcodebuild -downloadPlatform iOS
           fi
+          UDID=$(xcrun simctl list devices available -j | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          for runtime, devices in data['devices'].items():
+              for d in devices:
+                  if d['name'] == '$DEVICE_NAME' and d['isAvailable']:
+                      print(d['udid']); sys.exit()
+          ")
+          xcrun simctl boot "$UDID" 2>/dev/null || true
 
-      - name: Build
+      - name: Test
         run: |
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=iPhone 16' \
-            build-for-testing
-
-      - name: Run unit tests
-        run: |
-          xcodebuild \
-            -scheme Scout \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
-            test-without-building
+            test


### PR DESCRIPTION
- Remove unused -enableCodeCoverage YES flag
- Merge build-for-testing and test-without-building into a single xcodebuild test step
- Boot simulator during Prepare step so it is ready when tests start
- Reduce timeout from 20 to 10 minutes