### PR TITLE
Add loading state to HomeView

### DIFF
--- a/Sources/Scout/UI/Home/HomeChecker.swift
+++ b/Sources/Scout/UI/Home/HomeChecker.swift
@@ -9,7 +9,13 @@ import CloudKit
 
 @MainActor
 class HomeChecker: ObservableObject {
-    @Published var schemaError: SchemaError?
+    enum State {
+        case loading
+        case ready
+        case schemaError(SchemaError)
+    }
+
+    @Published var state: State = .loading
     @Published var iCloudWarning = false
 
     func verify(container: CKContainer) async {
@@ -18,11 +24,12 @@ class HomeChecker: ObservableObject {
 
         do {
             try await container.verifySchema()
-            schemaError = nil
+            state = .ready
         } catch let error as SchemaError {
-            schemaError = error
+            state = .schemaError(error)
         } catch {
             // Ignore other errors (network, auth, etc.)
+            state = .ready
         }
     }
 }

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -23,10 +23,13 @@ public struct HomeView: View {
     public var body: some View {
         NavigationStack {
             Group {
-                if let schemaError = checker.schemaError {
-                    errorView(error: schemaError)
-                } else {
+                switch checker.state {
+                case .loading:
+                    ProgressView()
+                case .ready:
                     HomeContent()
+                case .schemaError(let error):
+                    errorView(error: error)
                 }
             }
             .toolbar {


### PR DESCRIPTION
- Show ProgressView while schema verification is in progress
- Prevent content from flashing before schema error appears
- Refactor HomeChecker to use State enum instead of separate properties