### PR TITLE
Add tests for TelemetryFactory and CKTelemetryHandler

### DIFF
--- a/Tests/ScoutTests/Core/Telemetry/TelemetryFactoryTests.swift
+++ b/Tests/ScoutTests/Core/Telemetry/TelemetryFactoryTests.swift
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Metrics
+import Testing
+
+@testable import Scout
+
+struct TelemetryFactoryTests {
+    let factory = TelemetryFactory()
+
+    @Test("makeCounter returns CKTelemetryHandler")
+    func makeCounter() {
+        let handler = factory.makeCounter(label: "test", dimensions: [])
+        #expect(handler is CKTelemetryHandler)
+    }
+
+    @Test("makeFloatingPointCounter returns CKTelemetryHandler")
+    func makeFloatingPointCounter() {
+        let handler = factory.makeFloatingPointCounter(label: "test", dimensions: [])
+        #expect(handler is CKTelemetryHandler)
+    }
+
+    @Test("makeTimer returns CKTelemetryHandler")
+    func makeTimer() {
+        let handler = factory.makeTimer(label: "test", dimensions: [])
+        #expect(handler is CKTelemetryHandler)
+    }
+
+    @Test("makeMeter returns Idle handler")
+    func makeMeter() {
+        let handler = factory.makeMeter(label: "test", dimensions: [])
+        #expect(handler is CKTelemetryHandler.Idle)
+    }
+
+    @Test("makeRecorder returns Idle handler")
+    func makeRecorder() {
+        let handler = factory.makeRecorder(label: "test", dimensions: [], aggregate: false)
+        #expect(handler is CKTelemetryHandler.Idle)
+    }
+
+    @Test("makeCounter preserves label and dimensions")
+    func counterPreservesLabel() {
+        let dims = [("env", "prod"), ("version", "1.0")]
+        let handler = factory.makeCounter(label: "api_calls", dimensions: dims)
+        let telemetry = handler as? CKTelemetryHandler
+        #expect(telemetry?.label == "api_calls")
+        #expect(telemetry?.dimensions.count == 2)
+        #expect(telemetry?.dimensions[0].0 == "env")
+        #expect(telemetry?.dimensions[0].1 == "prod")
+    }
+
+    @Test("makeTimer preserves label")
+    func timerPreservesLabel() {
+        let handler = factory.makeTimer(label: "response_time", dimensions: [])
+        let telemetry = handler as? CKTelemetryHandler
+        #expect(telemetry?.label == "response_time")
+    }
+}

--- a/Tests/ScoutTests/Core/Telemetry/TelemetryHandlerTests.swift
+++ b/Tests/ScoutTests/Core/Telemetry/TelemetryHandlerTests.swift
@@ -11,7 +11,6 @@ import Testing
 @testable import Scout
 
 struct TelemetryHandlerTests {
-
     @Test("CKTelemetryHandler stores label")
     func storesLabel() {
         let handler = CKTelemetryHandler(label: "test_label", dimensions: [])

--- a/Tests/ScoutTests/Core/Telemetry/TelemetryHandlerTests.swift
+++ b/Tests/ScoutTests/Core/Telemetry/TelemetryHandlerTests.swift
@@ -1,0 +1,59 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Metrics
+import Testing
+
+@testable import Scout
+
+struct TelemetryHandlerTests {
+
+    @Test("CKTelemetryHandler stores label")
+    func storesLabel() {
+        let handler = CKTelemetryHandler(label: "test_label", dimensions: [])
+        #expect(handler.label == "test_label")
+    }
+
+    @Test("CKTelemetryHandler stores dimensions")
+    func storesDimensions() {
+        let dims = [("key1", "value1"), ("key2", "value2")]
+        let handler = CKTelemetryHandler(label: "test", dimensions: dims)
+        #expect(handler.dimensions.count == 2)
+        #expect(handler.dimensions[0].0 == "key1")
+        #expect(handler.dimensions[1].1 == "value2")
+    }
+
+    @Test("CKTelemetryHandler conforms to CounterHandler")
+    func conformsToCounter() {
+        let handler = CKTelemetryHandler(label: "test", dimensions: [])
+        #expect(handler is CounterHandler)
+    }
+
+    @Test("CKTelemetryHandler conforms to FloatingPointCounterHandler")
+    func conformsToFloatingPointCounter() {
+        let handler = CKTelemetryHandler(label: "test", dimensions: [])
+        #expect(handler is FloatingPointCounterHandler)
+    }
+
+    @Test("CKTelemetryHandler conforms to TimerHandler")
+    func conformsToTimer() {
+        let handler = CKTelemetryHandler(label: "test", dimensions: [])
+        #expect(handler is TimerHandler)
+    }
+
+    @Test("Idle conforms to MeterHandler")
+    func idleConformsToMeter() {
+        let idle = CKTelemetryHandler.Idle()
+        #expect(idle is MeterHandler)
+    }
+
+    @Test("Idle conforms to RecorderHandler")
+    func idleConformsToRecorder() {
+        let idle = CKTelemetryHandler.Idle()
+        #expect(idle is RecorderHandler)
+    }
+}


### PR DESCRIPTION
TelemetryFactory and CKTelemetryHandler had no test coverage. TelemetryFactoryTests verifies that each make method returns the correct handler type: CKTelemetryHandler for counters, floating-point counters, and timers, and CKTelemetryHandler.Idle for meters and recorders. It also checks that labels and dimensions are preserved through construction. TelemetryHandlerTests verifies protocol conformances (CounterHandler, FloatingPointCounterHandler, TimerHandler, MeterHandler, RecorderHandler) and property storage.