### PR TITLE
Exclude test target from coverage report

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: Coverage
         run: |
-          xcrun xccov view --report --only-targets TestResults.xcresult
+          xcrun xccov view --report --only-targets TestResults.xcresult | grep -v ScoutTests


### PR DESCRIPTION
- Filter out ScoutTests from coverage output