### PR TITLE
Add workflow_dispatch trigger to Swift workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
- Allow Swift workflow to be triggered manually and by the .github repo when reusable workflows change