### PR TITLE
Remove unused UIKit and SwiftUI imports from tests

### DIFF
--- a/Tests/ScoutTests/Core/Listener/NotificationListenerTests.swift
+++ b/Tests/ScoutTests/Core/Listener/NotificationListenerTests.swift
@@ -6,7 +6,6 @@
 // https://opensource.org/licenses/MIT.
 
 import Testing
-import UIKit
 import XCTest
 
 @testable import Scout

--- a/Tests/ScoutTests/UI/FilterCriteriaTests.swift
+++ b/Tests/ScoutTests/UI/FilterCriteriaTests.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import SwiftUI
 import Testing
 
 @testable import Scout


### PR DESCRIPTION
- Remove unused import UIKit from NotificationListenerTests
- Remove unused import SwiftUI from FilterCriteriaTests