### PR TITLE
Fix typo in UserActivityMonitorTests

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
@@ -13,10 +13,10 @@ extension CKError {
     var isSchemaError: Bool {
         switch code {
         case .unknownItem:
-            let message = localizedDescription.lowercased()
+            let message = (userInfo["ServerErrorDescription"] as? String)?.lowercased() ?? ""
             return message.contains("record type")
         case .invalidArguments, .serverRejectedRequest:
-            let message = localizedDescription.lowercased()
+            let message = (userInfo["ServerErrorDescription"] as? String)?.lowercased() ?? ""
             return message.contains("record type")
                 || message.contains("field")
                 || message.contains("not marked queryable")

--- a/Tests/ScoutTests/Core/Activity/UserActivityMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Activity/UserActivityMonitorTests.swift
@@ -12,7 +12,7 @@ import Testing
 
 @MainActor
 @Suite("UserActivityObject+Monitor")
-struct UserActivityObjectMontitorTests {
+struct UserActivityObjectMonitorTests {
     let context = NSManagedObjectContext.inMemoryContext()
 
     @Test("Trigger") func trigger() async throws {


### PR DESCRIPTION
- Renamed `UserActivityMontitorTests.swift` to `UserActivityMonitorTests.swift`
- Fixed class name from `UserActivityObjectMontitorTests` to `UserActivityObjectMonitorTests`