### PR TITLE
Reset to loading state on re-verification

### DIFF
--- a/Sources/Scout/UI/Home/HomeChecker.swift
+++ b/Sources/Scout/UI/Home/HomeChecker.swift
@@ -19,10 +19,11 @@ class HomeChecker: ObservableObject {
     @Published var iCloudWarning = false
 
     func verify(container: CKContainer) async {
-        let status = (try? await container.accountStatus()) ?? .couldNotDetermine
+        let status = try? await container.accountStatus()
         iCloudWarning = status != .available
 
         do {
+            state = .loading
             try await container.verifySchema()
             state = .ready
         } catch let error as SchemaError {


### PR DESCRIPTION
- Show loading indicator when re-verifying schema (e.g. after returning from background)
- Simplify account status check by removing redundant nil coalescing