### PR TITLE
Move RecordTyped protocol to CKPersistable.swift

### DIFF
--- a/Sources/Scout/Core/Matrix/MatrixValue.swift
+++ b/Sources/Scout/Core/Matrix/MatrixValue.swift
@@ -8,11 +8,6 @@
 import CloudKit
 import CoreData
 
-/// A type that identifies itself by a CloudKit record type name.
-protocol RecordTyped {
-    static var recordType: String { get }
-}
-
 /// A scalar type that can live in a matrix cell — currently `Int` and
 /// `Double`.
 ///

--- a/Sources/Scout/Core/Sync/CKPersistable.swift
+++ b/Sources/Scout/Core/Sync/CKPersistable.swift
@@ -7,6 +7,11 @@
 
 import CloudKit
 
+/// A type that identifies itself by a CloudKit record type name.
+protocol RecordTyped {
+    static var recordType: String { get }
+}
+
 /// Can be constructed from a `CKRecord` fetched from CloudKit.
 protocol CKInitializable {
     init(record: CKRecord) throws


### PR DESCRIPTION
- Move RecordTyped to live alongside related CloudKit protocols (CKInitializable, CKRepresentable)