### PR TITLE
Simplify verbose doc comments

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -10,22 +10,12 @@ import Foundation
 import Logging
 import Metrics
 
-/// Sets up the application's core services and infrastructure.
+/// Initializes Scout's global infrastructure.
 ///
-/// This function initializes the global CloudKit container, configures the logging and metrics systems,
-/// crash handler, and prepares notification activity listeners. It should be called on the main actor
-/// during application startup, and should only be invoked once.
+/// - Parameter container: The CloudKit container for all operations.
+/// - Throws: An error if initialization fails.
+/// - Important: Call from the main actor during app startup.
 ///
-/// - Parameter container: The `CKContainer` instance to be used for all CloudKit operations.
-///
-/// - Throws: An error if the notification listener setup fails.
-///
-/// - Important: This function must be called from the main actor context.
-///
-/// Example usage:
-/// ```swift
-/// try await setup(container: CKContainer.default())
-/// ```
 @MainActor
 public func setup(container: CKContainer) async throws {
     installExceptionHandler()

--- a/Sources/Scout/Core/Matrix/Batch/GridBatch.swift
+++ b/Sources/Scout/Core/Matrix/Batch/GridBatch.swift
@@ -7,18 +7,10 @@
 
 import CoreData
 
-/// A `MatrixBatch` of weekly lifecycle records
-/// (`DeviceObject`, `InstallObject`, `LaunchObject`, `SessionObject`,
-/// `VersionObject`).
+/// Groups weekly lifecycle records into matrices for syncing.
 ///
-/// Provides defaults for all three steps of the sync pipeline:
-/// - `group(in:)` — fetches all unsynced records sharing a week,
-/// - `parse(of:)` — groups them by hour-of-week and counts them,
-/// - `matrix(of:)` — wraps the cells in a `GridMatrix<Int>` named after
-///   the object's `recordType`.
-///
-/// Conformers only declare their `recordType` and `toRecord` — everything
-/// else is inherited.
+/// Conformers only need to declare `recordType` and `toRecord`;
+/// all batch grouping and parsing is inherited.
 ///
 protocol GridBatch: MatrixBatch & RecordTyped & CKRepresentable where Cell == GridCell<Int> {}
 

--- a/Sources/Scout/Core/Matrix/Cell/CellProtocol.swift
+++ b/Sources/Scout/Core/Matrix/Cell/CellProtocol.swift
@@ -7,13 +7,7 @@
 
 import CloudKit
 
-/// A single cell of a `Matrix`: a stringly-typed coordinate `key`
-/// (e.g. `"cell_3_14"`) plus a `value` of scalar type `Scalar`.
-///
-/// CloudKit records store cells as one flat field per cell keyed by
-/// `key`, so `init(key:value:)` parses the coordinate back from the
-/// string when reading a matrix.
-///
+/// A single cell of a matrix: a coordinate key and a scalar value.
 protocol CellProtocol: Combining, Sendable, Equatable {
     associatedtype Scalar: MatrixValue
 

--- a/Sources/Scout/Core/Matrix/MatrixValue.swift
+++ b/Sources/Scout/Core/Matrix/MatrixValue.swift
@@ -8,15 +8,7 @@
 import CloudKit
 import CoreData
 
-/// A scalar type that can live in a matrix cell — currently `Int` and
-/// `Double`.
-///
-/// Carries its own CloudKit `recordType` (e.g. `"DateIntMatrix"`) and a
-/// back-reference to the `MetricsObject` subclass that stores it
-/// (`IntMetricsObject` / `DoubleMetricsObject`). The back-reference lets
-/// `logMetrics<T: MatrixValue>` construct the right managed-object
-/// subclass generically.
-///
+/// A scalar type suitable for matrix cells and syncing.
 protocol MatrixValue: RecordTyped & AdditiveArithmetic & Comparable & Hashable & Sendable & CKRecordValueProtocol {
     associatedtype Object: MetricsValued where Object.Value == Self
 }

--- a/Sources/Scout/Core/Telemetry/MetricsObject.swift
+++ b/Sources/Scout/Core/Telemetry/MetricsObject.swift
@@ -8,12 +8,7 @@
 import CloudKit
 import CoreData
 
-/// `TrackedObject` for telemetry records, scoped by `name` (metric name)
-/// and `telemetry` (kind of telemetry — counter, gauge, …).
-///
-/// Abstract; concrete subclasses `IntMetricsObject` and
-/// `DoubleMetricsObject` add a typed `value` via `MetricsValued`.
-///
+/// Persists named telemetry records scoped by metric name and type.
 @objc(MetricsObject)
 class MetricsObject: TrackedObject {
     @NSManaged var name: String?

--- a/Sources/Scout/Core/Telemetry/MetricsValued.swift
+++ b/Sources/Scout/Core/Telemetry/MetricsValued.swift
@@ -7,13 +7,7 @@
 
 import CoreData
 
-/// A concrete `MetricsObject` that stores a typed scalar `Value`
-/// (either `Int` or `Double`) and participates in the sync/matrix
-/// pipeline.
-///
-/// Required by `logMetrics<T: MatrixValue>` so it can construct the right
-/// `T.Object` managed-object subclass generically from a scalar value.
-///
+/// A typed metrics object that participates in sync and matrix pipelines.
 protocol MetricsValued: MetricsObject & Syncable & MatrixBatch {
     associatedtype Value where Cell.Scalar == Value
     var value: Value { get set }

--- a/Sources/Scout/UI/Chart/ChartComposing.swift
+++ b/Sources/Scout/UI/Chart/ChartComposing.swift
@@ -8,19 +8,7 @@
 import Charts
 import Foundation
 
-/// A protocol for matrix cells that can be transformed back into chart-ready points by
-/// recalculating their actual `Date` from matrix context.
-///
-/// In essence:
-/// - The matrix stores a base "week date" (e.g., the start of the week).
-/// - After applying a revert/unflatten transformation, each cell must recompute its actual
-///   timestamp relative to that base using other matrix properties (such as day/row/column).
-///
-/// How it works:
-/// - Conforming cells provide `secondsSinceBase`, the time offset from the matrix’s base week date.
-/// - The offset is combined with the matrix’s stored base date to derive the final `Date`,
-///   enabling stable reconstruction of time series data after transformations.
-///
+/// A matrix cell that can reconstruct its actual date from matrix context.
 protocol ChartComposing: CellProtocol {
     var secondsSinceBase: Int { get }
 }


### PR DESCRIPTION
- Remove implementation details from doc comments (concrete type names, internal wiring, algorithm steps)
- Focus on WHAT types do, not HOW they work
- Affected: GridBatch, MatrixValue, CellProtocol, MetricsObject, MetricsValued, Setup, ChartComposing