### PR TITLE
Do not cancel CI builds on main branch

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ios-tests-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   lint:


### PR DESCRIPTION
- Keep cancel-in-progress for PR branches to avoid redundant builds
- Disable it for main so consecutive merges don't hide failures