### PR TITLE
fix(session): initialize session UUID for consistent state management

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -37,7 +37,8 @@ public func setup(container: CKContainer) async throws {
         DeviceObject.trigger,
         InstallObject.trigger,
         VersionObject.trigger,
-        LaunchObject.trigger
+        LaunchObject.trigger,
+        SessionObject.trigger
     )
 
     LoggingSystem.bootstrap { label in

--- a/Sources/Scout/Core/Lifecycle/IDs.swift
+++ b/Sources/Scout/Core/Lifecycle/IDs.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum IDs {
-    nonisolated(unsafe) static var session: UUID?
+    nonisolated(unsafe) static var session = UUID()
 
     static let launch = UUID()
 


### PR DESCRIPTION
Ensure the session UUID is initialized to maintain a consistent state across the application. This change modifies the session variable to be non-optional, preventing potential issues with uninitialized states. Additionally, the session trigger is integrated into the setup process for better management.