### PR TITLE
Replace hardcoded record type strings with constants

### DIFF
--- a/Sources/Scout/Core/Activity/UserActivity+MatrixBatch.swift
+++ b/Sources/Scout/Core/Activity/UserActivity+MatrixBatch.swift
@@ -13,7 +13,7 @@ extension UserActivity: MatrixBatch {
             throw .init("month")
         }
         return Matrix(
-            recordType: "PeriodMatrix",
+            recordType: PeriodCell<Int>.recordType,
             date: month,
             name: "ActiveUser",
             cells: parse(of: batch)

--- a/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
@@ -17,8 +17,12 @@ struct SchemaError: LocalizedError {
 }
 
 private let schemaRecordTypes = [
-    "Event", "Session", "Crash",
-    "DateIntMatrix", "DateDoubleMatrix", "PeriodMatrix",
+    EventObject.recordType,
+    SessionObject.recordType,
+    CrashObject.recordType,
+    Int.recordType,
+    Double.recordType,
+    PeriodCell<Int>.recordType,
 ]
 
 extension CKContainer {

--- a/Sources/Scout/Core/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Crash/CrashObject.swift
@@ -10,6 +10,7 @@ import CoreData
 
 @objc(CrashObject)
 final class CrashObject: NamedObject, Syncable, MatrixBatch {
+    static let recordType = "Crash"
     @NSManaged var crashID: UUID?
     @NSManaged var reason: String?
     @NSManaged var stackTrace: Data?
@@ -25,7 +26,7 @@ final class CrashObject: NamedObject, Syncable, MatrixBatch {
 
 extension CrashObject: CKRepresentable {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: "Crash")
+        let record = CKRecord(recordType: Self.recordType)
 
         record["name"] = name
         record["reason"] = reason

--- a/Sources/Scout/Core/Log/EventObject.swift
+++ b/Sources/Scout/Core/Log/EventObject.swift
@@ -10,6 +10,7 @@ import CoreData
 
 @objc(EventObject)
 final class EventObject: NamedObject, Syncable, MatrixBatch {
+    static let recordType = "Event"
     @NSManaged var eventID: UUID?
     @NSManaged var level: String?
     @NSManaged var paramCount: Int64
@@ -26,7 +27,7 @@ final class EventObject: NamedObject, Syncable, MatrixBatch {
 
 extension EventObject: CKRepresentable {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: "Event")
+        let record = CKRecord(recordType: Self.recordType)
 
         record["name"] = name
         record["level"] = level

--- a/Sources/Scout/Core/Matrix/MatrixValue.swift
+++ b/Sources/Scout/Core/Matrix/MatrixValue.swift
@@ -10,15 +10,15 @@ import CoreData
 
 protocol MatrixValue: AdditiveArithmetic & Comparable & Hashable & Sendable & CKRecordValueProtocol {
     associatedtype Object: MetricsValued where Object.Value == Self
-    static var recordName: String { get }
+    static var recordType: String { get }
 }
 
 extension Int: MatrixValue {
     typealias Object = IntMetricsObject
-    static let recordName = "DateIntMatrix"
+    static let recordType = "DateIntMatrix"
 }
 
 extension Double: MatrixValue {
     typealias Object = DoubleMetricsObject
-    static let recordName = "DateDoubleMatrix"
+    static let recordType = "DateDoubleMatrix"
 }

--- a/Sources/Scout/Core/Matrix/NamedObject.swift
+++ b/Sources/Scout/Core/Matrix/NamedObject.swift
@@ -19,7 +19,7 @@ class NamedObject: SyncableObject {
             throw .init("week")
         }
         return Matrix(
-            recordType: "DateIntMatrix",
+            recordType: Int.recordType,
             date: week,
             name: name,
             cells: parse(of: batch)

--- a/Sources/Scout/Core/Matrix/PeriodCell.swift
+++ b/Sources/Scout/Core/Matrix/PeriodCell.swift
@@ -8,6 +8,8 @@
 import CloudKit
 
 struct PeriodCell<T: MatrixValue> {
+    static var recordType: String { "PeriodMatrix" }
+
     let period: ActivityPeriod
     let day: Int
     let value: T

--- a/Sources/Scout/Core/Session/SessionObject+MatrixBatch.swift
+++ b/Sources/Scout/Core/Session/SessionObject+MatrixBatch.swift
@@ -11,7 +11,7 @@ extension SessionObject: MatrixBatch {
             throw .init("week")
         }
         return Matrix(
-            recordType: "DateIntMatrix",
+            recordType: Int.recordType,
             date: week,
             name: "Session",
             cells: parse(of: batch)

--- a/Sources/Scout/Core/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Session/SessionObject.swift
@@ -10,6 +10,7 @@ import CoreData
 
 @objc(SessionObject)
 final class SessionObject: SyncableObject, Syncable {
+    static let recordType = "Session"
     @NSManaged var endDate: Date?
 
     static func group(in context: NSManagedObjectContext) throws -> [SessionObject]? {
@@ -19,7 +20,7 @@ final class SessionObject: SyncableObject, Syncable {
 
 extension SessionObject: CKRepresentable {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: "Session")
+        let record = CKRecord(recordType: Self.recordType)
 
         record["start_date"] = date
         record["end_date"] = endDate

--- a/Sources/Scout/Core/Telemetry/MetricsObject+Group.swift
+++ b/Sources/Scout/Core/Telemetry/MetricsObject+Group.swift
@@ -28,7 +28,7 @@ class MetricsObject: SyncableObject {
             throw .init("week")
         }
         return Matrix(
-            recordType: T.Value.recordName,
+            recordType: T.Value.recordType,
             date: week,
             name: name,
             category: telemetry,

--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -20,7 +20,7 @@ class ActivityProvider: QueryProvider<ActivityMatrix> {
             )
 
             return CKQuery(
-                recordType: "PeriodMatrix",
+                recordType: PeriodCell<Int>.recordType,
                 predicate: predicate
             )
         }

--- a/Sources/Scout/UI/Crash/Crash+Sample.swift
+++ b/Sources/Scout/UI/Crash/Crash+Sample.swift
@@ -23,7 +23,7 @@ extension Crash {
         ]
 
         return crashes.enumerated().map { index, crash in
-            let record = CKRecord(recordType: "Crash", recordID: CKRecord.ID())
+            let record = CKRecord(recordType: CrashObject.recordType, recordID: CKRecord.ID())
             record["name"] = crash.name
             record["reason"] = crash.reason
             record["date"] = Date().addingTimeInterval(TimeInterval(-index * 7200))

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -15,7 +15,7 @@ class CrashProvider: ObservableObject {
 
     func fetch(in database: AppDatabase) async {
         do {
-            let query = CKQuery(recordType: "Crash", predicate: Self.predicate)
+            let query = CKQuery(recordType: CrashObject.recordType, predicate: Self.predicate)
             query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
 
             let results = try await database.read(

--- a/Sources/Scout/UI/Database/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/DefaultDatabase.swift
@@ -12,9 +12,9 @@ struct DefaultDatabase: AppDatabase {
         let records: [CKRecord]
 
         switch query.recordType {
-        case "Crash":
+        case CrashObject.recordType:
             records = Crash.sampleRecords
-        case "DateIntMatrix":
+        case Int.recordType:
             records = GridMatrix<Int>.sampleRecords
         default:
             records = Event.sampleRecords

--- a/Sources/Scout/UI/Event/Event+Sample.swift
+++ b/Sources/Scout/UI/Event/Event+Sample.swift
@@ -43,7 +43,7 @@ extension Event {
         ]
 
         return eventLevels.enumerated().map { index, event in
-            let record = CKRecord(recordType: "Event", recordID: CKRecord.ID())
+            let record = CKRecord(recordType: EventObject.recordType, recordID: CKRecord.ID())
             record["name"] = event.key
             record["userID"] = UUID().uuidString
             record["sessionID"] = UUID().uuidString

--- a/Sources/Scout/UI/Event/EventProvider.swift
+++ b/Sources/Scout/UI/Event/EventProvider.swift
@@ -17,7 +17,7 @@ class EventProvider: ObservableObject {
 
     func fetch(for filter: Event.Query, in database: AppDatabase) async {
         do {
-            let query = CKQuery(recordType: "Event", predicate: filter.buildPredicate())
+            let query = CKQuery(recordType: EventObject.recordType, predicate: filter.buildPredicate())
             query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
 
             let results = try await database.read(

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -57,7 +57,7 @@ public struct HomeView: View {
 
 #Preview("Schema Error") {
     ErrorView(
-        error: SchemaError(recordTypes: ["Crash", "PeriodMatrix"]),
+        error: SchemaError(recordTypes: [CrashObject.recordType, PeriodCell<Int>.recordType]),
         retry: {}
     )
 }

--- a/Sources/Scout/UI/Metrics/MetricsProvider.swift
+++ b/Sources/Scout/UI/Metrics/MetricsProvider.swift
@@ -20,7 +20,7 @@ class MetricsProvider<T: ChartNumeric>: QueryProvider<GridMatrix<T>> {
             )
 
             return CKQuery(
-                recordType: T.recordName,
+                recordType: T.recordType,
                 predicate: predicate
             )
         }

--- a/Sources/Scout/UI/Metrics/Series/GridMatrix+Sample.swift
+++ b/Sources/Scout/UI/Metrics/Series/GridMatrix+Sample.swift
@@ -17,7 +17,7 @@ extension Matrix where T == GridCell<Int> {
                 return nil
             }
 
-            let record = CKRecord(recordType: "DateIntMatrix")
+            let record = CKRecord(recordType: Int.recordType)
             record["date"] = weekStart
             record["name"] = "event_name"
 

--- a/Sources/Scout/UI/Stats/StatProvider.swift
+++ b/Sources/Scout/UI/Stats/StatProvider.swift
@@ -25,7 +25,7 @@ class StatProvider: QueryProvider<GridMatrix<Int>> {
             )
 
             return CKQuery(
-                recordType: "DateIntMatrix",
+                recordType: Int.recordType,
                 predicate: predicate
             )
         }

--- a/Tests/ScoutTests/Core/Matrix/MatrixLookupTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/MatrixLookupTests.swift
@@ -20,7 +20,7 @@ struct MatrixLookupTests {
         database.records = [CKRecord.matrixStub(name: "other", date: Date().addingTimeInterval(-3600))]
 
         let matrix = Matrix<GridCell<Int>>(
-            recordType: "DateIntMatrix",
+            recordType: Int.recordType,
             date: Date(),
             name: "target",
             cells: []
@@ -37,7 +37,7 @@ struct MatrixLookupTests {
         database.records = [match]
 
         let query = Matrix<GridCell<Int>>(
-            recordType: "DateIntMatrix",
+            recordType: Int.recordType,
             date: date,
             name: "target",
             cells: []
@@ -46,7 +46,7 @@ struct MatrixLookupTests {
         let existing = try #require(try await query.lookupExisting(in: database))
         let parsed = try Matrix<GridCell<Int>>(record: match)
 
-        #expect(existing.recordType == "DateIntMatrix")
+        #expect(existing.recordType == Int.recordType)
         #expect(existing.name == "target")
         #expect(existing.date == date)
         #expect(Set(existing.cells) == Set(parsed.cells))

--- a/Tests/ScoutTests/Core/Matrix/NamedObjectTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/NamedObjectTests.swift
@@ -39,7 +39,7 @@ struct NamedObjectTests {
 
         let matrix = try NamedObject.matrix(of: batch)
 
-        #expect(matrix.recordType == "DateIntMatrix")
+        #expect(matrix.recordType == Int.recordType)
         #expect(matrix.name == "signal")
         #expect(matrix.date == date.startOfWeek)
         #expect(matrix.cells.count == 2)

--- a/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
@@ -22,7 +22,7 @@ struct SyncCoordinatorTests {
             database: database,
             maxRetry: 3,
             matrix: Matrix(
-                recordType: "DateIntMatrix",
+                recordType: Int.recordType,
                 date: now,
                 name: "matrix",
                 cells: []
@@ -34,7 +34,7 @@ struct SyncCoordinatorTests {
     func testUploadSuccess() async throws {
         try await coordinator.upload()
 
-        #expect(database.records.filter { $0.recordType == "DateIntMatrix" }.count == 1)
+        #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
     }
 
     @Test("Upload retries and merges on serverRecordChanged error")
@@ -43,7 +43,7 @@ struct SyncCoordinatorTests {
 
         try await coordinator.upload()
 
-        #expect(database.records.filter { $0.recordType == "DateIntMatrix" }.count == 1)
+        #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
     }
 
     @Test("Upload falls back to newMatrix after max retries")
@@ -53,7 +53,7 @@ struct SyncCoordinatorTests {
         }
         try await coordinator.upload()
 
-        #expect(database.records.filter { $0.recordType == "DateIntMatrix" }.count == 1)
+        #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
     }
 }
 

--- a/Tests/ScoutTests/Stubs/CKRecord+Stub.swift
+++ b/Tests/ScoutTests/Stubs/CKRecord+Stub.swift
@@ -7,12 +7,14 @@
 
 import CloudKit
 
+@testable import Scout
+
 extension CKRecord {
     static func matrixStub(
         name: String = "matrix",
         date: Date = Date()
     ) -> CKRecord {
-        let matrix = CKRecord(recordType: "DateIntMatrix")
+        let matrix = CKRecord(recordType: Int.recordType)
         matrix["name"] = name
         matrix["date"] = date
         matrix["cell_1_01"] = 3

--- a/Tests/ScoutTests/Transient/InMemoryDatabase.swift
+++ b/Tests/ScoutTests/Transient/InMemoryDatabase.swift
@@ -55,6 +55,6 @@ final class InMemoryDatabase: Database, @unchecked Sendable {
 
 extension InMemoryDatabase {
     var events: [CKRecord] {
-        records.filter { $0.recordType == "Event" }
+        records.filter { $0.recordType == EventObject.recordType }
     }
 }


### PR DESCRIPTION
- Add `static let recordType` to `EventObject`, `SessionObject`, `CrashObject`
- Add `static var recordType` to `PeriodCell`
- Rename `MatrixValue.recordName` to `recordType` for consistency with CloudKit API
- Replace all hardcoded record type strings across Sources and Tests