### PR TITLE
Add tests for LogCrash, SessionMonitor, and DateObject

### DIFF
--- a/Sources/Scout/Core/Log/Log.swift
+++ b/Sources/Scout/Core/Log/Log.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import CoreData
 import Logging
 

--- a/Sources/Scout/Core/Matrix/CellProtocol.swift
+++ b/Sources/Scout/Core/Matrix/CellProtocol.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 
 protocol CellProtocol: Combining, Sendable, Equatable {
     associatedtype Scalar: MatrixValue

--- a/Sources/Scout/Core/Matrix/GridCell.swift
+++ b/Sources/Scout/Core/Matrix/GridCell.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 
 struct GridCell<T: MatrixValue>: Hashable {
     let row: Int

--- a/Sources/Scout/Core/Matrix/PeriodCell.swift
+++ b/Sources/Scout/Core/Matrix/PeriodCell.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 
 struct PeriodCell<T: MatrixValue> {
     static var recordType: String { "PeriodMatrix" }

--- a/Sources/Scout/Core/Telemetry/MetricsObject.swift
+++ b/Sources/Scout/Core/Telemetry/MetricsObject.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import CoreData
 
 @objc(MetricsObject)

--- a/Sources/Scout/UI/Chart/ChartPoint.swift
+++ b/Sources/Scout/UI/Chart/ChartPoint.swift
@@ -6,7 +6,6 @@
 // https://opensource.org/licenses/MIT.
 
 import Charts
-import CloudKit
 
 struct ChartPoint<T: ChartNumeric>: Identifiable, ChartSeries {
     let id = UUID()

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import SwiftUI
 
 struct CrashListView: View {

--- a/Sources/Scout/UI/Event/EventList.swift
+++ b/Sources/Scout/UI/Event/EventList.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import SwiftUI
 
 struct EventList: View {

--- a/Sources/Scout/UI/Event/History/HistoryView.swift
+++ b/Sources/Scout/UI/Event/History/HistoryView.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import SwiftUI
 
 struct HistoryView: View {

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import SwiftUI
 
 struct ParamList: View {

--- a/Tests/ScoutTests/Core/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Crash/LogCrashTests.swift
@@ -1,0 +1,90 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("LogCrash")
+struct LogCrashTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("logCrash persists crash info to Core Data")
+    func testLogCrashPersists() throws {
+        let crash = CrashInfo(
+            name: "TestException",
+            reason: "Something went wrong",
+            stackTrace: ["frame1", "frame2"]
+        )
+
+        try logCrash(crash, context: context)
+
+        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
+        let results = try context.fetch(request)
+
+        #expect(results.count == 1)
+
+        let object = results[0]
+        #expect(object.name == "TestException")
+        #expect(object.reason == "Something went wrong")
+        #expect(object.crashID != nil)
+        #expect(object.date == crash.date)
+    }
+
+    @Test("logCrash encodes stack trace as JSON")
+    func testLogCrashEncodesStackTrace() throws {
+        let crash = CrashInfo(
+            name: "SIGABRT",
+            reason: nil,
+            stackTrace: ["0x1234", "0x5678"]
+        )
+
+        try logCrash(crash, context: context)
+
+        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
+        let object = try #require(try context.fetch(request).first)
+        let data = try #require(object.stackTrace)
+        let decoded = try JSONDecoder().decode([String].self, from: data)
+
+        #expect(decoded == ["0x1234", "0x5678"])
+    }
+
+    @Test("logCrash overrides IDs from crash info")
+    func testLogCrashOverridesIDs() throws {
+        let crash = CrashInfo(
+            name: "TestCrash",
+            reason: nil,
+            stackTrace: []
+        )
+
+        try logCrash(crash, context: context)
+
+        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
+        let object = try #require(try context.fetch(request).first)
+
+        #expect(object.userID == crash.userID)
+        #expect(object.launchID == crash.launchID)
+    }
+
+    @Test("logCrash handles nil reason")
+    func testLogCrashNilReason() throws {
+        let crash = CrashInfo(
+            name: "NilReason",
+            reason: nil,
+            stackTrace: []
+        )
+
+        try logCrash(crash, context: context)
+
+        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
+        let object = try #require(try context.fetch(request).first)
+
+        #expect(object.reason == nil)
+    }
+}

--- a/Tests/ScoutTests/Core/Session/SessionMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Session/SessionMonitorTests.swift
@@ -1,0 +1,58 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("SessionObject+Monitor")
+struct SessionMonitorTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("trigger creates a new session")
+    func testTrigger() throws {
+        try SessionObject.trigger(in: context)
+
+        let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
+        let sessions = try context.fetch(request)
+
+        #expect(sessions.count == 1)
+        #expect(sessions[0].date != nil)
+        #expect(sessions[0].endDate == nil)
+    }
+
+    @Test("complete sets endDate on current session")
+    func testComplete() throws {
+        try SessionObject.trigger(in: context)
+        try SessionObject.complete(in: context)
+
+        let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
+        let sessions = try context.fetch(request)
+
+        #expect(sessions.count == 1)
+        #expect(sessions[0].endDate != nil)
+    }
+
+    @Test("complete throws notFound when no session exists")
+    func testCompleteNotFound() throws {
+        #expect(throws: MonitorError.self) {
+            try SessionObject.complete(in: context)
+        }
+    }
+
+    @Test("complete throws alreadyCompleted for finished session")
+    func testCompleteAlreadyCompleted() throws {
+        try SessionObject.trigger(in: context)
+        try SessionObject.complete(in: context)
+
+        #expect(throws: MonitorError.self) {
+            try SessionObject.complete(in: context)
+        }
+    }
+}

--- a/Tests/ScoutTests/Core/Utilities/DateObjectTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/DateObjectTests.swift
@@ -1,0 +1,66 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("DateObject")
+struct DateObjectTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("Setting date computes all derived properties")
+    func testDateSetterComputesDerived() throws {
+        let entity = NSEntityDescription.entity(forEntityName: "SessionObject", in: context)!
+        let object = SessionObject(entity: entity, insertInto: context)
+
+        let date = Date(timeIntervalSince1970: 1_700_000_000)  // 2023-11-14 22:13:20 UTC
+        object.date = date
+
+        #expect(object.datePrimitive == date)
+        #expect(object.hour == date.startOfHour)
+        #expect(object.day == date.startOfDay)
+        #expect(object.week == date.startOfWeek)
+        #expect(object.month == date.startOfMonth)
+    }
+
+    @Test("Setting date to nil clears derived properties")
+    func testDateSetterNil() throws {
+        let entity = NSEntityDescription.entity(forEntityName: "SessionObject", in: context)!
+        let object = SessionObject(entity: entity, insertInto: context)
+
+        object.date = Date()
+        object.date = nil
+
+        #expect(object.datePrimitive == nil)
+        #expect(object.hour == nil)
+        #expect(object.day == nil)
+        #expect(object.week == nil)
+        #expect(object.month == nil)
+    }
+
+    @Test("Derived properties are consistent across date changes")
+    func testDateSetterConsistency() throws {
+        let entity = NSEntityDescription.entity(forEntityName: "SessionObject", in: context)!
+        let object = SessionObject(entity: entity, insertInto: context)
+
+        let date1 = Date(timeIntervalSince1970: 1_700_000_000)
+        let date2 = Date(timeIntervalSince1970: 1_710_000_000)
+
+        object.date = date1
+        let hour1 = object.hour
+
+        object.date = date2
+        let hour2 = object.hour
+
+        #expect(hour1 == date1.startOfHour)
+        #expect(hour2 == date2.startOfHour)
+        #expect(hour1 != hour2)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LogCrashTests`: verifies crash persistence to Core Data, stack trace JSON encoding, ID overrides from crash info, and nil reason handling
- Add `SessionMonitorTests`: verifies `trigger()` creates sessions, `complete()` sets endDate, and error cases (`notFound`, `alreadyCompleted`)
- Add `DateObjectTests`: verifies the `date` setter computes all derived properties (`hour`, `day`, `week`, `month`), handles nil, and stays consistent across changes

## Test plan
- [ ] Run `swift test` to verify all new tests pass
- [ ] Verify no regressions in existing tests

https://claude.ai/code/session_01HWnWNhjdHS4nZgnmtVdUZH