### PR TITLE
Add cleanup for synced and stale objects at startup

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -22,7 +22,10 @@ public func setup(container: CKContainer) async throws {
     installSignalHandler()
 
     await CrashArchive.system.flush()
-    try await persistentContainer.performBackgroundTask(completeStaleSessions)
+    try await persistentContainer.performBackgroundTasks(
+        completeStaleSessions,
+        SyncableObject.cleanup
+    )
 
     let syncController = SyncController(container: container)
     let sync = syncController.synchronize

--- a/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension SyncableObject {
+    /// Deletes synced objects older than 7 days and objects that
+    /// exceeded the sync attempt limit.
+    ///
+    static func cleanup(in context: NSManagedObjectContext) throws {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: Date())! as NSDate
+
+        let request = NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
+        request.predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
+            NSPredicate(format: "isSynced == true AND datePrimitive < %@", cutoff),
+            NSPredicate(format: "isSynced == false AND syncAttempts > %d", maxSyncAttempts),
+        ])
+
+        for object in try context.fetch(request) {
+            context.delete(object)
+        }
+
+        try context.save()
+    }
+}

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -7,7 +7,7 @@
 
 import CoreData
 
-private let maxSyncAttempts = 10
+let maxSyncAttempts = 10
 
 /// Marker for `SyncableObject` subclasses that know how to gather
 /// themselves into sync-ready batches.

--- a/Tests/ScoutTests/Core/Sync/CleanupTests.swift
+++ b/Tests/ScoutTests/Core/Sync/CleanupTests.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("SyncableObject.cleanup")
+struct CleanupTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("Deletes synced objects older than 7 days")
+    func deletesSyncedOld() throws {
+        let old = Date(timeIntervalSinceNow: -8 * 86400)
+        EventObject.stub(name: "old", date: old, synced: true, in: context)
+        try context.save()
+
+        try SyncableObject.cleanup(in: context)
+
+        let request = NSFetchRequest<EventObject>(entityName: "EventObject")
+        #expect(try context.fetch(request).isEmpty)
+    }
+
+    @Test("Keeps synced objects newer than 7 days")
+    func keepsSyncedRecent() throws {
+        let recent = Date(timeIntervalSinceNow: -6 * 86400)
+        EventObject.stub(name: "recent", date: recent, synced: true, in: context)
+        try context.save()
+
+        try SyncableObject.cleanup(in: context)
+
+        let request = NSFetchRequest<EventObject>(entityName: "EventObject")
+        #expect(try context.fetch(request).count == 1)
+    }
+
+    @Test("Deletes objects that exceeded sync attempt limit")
+    func deletesStale() throws {
+        let event = EventObject.stub(name: "stale", synced: false, in: context)
+        event.syncAttempts = 11
+        try context.save()
+
+        try SyncableObject.cleanup(in: context)
+
+        let request = NSFetchRequest<EventObject>(entityName: "EventObject")
+        #expect(try context.fetch(request).isEmpty)
+    }
+
+    @Test("Keeps unsynced objects under attempt limit")
+    func keepsUnsynced() throws {
+        let event = EventObject.stub(name: "pending", synced: false, in: context)
+        event.syncAttempts = 5
+        try context.save()
+
+        try SyncableObject.cleanup(in: context)
+
+        let request = NSFetchRequest<EventObject>(entityName: "EventObject")
+        #expect(try context.fetch(request).count == 1)
+    }
+}


### PR DESCRIPTION
- Delete synced objects older than 7 days
- Delete objects that exceeded the sync attempt limit
- Runs at app startup alongside stale session cleanup