### PR TITLE
Handle CKError.unknownItem in schema verification

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
@@ -13,6 +13,9 @@ extension CKError {
     /// is missing or outdated (e.g. unknown record type, missing indexes).
     var isSchemaError: Bool {
         switch code {
+        case .unknownItem:
+            let message = localizedDescription.lowercased()
+            return message.contains("record type")
         case .invalidArguments, .serverRejectedRequest:
             let message = localizedDescription.lowercased()
             return message.contains("record type")


### PR DESCRIPTION
- Add .unknownItem (code 11) to isSchemaError to detect missing record types like "Did not find record type: Crash"