### PR TITLE
Add swift-format linting to CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,6 +11,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    runs-on: macos-15
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Lint
+        run: xcrun swift-format lint --strict --recursive Sources Tests
+
   tests:
     name: test-ios-${{ matrix.ios }}
     runs-on: ${{ matrix.os }}

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "indentation": {
+    "spaces": 4
+  },
+  "lineLength": 160,
+  "rules": {
+    "AlwaysUseLiteralForEmptyCollectionInit": true,
+    "BeginDocumentationCommentWithOneLineSummary": true,
+    "NeverUseImplicitlyUnwrappedOptionals": true,
+    "NoEmptyLinesOpeningClosingBraces": true,
+    "NoLeadingUnderscores": true,
+    "OmitExplicitReturns": true,
+    "UseEarlyExits": true,
+    "UseWhereClausesInForLoops": true,
+    "ValidateDocumentationComments": true
+  }
+}

--- a/Sources/Scout/Core/Activity/ActivityPeriod+Domain.swift
+++ b/Sources/Scout/Core/Activity/ActivityPeriod+Domain.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 extension ActivityPeriod {
-
     /// Selects the per-period counter used for DAU/WAU/MAU.
     ///
     /// - `.daily`   -> daily active users (DAU) via `UserActivity.dayCount`
@@ -29,7 +28,7 @@ extension ActivityPeriod {
         }
     }
 
-    /// Defines the calendar span for the metric window:
+    /// Defines the calendar span for the metric window.
     ///
     /// - `.daily`   -> `.day` (DAU window)
     /// - `.weekly`  -> `.weekOfYear` (WAU window)

--- a/Sources/Scout/Core/Activity/UserActivity.swift
+++ b/Sources/Scout/Core/Activity/UserActivity.swift
@@ -10,7 +10,6 @@ import CoreData
 
 @objc(UserActivity)
 final class UserActivity: SyncableObject, Syncable {
-
     @NSManaged var dayCount: Int32
     @NSManaged var monthCount: Int32
     @NSManaged var period: String?

--- a/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
@@ -22,8 +22,8 @@ private let schemaRecordTypes = [
 ]
 
 extension CKContainer {
-
     /// Queries each record type to verify the CloudKit schema is up to date.
+    ///
     /// Throws a `SchemaError` if any record types have schema issues.
     ///
     func verifySchema() async throws {

--- a/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
@@ -8,7 +8,6 @@
 import CloudKit
 
 extension CKError {
-
     /// Returns `true` when the error indicates the CloudKit schema
     /// is missing or outdated (e.g. unknown record type, missing indexes).
     var isSchemaError: Bool {

--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -30,7 +30,7 @@ import Metrics
 public func setup(container: CKContainer) async throws {
     installExceptionHandler()
     installSignalHandler()
-    
+
     await CrashArchive.system.flush()
 
     try NotificationListener.appState.setup()

--- a/Sources/Scout/Core/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Crash/CrashObject.swift
@@ -10,7 +10,6 @@ import CoreData
 
 @objc(CrashObject)
 final class CrashObject: NamedObject, Syncable, MatrixBatch {
-
     @NSManaged var crashID: UUID?
     @NSManaged var reason: String?
     @NSManaged var stackTrace: Data?

--- a/Sources/Scout/Core/Database/Database.swift
+++ b/Sources/Scout/Core/Database/Database.swift
@@ -6,6 +6,7 @@
 // https://opensource.org/licenses/MIT.
 
 /// Database represents the core data access surface used by the package's model layer.
+///
 /// It composes read and write capabilities over CloudKit records.
 ///
 /// UI code should prefer the higher-level facade `AppDatabase`.

--- a/Sources/Scout/Core/ID/IDObject.swift
+++ b/Sources/Scout/Core/ID/IDObject.swift
@@ -9,7 +9,6 @@ import CoreData
 
 @objc(IDObject)
 class IDObject: DateObject {
-
     @NSManaged var launchID: UUID?
     @NSManaged var sessionID: UUID?
     @NSManaged var userID: UUID?

--- a/Sources/Scout/Core/Log/EventObject.swift
+++ b/Sources/Scout/Core/Log/EventObject.swift
@@ -10,7 +10,6 @@ import CoreData
 
 @objc(EventObject)
 final class EventObject: NamedObject, Syncable, MatrixBatch {
-
     @NSManaged var eventID: UUID?
     @NSManaged var level: String?
     @NSManaged var paramCount: Int64

--- a/Sources/Scout/Core/Log/LogHandler.swift
+++ b/Sources/Scout/Core/Log/LogHandler.swift
@@ -45,7 +45,6 @@ struct CKLogHandler: LogHandler {
                     )
                 }
                 try await SyncController.shared.synchronize()
-
             } catch {
                 print(error.localizedDescription)
             }

--- a/Sources/Scout/Core/Matrix/GridCell.swift
+++ b/Sources/Scout/Core/Matrix/GridCell.swift
@@ -59,11 +59,10 @@ extension GridCell: Combining {
 
 extension GridCell: Comparable {
     static func < (lhs: GridCell<T>, rhs: GridCell<T>) -> Bool {
-        if lhs.row == rhs.row {
-            return lhs.column < rhs.column
-        } else {
+        guard lhs.row == rhs.row else {
             return lhs.row < rhs.row
         }
+        return lhs.column < rhs.column
     }
 }
 

--- a/Sources/Scout/Core/Matrix/Matrix.swift
+++ b/Sources/Scout/Core/Matrix/Matrix.swift
@@ -20,7 +20,7 @@ struct Matrix<T: CellProtocol> {
 
 extension Matrix: Combining {
     func isDuplicate(of other: Matrix<T>) -> Bool {
-        return date == other.date
+        date == other.date
             && name == other.name
             && category == other.category
             && recordType == other.recordType

--- a/Sources/Scout/Core/Matrix/NamedObject.swift
+++ b/Sources/Scout/Core/Matrix/NamedObject.swift
@@ -9,7 +9,6 @@ import CoreData
 
 @objc(NamedObject)
 class NamedObject: SyncableObject {
-
     @NSManaged var name: String?
 
     static func matrix(of batch: [NamedObject]) throws(MatrixPropertyError) -> GridMatrix<Int> {

--- a/Sources/Scout/Core/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Session/SessionObject.swift
@@ -10,7 +10,6 @@ import CoreData
 
 @objc(SessionObject)
 final class SessionObject: SyncableObject, Syncable {
-
     @NSManaged var endDate: Date?
 
     static func group(in context: NSManagedObjectContext) throws -> [SessionObject]? {

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -13,7 +13,6 @@ protocol Syncable: SyncableObject {
 
 @objc(SyncableObject)
 class SyncableObject: IDObject {
-
     @NSManaged var isSynced: Bool
 
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {

--- a/Sources/Scout/Core/Telemetry/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Telemetry/MetricsObject+Group.swift
@@ -10,7 +10,6 @@ import CoreData
 
 @objc(MetricsObject)
 class MetricsObject: SyncableObject {
-
     @NSManaged var name: String?
     @NSManaged var telemetry: String?
 

--- a/Sources/Scout/Core/Telemetry/Telemetry.swift
+++ b/Sources/Scout/Core/Telemetry/Telemetry.swift
@@ -5,8 +5,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-/// This type is not used directly in the current version of the package,
-/// but is reserved for future telemetry expansion and metrics export.
+/// This type is not used directly in the current version of the package, but is reserved for future telemetry expansion and metrics export.
+///
 /// Keeping it now helps establish a consistent data format (see Telemetry.Export)
 /// and simplifies integration in upcoming releases.
 ///

--- a/Sources/Scout/Core/Telemetry/TelemetryFactory.swift
+++ b/Sources/Scout/Core/Telemetry/TelemetryFactory.swift
@@ -17,15 +17,15 @@ struct TelemetryFactory: MetricsFactory {
         CKTelemetryHandler(label: label, dimensions: dimensions)
     }
 
-    func makeMeter(label: String,dimensions: [(String, String)]) -> MeterHandler {
+    func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
         CKTelemetryHandler.Idle()
     }
 
-    func makeRecorder(label: String,dimensions: [(String, String)],aggregate: Bool) -> RecorderHandler {
+    func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
         CKTelemetryHandler.Idle()
     }
 
-    func makeTimer(label: String,dimensions: [(String, String)]) -> TimerHandler {
+    func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
         CKTelemetryHandler(label: label, dimensions: dimensions)
     }
 

--- a/Sources/Scout/Core/Utilities/DateObject.swift
+++ b/Sources/Scout/Core/Utilities/DateObject.swift
@@ -9,7 +9,6 @@ import CoreData
 
 @objc(DateObject)
 class DateObject: NSManagedObject, Identifiable {
-
     @NSManaged var datePrimitive: Date?
     @NSManaged var day: Date?
     @NSManaged var hour: Date?

--- a/Sources/Scout/UI/Chart/ChartSeries.swift
+++ b/Sources/Scout/UI/Chart/ChartSeries.swift
@@ -14,7 +14,6 @@ protocol ChartSeries: HasCount {
 }
 
 extension Collection where Element: ChartSeries {
-
     func bucket(on period: some ChartTimeScale) -> [Element] {
         bucket(in: period.initialRange, component: period.pointComponent)
     }

--- a/Sources/Scout/UI/Chart/ChartTimeScale.swift
+++ b/Sources/Scout/UI/Chart/ChartTimeScale.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 protocol ChartTimeScale: Identifiable, Hashable {
-
     /// Major axis segmentation (big bands).
     ///
     /// Each block represents one whole `Calendar.Component` in the visible time window (`range`).
@@ -46,7 +45,6 @@ protocol ChartTimeScale: Identifiable, Hashable {
 // MARK: - Helpers
 
 extension ChartTimeScale {
-
     var today: Date {
         Date().startOfDay
     }

--- a/Sources/Scout/UI/Chart/Range/Range+Label.swift
+++ b/Sources/Scout/UI/Chart/Range/Range+Label.swift
@@ -12,10 +12,9 @@ extension Range<Date> {
         let from = formatter.string(from: lowerBound)
         let to = formatter.string(from: upperBound.addingDay(-1))
 
-        if from == to {
-            return from
-        } else {
+        guard from == to else {
             return "\(from) – \(to)"
         }
+        return from
     }
 }

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -16,9 +16,9 @@ struct CrashDetailView: View {
         List {
             headerSection
 
-//            if let reason = crash.reason {
-//                reasonSection(reason)
-//            }
+            //            if let reason = crash.reason {
+            //                reasonSection(reason)
+            //            }
 
             if !crash.stackTrace.isEmpty {
                 stackTraceSection
@@ -46,7 +46,7 @@ struct CrashDetailView: View {
 
             if let reason = crash.reason {
                 Text("REASON:   ").fontWeight(.bold)
-                + Text(reason).fontWeight(.bold).foregroundColor(.red)
+                    + Text(reason).fontWeight(.bold).foregroundColor(.red)
             }
         }
         .padding(.vertical, 4)

--- a/Sources/Scout/UI/Database/AppDatabase.swift
+++ b/Sources/Scout/UI/Database/AppDatabase.swift
@@ -9,6 +9,7 @@ import CloudKit
 import SwiftUI
 
 /// AppDatabase defines the read-only database surface used by the UI.
+///
 /// It abstracts record lookup and query operations for use in SwiftUI
 /// and is intended for dependency injection via the environment.
 ///

--- a/Sources/Scout/UI/Database/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/DefaultDatabase.swift
@@ -30,5 +30,4 @@ struct DefaultDatabase: AppDatabase {
     func lookup(id: CKRecord.ID) async throws -> CKRecord {
         Event.sampleRecords.randomElement()!
     }
-
 }

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct AnalyticsView: View {
-
     @State private var filter = Event.Query()
 
     @StateObject private var provider = EventProvider()

--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -45,7 +45,7 @@ extension EventView {
         }
 
         var seeAll: (() -> Void)? {
-            if let _ = try? param.result?.get(), count > 3 {
+            if (try? param.result?.get()) != nil, count > 3 {
                 { isParamPresented = true }
             } else {
                 nil

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -91,7 +91,7 @@ struct ParamRow: View {
         let items = [
             ParamProvider.Item(key: "key1", value: "value1"),
             ParamProvider.Item(key: "key2", value: "value2"),
-            ParamProvider.Item(key: "key3", value: "value3")
+            ParamProvider.Item(key: "key3", value: "value3"),
         ]
         ParamList(items: items)
     }

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -61,4 +61,3 @@ public struct HomeView: View {
         retry: {}
     )
 }
-

--- a/Sources/Scout/UI/Message/MessageView.swift
+++ b/Sources/Scout/UI/Message/MessageView.swift
@@ -12,7 +12,6 @@ struct MessageView: View {
     let level: Message.Level
 
     var body: some View {
-
         Text(text)
             .font(.system(size: 16))
             .multilineTextAlignment(.center)

--- a/Tests/ScoutTests/Core/Activity/ActivityPeriodTests.swift
+++ b/Tests/ScoutTests/Core/Activity/ActivityPeriodTests.swift
@@ -11,7 +11,6 @@ import Testing
 @testable import Scout
 
 struct ActivityPeriodTests {
-
     // MARK: - Raw Values
 
     @Test("Raw values encode correctly")

--- a/Tests/ScoutTests/Core/Bootstrap/NotificationListenerTests.swift
+++ b/Tests/ScoutTests/Core/Bootstrap/NotificationListenerTests.swift
@@ -11,7 +11,6 @@ import XCTest
 @testable import Scout
 
 struct NotificationListenerTests {
-
     @Test("Success setup") func testSuccessSetup() async throws {
         let listener = NotificationListener(table: [:])
         #expect(throws: Never.self) {
@@ -29,7 +28,6 @@ struct NotificationListenerTests {
 }
 
 class NotificationListenerTestCase: XCTestCase {
-
     // Special case not covering with SwiftTesting
     func testNotificationHandling() async throws {
         let expectation = XCTestExpectation(description: "Notification handling")

--- a/Tests/ScoutTests/Core/Bootstrap/SchemaErrorTests.swift
+++ b/Tests/ScoutTests/Core/Bootstrap/SchemaErrorTests.swift
@@ -12,7 +12,6 @@ import Testing
 
 @Suite("CKError.isSchemaError")
 struct SchemaErrorTests {
-
     // MARK: - Matching codes with schema messages
 
     @Test("invalidArguments with 'record type' message")

--- a/Tests/ScoutTests/Core/Crash/CrashArchiveTests.swift
+++ b/Tests/ScoutTests/Core/Crash/CrashArchiveTests.swift
@@ -12,7 +12,6 @@ import Testing
 
 @Suite("CrashArchive")
 struct CrashArchiveTests {
-
     @Test("write creates directory and crash file")
     func testWriteCreatesCrashFile() throws {
         let tempDir = FileManager.default.temporaryDirectory

--- a/Tests/ScoutTests/Core/Database/ChunkedTests.swift
+++ b/Tests/ScoutTests/Core/Database/ChunkedTests.swift
@@ -10,7 +10,6 @@ import Testing
 @testable import Scout
 
 struct ChunkedTests {
-
     @Test("Empty array returns empty result")
     func empty() {
         let result = [Int]().chunked(into: 5)

--- a/Tests/ScoutTests/Core/Database/RecordChunkTests.swift
+++ b/Tests/ScoutTests/Core/Database/RecordChunkTests.swift
@@ -11,7 +11,6 @@ import Testing
 @testable import Scout
 
 struct RecordChunkTests {
-
     @Test("Addition concatenates records")
     func addition() {
         let r1 = CKRecord(recordType: "A")

--- a/Tests/ScoutTests/Core/Log/EventObjectTests.swift
+++ b/Tests/ScoutTests/Core/Log/EventObjectTests.swift
@@ -21,7 +21,7 @@ struct EventObjectTests {
         let batch: [EventObject] = [
             .stub(name: "name", date: date, in: context),
             .stub(name: "name", date: date, in: context),
-            .stub(name: "name", date: date.addingHour(), in: context)
+            .stub(name: "name", date: date.addingHour(), in: context),
         ]
 
         let cells = EventObject.parse(of: batch)

--- a/Tests/ScoutTests/Core/Matrix/CombiningTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/CombiningTests.swift
@@ -10,7 +10,6 @@ import Testing
 @testable import Scout
 
 struct CombiningTests {
-
     // MARK: - mergeDuplicates
 
     @Test("Merge duplicates combines matching cells")

--- a/Tests/ScoutTests/Core/Matrix/MatrixLookupTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/MatrixLookupTests.swift
@@ -5,9 +5,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import Testing
-import Foundation
 import CloudKit
+import Foundation
+import Testing
 
 @testable import Scout
 

--- a/Tests/ScoutTests/Core/Matrix/NamedObjectTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/NamedObjectTests.swift
@@ -48,7 +48,7 @@ struct NamedObjectTests {
     @Test("matrix(of:) throws when name is missing")
     func testMatrixThrowsOnMissingName() throws {
         let batch: [NamedObject] = [
-            .stub(name: nil, date: date, in: context),
+            .stub(name: nil, date: date, in: context)
         ]
 
         #expect(throws: MatrixPropertyError.self) {

--- a/Tests/ScoutTests/Core/Matrix/PeriodCellTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/PeriodCellTests.swift
@@ -10,7 +10,6 @@ import Testing
 @testable import Scout
 
 struct PeriodCellTests {
-
     // MARK: - Key Generation
 
     @Test("Key encodes period and day")

--- a/Tests/ScoutTests/Core/Session/SessionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Session/SessionObjectTests.swift
@@ -26,9 +26,10 @@ struct SessionObjectTests {
 
         let cells = SessionObject.parse(of: batch)
 
-        #expect(cells.sorted() == [
-            GridCell(row: 1, column: 0, value: 2),
-            GridCell(row: 1, column: 1, value: 1),
-        ])
+        #expect(
+            cells.sorted() == [
+                GridCell(row: 1, column: 0, value: 2),
+                GridCell(row: 1, column: 1, value: 1),
+            ])
     }
 }

--- a/Tests/ScoutTests/Core/Sync/SyncableObjectBatchTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncableObjectBatchTests.swift
@@ -26,10 +26,11 @@ struct SyncableObjectBatchTests {
 
         try context.save()
 
-        let batch = try #require(try SyncableObject.batch(
-            in: context,
-            matching: [\EventObject.name, \.week]
-        ))
+        let batch = try #require(
+            try SyncableObject.batch(
+                in: context,
+                matching: [\EventObject.name, \.week]
+            ))
 
         #expect(Set(batch.map(\.name)).count == 1)
     }
@@ -54,10 +55,11 @@ struct SyncableObjectBatchTests {
         let event = EventObject.stub(name: "EventC", date: week, synced: false, in: context)
         try context.save()
 
-        let batch = try #require(try SyncableObject.batch(
-            in: context,
-            matching: [\EventObject.name, \.week]
-        ))
+        let batch = try #require(
+            try SyncableObject.batch(
+                in: context,
+                matching: [\EventObject.name, \.week]
+            ))
 
         #expect(batch.count == 1)
         #expect(batch.first === event)


### PR DESCRIPTION
- Add .swift-format config (4-space indent, 120 line length)
- Add lint job to CI workflow
- Fix all existing format violations