### PR TITLE
Update lint runner to macos-26

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
- Match test runner version for consistent Xcode toolchain