### PR TITLE
Style schema error description with underlined record types

### DIFF
--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -56,7 +56,7 @@ public struct HomeView: View {
     }
 
     private func errorView(error: SchemaError) -> some View {
-        ErrorView(error: error) {
+        ErrorView(description: error.styledDescription) {
             Task {
                 await checker.verify(container: container)
             }
@@ -64,9 +64,21 @@ public struct HomeView: View {
     }
 }
 
+extension SchemaError {
+    fileprivate var styledDescription: Text {
+        let types = recordTypes.joined(separator: ", ")
+
+        return Text("CloudKit schema is outdated. Missing record types: ")
+            + Text(types).underline()
+            + Text(". Upload the Schema file via CloudKit Console.")
+    }
+}
+
 #Preview("Schema Error") {
     ErrorView(
-        error: SchemaError(recordTypes: [CrashObject.recordType, PeriodCell<Int>.recordType]),
+        description: Text("CloudKit schema is outdated. Missing record types: ")
+            + Text("Crash, PeriodValue").underline()
+            + Text(". Upload the Schema file via CloudKit Console."),
         retry: {}
     )
 }

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -76,9 +76,7 @@ extension SchemaError {
 
 #Preview("Schema Error") {
     ErrorView(
-        description: Text("CloudKit schema is outdated. Missing record types: ")
-            + Text("Crash, PeriodValue").underline()
-            + Text(". Upload the Schema file via CloudKit Console."),
+        description: SchemaError(recordTypes: ["Crash", "PeriodValue"]).styledDescription,
         retry: {}
     )
 }

--- a/Sources/Scout/UI/Provider/ErrorView.swift
+++ b/Sources/Scout/UI/Provider/ErrorView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ErrorView: View {
-    let error: Error
+    let description: Text
     let retry: (() -> Void)?
 
     var body: some View {
@@ -23,7 +23,7 @@ struct ErrorView: View {
                 .font(.title2)
                 .bold()
 
-            Text(error.localizedDescription)
+            description
                 .font(.body)
                 .multilineTextAlignment(.center)
 
@@ -48,14 +48,9 @@ struct ErrorView: View {
 }
 
 #Preview("ErrorView") {
-    let errorText =
-        "This is a sample error message that is intentionally made very long to test how the \(ErrorView.self) handles multiline text display. It should properly wrap and be readable without any issues."
-
     ErrorView(
-        error: NSError(
-            domain: "",
-            code: 0,
-            userInfo: [NSLocalizedDescriptionKey: errorText]
+        description: Text(
+            "This is a sample error message that is intentionally made very long to test how the ErrorView handles multiline text display. It should properly wrap and be readable without any issues."
         ),
         retry: {}
     )

--- a/Sources/Scout/UI/Provider/ProviderView.swift
+++ b/Sources/Scout/UI/Provider/ProviderView.swift
@@ -20,7 +20,7 @@ struct ProviderView<P: Provider, Content: View>: View {
         case .success(let data):
             content(data)
         case .failure(let error):
-            ErrorView(error: error, retry: fetch)
+            ErrorView(description: Text(error.localizedDescription), retry: fetch)
         }
     }
 


### PR DESCRIPTION
- Refactor ErrorView to accept `Text` instead of `Error` for richer text styling
- Underline missing record type names in the schema error message
- Move styled description logic to a `SchemaError` extension in the UI layer
- Update ProviderView to use the new ErrorView API