### PR TITLE
feat(session): cache session ID on app state change

### DIFF
--- a/Sources/Scout/Core/Bootstrap/NotificationListener.AppState.swift
+++ b/Sources/Scout/Core/Bootstrap/NotificationListener.AppState.swift
@@ -11,6 +11,8 @@ extension NotificationListener {
     @MainActor static func appState(sync: @escaping SyncAction) -> NotificationListener {
         NotificationListener(table: [
             UIApplication.willEnterForegroundNotification: {
+                IDs.session = UUID()
+
                 try await persistentContainer.performBackgroundTasks(
                     SessionObject.trigger,
                     UserActivityObject.trigger

--- a/Sources/Scout/Core/Lifecycle/IDObject.swift
+++ b/Sources/Scout/Core/Lifecycle/IDObject.swift
@@ -21,9 +21,9 @@ class IDObject: DateObject {
 
     override func awakeFromInsert() {
         super.awakeFromInsert()
-        setPrimitiveValue(IDs.device, forKey: #keyPath(IDObject.deviceID))
-        setPrimitiveValue(IDs.install, forKey: #keyPath(IDObject.installID))
-        setPrimitiveValue(IDs.launch, forKey: #keyPath(IDObject.launchID))
+        deviceID = IDs.device
+        installID = IDs.install
+        launchID = IDs.launch
     }
 
     var metadata: [String: Any] {

--- a/Sources/Scout/Core/Lifecycle/IDs.swift
+++ b/Sources/Scout/Core/Lifecycle/IDs.swift
@@ -5,22 +5,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CoreData
 import Foundation
 
 enum IDs {
-    static var session: UUID? {
-        session(in: persistentContainer.viewContext)
-    }
-
-    static func session(in context: NSManagedObjectContext) -> UUID? {
-        let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
-        request.predicate = NSPredicate(format: "launchID == %@", launch as CVarArg)
-        request.fetchLimit = 1
-        let session = try? context.fetch(request).first
-        return session?.sessionID
-    }
+    nonisolated(unsafe) static var session: UUID?
 
     static let launch = UUID()
 

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
@@ -14,11 +14,6 @@ final class SessionObject: TrackedObject, Syncable, GridBatch {
 
     @NSManaged var endDate: Date?
 
-    override func awakeFromInsert() {
-        super.awakeFromInsert()
-        setPrimitiveValue(UUID(), forKey: #keyPath(TrackedObject.sessionID))
-    }
-
     func launch(in context: NSManagedObjectContext) throws -> LaunchObject? {
         let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
         request.predicate = NSPredicate(format: "launchID == %@", launchID! as CVarArg)

--- a/Sources/Scout/Core/Lifecycle/TrackedObject.swift
+++ b/Sources/Scout/Core/Lifecycle/TrackedObject.swift
@@ -21,8 +21,6 @@ class TrackedObject: SyncableObject {
 
     override func awakeFromInsert() {
         super.awakeFromInsert()
-        if let managedObjectContext {
-            setPrimitiveValue(IDs.session(in: managedObjectContext), forKey: #keyPath(TrackedObject.sessionID))
-        }
+        sessionID = IDs.session
     }
 }


### PR DESCRIPTION
- Cache the session ID when the app state changes to foreground.
- Update the session ID handling in the IDObject class.
- Modify the SessionObject to remove unnecessary awakeFromInsert logic.
- Adjust the TrackedObject to directly assign the session ID.

Caching the session ID improves performance by reducing the need for repeated fetches from the persistent store. This change enhances the app's responsiveness and ensures that the session ID is readily available when needed.