### PR TITLE
Fix missing upper bound in StatProvider query

### DIFF
--- a/Sources/Scout/UI/Stats/StatProvider.swift
+++ b/Sources/Scout/UI/Stats/StatProvider.swift
@@ -19,8 +19,9 @@ class StatProvider: QueryProvider<GridMatrix<Int>> {
             let dateRange = Calendar.utc.defaultRange
 
             let predicate = NSPredicate(
-                format: "date >= %@ AND name == %@",
+                format: "date >= %@ AND date < %@ AND name == %@",
                 dateRange.lowerBound as NSDate,
+                dateRange.upperBound as NSDate,
                 eventName
             )
 


### PR DESCRIPTION
- The CKQuery predicate in `StatProvider` was missing the upper bound date filter, only checking `date >= %@`
- Added `date < %@` with `dateRange.upperBound` to correctly constrain the query to the intended date range