### PR TITLE
Implement log(event:) to fix swift-log deprecation warning

### DIFF
--- a/Sources/Scout/Core/Log/Log.swift
+++ b/Sources/Scout/Core/Log/Log.swift
@@ -10,25 +10,18 @@ import CoreData
 import Logging
 
 /// Persists a log event to Core Data.
-///
-func log(
-    _ name: String,
-    level: Logger.Level,
-    metadata: Logger.Metadata?,
-    date: Date,
-    context: NSManagedObjectContext
-) throws {
+func log(_ event: LogEvent, date: Date, context: NSManagedObjectContext) throws {
     let entity = NSEntityDescription.entity(forEntityName: "EventObject", in: context)!
-    let event = EventObject(entity: entity, insertInto: context)
+    let object = EventObject(entity: entity, insertInto: context)
 
-    event.eventID = UUID()
-    event.date = date
-    event.level = level.rawValue
-    event.name = name
+    object.eventID = UUID()
+    object.date = date
+    object.level = event.level.rawValue
+    object.name = event.message.description
 
-    if let params = metadata?.compactMapValues(\.stringValue) {
-        event.params = try JSONEncoder().encode(params)
-        event.paramCount = Int64(params.count)
+    if let params = event.metadata?.compactMapValues(\.stringValue) {
+        object.params = try JSONEncoder().encode(params)
+        object.paramCount = Int64(params.count)
     }
 
     try context.save()

--- a/Sources/Scout/Core/Log/LogHandler.swift
+++ b/Sources/Scout/Core/Log/LogHandler.swift
@@ -9,7 +9,6 @@ import Foundation
 import Logging
 
 /// A log handler that persists log events to CloudKit via Core Data.
-///
 struct CKLogHandler: LogHandler {
     let sync: SyncAction
     let label: String
@@ -23,25 +22,11 @@ struct CKLogHandler: LogHandler {
         set { metadata[key] = newValue }
     }
 
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
+    func log(event: LogEvent) {
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
-                    try Scout.log(
-                        message.description,
-                        level: level,
-                        metadata: metadata,
-                        date: Date(),
-                        context: context
-                    )
+                    try Scout.log(event, date: Date(), context: context)
                 }
                 try await self.sync()
             } catch {

--- a/Tests/ScoutTests/Core/Log/LogTest.swift
+++ b/Tests/ScoutTests/Core/Log/LogTest.swift
@@ -11,16 +11,22 @@ import Testing
 
 @testable import Scout
 
+private func makeEvent(
+    _ message: String, level: Logger.Level = .info, metadata: Logger.Metadata? = nil
+) -> LogEvent {
+    LogEvent(
+        level: level, message: "\(message)", metadata: metadata,
+        source: nil, file: #file, function: #function, line: #line
+    )
+}
+
 @MainActor
 @Test("Logging an event") func testLogEvent() throws {
     let context = NSManagedObjectContext.inMemoryContext()
     let date = Date()
-    let metadata: Logger.Metadata = ["key": .string("value")]
 
     try log(
-        "Test Event",
-        level: .info,
-        metadata: metadata,
+        makeEvent("Test Event", metadata: ["key": .string("value")]),
         date: date,
         context: context
     )
@@ -53,7 +59,7 @@ import Testing
         "tags": .array([.string("a"), .string("b"), .string("c")])
     ]
 
-    try log("Array Event", level: .info, metadata: metadata, date: Date(), context: context)
+    try log(makeEvent("Array Event", metadata: metadata), date: Date(), context: context)
 
     let events = try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject"))
     let paramData = try #require(events.first?.params)
@@ -69,7 +75,7 @@ import Testing
         "user": .dictionary(["name": .string("Alice"), "role": .string("admin")])
     ]
 
-    try log("Dict Event", level: .info, metadata: metadata, date: Date(), context: context)
+    try log(makeEvent("Dict Event", metadata: metadata), date: Date(), context: context)
 
     let events = try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject"))
     let paramData = try #require(events.first?.params)
@@ -87,7 +93,7 @@ import Testing
         "map": .dictionary(["key": .string("val")]),
     ]
 
-    try log("Mixed Event", level: .info, metadata: metadata, date: Date(), context: context)
+    try log(makeEvent("Mixed Event", metadata: metadata), date: Date(), context: context)
 
     let events = try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject"))
     let paramData = try #require(events.first?.params)


### PR DESCRIPTION
- Replace deprecated log(level:message:metadata:source:file:function:line:) with log(event:)
- Updates swift-log to 1.12.0