### PR TITLE
refactor(setup): remove SyncableObject.cleanup from background tasks

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -25,7 +25,6 @@ public func setup(container: CKContainer) async throws {
     try await persistentContainer.performBackgroundTasks(
         SessionObject.completeStale,
         LaunchObject.completeStale,
-        SyncableObject.cleanup
     )
 
     let syncController = SyncController(container: container)


### PR DESCRIPTION
Eliminate the `SyncableObject.cleanup` call from background tasks to streamline the setup process. This change enhances performance by reducing unnecessary operations during the setup phase.