### PR TITLE
Add illustrated empty states

### DIFF
--- a/Sources/Scout/UI/Controls/Placeholder.swift
+++ b/Sources/Scout/UI/Controls/Placeholder.swift
@@ -9,14 +9,41 @@ import SwiftUI
 
 struct Placeholder: View {
     let text: String
+    var systemImage: String?
+    var description: String?
 
     var body: some View {
-        Text(text)
-            .font(.system(size: 18, weight: .semibold))
-            .foregroundStyle(.gray.opacity(0.7))
+        VStack(spacing: 12) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .font(.system(size: 36))
+                    .foregroundStyle(.gray.opacity(0.5))
+            }
+
+            Text(text)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(.gray.opacity(0.7))
+
+            if let description {
+                Text(description)
+                    .font(.body)
+                    .kerning(0.3)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .padding()
     }
 }
 
-#Preview {
+#Preview("Text Only") {
     Placeholder(text: "No results")
+}
+
+#Preview("With Icon") {
+    Placeholder(
+        text: "No crashes",
+        systemImage: "checkmark.shield",
+        description: "No crash reports have been recorded"
+    )
 }

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -16,7 +16,12 @@ struct CrashListView: View {
         Group {
             if let crashes = provider.crashes {
                 if crashes.isEmpty {
-                    Placeholder(text: "No crashes").frame(maxHeight: .infinity)
+                    Placeholder(
+                        text: "No crashes",
+                        systemImage: "checkmark.shield",
+                        description: "No crash reports have been recorded"
+                    )
+                    .frame(maxHeight: .infinity)
                 } else {
                     List {
                         ForEach(crashes, content: row)
@@ -80,5 +85,17 @@ struct CrashListView: View {
 #Preview {
     NavigationStack {
         CrashListView()
+    }
+}
+
+#Preview("Empty State") {
+    NavigationStack {
+        Placeholder(
+            text: "No crashes",
+            systemImage: "checkmark.shield",
+            description: "No crash reports have been recorded"
+        )
+        .frame(maxHeight: .infinity)
+        .navigationTitle("Crashes")
     }
 }

--- a/Sources/Scout/UI/Event/EventList.swift
+++ b/Sources/Scout/UI/Event/EventList.swift
@@ -23,7 +23,12 @@ struct EventList: View {
     var body: some View {
         if let events = provider.events {
             if events.isEmpty {
-                Placeholder(text: "No results").frame(maxHeight: .infinity)
+                Placeholder(
+                    text: "No results",
+                    systemImage: "list.bullet",
+                    description: "Events will appear here once your app starts logging"
+                )
+                .frame(maxHeight: .infinity)
             } else {
                 List {
                     ForEach(events, content: row)
@@ -81,5 +86,15 @@ struct EventList: View {
         .alignmentGuide(.listRowSeparatorTrailing) { dimension in
             dimension[.trailing]
         }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Empty State") {
+    let provider = EventProvider()
+    provider.events = []
+    return NavigationStack {
+        EventList(provider: provider)
     }
 }

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -26,7 +26,12 @@ struct MetricsContent<T: ChartNumeric>: View {
             let ranked = groups.ranked(on: period)
 
             if ranked.isEmpty {
-                Placeholder(text: "No results").frame(maxHeight: .infinity)
+                Placeholder(
+                    text: "No results",
+                    systemImage: "chart.bar",
+                    description: "Metrics will appear here once your app records data"
+                )
+                .frame(maxHeight: .infinity)
             } else {
                 List(ranked) { group in
                     Row {
@@ -58,5 +63,19 @@ struct MetricsContent<T: ChartNumeric>: View {
         .monospaced()
         .font(.system(size: 17))
         .lineLimit(1)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Empty State") {
+    NavigationStack {
+        Placeholder(
+            text: "No results",
+            systemImage: "chart.bar",
+            description: "Metrics will appear here once your app records data"
+        )
+        .frame(maxHeight: .infinity)
+        .navigationTitle("Metrics")
     }
 }


### PR DESCRIPTION
- Update `Placeholder` with optional `systemImage` and `description` parameters for richer empty states
- Add SF Symbol icons and descriptive subtitles to EventList, CrashListView, and MetricsContent
- Add empty state previews to all affected screens
- Keep ChartView text-only (constrained space inside `.chartBackground`)

Closes #337