### PR TITLE
Extract iCloud warning into a view modifier

### DIFF
--- a/Sources/Scout/UI/Home/HomeChecker.swift
+++ b/Sources/Scout/UI/Home/HomeChecker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Mikhail Kasianov
+// Copyright 2026 Mikhail Kasianov
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -13,7 +13,6 @@ public struct HomeView: View {
 
     @StateObject private var tint = Tint()
     @StateObject private var checker = HomeChecker()
-    @State private var iCloudAlertPresented = false
     @Environment(\.dismiss) var dismiss
 
     public init(container: CKContainer) {
@@ -30,27 +29,13 @@ public struct HomeView: View {
                 }
             }
             .toolbar {
-                if checker.iCloudWarning {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Button {
-                            iCloudAlertPresented = true
-                        } label: {
-                            Image(systemName: "icloud.slash")
-                                .foregroundStyle(.orange)
-                        }
-                    }
-                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Close") {
                         dismiss()
                     }
                 }
             }
-            .alert("iCloud Unavailable", isPresented: $iCloudAlertPresented) {
-                Button("OK", role: .cancel) {}
-            } message: {
-                Text("Sign in to iCloud to sync data.")
-            }
+            .iCloudWarning(checker.iCloudWarning)
             .navigationBarTitle("Home")
         }
         .task {

--- a/Sources/Scout/UI/Home/ICloudWarning.swift
+++ b/Sources/Scout/UI/Home/ICloudWarning.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    func iCloudWarning(_ isPresented: Bool) -> some View {
+        modifier(ICloudWarningModifier(isWarning: isPresented))
+    }
+}
+
+private struct ICloudWarningModifier: ViewModifier {
+    let isWarning: Bool
+
+    @State private var isAlertPresented = false
+
+    func body(content: Content) -> some View {
+        content
+            .toolbar {
+                if isWarning {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button {
+                            isAlertPresented = true
+                        } label: {
+                            Image(systemName: "icloud.slash")
+                                .foregroundStyle(.orange)
+                        }
+                    }
+                }
+            }
+            .alert("iCloud Unavailable", isPresented: $isAlertPresented) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Sign in to iCloud to sync data.")
+            }
+    }
+}


### PR DESCRIPTION
- Move iCloud warning toolbar icon, alert, and state into a reusable ICloudWarningModifier
- Add .iCloudWarning() view extension for clean call-site usage
- Update copyright year to 2026 on new files