### PR TITLE
Treat Swift warnings as errors in CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -51,7 +51,7 @@ jobs:
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
             -enableCodeCoverage YES \
-            OTHER_SWIFT_FLAGS="-warnings-as-errors" \
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
             build-for-testing
 
       - name: Test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -51,6 +51,7 @@ jobs:
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
             -enableCodeCoverage YES \
+            OTHER_SWIFT_FLAGS="-warnings-as-errors" \
             build-for-testing
 
       - name: Test


### PR DESCRIPTION
- Add OTHER_SWIFT_FLAGS="-warnings-as-errors" to build step