### PR TITLE
Fix infinite recursion in uncaught exception handler

### DIFF
--- a/Sources/Scout/Core/Crash/ExceptionHandler.swift
+++ b/Sources/Scout/Core/Crash/ExceptionHandler.swift
@@ -7,10 +7,11 @@
 
 import Foundation
 
-private nonisolated(unsafe) var previousExceptionHandler = NSGetUncaughtExceptionHandler()
+private nonisolated(unsafe) var previousExceptionHandler: NSUncaughtExceptionHandler?
 
 /// Installs a handler for uncaught NSExceptions.
 func installExceptionHandler() {
+    previousExceptionHandler = NSGetUncaughtExceptionHandler()
     NSSetUncaughtExceptionHandler { exception in
         let crash = CrashInfo(
             name: exception.name.rawValue,


### PR DESCRIPTION
- `previousExceptionHandler` was a lazily-initialized top-level variable (`= NSGetUncaughtExceptionHandler()`)
- In Swift, top-level variables are initialized on first access, not at declaration time
- First access happened inside the exception handler closure — after the Scout handler was already installed
- `NSGetUncaughtExceptionHandler()` returned the Scout handler itself, causing infinite recursion → stack overflow → SIGSEGV
- Fixed by explicitly capturing the previous handler inside `installExceptionHandler()` before setting the new one