### PR TITLE
Fix sync coordinator infinite retry loop and redundant lookups

### DIFF
--- a/Sources/Scout/Core/Matrix/Matrix+Lookup.swift
+++ b/Sources/Scout/Core/Matrix/Matrix+Lookup.swift
@@ -11,10 +11,9 @@ extension Matrix {
     func lookupExisting(in database: RecordReader) async throws -> Self? {
         let predicate = NSCompoundPredicate(type: .and, subpredicates: predicates)
         let query = CKQuery(recordType: recordType, predicate: predicate)
-        let matrices = try await database.readAll(matching: query, fields: nil)
-        let matrix = try matrices.randomElement().map(Matrix.init)
+        let chunk = try await database.read(matching: query, fields: nil)
 
-        return matrix
+        return try chunk.records.first.map(Matrix.init)
     }
 
     private var predicates: [NSPredicate] {

--- a/Sources/Scout/Core/Sync/SyncCoordinator.swift
+++ b/Sources/Scout/Core/Sync/SyncCoordinator.swift
@@ -34,9 +34,9 @@ extension SyncCoordinator {
         do {
             try await database.write(record: snapshot.toRecord)
         } catch let error as CKError where error.code == CKError.serverRecordChanged {
-            if retry > maxRetry {
-                try await upload(snapshot: matrix, retry: 1)
-            } else if let serverRecord = error.userInfo[CKRecordChangedErrorServerRecordKey] as? CKRecord {
+            guard retry <= maxRetry else { throw error }
+
+            if let serverRecord = error.userInfo[CKRecordChangedErrorServerRecordKey] as? CKRecord {
                 try await upload(snapshot: try Matrix(record: serverRecord) + matrix, retry: retry + 1)
             }
         }


### PR DESCRIPTION
- Fix infinite loop in SyncCoordinator: throw error when retry limit exceeded instead of resetting counter
- Fix lookupExisting: read single page instead of all pages, use first match instead of random