### PR TITLE
Compare framework size against main branch

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -59,23 +59,23 @@ jobs:
           key: framework-size-ios-${{ matrix.ios }}-
           restore-keys: framework-size-ios-${{ matrix.ios }}-
 
-      - name: Framework size
+      - name: Binary size
         run: |
-          FRAMEWORK=$(find ~/Library/Developer/Xcode/DerivedData \
-            -path "*/PackageFrameworks/Scout.framework" -print -quit 2>/dev/null)
+          OBJ_DIR=$(find ~/Library/Developer/Xcode/DerivedData \
+            -path "*/Scout.build/Objects-normal/arm64" -print -quit 2>/dev/null)
 
-          CURRENT=$(du -sk "$FRAMEWORK" 2>/dev/null | cut -f1)
+          CURRENT=$(du -sk "$OBJ_DIR" 2>/dev/null | cut -f1)
 
           if [ -f main-framework-size.txt ]; then
             MAIN=$(cat main-framework-size.txt)
             DIFF=$((CURRENT - MAIN))
             if [ "$DIFF" -eq 0 ]; then
-              echo "Scout.framework: ${CURRENT}KB" >> "$GITHUB_STEP_SUMMARY"
+              echo "Scout: ${CURRENT}KB" >> "$GITHUB_STEP_SUMMARY"
             else
-              printf 'Scout.framework: %sKB (%+dKB)\n' "$CURRENT" "$DIFF" >> "$GITHUB_STEP_SUMMARY"
+              printf 'Scout: %sKB (%+dKB)\n' "$CURRENT" "$DIFF" >> "$GITHUB_STEP_SUMMARY"
             fi
           else
-            echo "Scout.framework: ${CURRENT}KB" >> "$GITHUB_STEP_SUMMARY"
+            echo "Scout: ${CURRENT}KB" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "$CURRENT" > main-framework-size.txt

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -65,17 +65,19 @@ jobs:
             -path "*/Scout.build/Objects-normal/arm64" -print -quit 2>/dev/null)
 
           CURRENT=$(du -sk "$OBJ_DIR" 2>/dev/null | cut -f1)
+          MB=$(awk "BEGIN { printf \"%.1f\", $CURRENT / 1024 }")
 
           if [ -f main-framework-size.txt ]; then
             MAIN=$(cat main-framework-size.txt)
             DIFF=$((CURRENT - MAIN))
             if [ "$DIFF" -eq 0 ]; then
-              echo "Scout: ${CURRENT}KB" >> "$GITHUB_STEP_SUMMARY"
+              echo "Scout: ${MB}MB" >> "$GITHUB_STEP_SUMMARY"
             else
-              printf 'Scout: %sKB (%+dKB)\n' "$CURRENT" "$DIFF" >> "$GITHUB_STEP_SUMMARY"
+              DIFF_KB=$(awk "BEGIN { printf \"%+d\", $DIFF }")
+              echo "Scout: ${MB}MB (${DIFF_KB}KB)" >> "$GITHUB_STEP_SUMMARY"
             fi
           else
-            echo "Scout: ${CURRENT}KB" >> "$GITHUB_STEP_SUMMARY"
+            echo "Scout: ${MB}MB" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "$CURRENT" > main-framework-size.txt

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -53,12 +53,38 @@ jobs:
             -enableCodeCoverage YES \
             build-for-testing
 
+      - uses: actions/cache/restore@v4
+        with:
+          path: main-framework-size.txt
+          key: framework-size-ios-${{ matrix.ios }}-
+          restore-keys: framework-size-ios-${{ matrix.ios }}-
+
       - name: Framework size
         run: |
           FRAMEWORK=$(find ~/Library/Developer/Xcode/DerivedData \
             -path "*/PackageFrameworks/Scout.framework" -print -quit 2>/dev/null)
 
-          du -sh "$FRAMEWORK" 2>/dev/null | cut -f1 >> "$GITHUB_STEP_SUMMARY"
+          CURRENT=$(du -sk "$FRAMEWORK" 2>/dev/null | cut -f1)
+
+          if [ -f main-framework-size.txt ]; then
+            MAIN=$(cat main-framework-size.txt)
+            DIFF=$((CURRENT - MAIN))
+            if [ "$DIFF" -eq 0 ]; then
+              echo "Scout.framework: ${CURRENT}KB" >> "$GITHUB_STEP_SUMMARY"
+            else
+              printf 'Scout.framework: %sKB (%+dKB)\n' "$CURRENT" "$DIFF" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "Scout.framework: ${CURRENT}KB" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "$CURRENT" > main-framework-size.txt
+
+      - uses: actions/cache/save@v4
+        if: github.ref == 'refs/heads/main'
+        with:
+          path: main-framework-size.txt
+          key: framework-size-ios-${{ matrix.ios }}-${{ github.sha }}
 
       - name: Test
         run: |


### PR DESCRIPTION
- Cache framework size on main builds
- Restore cached size on PR builds and show diff in job summary
- Display as e.g. "Scout.framework: 320KB (+8KB)"