### PR TITLE
Remove typed throws from Telemetry.init

### DIFF
--- a/Sources/Scout/Core/Telemetry/Telemetry.Export.swift
+++ b/Sources/Scout/Core/Telemetry/Telemetry.Export.swift
@@ -26,9 +26,9 @@ extension Telemetry {
         }
     }
 
-    init(name: String, value: Double) throws(ExportError) {
+    init(name: String, value: Double) throws {
         guard let type = Export(rawValue: name) else {
-            throw .invalidName
+            throw ExportError.invalidName
         }
 
         switch type {


### PR DESCRIPTION
- Replace throws(ExportError) with plain throws
- ExportError is never caught by type