### PR TITLE
Revert simulator boot step from CI workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,19 +20,9 @@ jobs:
 
       - name: Prepare simulator
         run: |
-          DEVICE_NAME="iPhone 16"
-          if ! xcrun simctl list devices available | grep -q "$DEVICE_NAME"; then
+          if ! xcrun simctl list devices available | grep -q "iPhone"; then
             xcodebuild -downloadPlatform iOS
           fi
-          UDID=$(xcrun simctl list devices available -j | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          for runtime, devices in data['devices'].items():
-              for d in devices:
-                  if d['name'] == '$DEVICE_NAME' and d['isAvailable']:
-                      print(d['udid']); sys.exit()
-          ")
-          xcrun simctl boot "$UDID" 2>/dev/null || true
 
       - name: Build
         run: |


### PR DESCRIPTION
- Remove UDID lookup via python3 and explicit simulator boot from the Prepare simulator step
- Restore the original simple iPhone availability check