### PR TITLE
Use checkout v4 with Node.js 24

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,9 +14,11 @@ jobs:
   tests:
     runs-on: macos-15
     timeout-minutes: 10
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Prepare simulator
         run: |


### PR DESCRIPTION
- Revert checkout action from v5 to v4
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env to suppress deprecation warning