### PR TITLE
Add stale PR auto-close workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Stale PRs
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Close stale PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CUTOFF=$(date -u -d '14 days ago' +%Y-%m-%dT%H:%M:%SZ)
+
+          gh pr list --repo ${{ github.repository }} --state open --json number,updatedAt --jq \
+            ".[] | select(.updatedAt < \"$CUTOFF\") | .number" | while read -r PR; do
+              gh pr close "$PR" --repo ${{ github.repository }} --delete-branch --comment "Closing: no activity for 14 days."
+          done


### PR DESCRIPTION
- Close PRs with no activity for 14 days
- Runs daily at 9:00 UTC
- Deletes branch on close