### PR TITLE
Add macOS 13 and macOS 14 to CI matrix

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,6 +19,12 @@ jobs:
     strategy:
       matrix:
         include:
+          - os: macos-13
+            device: iPhone 14
+            ios: 16
+          - os: macos-14
+            device: iPhone 15
+            ios: 17
           - os: macos-15
             device: iPhone 16
             ios: 18


### PR DESCRIPTION
- Add macOS 13 and macOS 14 runners with iPhone 15 / iOS 17
- Rename job names from test-ios-* to test-macos-* to avoid duplicates