### PR TITLE
Strengthen FilterCriteria apply test to verify binding write-back

### DIFF
--- a/Tests/ScoutTests/UI/FilterCriteriaTests.swift
+++ b/Tests/ScoutTests/UI/FilterCriteriaTests.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import SwiftUI
 import Testing
 
 @testable import Scout
@@ -38,11 +39,37 @@ struct FilterCriteriaTests {
         #expect(criteria.isApplyEnabled)
     }
 
-    @Test("Check apply functionality") func testApply() {
-        criteria.toggle(.one)
-        criteria.apply()
+    @Test("Apply writes cache back to the binding on deinit") func testApply() {
+        final class Holder { var value = Set<TestEnum>() }
+        let holder = Holder()
+        let binding = Binding<Set<TestEnum>>(
+            get: { holder.value },
+            set: { holder.value = $0 }
+        )
 
-        #expect(criteria.isApplyEnabled)
+        do {
+            let criteria = FilterCriteria(selected: binding)
+            criteria.toggle(.one)
+            criteria.apply()
+        }
+
+        #expect(holder.value == [.one])
+    }
+
+    @Test("Binding is unchanged when apply is not called") func testApplyNotCalled() {
+        final class Holder { var value = Set<TestEnum>() }
+        let holder = Holder()
+        let binding = Binding<Set<TestEnum>>(
+            get: { holder.value },
+            set: { holder.value = $0 }
+        )
+
+        do {
+            let criteria = FilterCriteria(selected: binding)
+            criteria.toggle(.one)
+        }
+
+        #expect(holder.value.isEmpty)
     }
 
     @Test("Check if reset button is disabled when no items are enabled") func testIsResetEnabled() {


### PR DESCRIPTION
The existing testApply in FilterCriteriaTests called criteria.apply() and then asserted criteria.isApplyEnabled, but isApplyEnabled is derived solely from the cache state (!cache.isEmpty and cache != selected.wrappedValue) and is not affected by apply() at all, so the assertion would have passed whether or not apply() was ever invoked. That makes the test effectively a no-op for the apply behavior it claims to cover. This change replaces the assertion with one that observes the actual contract of apply(): the apply() call flips the isApplied flag so that the deinit writes the mutated cache back to the selected Binding. The test now constructs a real Binding over a small Holder reference type, runs the FilterCriteria through toggle and apply inside a nested scope so it deinits deterministically, and asserts that the holder ends up holding the toggled set. A companion testApplyNotCalled locks in the symmetric guarantee that skipping apply() leaves the binding untouched.