### PR TITLE
Remove unused code: dead mutating date methods

### DIFF
--- a/Sources/Scout/Core/Utilities/Date+Add.swift
+++ b/Sources/Scout/Core/Utilities/Date+Add.swift
@@ -37,20 +37,4 @@ extension Date {
     mutating func addDay(_ value: Int = 1) {
         self = addingDay(value)
     }
-
-    mutating func addHour(_ value: Int = 1) {
-        self = addingHour(value)
-    }
-
-    mutating func addWeek(_ value: Int = 1) {
-        self = addingWeek(value)
-    }
-
-    mutating func addMonth(_ value: Int = 1) {
-        self = addingMonth(value)
-    }
-
-    mutating func addYear(_ value: Int = 1) {
-        self = addingYear(value)
-    }
 }

--- a/Tests/ScoutTests/Core/Utilities/DateAddComponentTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/DateAddComponentTests.swift
@@ -85,5 +85,4 @@ struct DateAddComponentTests {
         date.addDay()
         #expect(date.timeIntervalSince(base) == 86400)
     }
-
 }

--- a/Tests/ScoutTests/Core/Utilities/DateAddComponentTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/DateAddComponentTests.swift
@@ -86,33 +86,4 @@ struct DateAddComponentTests {
         #expect(date.timeIntervalSince(base) == 86400)
     }
 
-    @Test("addHour mutates in place")
-    func addHourMutating() {
-        var date = base
-        date.addHour(2)
-        #expect(date.timeIntervalSince(base) == 7200)
-    }
-
-    @Test("addWeek mutates in place")
-    func addWeekMutating() {
-        var date = base
-        date.addWeek()
-        #expect(date.timeIntervalSince(base) == 86400 * 7)
-    }
-
-    @Test("addMonth mutates in place")
-    func addMonthMutating() {
-        var date = base
-        date.addMonth()
-        let components = Calendar.utc.dateComponents([.month], from: base, to: date)
-        #expect(components.month == 1)
-    }
-
-    @Test("addYear mutates in place")
-    func addYearMutating() {
-        var date = base
-        date.addYear()
-        let components = Calendar.utc.dateComponents([.year], from: base, to: date)
-        #expect(components.year == 1)
-    }
 }


### PR DESCRIPTION
The mutating methods addHour, addWeek, addMonth, and addYear in Date+Add.swift are defined but never called anywhere in production code. Only addDay is actually used (in UserActivityObject.Provider). This removes the four unused mutating methods and their corresponding test cases in DateAddComponentTests.swift to reduce dead code.