### PR TITLE
Use generic iOS Simulator destination in CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,8 +20,10 @@ jobs:
       matrix:
         include:
           - os: macos-15
+            device: iPhone 16
             ios: 18
           - os: macos-26
+            device: iPhone 17
             ios: 26
 
     steps:
@@ -31,12 +33,12 @@ jobs:
         run: |
           xcodebuild \
             -scheme Scout \
-            -destination 'platform=iOS Simulator' \
+            -destination 'platform=iOS Simulator,name=${{ matrix.device }},OS=latest' \
             build-for-testing
 
       - name: Test
         run: |
           xcodebuild \
             -scheme Scout \
-            -destination 'platform=iOS Simulator' \
+            -destination 'platform=iOS Simulator,name=${{ matrix.device }},OS=latest' \
             test-without-building

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,10 +20,8 @@ jobs:
       matrix:
         include:
           - os: macos-15
-            device: iPhone 16
             ios: 18
           - os: macos-26
-            device: iPhone 17
             ios: 26
 
     steps:
@@ -33,12 +31,12 @@ jobs:
         run: |
           xcodebuild \
             -scheme Scout \
-            -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
+            -destination 'platform=iOS Simulator' \
             build-for-testing
 
       - name: Test
         run: |
           xcodebuild \
             -scheme Scout \
-            -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
+            -destination 'platform=iOS Simulator' \
             test-without-building


### PR DESCRIPTION
- Replace specific device names with generic platform destination
- Fixes build failure due to missing iPhone 16 simulator on macos-15 runner