### PR TITLE
feat(setup): add UserActivityObject.trigger to setup process

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -37,7 +37,8 @@ public func setup(container: CKContainer) async throws {
         InstallObject.trigger,
         VersionObject.trigger,
         LaunchObject.trigger,
-        SessionObject.trigger
+        SessionObject.trigger,
+        UserActivityObject.trigger
     )
 
     LoggingSystem.bootstrap { label in


### PR DESCRIPTION
Incorporate `UserActivityObject.trigger` into the setup process to enhance functionality. This change allows for better tracking of user activities during the setup phase. The update ensures that all relevant triggers are included for a comprehensive setup experience.