### PR TITLE
Replace Period.all with CaseIterable

### DIFF
--- a/Sources/Scout/UI/Chart/Picker/Period.swift
+++ b/Sources/Scout/UI/Chart/Picker/Period.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-enum Period: String, Identifiable {
-    static let all = [Period.today, .yesterday, .week, .month, .year]
+enum Period: String, CaseIterable, Identifiable {
     static let summary = [Period.week, .month, .year]
 
     case today

--- a/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
@@ -38,6 +38,6 @@ extension ChartExtent {
 #Preview {
     PeriodPicker(
         extent: .constant(ChartExtent(period: Period.today)),
-        periods: Period.all
+        periods: Period.allCases
     )
 }

--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -66,7 +66,7 @@ extension EventView {
             _stat = StateObject(
                 wrappedValue: StatProvider(
                     eventName: eventName,
-                    periods: Period.all
+                    periods: Period.allCases
                 )
             )
         }
@@ -80,7 +80,7 @@ extension EventView {
                 color: .blue,
                 showList: true
             )
-            ForEach(Period.all) { period in
+            ForEach(Period.allCases) { period in
                 StatRow(
                     config: statConfig,
                     period: period,

--- a/Sources/Scout/UI/Metrics/MetricsList.swift
+++ b/Sources/Scout/UI/Metrics/MetricsList.swift
@@ -21,7 +21,7 @@ struct MetricsList: View {
 
     var body: some View {
         Picker("Period", selection: $period) {
-            ForEach(Period.all) { period in
+            ForEach(Period.allCases) { period in
                 Text(period.shortTitle.uppercased())
             }
         }

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -22,7 +22,7 @@ struct MetricsView<T: ChartNumeric>: View {
 
     var body: some View {
         Picker("Period", selection: $extent.period) {
-            ForEach(Period.all) { period in
+            ForEach(Period.allCases) { period in
                 Text(period.shortTitle.uppercased())
             }
         }

--- a/Sources/Scout/UI/Stats/StatRow.swift
+++ b/Sources/Scout/UI/Stats/StatRow.swift
@@ -43,7 +43,7 @@ struct StatRow: View {
             StatRow(
                 config: StatConfig(title: "Events", color: .blue, showList: true),
                 period: .today,
-                stat: StatProvider(eventName: "event_name", periods: Period.all)
+                stat: StatProvider(eventName: "event_name", periods: Period.allCases)
             )
         }
     }

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -81,7 +81,7 @@ struct StatView: View {
 // MARK: - Preview
 
 #Preview("StatView") {
-    let stat = StatProvider(eventName: "app_launch", periods: Period.all)
+    let stat = StatProvider(eventName: "app_launch", periods: Period.allCases)
     stat.result = .success([])
     return NavigationStack {
         StatView(


### PR DESCRIPTION
- Make `Period` conform to `CaseIterable` and replace manual `static let all` with `allCases`
- Prevents the list from getting out of sync when new cases are added