### PR TITLE
Reformat Notify workflow curl into multi-line form

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -14,4 +14,8 @@ jobs:
     steps:
       - name: Trigger scout-ip
         run: |
-          curl -X POST             -H "Authorization: Bearer ${{ secrets.GH_PAT }}"             -H "Accept: application/vnd.github+json"             https://api.github.com/repos/kasianov-mikhail/scout-ip/dispatches             -d '{"event_type":"scout-updated"}'
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.GH_PAT }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/kasianov-mikhail/scout-ip/dispatches \
+            -d '{"event_type":"scout-updated"}'


### PR DESCRIPTION
- Reformat the single-line `curl` in `notify.yml` into a multi-line command with backslash continuations for readability
- Serves as a smoke test for the Notify → scout-ip `update-dependency` workflow chain, which now includes the Scout commit sha in the auto-PR title
