### PR TITLE
Move frame expansion into Placeholder

### DIFF
--- a/Sources/Scout/UI/Chart/ChartView.swift
+++ b/Sources/Scout/UI/Chart/ChartView.swift
@@ -30,7 +30,9 @@ struct ChartView<T: ChartNumeric>: View {
         }
         .chartBackground { _ in
             if segment.total == .zero {
-                Placeholder(text: "No results")
+                Text("No results")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(.gray.opacity(0.7))
             }
         }
         .aspectRatio(4 / 3, contentMode: .fit)

--- a/Sources/Scout/UI/Controls/Placeholder.swift
+++ b/Sources/Scout/UI/Controls/Placeholder.swift
@@ -43,6 +43,7 @@ struct Placeholder: View {
             }
         }
         .padding()
+        .frame(maxHeight: .infinity)
     }
 }
 

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -21,7 +21,6 @@ struct CrashListView: View {
                         systemImage: "checkmark.shield",
                         description: "No crash reports have been recorded"
                     )
-                    .frame(maxHeight: .infinity)
                 } else {
                     List {
                         ForEach(crashes, content: row)
@@ -95,7 +94,6 @@ struct CrashListView: View {
             systemImage: "checkmark.shield",
             description: "No crash reports have been recorded"
         )
-        .frame(maxHeight: .infinity)
         .navigationTitle("Crashes")
     }
 }

--- a/Sources/Scout/UI/Event/EventList.swift
+++ b/Sources/Scout/UI/Event/EventList.swift
@@ -29,7 +29,6 @@ struct EventList: View {
                     description: "Events will appear here once your app starts logging",
                     code: "logger.info(\"button_tapped\")"
                 )
-                .frame(maxHeight: .infinity)
             } else {
                 List {
                     ForEach(events, content: row)

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -32,7 +32,6 @@ struct MetricsContent<T: ChartNumeric>: View {
                     description: "Metrics will appear here once your app records data",
                     code: "Counter(label: \"api_calls\").increment()"
                 )
-                .frame(maxHeight: .infinity)
             } else {
                 List(ranked) { group in
                     Row {
@@ -77,7 +76,6 @@ struct MetricsContent<T: ChartNumeric>: View {
             description: "Metrics will appear here once your app records data",
             code: "Counter(label: \"api_calls\").increment()"
         )
-        .frame(maxHeight: .infinity)
         .navigationTitle("Metrics")
     }
 }


### PR DESCRIPTION
- Embed .frame(maxHeight: .infinity) inside Placeholder so call sites don't repeat it
- Replace Placeholder in ChartView with inline Text since chart background needs compact layout
- Remove redundant .frame(maxHeight: .infinity) from EventList, CrashListView, and MetricsContent

Part of #337