### PR TITLE
Pluralize schema error message

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
@@ -10,9 +10,13 @@ import CloudKit
 struct SchemaError: LocalizedError {
     let recordTypes: [String]
 
+    var noun: String {
+        recordTypes.count == 1 ? "record type" : "record types"
+    }
+
     var errorDescription: String? {
         let list = recordTypes.joined(separator: ", ")
-        return "CloudKit schema is outdated. Missing record types: \(list). Upload the Schema file via CloudKit Console."
+        return "CloudKit schema is outdated. Missing \(noun): \(list). Upload the Schema file via CloudKit Console."
     }
 }
 

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -58,10 +58,10 @@ public struct HomeView: View {
 
 extension SchemaError {
     fileprivate var styledDescription: Text {
-        let types = recordTypes.joined(separator: ", ")
+        let list = recordTypes.joined(separator: ", ")
 
-        return Text("CloudKit schema is outdated. Missing record types: ")
-            + Text(types).underline()
+        return Text("CloudKit schema is outdated. Missing \(noun): ")
+            + Text(list).underline()
             + Text(". Upload the Schema file via CloudKit Console.")
     }
 }


### PR DESCRIPTION
- Add `noun` property to `SchemaError` that returns singular/plural form based on count
- Use it in both `errorDescription` and `styledDescription`