### PR TITLE
Rename dismissToolbar to dismissable

### DIFF
--- a/Sources/Scout/UI/Home/Dismissable.swift
+++ b/Sources/Scout/UI/Home/Dismissable.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 extension View {
-    func dismissToolbar() -> some View {
-        modifier(DismissToolbarModifier())
+    func dismissable() -> some View {
+        modifier(DismissableModifier())
     }
 }
 
-private struct DismissToolbarModifier: ViewModifier {
+private struct DismissableModifier: ViewModifier {
     @Environment(\.dismiss) var dismiss
 
     func body(content: Content) -> some View {

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -30,7 +30,7 @@ public struct HomeView: View {
                     errorView(error: error)
                 }
             }
-            .dismissToolbar()
+            .dismissable()
             .iCloudWarning(checker.iCloudWarning)
             .navigationBarTitle("Home")
         }


### PR DESCRIPTION
- Rename `dismissToolbar()` view modifier to `dismissable()` for a cleaner, more SwiftUI-idiomatic API
- Rename file and internal modifier type to match