### PR TITLE
Upload individual records before matrix in sync engine

### DIFF
--- a/Sources/Scout/Core/Sync/SyncCoordinator.swift
+++ b/Sources/Scout/Core/Sync/SyncCoordinator.swift
@@ -7,7 +7,7 @@
 
 import CloudKit
 
-struct SyncCoordinator<T: CellProtocol> {
+struct SyncCoordinator<T: CellProtocol>: @unchecked Sendable {
     let database: Database
     let maxRetry: Int
     let matrix: Matrix<T>

--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -14,18 +14,18 @@ struct SyncEngine: @unchecked Sendable {
 
     @MainActor func send<T: Syncable & MatrixBatch>(type syncable: T.Type) async throws {
         while let batch = try syncable.group(in: context) {
+            if let objects = batch as? [CKRepresentable] {
+                try await database.write(
+                    records: objects.map(\.toRecord)
+                )
+            }
+
             try await SyncCoordinator(
                 database: database,
                 maxRetry: 3,
                 batch: batch
             )
             .upload()
-
-            if let objects = batch as? [CKRepresentable] {
-                try await database.write(
-                    records: objects.map(\.toRecord)
-                )
-            }
 
             for object in batch {
                 object.isSynced = true


### PR DESCRIPTION
- If record upload succeeded but matrix upload failed, the batch remained unsynced
- On retry, the matrix merge used additive cell combining (`GridCell.+`), silently double-counting the data
- Reordering so records go first prevents this: if records succeed but matrix fails, the retry only adds the matrix (no double-count)
- The reverse edge case (records duplicated on retry) is less harmful — duplicates are visible and can be deduplicated by `crashID`/`uuid`