### PR TITLE
Refactor stats views to remove StatView.Config

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -75,14 +75,11 @@ extension EventView {
             Header(title: "Stats").task {
                 await stat.fetchIfNeeded(in: database)
             }
-            let statConfig = StatConfig(
-                title: "Stats",
-                color: .blue,
-                showList: true
-            )
             ForEach(Period.allCases) { period in
                 StatRow(
-                    config: statConfig,
+                    title: "Stats",
+                    color: .blue,
+                    showList: true,
                     period: period,
                     stat: stat
                 )

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -48,14 +48,11 @@ struct HomeContent: View {
 
     private var crashSection: some View {
         Section {
-            let statConfig = StatConfig(
-                title: "Crashes",
-                color: .red,
-                showList: false
-            )
             ForEach(Period.summary) { period in
                 StatRow(
-                    config: statConfig,
+                    title: "Crashes",
+                    color: .red,
+                    showList: false,
                     period: period,
                     stat: crashStat
                 )
@@ -93,14 +90,11 @@ struct HomeContent: View {
 
     private var sessionSection: some View {
         Section {
-            let statConfig = StatConfig(
-                title: "Sessions",
-                color: .purple,
-                showList: false
-            )
             ForEach(Period.summary) { period in
                 StatRow(
-                    config: statConfig,
+                    title: "Sessions",
+                    color: .purple,
+                    showList: false,
                     period: period,
                     stat: sessionStat
                 )

--- a/Sources/Scout/UI/Stats/StatRow.swift
+++ b/Sources/Scout/UI/Stats/StatRow.swift
@@ -7,10 +7,10 @@
 
 import SwiftUI
 
-typealias StatConfig = StatView.Config
-
 struct StatRow: View {
-    let config: StatConfig
+    let title: String
+    let color: Color
+    let showList: Bool
     let period: Period
 
     @ObservedObject var stat: StatProvider
@@ -28,9 +28,15 @@ struct StatRow: View {
 
                 RedactedText(count: count)
             }
-            .foregroundColor(config.color)
+            .foregroundColor(color)
         } destination: {
-            StatView(config: config, stat: stat, period: period)
+            StatView(
+                title: title,
+                color: color,
+                showList: showList,
+                stat: stat,
+                period: period
+            )
         }
     }
 }
@@ -41,7 +47,9 @@ struct StatRow: View {
     NavigationStack {
         List {
             StatRow(
-                config: StatConfig(title: "Events", color: .blue, showList: true),
+                title: "Events",
+                color: .blue,
+                showList: true,
                 period: .today,
                 stat: StatProvider(eventName: "event_name", periods: Period.allCases)
             )

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -9,20 +9,18 @@ import Charts
 import SwiftUI
 
 struct StatView: View {
-    struct Config {
-        let title: String
-        let color: Color
-        let showList: Bool
-    }
-
-    let config: Config
+    let title: String
+    let color: Color
+    let showList: Bool
 
     @State var extent: ChartExtent<Period>
     @ObservedObject var stat: StatProvider
     @EnvironmentObject var tint: Tint
 
-    init(config: Config, stat: StatProvider, period: Period) {
-        self.config = config
+    init(title: String, color: Color, showList: Bool, stat: StatProvider, period: Period) {
+        self.title = title
+        self.color = color
+        self.showList = showList
         self.stat = stat
         self._extent = State(wrappedValue: ChartExtent(period: period))
     }
@@ -39,10 +37,10 @@ struct StatView: View {
                     let segment = extent.segment(from: points)
 
                     ChartView(segment: segment, timing: extent)
-                        .foregroundStyle(config.color)
-                        .listRowSeparator(config.showList ? .visible : .hidden, edges: .bottom)
+                        .foregroundStyle(color)
+                        .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
 
-                    if config.showList {
+                    if showList {
                         total(count: segment.total)
                     }
                 }
@@ -50,7 +48,7 @@ struct StatView: View {
                 .scrollDisabled(true)
             }
         }
-        .navigationTitle(config.title)
+        .navigationTitle(title)
         .onAppear {
             tint.value = nil
         }
@@ -85,18 +83,12 @@ struct StatView: View {
     stat.result = .success([])
     return NavigationStack {
         StatView(
-            config: StatView.Config(title: "App Launch", color: .blue, showList: true),
+            title: "App Launch",
+            color: .blue,
+            showList: true,
             stat: stat,
             period: .yesterday
         )
         .environmentObject(Tint())
-    }
-}
-
-// MARK: -
-
-extension StatView.Config: CustomDebugStringConvertible {
-    var debugDescription: String {
-        "StatView.Configuration(title: \(title), color: \(color), showList: \(showList))"
     }
 }


### PR DESCRIPTION
Removed StatView.Config and switched StatView and StatRow to explicit title, color, and showList parameters. Updated all call sites in HomeContent and EventView.Sections, including previews. A code search no longer finds StatView.Config or StatConfig references, and local swift test is blocked in this CLI environment because UIKit is unavailable.