### PR TITLE
Refactor StatRow to accept destination via ViewBuilder

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -77,12 +77,18 @@ extension EventView {
             }
             ForEach(Period.allCases) { period in
                 StatRow(
-                    title: "Stats",
                     color: .blue,
-                    showList: true,
                     period: period,
                     stat: stat
-                )
+                ) {
+                    StatView(
+                        title: "Stats",
+                        color: .blue,
+                        showList: true,
+                        stat: stat,
+                        period: period
+                    )
+                }
             }
         }
     }

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -50,12 +50,18 @@ struct HomeContent: View {
         Section {
             ForEach(Period.summary) { period in
                 StatRow(
-                    title: "Crashes",
                     color: .red,
-                    showList: false,
                     period: period,
                     stat: crashStat
-                )
+                ) {
+                    StatView(
+                        title: "Crashes",
+                        color: .red,
+                        showList: false,
+                        stat: crashStat,
+                        period: period
+                    )
+                }
             }
 
             Row {
@@ -92,12 +98,18 @@ struct HomeContent: View {
         Section {
             ForEach(Period.summary) { period in
                 StatRow(
-                    title: "Sessions",
                     color: .purple,
-                    showList: false,
                     period: period,
                     stat: sessionStat
-                )
+                ) {
+                    StatView(
+                        title: "Sessions",
+                        color: .purple,
+                        showList: false,
+                        stat: sessionStat,
+                        period: period
+                    )
+                }
             }
         } header: {
             Header(title: "Sessions").task {

--- a/Sources/Scout/UI/Stats/StatRow.swift
+++ b/Sources/Scout/UI/Stats/StatRow.swift
@@ -7,13 +7,12 @@
 
 import SwiftUI
 
-struct StatRow: View {
-    let title: String
+struct StatRow<Destination: View>: View {
     let color: Color
-    let showList: Bool
     let period: Period
 
     @ObservedObject var stat: StatProvider
+    @ViewBuilder let destination: () -> Destination
 
     var body: some View {
         Row {
@@ -30,13 +29,7 @@ struct StatRow: View {
             }
             .foregroundColor(color)
         } destination: {
-            StatView(
-                title: title,
-                color: color,
-                showList: showList,
-                stat: stat,
-                period: period
-            )
+            destination()
         }
     }
 }
@@ -47,12 +40,12 @@ struct StatRow: View {
     NavigationStack {
         List {
             StatRow(
-                title: "Events",
                 color: .blue,
-                showList: true,
                 period: .today,
                 stat: StatProvider(eventName: "event_name", periods: Period.allCases)
-            )
+            ) {
+                Text("Detail")
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the `StatRow` component to improve flexibility and reusability by converting it into a generic view that accepts a destination view as a parameter. This change removes the need to pass presentation-related properties (`title`, `showList`) directly to `StatRow`, instead delegating the construction of the detailed view to the caller. As a result, usage sites in `HomeContent` and `EventView.Sections` are updated accordingly.

**Component Refactoring and API Improvements:**

* Refactored `StatRow` to be a generic view (`StatRow<Destination: View>`) that accepts a `destination` view builder closure, removing the `title` and `showList` properties and allowing callers to specify the destination view content. [[1]](diffhunk://#diff-3c7e25a0c557765003ada157cd8796bc9bd3d2c0297322e4692a2a06aaa3fc9dL10-R15) [[2]](diffhunk://#diff-3c7e25a0c557765003ada157cd8796bc9bd3d2c0297322e4692a2a06aaa3fc9dL33-R32)
* Updated all usage sites (`HomeContent`, `EventView.Sections`, and the `StatRow` preview) to construct the appropriate `StatView` or placeholder as the destination, passing the required properties directly to `StatView` instead of through `StatRow`. [[1]](diffhunk://#diff-7def4a81f7b7e6d75942a689a04427bdbc370892b7968f25572d2de9e00a70b2L53-R65) [[2]](diffhunk://#diff-7def4a81f7b7e6d75942a689a04427bdbc370892b7968f25572d2de9e00a70b2L95-R113) [[3]](diffhunk://#diff-eabaa968472a7cf4c7fc592517dcdb1fe30808e48cddef10f2a9607373082c0cL80-R95) [[4]](diffhunk://#diff-3c7e25a0c557765003ada157cd8796bc9bd3d2c0297322e4692a2a06aaa3fc9dL50-R48)

These changes make `StatRow` more composable and better aligned with SwiftUI best practices.