### PR TITLE
Set locale to "en_US" for date formatters

### DIFF
--- a/Sources/Scout/UI/Chart/Range/RangeControl.swift
+++ b/Sources/Scout/UI/Chart/Range/RangeControl.swift
@@ -12,6 +12,7 @@ struct RangeControl<T: ChartTimeScale>: View {
 
     let formatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
         formatter.dateStyle = .medium
         return formatter
     }()

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -55,7 +55,7 @@ struct CrashListView: View {
                 Spacer()
 
                 if let date = crash.date {
-                    Text(date, style: .relative)
+                    date.relativeText
                         .font(.system(size: 15))
                         .foregroundStyle(Color.gray)
                 }

--- a/Sources/Scout/UI/Event/EventStatList.swift
+++ b/Sources/Scout/UI/Event/EventStatList.swift
@@ -16,7 +16,7 @@ struct EventStatList: View {
 
     let formatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateStyle = .short
+        formatter.locale = Locale(identifier: "en_US")
         formatter.dateFormat = "d MMM"
         return formatter
     }()

--- a/Sources/Scout/UI/Utilities/Date+RelativeText.swift
+++ b/Sources/Scout/UI/Utilities/Date+RelativeText.swift
@@ -19,6 +19,7 @@ extension Date {
 
 nonisolated(unsafe) private let relativeFormatter: RelativeDateTimeFormatter = {
     let formatter = RelativeDateTimeFormatter()
+    formatter.locale = Locale(identifier: "en_US")
     formatter.unitsStyle = .abbreviated
     return formatter
 }()


### PR DESCRIPTION
Standardize date formatting across the application by setting the locale to "en_US" in various components, ensuring consistent date representation. This change affects the RangeControl, EventStatList, and CrashListView.