### PR TITLE
Extract parseCellKey to deduplicate cell key parsing

### DIFF
--- a/Sources/Scout/Core/Matrix/Cell/CellProtocol.swift
+++ b/Sources/Scout/Core/Matrix/Cell/CellProtocol.swift
@@ -23,6 +23,16 @@ protocol CellProtocol: Combining, Sendable, Equatable {
     init(key: String, value: Scalar)
 }
 
+/// Splits a cell key like `"cell_X_Y"` into its three components.
+///
+/// Returns `nil` if the key doesn't have exactly three underscore-separated parts.
+///
+func parseCellKey(_ key: String) -> (prefix: String, first: String, second: String)? {
+    let parts = key.components(separatedBy: "_")
+    guard parts.count == 3 else { return nil }
+    return (parts[0], parts[1], parts[2])
+}
+
 extension Int {
     var leadingZero: String {
         String(format: "%02d", self)

--- a/Sources/Scout/Core/Matrix/Cell/GridCell.swift
+++ b/Sources/Scout/Core/Matrix/Cell/GridCell.swift
@@ -23,15 +23,13 @@ extension GridCell: CellProtocol {
     }
 
     init(key: String, value: T) {
-        let parts = key.components(separatedBy: "_")
-
-        guard parts.count == 3 else {
+        guard let parts = parseCellKey(key) else {
             fatalError("Invalid key format")
         }
-        guard let row = Int(parts[1]) else {
+        guard let row = Int(parts.first) else {
             fatalError("Invalid row index")
         }
-        guard let column = Int(parts[2]) else {
+        guard let column = Int(parts.second) else {
             fatalError("Invalid column index")
         }
 

--- a/Sources/Scout/Core/Matrix/Cell/PeriodCell.swift
+++ b/Sources/Scout/Core/Matrix/Cell/PeriodCell.swift
@@ -23,15 +23,13 @@ extension PeriodCell: CellProtocol {
     }
 
     init(key: String, value: T) {
-        let parts = key.components(separatedBy: "_")
-
-        guard parts.count == 3 else {
+        guard let parts = parseCellKey(key) else {
             fatalError("Invalid key format")
         }
-        guard let period = ActivityPeriod(rawValue: String(parts[1])) else {
+        guard let period = ActivityPeriod(rawValue: parts.first) else {
             fatalError("Invalid period")
         }
-        guard let day = Int(parts[2]) else {
+        guard let day = Int(parts.second) else {
             fatalError("Invalid day")
         }
 


### PR DESCRIPTION
- Add parseCellKey helper to split "cell_X_Y" format keys
- Simplify GridCell and PeriodCell init(key:value:) to use it