### PR TITLE
Adjust sessionID initialization in tracked objects

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
@@ -14,6 +14,11 @@ final class SessionObject: TrackedObject, Syncable, GridBatch {
 
     @NSManaged var endDate: Date?
 
+    override func awakeFromInsert() {
+        super.awakeFromInsert()
+        setPrimitiveValue(UUID(), forKey: #keyPath(TrackedObject.sessionID))
+    }
+
     func launch(in context: NSManagedObjectContext) throws -> LaunchObject? {
         let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
         request.predicate = NSPredicate(format: "launchID == %@", launchID! as CVarArg)

--- a/Sources/Scout/Core/Lifecycle/TrackedObject.swift
+++ b/Sources/Scout/Core/Lifecycle/TrackedObject.swift
@@ -21,6 +21,8 @@ class TrackedObject: SyncableObject {
 
     override func awakeFromInsert() {
         super.awakeFromInsert()
-        setPrimitiveValue(UUID(), forKey: #keyPath(TrackedObject.sessionID))
+        if let managedObjectContext {
+            setPrimitiveValue(IDs.session(in: managedObjectContext), forKey: #keyPath(TrackedObject.sessionID))
+        }
     }
 }


### PR DESCRIPTION
Change how sessionID is initialized on insert: TrackedObject.awakeFromInsert now only sets sessionID from IDs.session(in:) when a managedObjectContext is available, avoiding unconditional UUID assignment without a context. SessionObject overrides awakeFromInsert to assign a fresh UUID for its own sessionID. This moves the default UUID assignment out of TrackedObject and ensures session IDs come from the context when possible.