### PR TITLE
Refactor StatView to use ChartExtent directly

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -84,8 +84,8 @@ extension EventView {
                     StatView(
                         color: .blue,
                         showList: true,
-                        stat: stat,
-                        period: period
+                        extent: ChartExtent(period: period),
+                        stat: stat
                     )
                     .navigationTitle("Stats")
                 }

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -57,8 +57,8 @@ struct HomeContent: View {
                     StatView(
                         color: .red,
                         showList: false,
-                        stat: crashStat,
-                        period: period
+                        extent: ChartExtent(period: period),
+                        stat: crashStat
                     )
                     .navigationTitle("Crashes")
                 }
@@ -105,8 +105,8 @@ struct HomeContent: View {
                     StatView(
                         color: .purple,
                         showList: false,
-                        stat: sessionStat,
-                        period: period
+                        extent: ChartExtent(period: period),
+                        stat: sessionStat
                     )
                     .navigationTitle("Sessions")
                 }

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -16,13 +16,6 @@ struct StatView: View {
     @ObservedObject var stat: StatProvider
     @EnvironmentObject var tint: Tint
 
-    init(color: Color, showList: Bool, stat: StatProvider, period: Period) {
-        self.color = color
-        self.showList = showList
-        self.stat = stat
-        self._extent = State(wrappedValue: ChartExtent(period: period))
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             PeriodPicker(extent: $extent, periods: stat.periods)
@@ -78,12 +71,13 @@ struct StatView: View {
 #Preview("StatView") {
     let stat = StatProvider(eventName: "app_launch", periods: Period.allCases)
     stat.result = .success([])
+
     return NavigationStack {
         StatView(
             color: .blue,
             showList: true,
-            stat: stat,
-            period: .yesterday
+            extent: ChartExtent(period: .yesterday),
+            stat: stat
         )
         .navigationTitle("App Launch")
         .environmentObject(Tint())


### PR DESCRIPTION
Remove the period parameter from StatView and directly utilize ChartExtent for managing periods. This simplifies the StatView initialization and improves code clarity.