### PR TITLE
Fix incorrect claim about upload-schema.sh deploying to production

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -17,10 +17,12 @@ Upload the [schema file](https://github.com/kasianov-mikhail/scout/blob/main/Sch
 xcrun cktool save-token
 ```
 
-Then run the upload script included in the repository. It will update both development and production environments:
+Then run the upload script included in the repository. It will update the development environment:
 ```bash
 ./upload-schema.sh <your-team-id> <your-container-id>
 ```
+
+To deploy the schema to production, use the [CloudKit Dashboard](https://icloud.developer.apple.com/dashboard/).
 
 ### Option B: Using CloudKit Dashboard
 


### PR DESCRIPTION
The documentation stated the script updates both development and production
environments, but it only uploads to development. Added a note about using
the CloudKit Dashboard for production deployment.

https://claude.ai/code/session_01S78fYKkvxkrqiCWSfqV65U