### PR TITLE
Refresh iCloud status on foreground

### DIFF
--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -7,6 +7,7 @@
 
 import CloudKit
 import SwiftUI
+import UIKit
 
 public struct HomeView: View {
     let container: CKContainer
@@ -40,6 +41,11 @@ public struct HomeView: View {
         }
         .task {
             await checker.verify(container: container)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            Task {
+                await checker.verify(container: container)
+            }
         }
         .tint(tint.value)
         .environmentObject(tint)


### PR DESCRIPTION
- Re-check iCloud account status when the app returns from background
- Handles the case where the user signs into iCloud while the app is suspended
- The iCloud warning icon will automatically dismiss upon return