### PR TITLE
Simplify sync predicates and run cleanup before sync

### DIFF
--- a/Sources/Scout/Core/Sync/SyncController.swift
+++ b/Sources/Scout/Core/Sync/SyncController.swift
@@ -31,6 +31,8 @@ typealias SyncAction = @MainActor () async throws -> Void
         let jobPlan = SyncJobPlan(engine: engine)
 
         try await dispatcher.performEnsuringBackground {
+            try SyncableObject.cleanup(in: persistentContainer.viewContext)
+
             for job in jobPlan.jobs.shuffled() {
                 try await job()
             }

--- a/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
@@ -7,6 +7,8 @@
 
 import CoreData
 
+private let maxSyncAttempts = 10
+
 extension SyncableObject {
     /// Deletes synced objects older than 7 days and objects that
     /// exceeded the sync attempt limit.

--- a/Sources/Scout/Core/Sync/SyncableObject+Predicates.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Predicates.swift
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension SyncableObject {
+    static var stalePredicate: NSPredicate {
+        NSPredicate(format: "endDate == nil AND launchID != %@", IDs.launch as CVarArg)
+    }
+
+    static var pendingPredicate: NSPredicate {
+        NSPredicate(format: "isSynced == false")
+    }
+}

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -7,8 +7,6 @@
 
 import CoreData
 
-let maxSyncAttempts = 10
-
 /// Marker for `SyncableObject` subclasses that know how to gather
 /// themselves into sync-ready batches.
 ///
@@ -23,14 +21,6 @@ protocol Syncable: SyncableObject {
 class SyncableObject: IDObject {
     @NSManaged var isSynced: Bool
     @NSManaged var syncAttempts: Int
-
-    static var stalePredicate: NSPredicate {
-        NSPredicate(format: "endDate == nil AND launchID != %@", IDs.launch as CVarArg)
-    }
-
-    static var pendingPredicate: NSPredicate {
-        NSPredicate(format: "isSynced == false AND syncAttempts <= %d", maxSyncAttempts)
-    }
 
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {
         let entityName = String(describing: T.self)

--- a/Tests/ScoutTests/Core/Sync/SyncableObject+BatchTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncableObject+BatchTests.swift
@@ -65,33 +65,4 @@ struct SyncableObjectBatchTests {
         #expect(batch.first === event)
     }
 
-    @Test("Batch excludes objects that exceeded sync attempt limit")
-    func testBatchExcludesStale() throws {
-        let event = EventObject.stub(name: "EventD", synced: false, in: context)
-        event.syncAttempts = 11
-        try context.save()
-
-        let batch = try SyncableObject.batch(
-            in: context,
-            matching: [\EventObject.name]
-        )
-
-        #expect(batch == nil)
-    }
-
-    @Test("Batch includes objects at sync attempt limit")
-    func testBatchIncludesAtLimit() throws {
-        let event = EventObject.stub(name: "EventE", synced: false, in: context)
-        event.syncAttempts = 10
-        try context.save()
-
-        let batch = try #require(
-            try SyncableObject.batch(
-                in: context,
-                matching: [\EventObject.name]
-            ))
-
-        #expect(batch.count == 1)
-        #expect(batch.first === event)
-    }
 }


### PR DESCRIPTION
- Extract predicates to SyncableObject+Predicates.swift
- Simplify pendingPredicate: remove syncAttempts check (cleanup handles it)
- Run cleanup before each sync in SyncController
- Move maxSyncAttempts to cleanup file (only consumer)
- Remove obsolete batch attempt limit tests
- Rename SyncableObjectBatchTests to follow naming pattern