### PR TITLE
Update actions/checkout from v5 to v6

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Prepare simulator
         run: |


### PR DESCRIPTION
- Update actions/checkout from v5 to v6
- May help resolve CI timing regression introduced with v5 upgrade