### PR TITLE
Improve test quality: replace force unwraps with #require

### DIFF
--- a/Tests/ScoutTests/Core/Matrix/MatrixValueTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/MatrixValueTests.swift
@@ -10,47 +10,13 @@ import Testing
 @testable import Scout
 
 struct MatrixValueTests {
-    // MARK: - Int conformance
-
     @Test("Int recordType is DateIntMatrix")
     func intRecordType() {
         #expect(Int.recordType == "DateIntMatrix")
     }
 
-    @Test("Int conforms to AdditiveArithmetic")
-    func intAdditiveArithmetic() {
-        let a: Int = 3
-        let b: Int = 5
-        #expect(a + b == 8)
-        #expect(b - a == 2)
-        #expect(Int.zero == 0)
-    }
-
-    @Test("Int conforms to Comparable")
-    func intComparable() {
-        #expect(1 < 2)
-        #expect(!(2 < 1))
-    }
-
-    // MARK: - Double conformance
-
     @Test("Double recordType is DateDoubleMatrix")
     func doubleRecordType() {
         #expect(Double.recordType == "DateDoubleMatrix")
-    }
-
-    @Test("Double conforms to AdditiveArithmetic")
-    func doubleAdditiveArithmetic() {
-        let a: Double = 1.5
-        let b: Double = 2.5
-        #expect(a + b == 4.0)
-        #expect(b - a == 1.0)
-        #expect(Double.zero == 0.0)
-    }
-
-    @Test("Double conforms to Comparable")
-    func doubleComparable() {
-        #expect(1.0 < 2.0)
-        #expect(!(2.0 < 1.0))
     }
 }

--- a/Tests/ScoutTests/Core/Matrix/NamedObjectTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/NamedObjectTests.swift
@@ -19,9 +19,9 @@ struct NamedObjectTests {
     @Test("parse(of:) groups by hour and counts")
     func testParseOf() throws {
         let batch: [NamedObject] = [
-            .stub(name: "crash", date: date, in: context),
-            .stub(name: "crash", date: date, in: context),
-            .stub(name: "crash", date: date.addingHour(), in: context),
+            try .stub(name: "crash", date: date, in: context),
+            try .stub(name: "crash", date: date, in: context),
+            try .stub(name: "crash", date: date.addingHour(), in: context),
         ]
 
         let cells = NamedObject.parse(of: batch)
@@ -33,8 +33,8 @@ struct NamedObjectTests {
     @Test("matrix(of:) produces correct record type and name")
     func testMatrixOf() throws {
         let batch: [NamedObject] = [
-            .stub(name: "signal", date: date, in: context),
-            .stub(name: "signal", date: date.addingHour(), in: context),
+            try .stub(name: "signal", date: date, in: context),
+            try .stub(name: "signal", date: date.addingHour(), in: context),
         ]
 
         let matrix = try NamedObject.matrix(of: batch)
@@ -48,7 +48,7 @@ struct NamedObjectTests {
     @Test("matrix(of:) throws when name is missing")
     func testMatrixThrowsOnMissingName() throws {
         let batch: [NamedObject] = [
-            .stub(name: nil, date: date, in: context)
+            try .stub(name: nil, date: date, in: context)
         ]
 
         #expect(throws: MatrixPropertyError.self) {
@@ -58,7 +58,7 @@ struct NamedObjectTests {
 
     @Test("matrix(of:) throws when week is missing")
     func testMatrixThrowsOnMissingWeek() throws {
-        let entity = NSEntityDescription.entity(forEntityName: "EventObject", in: context)!
+        let entity = try #require(NSEntityDescription.entity(forEntityName: "EventObject", in: context))
         let object = EventObject(entity: entity, insertInto: context)
         object.name = "test"
 
@@ -75,8 +75,8 @@ extension NamedObject {
         name: String?,
         date: Date,
         in context: NSManagedObjectContext
-    ) -> NamedObject {
-        let entity = NSEntityDescription.entity(forEntityName: "EventObject", in: context)!
+    ) throws -> NamedObject {
+        let entity = try #require(NSEntityDescription.entity(forEntityName: "EventObject", in: context))
         let object = EventObject(entity: entity, insertInto: context)
         object.name = name
         object.date = date

--- a/Tests/ScoutTests/Core/Utilities/ArrayGroupingTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/ArrayGroupingTests.swift
@@ -18,13 +18,13 @@ struct ArrayGroupingTests {
     }
 
     @Test("Group by weekday and hour")
-    func testGroupedByWeekdayAndHour() {
+    func testGroupedByWeekdayAndHour() throws {
         // 2025-08-24 10:00 UTC is a Sunday
-        let date1 = ISO8601DateFormatter().date(from: "2025-08-24T10:00:00Z")!
+        let date1 = try #require(ISO8601DateFormatter().date(from: "2025-08-24T10:00:00Z"))
         // 2025-08-24 11:00 UTC, same day, different hour
-        let date2 = ISO8601DateFormatter().date(from: "2025-08-24T11:00:00Z")!
+        let date2 = try #require(ISO8601DateFormatter().date(from: "2025-08-24T11:00:00Z"))
         // 2025-08-25 10:00 UTC is a Monday
-        let date3 = ISO8601DateFormatter().date(from: "2025-08-25T10:00:00Z")!
+        let date3 = try #require(ISO8601DateFormatter().date(from: "2025-08-25T10:00:00Z"))
 
         let data = [
             TestElement(id: 1, date: date1),

--- a/Tests/ScoutTests/Core/Utilities/DateStartTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/DateStartTests.swift
@@ -14,7 +14,7 @@ struct DateStartTests {
     let date: Date
     let set: Set<Calendar.Component> = [.year, .month, .day, .hour, .minute, .second]
 
-    init() {
+    init() throws {
         let components = DateComponents(
             year: 2030,
             month: 3,
@@ -23,7 +23,7 @@ struct DateStartTests {
             minute: 9,
             second: 11
         )
-        date = Calendar.utc.date(from: components)!
+        date = try #require(Calendar.utc.date(from: components))
     }
 
     @Test("Start of an hour") func startOfHour() {

--- a/Tests/ScoutTests/Core/Utilities/UserDefaultsUUIDTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/UserDefaultsUUIDTests.swift
@@ -14,9 +14,9 @@ struct UserDefaultsUUIDTests {
     let defaults: UserDefaults
     let prefix: String
 
-    init() {
+    init() throws {
         prefix = UUID().uuidString
-        defaults = UserDefaults(suiteName: "UserDefaultsUUIDTests_\(prefix)")!
+        defaults = try #require(UserDefaults(suiteName: "UserDefaultsUUIDTests_\(prefix)"))
     }
 
     @Test("UUID round-trips through UserDefaults")

--- a/Tests/ScoutTests/UI/RangeLabelTests.swift
+++ b/Tests/ScoutTests/UI/RangeLabelTests.swift
@@ -17,18 +17,18 @@ struct RangeLabelTests {
         return formatter
     }()
 
-    @Test("Single day range") func testSingleDayRange() {
-        let startDate = formatter.date(from: "2024-01-01")!
-        let endDate = formatter.date(from: "2024-01-02")!
+    @Test("Single day range") func testSingleDayRange() throws {
+        let startDate = try #require(formatter.date(from: "2024-01-01"))
+        let endDate = try #require(formatter.date(from: "2024-01-02"))
         let range = startDate..<endDate
         let label = range.label(using: formatter)
 
         #expect(label == "2024-01-01")
     }
 
-    @Test("Multiple days range") func testMultipleDaysRange() {
-        let startDate = formatter.date(from: "2024-01-01")!
-        let endDate = formatter.date(from: "2024-01-04")!
+    @Test("Multiple days range") func testMultipleDaysRange() throws {
+        let startDate = try #require(formatter.date(from: "2024-01-01"))
+        let endDate = try #require(formatter.date(from: "2024-01-04"))
         let range = startDate..<endDate
         let label = range.label(using: formatter)
 


### PR DESCRIPTION
## Summary
- Replace force unwraps (`!`) with `try #require()` in 5 test files for proper failure reporting instead of crashes: `RangeLabelTests`, `NamedObjectTests`, `UserDefaultsUUIDTests`, `DateStartTests`, `ArrayGroupingTests`
- Remove 4 tests in `MatrixValueTests` that only verified Swift standard library behavior (`AdditiveArithmetic`, `Comparable` for `Int`/`Double`) rather than project code

## Test plan
- [ ] Run `swift test` to verify all tests still pass
- [ ] Verify `swift-format lint --strict --recursive Tests` passes

https://claude.ai/code/session_01TKFNHMqQJ7BzNjdXbeSXeE