### PR TITLE
Add build time and binary size to CI summary

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -47,11 +47,32 @@ jobs:
 
       - name: Build
         run: |
+          start=$(date +%s)
+
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
             -enableCodeCoverage YES \
             build-for-testing
+
+          echo "duration=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+
+      - name: Build summary
+        run: |
+          BUILD_DIR=$(xcodebuild \
+            -scheme Scout \
+            -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
+            -showBuildSettings 2>/dev/null \
+            | awk '/^\s*BUILT_PRODUCTS_DIR =/ { print $3; exit }')
+
+          SIZE=$(du -sh "$BUILD_DIR/PackageFrameworks/Scout.framework" 2>/dev/null | cut -f1 || echo "–")
+
+          {
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Build time | ${duration}s |"
+            echo "| Framework size | $SIZE |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Test
         run: |


### PR DESCRIPTION
- Measure build duration and write it to the job summary
- Report Scout.framework size from build products