### PR TITLE
Use server error description for schema error detection

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKError+Schema.swift
@@ -13,10 +13,10 @@ extension CKError {
     var isSchemaError: Bool {
         switch code {
         case .unknownItem:
-            let message = localizedDescription.lowercased()
+            let message = (userInfo["ServerErrorDescription"] as? String)?.lowercased() ?? ""
             return message.contains("record type")
         case .invalidArguments, .serverRejectedRequest:
-            let message = localizedDescription.lowercased()
+            let message = (userInfo["ServerErrorDescription"] as? String)?.lowercased() ?? ""
             return message.contains("record type")
                 || message.contains("field")
                 || message.contains("not marked queryable")

--- a/Tests/ScoutTests/Core/Bootstrap/SchemaErrorTests.swift
+++ b/Tests/ScoutTests/Core/Bootstrap/SchemaErrorTests.swift
@@ -74,7 +74,10 @@ struct SchemaErrorTests {
         let nsError = NSError(
             domain: CKErrorDomain,
             code: code.rawValue,
-            userInfo: [NSLocalizedDescriptionKey: message]
+            userInfo: [
+                NSLocalizedDescriptionKey: message,
+                "ServerErrorDescription": message,
+            ]
         )
         return CKError(_nsError: nsError)
     }


### PR DESCRIPTION
- Replace `localizedDescription` with `userInfo["ServerErrorDescription"]` in `CKError.isSchemaError`
- The server error description is a non-localized English string from CloudKit servers, making schema error detection reliable across all locales and OS versions
- Falls back to an empty string when the key is absent, so non-schema errors still return `false`