### PR TITLE
Fix duplicate crash reports for uncaught exceptions

### DIFF
--- a/Sources/Scout/Core/Crash/ExceptionHandler.swift
+++ b/Sources/Scout/Core/Crash/ExceptionHandler.swift
@@ -19,6 +19,11 @@ func installExceptionHandler() {
             stackTrace: exception.callStackSymbols
         )
         CrashArchive.system.write(crash)
+
+        // Reset SIGABRT to default so the abort() that follows
+        // doesn't produce a duplicate crash report.
+        signal(SIGABRT, SIG_DFL)
+
         previousExceptionHandler?(exception)
     }
 }


### PR DESCRIPTION
- Uncaught NSExceptions were producing two crash reports: one from the exception handler and a duplicate SIGABRT from the signal handler when `abort()` fires
- Reset SIGABRT to `SIG_DFL` after writing the exception crash report, so the signal handler is no longer installed when `abort()` follows