### PR TITLE
Require Sendable on Database protocols

### DIFF
--- a/Sources/Scout/Core/Database/RecordReader.swift
+++ b/Sources/Scout/Core/Database/RecordReader.swift
@@ -7,7 +7,7 @@
 
 import CloudKit
 
-protocol RecordReader {
+protocol RecordReader: Sendable {
     func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk
     func readMore(from cursor: CKQueryOperation.Cursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk
 }

--- a/Sources/Scout/Core/Database/RecordWriter.swift
+++ b/Sources/Scout/Core/Database/RecordWriter.swift
@@ -10,7 +10,7 @@ import CloudKit
 /// Maximum number of records per CloudKit modify request.
 private let maxBatchSize = 400
 
-protocol RecordWriter {
+protocol RecordWriter: Sendable {
     func write(record: CKRecord) async throws
     func write(records: [CKRecord]) async throws
 }

--- a/Sources/Scout/Core/Sync/SyncCoordinator.swift
+++ b/Sources/Scout/Core/Sync/SyncCoordinator.swift
@@ -7,7 +7,7 @@
 
 import CloudKit
 
-struct SyncCoordinator<T: CellProtocol>: @unchecked Sendable {
+struct SyncCoordinator<T: CellProtocol>: Sendable {
     let database: Database
     let maxRetry: Int
     let matrix: Matrix<T>

--- a/Tests/ScoutTests/Transient/InMemoryDatabase.swift
+++ b/Tests/ScoutTests/Transient/InMemoryDatabase.swift
@@ -9,7 +9,7 @@ import CloudKit
 
 @testable import Scout
 
-final class InMemoryDatabase: Database {
+final class InMemoryDatabase: Database, @unchecked Sendable {
     var records: [CKRecord] = []
     var errors: [Error] = []
     var writeErrors: [Error] = []


### PR DESCRIPTION
- Add Sendable requirement to RecordWriter and RecordReader protocols
- Replace @unchecked Sendable on SyncCoordinator with proper Sendable conformance
- Mark test mock InMemoryDatabase as @unchecked Sendable (mutable state)