### PR TITLE
Refactor StatView to use environment color

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -82,7 +82,6 @@ extension EventView {
                     stat: stat
                 ) {
                     StatView(
-                        color: .blue,
                         showList: true,
                         extent: ChartExtent(period: period),
                         stat: stat

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -55,11 +55,11 @@ struct HomeContent: View {
                     stat: crashStat
                 ) {
                     StatView(
-                        color: .red,
                         showList: false,
                         extent: ChartExtent(period: period),
                         stat: crashStat
                     )
+                    .environment(\.chartColor, .red)
                     .navigationTitle("Crashes")
                 }
             }
@@ -103,11 +103,11 @@ struct HomeContent: View {
                     stat: sessionStat
                 ) {
                     StatView(
-                        color: .purple,
                         showList: false,
                         extent: ChartExtent(period: period),
                         stat: sessionStat
                     )
+                    .environment(\.chartColor, .purple)
                     .navigationTitle("Sessions")
                 }
             }

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -9,12 +9,12 @@ import Charts
 import SwiftUI
 
 struct StatView: View {
-    let color: Color
     let showList: Bool
 
     @State var extent: ChartExtent<Period>
     @ObservedObject var stat: StatProvider
     @EnvironmentObject var tint: Tint
+    @Environment(\.chartColor) var color
 
     var body: some View {
         VStack(spacing: 0) {
@@ -66,7 +66,9 @@ struct StatView: View {
     }
 }
 
-// MARK: - Preview
+extension EnvironmentValues {
+    @Entry var chartColor: Color = .blue
+}
 
 #Preview("StatView") {
     let stat = StatProvider(eventName: "app_launch", periods: Period.allCases)
@@ -74,7 +76,6 @@ struct StatView: View {
 
     return NavigationStack {
         StatView(
-            color: .blue,
             showList: true,
             extent: ChartExtent(period: .yesterday),
             stat: stat


### PR DESCRIPTION
Replace direct color parameters in StatView with an environment color, allowing for more flexible theming and consistency across the application.