### PR TITLE
Extract PaginatingProvider to deduplicate fetch logic

### DIFF
--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -14,7 +14,7 @@ struct CrashListView: View {
 
     var body: some View {
         Group {
-            if let crashes = provider.crashes {
+            if let crashes = provider.items {
                 if crashes.isEmpty {
                     Placeholder(
                         text: "No crashes",

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -9,39 +9,19 @@ import CloudKit
 import SwiftUI
 
 @MainActor
-class CrashProvider: ObservableObject {
-    @Published var crashes: [Crash]?
-    @Published var cursor: CKQueryOperation.Cursor?
-
+class CrashProvider: PaginatingProvider<Crash> {
     func fetch(in database: AppDatabase) async {
-        do {
-            let query = CKQuery(recordType: CrashObject.recordType, predicate: Self.predicate)
-            query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
-
-            let results = try await database.read(
-                matching: query,
-                fields: Crash.desiredKeys
-            )
-
-            self.cursor = results.cursor
-            self.crashes = try results.records.map(Crash.init)
-        } catch {
-            self.crashes = []
-        }
+        let query = CKQuery(recordType: CrashObject.recordType, predicate: Self.predicate)
+        query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+        await fetch(matching: query, fields: Crash.desiredKeys, in: database)
     }
 
-    func fetchMore(cursor: CKQueryOperation.Cursor, in database: AppDatabase) async {
-        do {
-            let results = try await database.readMore(
-                from: cursor,
-                fields: nil
-            )
+    override func handleFetchError(_ error: Error) {
+        self.items = []
+    }
 
-            self.cursor = results.cursor
-            self.crashes?.append(contentsOf: try results.records.map(Crash.init))
-        } catch {
-            // Keep existing data on pagination failure
-        }
+    override func handlePaginationError(_ error: Error) {
+        // Keep existing data on pagination failure
     }
 
     private static var predicate: NSPredicate {

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -28,7 +28,7 @@ struct AnalyticsView: View {
         .autocorrectionDisabled(true)  // stop keyboard suggestions
         .keyboardType(.alphabet)  // stop keyboard suggestions
         .searchSuggestions {
-            if let events = provider.events, filter.text.isEmpty {
+            if let events = provider.items, filter.text.isEmpty {
                 ForEach(events.unique(by: \.name, max: 7), id: \.self) {
                     Suggestion(text: $0)
                 }
@@ -43,12 +43,12 @@ struct AnalyticsView: View {
             )  // hide keyboard on suggestion selected
 
             Task {
-                search.events = nil
+                search.items = nil
                 await search.fetch(for: filter, in: database)
             }
         }
         .onChange(of: filter.text) { _ in
-            search.events?.removeAll()
+            search.items?.removeAll()
         }
         .navigationTitle("Events")
         .onAppear {
@@ -72,7 +72,7 @@ struct AnalyticsView: View {
             }
             .onChange(of: filter.levels) { _ in
                 Task {
-                    provider.events = nil
+                    provider.items = nil
                     await fetch()
                 }
             }

--- a/Sources/Scout/UI/Event/EventList.swift
+++ b/Sources/Scout/UI/Event/EventList.swift
@@ -15,7 +15,7 @@ struct EventList: View {
     @ObservedObject var provider: EventProvider
 
     var body: some View {
-        if let events = provider.events {
+        if let events = provider.items {
             if events.isEmpty {
                 Placeholder(
                     text: "No results",
@@ -83,7 +83,7 @@ struct EventList: View {
 
 #Preview("Empty State") {
     let provider = EventProvider()
-    provider.events = []
+    provider.items = []
     return NavigationStack {
         EventList(provider: provider)
     }

--- a/Sources/Scout/UI/Event/EventProvider.swift
+++ b/Sources/Scout/UI/Event/EventProvider.swift
@@ -10,39 +10,10 @@ import Foundation
 import SwiftUI
 
 @MainActor
-class EventProvider: ObservableObject {
-    @Published var events: [Event]?
-    @Published var cursor: CKQueryOperation.Cursor?
-    @Published var message: Message?
-
+class EventProvider: PaginatingProvider<Event> {
     func fetch(for filter: Event.Query, in database: AppDatabase) async {
-        do {
-            let query = CKQuery(recordType: EventObject.recordType, predicate: filter.buildPredicate())
-            query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
-
-            let results = try await database.read(
-                matching: query,
-                fields: Event.desiredKeys
-            )
-
-            self.cursor = results.cursor
-            self.events = try results.records.map(Event.init)
-        } catch {
-            self.message = Message(error.localizedDescription, level: .error)
-        }
-    }
-
-    func fetchMore(cursor: CKQueryOperation.Cursor, in database: AppDatabase) async {
-        do {
-            let results = try await database.readMore(
-                from: cursor,
-                fields: nil
-            )
-
-            self.cursor = results.cursor
-            self.events?.append(contentsOf: try results.records.map(Event.init))
-        } catch {
-            self.message = Message(error.localizedDescription, level: .error)
-        }
+        let query = CKQuery(recordType: EventObject.recordType, predicate: filter.buildPredicate())
+        query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+        await fetch(matching: query, fields: Event.desiredKeys, in: database)
     }
 }

--- a/Sources/Scout/UI/Event/History/HistoryView.swift
+++ b/Sources/Scout/UI/Event/History/HistoryView.swift
@@ -52,13 +52,13 @@ struct HistoryView: View {
         }
         .onChange(of: filter.category) { _ in
             Task {
-                provider.events = nil
+                provider.items = nil
                 await fetch()
             }
         }
         .onChange(of: filter.option) { _ in
             Task {
-                provider.events = nil
+                provider.items = nil
                 await fetch()
             }
         }

--- a/Sources/Scout/UI/Provider/PaginatingProvider.swift
+++ b/Sources/Scout/UI/Provider/PaginatingProvider.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import SwiftUI
+
+/// A provider that handles paginated CloudKit queries.
+///
+/// Subclasses supply their query and desired keys; this class manages
+/// the cursor, appending pages, and error handling.
+///
+@MainActor
+class PaginatingProvider<Item: RecordDecodable>: ObservableObject {
+    @Published var items: [Item]?
+    @Published var cursor: CKQueryOperation.Cursor?
+    @Published var message: Message?
+
+    func fetch(
+        matching query: CKQuery, fields: [CKRecord.FieldKey]?, in database: AppDatabase
+    ) async {
+        do {
+            let results = try await database.read(matching: query, fields: fields)
+            self.cursor = results.cursor
+            self.items = try results.records.map(Item.init)
+        } catch {
+            handleFetchError(error)
+        }
+    }
+
+    func fetchMore(cursor: CKQueryOperation.Cursor, in database: AppDatabase) async {
+        do {
+            let results = try await database.readMore(from: cursor, fields: nil)
+            self.cursor = results.cursor
+            self.items?.append(contentsOf: try results.records.map(Item.init))
+        } catch {
+            handlePaginationError(error)
+        }
+    }
+
+    /// Override to customize initial fetch error handling.
+    ///
+    func handleFetchError(_ error: Error) {
+        self.message = Message(error.localizedDescription, level: .error)
+    }
+
+    /// Override to customize pagination error handling.
+    ///
+    func handlePaginationError(_ error: Error) {
+        self.message = Message(error.localizedDescription, level: .error)
+    }
+}


### PR DESCRIPTION
- Add PaginatingProvider base class with shared fetch/fetchMore pagination logic
- Simplify EventProvider and CrashProvider to subclass it
- Rename .events/.crashes to .items