### PR TITLE
Remove unused imports from UI files

### DIFF
--- a/Sources/Scout/UI/Chart/ChartExtent.swift
+++ b/Sources/Scout/UI/Chart/ChartExtent.swift
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import SwiftUI
+import Foundation
 
 struct ChartExtent<T: ChartTimeScale> {
     var period: T {

--- a/Sources/Scout/UI/Chart/ChartNumeric.swift
+++ b/Sources/Scout/UI/Chart/ChartNumeric.swift
@@ -6,7 +6,6 @@
 // https://opensource.org/licenses/MIT.
 
 import Charts
-import Foundation
 
 /// A UI-layer specialization of `MatrixValue` for chart rendering.
 ///

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import SwiftUI
 
 struct CrashListView: View {

--- a/Sources/Scout/UI/Database/AppDatabase.swift
+++ b/Sources/Scout/UI/Database/AppDatabase.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import SwiftUI
 
 /// AppDatabase defines the read-only database surface used by the UI.

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -7,7 +7,6 @@
 
 import CloudKit
 import SwiftUI
-import UIKit
 
 public struct HomeView: View {
     let container: CKContainer


### PR DESCRIPTION
Several files under Sources/Scout/UI imported modules whose symbols were never actually referenced in the file. HomeView.swift imported UIKit but only used CloudKit and SwiftUI types. CrashListView.swift and AppDatabase.swift imported CloudKit but only used SwiftUI and internal Scout types. ChartExtent.swift imported SwiftUI but only uses Date and Range, which come from Foundation. ChartNumeric.swift imported Foundation but only defines a typealias of MatrixValue and Plottable from Charts. This change trims those imports to keep the module surface honest and slightly reduce compile-time dependencies. ChartExtent.swift swaps its SwiftUI import for Foundation because the file still needs Date. No functional code changes.