### PR TITLE
Add code snippets to empty state placeholders

### DIFF
--- a/Sources/Scout/UI/Controls/Placeholder.swift
+++ b/Sources/Scout/UI/Controls/Placeholder.swift
@@ -11,6 +11,7 @@ struct Placeholder: View {
     let text: String
     var systemImage: String?
     var description: String?
+    var code: String?
 
     var body: some View {
         VStack(spacing: 12) {
@@ -31,6 +32,15 @@ struct Placeholder: View {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
+
+            if let code {
+                Text(code)
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.3), lineWidth: 1))
+            }
         }
         .padding()
     }
@@ -45,5 +55,14 @@ struct Placeholder: View {
         text: "No crashes",
         systemImage: "checkmark.shield",
         description: "No crash reports have been recorded"
+    )
+}
+
+#Preview("With Code") {
+    Placeholder(
+        text: "No results",
+        systemImage: "list.bullet",
+        description: "Events will appear here once your app starts logging",
+        code: "logger.info(\"button_tapped\")"
     )
 }

--- a/Sources/Scout/UI/Event/EventList.swift
+++ b/Sources/Scout/UI/Event/EventList.swift
@@ -26,7 +26,8 @@ struct EventList: View {
                 Placeholder(
                     text: "No results",
                     systemImage: "list.bullet",
-                    description: "Events will appear here once your app starts logging"
+                    description: "Events will appear here once your app starts logging",
+                    code: "logger.info(\"button_tapped\")"
                 )
                 .frame(maxHeight: .infinity)
             } else {

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -29,7 +29,8 @@ struct MetricsContent<T: ChartNumeric>: View {
                 Placeholder(
                     text: "No results",
                     systemImage: "chart.bar",
-                    description: "Metrics will appear here once your app records data"
+                    description: "Metrics will appear here once your app records data",
+                    code: "Counter(label: \"api_calls\").increment()"
                 )
                 .frame(maxHeight: .infinity)
             } else {
@@ -73,7 +74,8 @@ struct MetricsContent<T: ChartNumeric>: View {
         Placeholder(
             text: "No results",
             systemImage: "chart.bar",
-            description: "Metrics will appear here once your app records data"
+            description: "Metrics will appear here once your app records data",
+            code: "Counter(label: \"api_calls\").increment()"
         )
         .frame(maxHeight: .infinity)
         .navigationTitle("Metrics")


### PR DESCRIPTION
- Add `code` parameter to `Placeholder` for displaying inline code snippets
- Show usage examples in EventList and MetricsContent empty states
- Use outline capsule style for the code display

Part of #337