### PR TITLE
Extract foregroundTask view modifier

### DIFF
--- a/Sources/Scout/UI/Home/ForegroundTask.swift
+++ b/Sources/Scout/UI/Home/ForegroundTask.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+import UIKit
+
+extension View {
+    func foregroundTask(action: @escaping () async -> Void) -> some View {
+        modifier(ForegroundTaskModifier(action: action))
+    }
+}
+
+private struct ForegroundTaskModifier: ViewModifier {
+    let action: () async -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .task {
+                await action()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+                Task {
+                    await action()
+                }
+            }
+    }
+}

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -34,13 +34,8 @@ public struct HomeView: View {
             .iCloudWarning(checker.iCloudWarning)
             .navigationBarTitle("Home")
         }
-        .task {
+        .foregroundTask {
             await checker.verify(container: container)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-            Task {
-                await checker.verify(container: container)
-            }
         }
         .tint(tint.value)
         .environmentObject(tint)


### PR DESCRIPTION
- Extract `.task` + `.onReceive(willEnterForegroundNotification)` pattern into a reusable `.foregroundTask` modifier
- Runs the action on appear and on every return from background