### PR TITLE
Notify scout-ip on successful tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -61,3 +61,16 @@ jobs:
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
             test-without-building
+
+  notify:
+    needs: tests
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.GH_PAT }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/kasianov-mikhail/scout-ip/dispatches \
+            -d '{"event_type":"scout-updated"}'


### PR DESCRIPTION
- Add notify job that triggers scout-ip TestFlight build via repository dispatch after tests pass on main