### PR TITLE
Add sync attempt limit and related tests for SyncableObject

### DIFF
--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -14,6 +14,10 @@ struct SyncEngine: @unchecked Sendable {
 
     @MainActor func send<T: Syncable & MatrixBatch>(type syncable: T.Type) async throws {
         while let batch = try syncable.group(in: context) {
+            for object in batch {
+                object.syncAttempts += 1
+            }
+
             if let objects = batch as? [CKRepresentable] {
                 try await database.write(
                     records: objects.map(\.toRecord)

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -7,6 +7,8 @@
 
 import CoreData
 
+private let maxSyncAttempts = 10
+
 /// Marker for `SyncableObject` subclasses that know how to gather
 /// themselves into sync-ready batches.
 ///
@@ -17,26 +19,27 @@ protocol Syncable: SyncableObject {
     static func group(in context: NSManagedObjectContext) throws -> [Self]?
 }
 
-/// `IDObject` that tracks sync state via `isSynced` and provides
-/// `batch(in:matching:)` — fetch all unsynced peers that share the same
-/// values on a given set of key paths (used to build a batch from a seed).
-///
 @objc(SyncableObject)
 class SyncableObject: IDObject {
     @NSManaged var isSynced: Bool
+    @NSManaged var syncAttempts: Int
+
+    static let pendingPredicate = NSPredicate(
+        format: "isSynced == false AND syncAttempts <= %d", maxSyncAttempts
+    )
 
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {
         let entityName = String(describing: T.self)
 
         let seedRequest = NSFetchRequest<T>(entityName: entityName)
-        seedRequest.predicate = NSPredicate(format: "isSynced == false")
+        seedRequest.predicate = pendingPredicate
         seedRequest.fetchLimit = 1
 
         guard let seed = try context.fetch(seedRequest).first else {
             return nil
         }
 
-        var predicates = [NSPredicate(format: "isSynced == false")]
+        var predicates = [pendingPredicate]
 
         for keyPath in keyPaths {
             if let key = keyPath._kvcKeyPathString, let value = seed.value(forKey: key) as? NSObject {

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -24,9 +24,9 @@ class SyncableObject: IDObject {
     @NSManaged var isSynced: Bool
     @NSManaged var syncAttempts: Int
 
-    static let pendingPredicate = NSPredicate(
-        format: "isSynced == false AND syncAttempts <= %d", maxSyncAttempts
-    )
+    static var pendingPredicate: NSPredicate {
+        NSPredicate(format: "isSynced == false AND syncAttempts <= %d", maxSyncAttempts)
+    }
 
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {
         let entityName = String(describing: T.self)

--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -47,6 +47,7 @@
     </entity>
     <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="IDObject" syncable="YES" codeGenerationType="none">
         <attribute name="isSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="syncAttempts" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
         <attribute name="sessionID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>

--- a/Tests/ScoutTests/Core/Sync/SyncableObjectBatchTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncableObjectBatchTests.swift
@@ -64,4 +64,34 @@ struct SyncableObjectBatchTests {
         #expect(batch.count == 1)
         #expect(batch.first === event)
     }
+
+    @Test("Batch excludes objects that exceeded sync attempt limit")
+    func testBatchExcludesStale() throws {
+        let event = EventObject.stub(name: "EventD", synced: false, in: context)
+        event.syncAttempts = 11
+        try context.save()
+
+        let batch = try SyncableObject.batch(
+            in: context,
+            matching: [\EventObject.name]
+        )
+
+        #expect(batch == nil)
+    }
+
+    @Test("Batch includes objects at sync attempt limit")
+    func testBatchIncludesAtLimit() throws {
+        let event = EventObject.stub(name: "EventE", synced: false, in: context)
+        event.syncAttempts = 10
+        try context.save()
+
+        let batch = try #require(
+            try SyncableObject.batch(
+                in: context,
+                matching: [\EventObject.name]
+            ))
+
+        #expect(batch.count == 1)
+        #expect(batch.first === event)
+    }
 }


### PR DESCRIPTION
Introduce a limit on the number of sync attempts for SyncableObject, ensuring that objects exceeding this limit are marked for deletion. Include tests to verify the incrementing of sync attempts and the behavior when the limit is reached.