### PR TITLE
Remove typed throws from MatrixBatch

### DIFF
--- a/Sources/Scout/Core/Activity/UserActivityObject+MatrixBatch.swift
+++ b/Sources/Scout/Core/Activity/UserActivityObject+MatrixBatch.swift
@@ -10,7 +10,7 @@ import Foundation
 extension UserActivityObject: MatrixBatch {
     static func matrix(of batch: [UserActivityObject]) throws -> Matrix<PeriodCell<Int>> {
         guard let month = batch.first?.month else {
-            throw .init("month")
+            throw MatrixPropertyError("month")
         }
         return Matrix(
             recordType: PeriodCell<Int>.recordType,

--- a/Sources/Scout/Core/Activity/UserActivityObject+MatrixBatch.swift
+++ b/Sources/Scout/Core/Activity/UserActivityObject+MatrixBatch.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension UserActivityObject: MatrixBatch {
-    static func matrix(of batch: [UserActivityObject]) throws(MatrixPropertyError) -> Matrix<PeriodCell<Int>> {
+    static func matrix(of batch: [UserActivityObject]) throws -> Matrix<PeriodCell<Int>> {
         guard let month = batch.first?.month else {
             throw .init("month")
         }

--- a/Sources/Scout/Core/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Crash/CrashObject.swift
@@ -19,7 +19,7 @@ final class CrashObject: NamedObject, Syncable {
         try batch(in: context, matching: [\.name, \.week])
     }
 
-    static func matrix(of batch: [CrashObject]) throws(MatrixPropertyError) -> GridMatrix<Int> {
+    static func matrix(of batch: [CrashObject]) throws -> GridMatrix<Int> {
         try NamedObject.matrix(of: batch)
     }
 }

--- a/Sources/Scout/Core/Log/EventObject.swift
+++ b/Sources/Scout/Core/Log/EventObject.swift
@@ -20,7 +20,7 @@ final class EventObject: NamedObject, Syncable {
         try batch(in: context, matching: [\.name, \.week])
     }
 
-    static func matrix(of batch: [EventObject]) throws(MatrixPropertyError) -> GridMatrix<Int> {
+    static func matrix(of batch: [EventObject]) throws -> GridMatrix<Int> {
         try NamedObject.matrix(of: batch)
     }
 }

--- a/Sources/Scout/Core/Matrix/Batch/GridBatch.swift
+++ b/Sources/Scout/Core/Matrix/Batch/GridBatch.swift
@@ -31,7 +31,7 @@ extension GridBatch where Self: Syncable {
 extension GridBatch where Self: DateObject {
     static func matrix(of batch: [Self]) throws -> GridMatrix<Int> {
         guard let week = batch.first?.week else {
-            throw .init("week")
+            throw MatrixPropertyError("week")
         }
         return Matrix(
             recordType: Int.recordType,

--- a/Sources/Scout/Core/Matrix/Batch/GridBatch.swift
+++ b/Sources/Scout/Core/Matrix/Batch/GridBatch.swift
@@ -29,7 +29,7 @@ extension GridBatch where Self: Syncable {
 }
 
 extension GridBatch where Self: DateObject {
-    static func matrix(of batch: [Self]) throws(MatrixPropertyError) -> GridMatrix<Int> {
+    static func matrix(of batch: [Self]) throws -> GridMatrix<Int> {
         guard let week = batch.first?.week else {
             throw .init("week")
         }

--- a/Sources/Scout/Core/Matrix/Batch/MatrixBatch.swift
+++ b/Sources/Scout/Core/Matrix/Batch/MatrixBatch.swift
@@ -15,7 +15,7 @@ import Foundation
 ///
 protocol MatrixBatch {
     associatedtype Cell: CellProtocol
-    static func matrix(of batch: [Self]) throws(MatrixPropertyError) -> Matrix<Cell>
+    static func matrix(of batch: [Self]) throws -> Matrix<Cell>
 }
 
 /// Thrown when a batch is missing a property required to form a matrix

--- a/Sources/Scout/Core/Matrix/Batch/NamedObject.swift
+++ b/Sources/Scout/Core/Matrix/Batch/NamedObject.swift
@@ -17,7 +17,7 @@ import CoreData
 class NamedObject: TrackedObject, MatrixBatch {
     @NSManaged var name: String?
 
-    static func matrix(of batch: [NamedObject]) throws(MatrixPropertyError) -> GridMatrix<Int> {
+    static func matrix(of batch: [NamedObject]) throws -> GridMatrix<Int> {
         guard let name = batch.first?.name else {
             throw .init("name")
         }

--- a/Sources/Scout/Core/Matrix/Batch/NamedObject.swift
+++ b/Sources/Scout/Core/Matrix/Batch/NamedObject.swift
@@ -19,10 +19,10 @@ class NamedObject: TrackedObject, MatrixBatch {
 
     static func matrix(of batch: [NamedObject]) throws -> GridMatrix<Int> {
         guard let name = batch.first?.name else {
-            throw .init("name")
+            throw MatrixPropertyError("name")
         }
         guard let week = batch.first?.week else {
-            throw .init("week")
+            throw MatrixPropertyError("week")
         }
         return Matrix(
             recordType: Int.recordType,

--- a/Sources/Scout/Core/Telemetry/MetricsObject.swift
+++ b/Sources/Scout/Core/Telemetry/MetricsObject.swift
@@ -23,7 +23,7 @@ class MetricsObject: TrackedObject {
         try batch(in: context, matching: [\.name, \.telemetry, \.week])
     }
 
-    static func matrix<T: MetricsValued>(of batch: [T]) throws(MatrixPropertyError) -> Matrix<T.Cell> {
+    static func matrix<T: MetricsValued>(of batch: [T]) throws -> Matrix<T.Cell> {
         guard let name = batch.first?.name else {
             throw .init("name")
         }

--- a/Sources/Scout/Core/Telemetry/MetricsObject.swift
+++ b/Sources/Scout/Core/Telemetry/MetricsObject.swift
@@ -25,13 +25,13 @@ class MetricsObject: TrackedObject {
 
     static func matrix<T: MetricsValued>(of batch: [T]) throws -> Matrix<T.Cell> {
         guard let name = batch.first?.name else {
-            throw .init("name")
+            throw MatrixPropertyError("name")
         }
         guard let telemetry = batch.first?.telemetry else {
-            throw .init("telemetry")
+            throw MatrixPropertyError("telemetry")
         }
         guard let week = batch.first?.week else {
-            throw .init("week")
+            throw MatrixPropertyError("week")
         }
         return Matrix(
             recordType: T.Value.recordType,


### PR DESCRIPTION
- Replace throws(MatrixPropertyError) with plain throws across all matrix(of:) methods
- MatrixPropertyError is kept as a regular error type since it provides useful context