### PR TITLE
Add tests for logCrash and logMetrics

### DIFF
--- a/Tests/ScoutTests/Core/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Crash/LogCrashTests.swift
@@ -1,0 +1,76 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("logCrash")
+struct LogCrashTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    private func makeCrashInfo(name: String, reason: String?, stackTrace: [String]) -> CrashInfo {
+        CrashInfo(name: name, reason: reason, stackTrace: stackTrace)
+    }
+
+    @Test("Creates a CrashObject with correct fields")
+    func createsCrashObject() throws {
+        let crash = makeCrashInfo(name: "SIGABRT", reason: "Fatal error", stackTrace: ["frame0"])
+
+        try logCrash(crash, context: context)
+
+        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
+        let results = try context.fetch(request)
+
+        #expect(results.count == 1)
+
+        let object = try #require(results.first)
+        #expect(object.name == "SIGABRT")
+        #expect(object.reason == "Fatal error")
+        #expect(object.date == crash.date)
+        #expect(object.crashID != nil)
+        #expect(object.value(forKey: "userID") as? UUID == crash.userID)
+        #expect(object.value(forKey: "launchID") as? UUID == crash.launchID)
+    }
+
+    @Test("Encodes stack trace as JSON data")
+    func encodesStackTrace() throws {
+        let crash = makeCrashInfo(name: "SIGSEGV", reason: nil, stackTrace: ["main", "start"])
+
+        try logCrash(crash, context: context)
+
+        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
+        let object = try #require(try context.fetch(request).first)
+
+        let data = try #require(object.stackTrace)
+        let decoded = try JSONDecoder().decode([String].self, from: data)
+        #expect(decoded == ["main", "start"])
+    }
+
+    @Test("Handles nil reason")
+    func handlesNilReason() throws {
+        let crash = makeCrashInfo(name: "EXC_BAD_ACCESS", reason: nil, stackTrace: [])
+
+        try logCrash(crash, context: context)
+
+        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
+        let object = try #require(try context.fetch(request).first)
+        #expect(object.reason == nil)
+    }
+
+    @Test("Saves to the context")
+    func savesToContext() throws {
+        let crash = makeCrashInfo(name: "SIGBUS", reason: nil, stackTrace: [])
+
+        try logCrash(crash, context: context)
+
+        #expect(!context.hasChanges)
+    }
+}

--- a/Tests/ScoutTests/Core/Telemetry/LogMetricsTests.swift
+++ b/Tests/ScoutTests/Core/Telemetry/LogMetricsTests.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("logMetrics")
+struct LogMetricsTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let date = Date(timeIntervalSinceReferenceDate: 0)
+
+    @Test("Persists an IntMetricsObject with correct fields")
+    func persistsIntMetrics() throws {
+        try logMetrics("api_calls", date: date, telemetry: .counter, value: 5, context)
+
+        let request = NSFetchRequest<IntMetricsObject>(entityName: "IntMetricsObject")
+        let results = try context.fetch(request)
+
+        #expect(results.count == 1)
+
+        let object = try #require(results.first)
+        #expect(object.name == "api_calls")
+        #expect(object.telemetry == "counter")
+        #expect(object.value == 5)
+        #expect(object.date == date)
+    }
+
+    @Test("Persists a DoubleMetricsObject with correct fields")
+    func persistsDoubleMetrics() throws {
+        try logMetrics("response_time", date: date, telemetry: .timer, value: 1.5, context)
+
+        let request = NSFetchRequest<DoubleMetricsObject>(entityName: "DoubleMetricsObject")
+        let results = try context.fetch(request)
+
+        #expect(results.count == 1)
+
+        let object = try #require(results.first)
+        #expect(object.name == "response_time")
+        #expect(object.telemetry == "timer")
+        #expect(object.value == 1.5)
+    }
+
+    @Test("Saves to the context")
+    func savesToContext() throws {
+        try logMetrics("metric", date: date, telemetry: .counter, value: 1, context)
+
+        #expect(!context.hasChanges)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LogCrashTests` covering crash object creation, stack trace JSON encoding, nil reason handling, and context persistence
- Add `LogMetricsTests` covering Int and Double metrics persistence with correct field values

## Test plan
- [ ] Run `swift test` to verify all new tests pass
- [ ] Verify `swift-format lint --strict --recursive Tests` passes

https://claude.ai/code/session_01TKFNHMqQJ7BzNjdXbeSXeE