### PR TITLE
Add code coverage reporting to CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,6 +40,7 @@ jobs:
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
+            -enableCodeCoverage YES \
             build-for-testing
 
       - name: Test
@@ -47,4 +48,10 @@ jobs:
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
+            -enableCodeCoverage YES \
+            -resultBundlePath TestResults \
             test-without-building
+
+      - name: Coverage
+        run: |
+          xcrun xccov view --report --only-targets TestResults.xcresult


### PR DESCRIPTION
- Enable code coverage in build and test steps
- Add Coverage step that prints per-target coverage report