### PR TITLE
Fix setup example in INSTALLATION.md

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -32,15 +32,10 @@ Then run the upload script included in the repository. It will update both devel
 ## Configure Scout
 
 ```swift
+import CloudKit
 import Scout
 
 let container = CKContainer(identifier: "YOUR_CONTAINER_ID")
 
-func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-) -> Bool {
-    try? Scout.setup(container: container)
-    return true
-}
+try await setup(container: container)
 ```


### PR DESCRIPTION
- Update the Configure Scout example to use the actual async API (`try await setup(...)`)
- Remove outdated synchronous `didFinishLaunchingWithOptions` boilerplate
- Add missing `import CloudKit`