### PR TITLE
Remove unused CKPersistable typealias

### DIFF
--- a/Sources/Scout/Core/Sync/CKPersistable.swift
+++ b/Sources/Scout/Core/Sync/CKPersistable.swift
@@ -7,8 +7,6 @@
 
 import CloudKit
 
-typealias CKPersistable = CKInitializable & CKRepresentable
-
 protocol CKInitializable {
     init(record: CKRecord) throws
 }


### PR DESCRIPTION
- Remove `CKPersistable` typealias that has no conformances
- `CKInitializable` and `CKRepresentable` protocols remain unchanged