### PR TITLE
Extract dismiss toolbar into a view modifier

### DIFF
--- a/Sources/Scout/UI/Home/DismissToolbar.swift
+++ b/Sources/Scout/UI/Home/DismissToolbar.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    func dismissToolbar() -> some View {
+        modifier(DismissToolbarModifier())
+    }
+}
+
+private struct DismissToolbarModifier: ViewModifier {
+    @Environment(\.dismiss) var dismiss
+
+    func body(content: Content) -> some View {
+        content.toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Close") {
+                    dismiss()
+                }
+            }
+        }
+    }
+}

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -14,8 +14,6 @@ public struct HomeView: View {
 
     @StateObject private var tint = Tint()
     @StateObject private var checker = HomeChecker()
-    @Environment(\.dismiss) var dismiss
-
     public init(container: CKContainer) {
         self.container = container
     }
@@ -32,13 +30,7 @@ public struct HomeView: View {
                     errorView(error: error)
                 }
             }
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Close") {
-                        dismiss()
-                    }
-                }
-            }
+            .dismissToolbar()
             .iCloudWarning(checker.iCloudWarning)
             .navigationBarTitle("Home")
         }


### PR DESCRIPTION
- Extract dismiss + close toolbar button from HomeView into a reusable DismissToolbarModifier
- Follow the same pattern as ICloudWarningModifier