### PR TITLE
Remove dead code

### DIFF
--- a/Sources/Scout/Core/Utilities/Date+Add.swift
+++ b/Sources/Scout/Core/Utilities/Date+Add.swift
@@ -34,10 +34,6 @@ extension Date {
 }
 
 extension Date {
-    mutating func add(_ component: Calendar.Component, value: Int = 1) {
-        self = adding(component, value: value)
-    }
-
     mutating func addDay(_ value: Int = 1) {
         self = addingDay(value)
     }

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -16,10 +16,6 @@ struct CrashDetailView: View {
         List {
             headerSection
 
-            //            if let reason = crash.reason {
-            //                reasonSection(reason)
-            //            }
-
             if !crash.stackTrace.isEmpty {
                 stackTraceSection
             }

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -51,11 +51,6 @@ struct AnalyticsView: View {
             search.events?.removeAll()
         }
         .navigationTitle("Events")
-        .onPreferenceChange(Message.Key.self) { message in
-            MainActor.assumeIsolated {
-                provider.message = message
-            }
-        }
         .onAppear {
             tint.value = nil
         }

--- a/Sources/Scout/UI/Message/Message.swift
+++ b/Sources/Scout/UI/Message/Message.swift
@@ -21,5 +21,4 @@ extension View {
     func message(_ message: Binding<Message?>) -> some View {
         modifier(MessageView.Presenter(message: message))
     }
-
 }

--- a/Sources/Scout/UI/Message/Message.swift
+++ b/Sources/Scout/UI/Message/Message.swift
@@ -22,17 +22,4 @@ extension View {
         modifier(MessageView.Presenter(message: message))
     }
 
-    func navigationMessage(_ message: Message?) -> some View {
-        preference(key: Message.Key.self, value: message)
-    }
-}
-
-extension Message {
-    struct Key: PreferenceKey {
-        static let defaultValue: Message? = nil
-
-        static func reduce(value: inout Message?, nextValue: () -> Message?) {
-            value = nextValue()
-        }
-    }
 }


### PR DESCRIPTION
Remove unused navigationMessage preference, commented-out crash reason, and unused Date.add mutating method.