### PR TITLE
Refactor StatView to set navigation titles directly in views

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -82,12 +82,12 @@ extension EventView {
                     stat: stat
                 ) {
                     StatView(
-                        title: "Stats",
                         color: .blue,
                         showList: true,
                         stat: stat,
                         period: period
                     )
+                    .navigationTitle("Stats")
                 }
             }
         }

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -55,12 +55,12 @@ struct HomeContent: View {
                     stat: crashStat
                 ) {
                     StatView(
-                        title: "Crashes",
                         color: .red,
                         showList: false,
                         stat: crashStat,
                         period: period
                     )
+                    .navigationTitle("Crashes")
                 }
             }
 
@@ -103,12 +103,12 @@ struct HomeContent: View {
                     stat: sessionStat
                 ) {
                     StatView(
-                        title: "Sessions",
                         color: .purple,
                         showList: false,
                         stat: sessionStat,
                         period: period
                     )
+                    .navigationTitle("Sessions")
                 }
             }
         } header: {

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -9,7 +9,6 @@ import Charts
 import SwiftUI
 
 struct StatView: View {
-    let title: String
     let color: Color
     let showList: Bool
 
@@ -17,8 +16,7 @@ struct StatView: View {
     @ObservedObject var stat: StatProvider
     @EnvironmentObject var tint: Tint
 
-    init(title: String, color: Color, showList: Bool, stat: StatProvider, period: Period) {
-        self.title = title
+    init(color: Color, showList: Bool, stat: StatProvider, period: Period) {
         self.color = color
         self.showList = showList
         self.stat = stat
@@ -48,7 +46,6 @@ struct StatView: View {
                 .scrollDisabled(true)
             }
         }
-        .navigationTitle(title)
         .onAppear {
             tint.value = nil
         }
@@ -83,12 +80,12 @@ struct StatView: View {
     stat.result = .success([])
     return NavigationStack {
         StatView(
-            title: "App Launch",
             color: .blue,
             showList: true,
             stat: stat,
             period: .yesterday
         )
+        .navigationTitle("App Launch")
         .environmentObject(Tint())
     }
 }


### PR DESCRIPTION
Remove the title parameter from StatView and set navigation titles directly in the views where StatView is used. This simplifies the component and improves title management.