### PR TITLE
Add Version and Install lifecycle tracking

### DIFF
--- a/Schema
+++ b/Schema
@@ -547,6 +547,48 @@ DEFINE SCHEMA
         GRANT READ TO "_world"
     );
 
+    RECORD TYPE Version (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
+        app_version     STRING QUERYABLE SEARCHABLE SORTABLE,
+        build_number    STRING QUERYABLE SEARCHABLE SORTABLE,
+        date            TIMESTAMP QUERYABLE SORTABLE,
+        day             TIMESTAMP QUERYABLE SORTABLE,
+        hour            TIMESTAMP QUERYABLE SORTABLE,
+        launch_id       STRING QUERYABLE SEARCHABLE SORTABLE,
+        month           TIMESTAMP QUERYABLE SORTABLE,
+        user_id         STRING QUERYABLE SEARCHABLE SORTABLE,
+        version         INT64 QUERYABLE SORTABLE,
+        week            TIMESTAMP QUERYABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE Install (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
+        date            TIMESTAMP QUERYABLE SORTABLE,
+        day             TIMESTAMP QUERYABLE SORTABLE,
+        hour            TIMESTAMP QUERYABLE SORTABLE,
+        launch_id       STRING QUERYABLE SEARCHABLE SORTABLE,
+        month           TIMESTAMP QUERYABLE SORTABLE,
+        user_id         STRING QUERYABLE SEARCHABLE SORTABLE,
+        version         INT64 QUERYABLE SORTABLE,
+        week            TIMESTAMP QUERYABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
     RECORD TYPE Session (
         "___createTime" TIMESTAMP,
         "___createdBy"  REFERENCE,

--- a/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
+++ b/Sources/Scout/Core/Bootstrap/Schema/CKContainer+Verify.swift
@@ -24,6 +24,8 @@ private let schemaRecordTypes = [
     EventObject.recordType,
     SessionObject.recordType,
     LaunchObject.recordType,
+    VersionObject.recordType,
+    InstallObject.recordType,
     CrashObject.recordType,
     Int.recordType,
     Double.recordType,

--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -35,6 +35,8 @@ public func setup(container: CKContainer) async throws {
 
     try NotificationListener.appState.setup()
     try await persistentContainer.performBackgroundTask(LaunchObject.trigger)
+    try await persistentContainer.performBackgroundTask(VersionObject.trigger)
+    try await persistentContainer.performBackgroundTask(InstallObject.trigger)
     SyncController.shared.container = container
     LoggingSystem.bootstrap(CKLogHandler.init)
     MetricsSystem.bootstrap(TelemetryFactory())

--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject+MatrixBatch.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject+MatrixBatch.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+extension InstallObject: MatrixBatch {
+    static func matrix(of batch: [InstallObject]) throws(MatrixPropertyError) -> GridMatrix<Int> {
+        guard let week = batch.first?.week else {
+            throw .init("week")
+        }
+        return Matrix(
+            recordType: Int.recordType,
+            date: week,
+            name: "Install",
+            cells: parse(of: batch)
+        )
+    }
+
+    static func parse(of batch: [InstallObject]) -> [GridCell<Int>] {
+        batch.grouped(by: \.date).mapValues(\.count).map(Cell.init)
+    }
+}

--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject+Monitor.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension InstallObject: PartialMonitor {
+    static func trigger(in context: NSManagedObjectContext) throws {
+        let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
+        request.fetchLimit = 1
+
+        guard try context.fetch(request).isEmpty else {
+            return
+        }
+
+        let entity = NSEntityDescription.entity(forEntityName: "InstallObject", in: context)!
+        let install = InstallObject(entity: entity, insertInto: context)
+        install.date = Date()
+        try context.save()
+    }
+}

--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import CoreData
+
+@objc(InstallObject)
+final class InstallObject: SyncableObject, Syncable {
+    static let recordType = "Install"
+
+    static func group(in context: NSManagedObjectContext) throws -> [InstallObject]? {
+        try batch(in: context, matching: [\.week])
+    }
+
+    func versions(in context: NSManagedObjectContext) throws -> [VersionObject] {
+        let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
+        request.predicate = NSPredicate(format: "userID == %@", userID! as CVarArg)
+        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        return try context.fetch(request)
+    }
+}
+
+extension InstallObject: CKRepresentable {
+    var toRecord: CKRecord {
+        let record = CKRecord(recordType: Self.recordType)
+
+        record["date"] = date
+
+        record.setValuesForKeys(metadata)
+
+        return record
+    }
+}

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
@@ -23,6 +23,13 @@ final class LaunchObject: SyncableObject, Syncable {
         request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
         return try context.fetch(request)
     }
+
+    func version(in context: NSManagedObjectContext) throws -> VersionObject? {
+        let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
+        request.predicate = NSPredicate(format: "launchID == %@", launchID! as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
 }
 
 extension LaunchObject: CKRepresentable {

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
@@ -16,6 +16,13 @@ final class SessionObject: TrackedObject, Syncable {
     static func group(in context: NSManagedObjectContext) throws -> [SessionObject]? {
         try batch(in: context, matching: [\.week])
     }
+
+    func launch(in context: NSManagedObjectContext) throws -> LaunchObject? {
+        let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
+        request.predicate = NSPredicate(format: "launchID == %@", launchID! as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
 }
 
 extension SessionObject: CKRepresentable {

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject+MatrixBatch.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject+MatrixBatch.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+extension VersionObject: MatrixBatch {
+    static func matrix(of batch: [VersionObject]) throws(MatrixPropertyError) -> GridMatrix<Int> {
+        guard let week = batch.first?.week else {
+            throw .init("week")
+        }
+        return Matrix(
+            recordType: Int.recordType,
+            date: week,
+            name: "Version",
+            category: batch.first?.appVersion,
+            cells: parse(of: batch)
+        )
+    }
+
+    static func parse(of batch: [VersionObject]) -> [GridCell<Int>] {
+        batch.grouped(by: \.date).mapValues(\.count).map(Cell.init)
+    }
+}

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject+Monitor.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension VersionObject: PartialMonitor {
+    static func trigger(in context: NSManagedObjectContext) throws {
+        let entity = NSEntityDescription.entity(forEntityName: "VersionObject", in: context)!
+        let version = VersionObject(entity: entity, insertInto: context)
+        version.date = Date()
+        version.appVersion = Bundle.main.marketingVersion
+        version.buildNumber = Bundle.main.buildNumber
+        try context.save()
+    }
+}
+
+extension Bundle {
+    var marketingVersion: String? {
+        infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+
+    var buildNumber: String? {
+        infoDictionary?["CFBundleVersion"] as? String
+    }
+}

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import CoreData
+
+@objc(VersionObject)
+final class VersionObject: SyncableObject, Syncable {
+    static let recordType = "Version"
+    @NSManaged var appVersion: String?
+    @NSManaged var buildNumber: String?
+
+    static func group(in context: NSManagedObjectContext) throws -> [VersionObject]? {
+        try batch(in: context, matching: [\.week])
+    }
+
+    func install(in context: NSManagedObjectContext) throws -> InstallObject? {
+        let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
+        request.predicate = NSPredicate(format: "userID == %@", userID! as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    func launches(in context: NSManagedObjectContext) throws -> [LaunchObject] {
+        let versionRequest = NSFetchRequest<VersionObject>(entityName: "VersionObject")
+        versionRequest.predicate = NSPredicate(format: "appVersion == %@", appVersion!)
+        let versions = try context.fetch(versionRequest)
+        let launchIDs = versions.compactMap(\.launchID)
+
+        let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
+        request.predicate = NSPredicate(format: "launchID IN %@", launchIDs)
+        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        return try context.fetch(request)
+    }
+}
+
+extension VersionObject: CKRepresentable {
+    var toRecord: CKRecord {
+        let record = CKRecord(recordType: Self.recordType)
+
+        record["date"] = date
+        record["app_version"] = appVersion
+        record["build_number"] = buildNumber
+        record["launch_id"] = launchID?.uuidString
+
+        record.setValuesForKeys(metadata)
+
+        return record
+    }
+}

--- a/Sources/Scout/Core/Sync/SyncJobPlan.swift
+++ b/Sources/Scout/Core/Sync/SyncJobPlan.swift
@@ -15,6 +15,8 @@ struct SyncJobPlan: Sendable {
             { try await engine.send(type: EventObject.self) },
             { try await engine.send(type: SessionObject.self) },
             { try await engine.send(type: LaunchObject.self) },
+            { try await engine.send(type: VersionObject.self) },
+            { try await engine.send(type: InstallObject.self) },
             { try await engine.send(type: UserActivityObject.self) },
             { try await engine.send(type: IntMetricsObject.self) },
             { try await engine.send(type: DoubleMetricsObject.self) },

--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -25,6 +25,8 @@
         <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="userID" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
+    <entity name="InstallObject" representedClassName="InstallObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none"/>
+
     <entity name="IntMetricsObject" representedClassName="IntMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="none">
         <attribute name="value" attributeType="Integer 64" usesScalarValueType="YES"/>
     </entity>
@@ -46,6 +48,10 @@
     </entity>
     <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
         <attribute name="sessionID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="VersionObject" representedClassName="VersionObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="buildNumber" optional="YES" attributeType="String"/>
     </entity>
     <entity name="UserActivityObject" representedClassName="UserActivityObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
         <attribute name="dayCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("InstallObject")
+struct InstallObjectTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let week = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
+
+    @Test("versions(in:) returns versions matching userID")
+    func testVersions() throws {
+        let install = InstallObject.stub(date: week, in: context)
+        let userID = install.userID!
+
+        let v1 = VersionObject.stub(date: week, appVersion: "1.0", in: context)
+        v1.userID = userID
+
+        let v2 = VersionObject.stub(date: week.addingHour(), appVersion: "2.0", in: context)
+        v2.userID = userID
+
+        // Version with different userID
+        VersionObject.stub(date: week, appVersion: "3.0", in: context).userID = UUID()
+
+        try context.save()
+
+        let versions = try install.versions(in: context)
+        #expect(versions.count == 2)
+        #expect(versions[0].appVersion == "1.0")
+        #expect(versions[1].appVersion == "2.0")
+    }
+}

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
@@ -32,4 +32,44 @@ struct LaunchObjectTests {
                 GridCell(row: 1, column: 1, value: 1),
             ])
     }
+
+    @Test("sessions(in:) returns sessions matching launchID")
+    func testSessions() throws {
+        let launch = LaunchObject.stub(date: week, in: context)
+        let launchID = launch.launchID!
+
+        let session1 = SessionObject.stub(date: week, in: context)
+        session1.launchID = launchID
+
+        let session2 = SessionObject.stub(date: week.addingHour(), in: context)
+        session2.launchID = launchID
+
+        // Session with different launchID
+        SessionObject.stub(date: week, in: context).launchID = UUID()
+
+        try context.save()
+
+        let sessions = try launch.sessions(in: context)
+        #expect(sessions.count == 2)
+        #expect(sessions[0].launchID == launchID)
+        #expect(sessions[1].launchID == launchID)
+    }
+
+    @Test("version(in:) returns version matching launchID")
+    func testVersion() throws {
+        let launch = LaunchObject.stub(date: week, in: context)
+        let launchID = launch.launchID!
+
+        let version = VersionObject.stub(date: week, appVersion: "2.0", in: context)
+        version.launchID = launchID
+
+        // Version with different launchID
+        VersionObject.stub(date: week, appVersion: "1.0", in: context).launchID = UUID()
+
+        try context.save()
+
+        let result = try launch.version(in: context)
+        #expect(result?.appVersion == "2.0")
+        #expect(result?.launchID == launchID)
+    }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
@@ -32,4 +32,21 @@ struct SessionObjectTests {
                 GridCell(row: 1, column: 1, value: 1),
             ])
     }
+
+    @Test("launch(in:) returns launch matching launchID")
+    func testLaunch() throws {
+        let session = SessionObject.stub(date: week, in: context)
+        let launchID = session.launchID!
+
+        let launch = LaunchObject.stub(date: week, in: context)
+        launch.launchID = launchID
+
+        // Launch with different launchID
+        LaunchObject.stub(date: week, in: context).launchID = UUID()
+
+        try context.save()
+
+        let result = try session.launch(in: context)
+        #expect(result?.launchID == launchID)
+    }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
@@ -1,0 +1,84 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("VersionObject")
+struct VersionObjectTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let week = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
+
+    @Test("parse(of:) produces correct GridCell<Int> counts by date")
+    func testParseOf() throws {
+        let batch: [VersionObject] = [
+            .stub(date: week, synced: false, in: context),
+            .stub(date: week, synced: false, in: context),
+            .stub(date: week.addingHour(), synced: false, in: context),
+        ]
+
+        let cells = VersionObject.parse(of: batch)
+
+        #expect(
+            cells.sorted() == [
+                GridCell(row: 1, column: 0, value: 2),
+                GridCell(row: 1, column: 1, value: 1),
+            ])
+    }
+
+    @Test("launches(in:) returns all launches with same appVersion")
+    func testLaunches() throws {
+        let launchID1 = UUID()
+        let launchID2 = UUID()
+        let launchID3 = UUID()
+
+        let v1 = VersionObject.stub(date: week, appVersion: "2.0", in: context)
+        v1.launchID = launchID1
+
+        let v2 = VersionObject.stub(date: week.addingHour(), appVersion: "2.0", in: context)
+        v2.launchID = launchID2
+
+        // Different version
+        let v3 = VersionObject.stub(date: week, appVersion: "1.0", in: context)
+        v3.launchID = launchID3
+
+        let l1 = LaunchObject.stub(date: week, in: context)
+        l1.launchID = launchID1
+
+        let l2 = LaunchObject.stub(date: week.addingHour(), in: context)
+        l2.launchID = launchID2
+
+        let l3 = LaunchObject.stub(date: week, in: context)
+        l3.launchID = launchID3
+
+        try context.save()
+
+        let launches = try v1.launches(in: context)
+        #expect(launches.count == 2)
+        #expect(launches.allSatisfy { $0.launchID == launchID1 || $0.launchID == launchID2 })
+    }
+
+    @Test("install(in:) returns install matching userID")
+    func testInstall() throws {
+        let version = VersionObject.stub(date: week, appVersion: "2.0", in: context)
+        let userID = version.userID!
+
+        let install = InstallObject.stub(date: week, in: context)
+        install.userID = userID
+
+        // Install with different userID
+        InstallObject.stub(date: week, in: context).userID = UUID()
+
+        try context.save()
+
+        let result = try version.install(in: context)
+        #expect(result?.userID == userID)
+    }
+}

--- a/Tests/ScoutTests/Stubs/InstallObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/InstallObject+Stub.swift
@@ -1,0 +1,26 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+@testable import Scout
+
+extension InstallObject {
+    @discardableResult static func stub(
+        date: Date,
+        synced: Bool = false,
+        in context: NSManagedObjectContext
+    ) -> InstallObject {
+        let entity = NSEntityDescription.entity(forEntityName: "InstallObject", in: context)!
+        let install = InstallObject(entity: entity, insertInto: context)
+
+        install.date = date
+        install.isSynced = synced
+
+        return install
+    }
+}

--- a/Tests/ScoutTests/Stubs/VersionObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/VersionObject+Stub.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+@testable import Scout
+
+extension VersionObject {
+    @discardableResult static func stub(
+        date: Date,
+        synced: Bool = false,
+        appVersion: String = "1.0",
+        in context: NSManagedObjectContext
+    ) -> VersionObject {
+        let entity = NSEntityDescription.entity(forEntityName: "VersionObject", in: context)!
+        let version = VersionObject(entity: entity, insertInto: context)
+
+        version.date = date
+        version.isSynced = synced
+        version.appVersion = appVersion
+
+        return version
+    }
+}


### PR DESCRIPTION
- Add VersionObject to record app version and build number per launch
- Add InstallObject to mark first-ever launch (one per user)
- Add query-based relationship helpers: Install → versions, Version → launches/install, Launch → sessions/version, Session → launch
- Update Core Data model, CloudKit Schema, sync plan, and schema verification