### PR TITLE
Implement RecordDecodable protocol for UI models

### DIFF
--- a/Sources/Scout/UI/Crash/Crash.swift
+++ b/Sources/Scout/UI/Crash/Crash.swift
@@ -29,11 +29,7 @@ extension Crash {
     ]
 }
 
-extension Crash {
-    init(results: (CKRecord.ID, Result<CKRecord, Error>)) throws {
-        try self.init(record: results.1.get())
-    }
-
+extension Crash: RecordDecodable {
     init(record: CKRecord) throws {
         name = record["name"] ?? ""
         reason = record["reason"]

--- a/Sources/Scout/UI/Database/RecordDecodable.swift
+++ b/Sources/Scout/UI/Database/RecordDecodable.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+/// A type that can be initialized from a CloudKit record.
+///
+/// Conforming types provide an `init(record:)` initializer that decodes
+/// a `CKRecord` into a UI model. A default `init(results:)` convenience
+/// initializer is provided that unwraps the result tuple returned by
+/// CloudKit batch fetch operations.
+///
+protocol RecordDecodable {
+    init(record: CKRecord) throws
+}
+
+extension RecordDecodable {
+    init(results: (CKRecord.ID, Result<CKRecord, Error>)) throws {
+        try self.init(record: results.1.get())
+    }
+}

--- a/Sources/Scout/UI/Device/Device.swift
+++ b/Sources/Scout/UI/Device/Device.swift
@@ -20,11 +20,7 @@ extension Device {
     ]
 }
 
-extension Device {
-    init(results: (CKRecord.ID, Result<CKRecord, Error>)) throws {
-        try self.init(record: results.1.get())
-    }
-
+extension Device: RecordDecodable {
     init(record: CKRecord) throws {
         date = record["date"]
         id = record.recordID

--- a/Sources/Scout/UI/Event/Event.swift
+++ b/Sources/Scout/UI/Event/Event.swift
@@ -30,11 +30,7 @@ extension Event {
     ]
 }
 
-extension Event {
-    init(results: (CKRecord.ID, Result<CKRecord, Error>)) throws {
-        try self.init(record: results.1.get())
-    }
-
+extension Event: RecordDecodable {
     init(record: CKRecord) throws {
         name = record["name"] ?? ""
         level = record["level"].flatMap { Level(rawValue: $0) }

--- a/Sources/Scout/UI/Install/Install.swift
+++ b/Sources/Scout/UI/Install/Install.swift
@@ -22,11 +22,7 @@ extension Install {
     ]
 }
 
-extension Install {
-    init(results: (CKRecord.ID, Result<CKRecord, Error>)) throws {
-        try self.init(record: results.1.get())
-    }
-
+extension Install: RecordDecodable {
     init(record: CKRecord) throws {
         date = record["date"]
         id = record.recordID

--- a/Sources/Scout/UI/Launch/Launch.swift
+++ b/Sources/Scout/UI/Launch/Launch.swift
@@ -24,11 +24,7 @@ extension Launch {
     ]
 }
 
-extension Launch {
-    init(results: (CKRecord.ID, Result<CKRecord, Error>)) throws {
-        try self.init(record: results.1.get())
-    }
-
+extension Launch: RecordDecodable {
     init(record: CKRecord) throws {
         startDate = record["start_date"]
         endDate = record["end_date"]

--- a/Sources/Scout/UI/Session/Session.swift
+++ b/Sources/Scout/UI/Session/Session.swift
@@ -26,11 +26,7 @@ extension Session {
     ]
 }
 
-extension Session {
-    init(results: (CKRecord.ID, Result<CKRecord, Error>)) throws {
-        try self.init(record: results.1.get())
-    }
-
+extension Session: RecordDecodable {
     init(record: CKRecord) throws {
         startDate = record["start_date"]
         endDate = record["end_date"]

--- a/Sources/Scout/UI/Version/Version.swift
+++ b/Sources/Scout/UI/Version/Version.swift
@@ -26,11 +26,7 @@ extension Version {
     ]
 }
 
-extension Version {
-    init(results: (CKRecord.ID, Result<CKRecord, Error>)) throws {
-        try self.init(record: results.1.get())
-    }
-
+extension Version: RecordDecodable {
     init(record: CKRecord) throws {
         date = record["date"]
         appVersion = record["app_version"]


### PR DESCRIPTION
Introduce the RecordDecodable protocol to streamline the initialization of UI models from CloudKit records. Remove legacy initializers to enhance code clarity and maintainability.