### PR TITLE
Fix typo in UserActivityMonitorTests

### DIFF
--- a/Tests/ScoutTests/Core/Activity/UserActivityMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Activity/UserActivityMonitorTests.swift
@@ -12,7 +12,7 @@ import Testing
 
 @MainActor
 @Suite("UserActivityObject+Monitor")
-struct UserActivityObjectMontitorTests {
+struct UserActivityObjectMonitorTests {
     let context = NSManagedObjectContext.inMemoryContext()
 
     @Test("Trigger") func trigger() async throws {


### PR DESCRIPTION
- Rename `UserActivityObjectMontitorTests` to `UserActivityObjectMonitorTests`
- Rename file from `UserActivityMontitorTests.swift` to `UserActivityMonitorTests.swift`