### PR TITLE
Chunk CloudKit write requests to respect 400-record limit

### DIFF
--- a/Sources/Scout/Core/Database/RecordWriter.swift
+++ b/Sources/Scout/Core/Database/RecordWriter.swift
@@ -7,6 +7,9 @@
 
 import CloudKit
 
+/// Maximum number of records per CloudKit modify request.
+private let maxBatchSize = 400
+
 protocol RecordWriter {
     func write(record: CKRecord) async throws
     func write(records: [CKRecord]) async throws
@@ -20,13 +23,23 @@ extension CKDatabase: RecordWriter {
     }
 
     func write(records: [CKRecord]) async throws {
-        try await runner { database in
-            try await database.modifyRecords(
-                saving: records,
-                deleting: [],
-                savePolicy: .ifServerRecordUnchanged,
-                atomically: true
-            )
+        for chunk in records.chunked(into: maxBatchSize) {
+            try await runner { database in
+                try await database.modifyRecords(
+                    saving: chunk,
+                    deleting: [],
+                    savePolicy: .ifServerRecordUnchanged,
+                    atomically: true
+                )
+            }
+        }
+    }
+}
+
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map {
+            Array(self[$0..<Swift.min($0 + size, count)])
         }
     }
 }

--- a/Tests/ScoutTests/Core/Database/ChunkedTests.swift
+++ b/Tests/ScoutTests/Core/Database/ChunkedTests.swift
@@ -1,0 +1,49 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Testing
+
+@testable import Scout
+
+struct ChunkedTests {
+
+    @Test("Empty array returns empty result")
+    func empty() {
+        let result = [Int]().chunked(into: 5)
+        #expect(result.isEmpty)
+    }
+
+    @Test("Array smaller than chunk size returns single chunk")
+    func smallerThanSize() {
+        let result = [1, 2, 3].chunked(into: 5)
+        #expect(result == [[1, 2, 3]])
+    }
+
+    @Test("Array equal to chunk size returns single chunk")
+    func equalToSize() {
+        let result = [1, 2, 3, 4, 5].chunked(into: 5)
+        #expect(result == [[1, 2, 3, 4, 5]])
+    }
+
+    @Test("Array larger than chunk size returns multiple chunks")
+    func largerThanSize() {
+        let result = [1, 2, 3, 4, 5, 6, 7].chunked(into: 3)
+        #expect(result == [[1, 2, 3], [4, 5, 6], [7]])
+    }
+
+    @Test("Chunk size of 1 returns individual elements")
+    func sizeOne() {
+        let result = [1, 2, 3].chunked(into: 1)
+        #expect(result == [[1], [2], [3]])
+    }
+
+    @Test("Exactly divisible array splits evenly")
+    func evenSplit() {
+        let result = Array(1...9).chunked(into: 3)
+        #expect(result == [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    }
+}


### PR DESCRIPTION
- modifyRecords fails when saving more than 400 records in a single request
- Split records into chunks of 400 before sending each batch
- Add unit tests for the chunked(into:) helper