### PR TITLE
Remove unused imports

### DIFF
--- a/Sources/Scout/UI/Chart/ChartPoint.swift
+++ b/Sources/Scout/UI/Chart/ChartPoint.swift
@@ -6,7 +6,6 @@
 // https://opensource.org/licenses/MIT.
 
 import Charts
-import CloudKit
 
 struct ChartPoint<T: ChartNumeric>: Identifiable, ChartSeries {
     let id = UUID()

--- a/Sources/Scout/UI/Chart/ChartPoint.swift
+++ b/Sources/Scout/UI/Chart/ChartPoint.swift
@@ -6,6 +6,7 @@
 // https://opensource.org/licenses/MIT.
 
 import Charts
+import Foundation
 
 struct ChartPoint<T: ChartNumeric>: Identifiable, ChartSeries {
     let id = UUID()


### PR DESCRIPTION
## Summary
- Remove unused `import CloudKit` from `ChartPoint.swift` — the file only uses `Charts` (for `Plottable` via `ChartNumeric`) and `Foundation` types (`UUID`, `Date`, `Calendar`)

## Test plan
- [ ] Verify project compiles with `swift build`
- [ ] Verify `swift-format lint --strict --recursive Sources` passes

https://claude.ai/code/session_01TKFNHMqQJ7BzNjdXbeSXeE