### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ios-tests-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
Potential fix for [https://github.com/kasianov-mikhail/scout/security/code-scanning/2](https://github.com/kasianov-mikhail/scout/security/code-scanning/2)

In general, the fix is to add a `permissions` block that restricts the `GITHUB_TOKEN` to the minimal required scope. Here, both jobs simply check out code and run local commands, so `contents: read` at the workflow level is sufficient and preserves existing behavior.

The best fix is to add a top-level `permissions` block (applies to all jobs that don’t override it) right after the `on:` section and before `concurrency:`. This will document and enforce that the token can only read repository contents. No other scopes (issues, pull-requests, etc.) are needed based on the shown steps, and we don’t need per-job overrides since both jobs have the same requirements. No imports or additional definitions are required, as this is purely a YAML configuration change.

Specifically, edit `.github/workflows/swift.yml` to insert:

```yaml
permissions:
  contents: read
```

between existing lines 7 and 9 (after the `pull_request` trigger and before `concurrency`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
