### PR TITLE
Assign crash IDs via properties instead of KVC

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
@@ -17,9 +17,9 @@ func logCrash(_ crash: CrashInfo, context: NSManagedObjectContext) throws {
     object.reason = crash.reason
     object.stackTrace = try? JSONEncoder().encode(crash.stackTrace)
 
-    // Override IDs from crash info (captured at crash time)
-    object.setValue(crash.installID, forKey: "installID")
-    object.setValue(crash.launchID, forKey: "launchID")
+    // Override IDs set by awakeFromInsert with values captured at crash time
+    object.installID = crash.installID
+    object.launchID = crash.launchID
 
     try context.save()
 }

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
@@ -36,8 +36,8 @@ struct LogCrashTests {
         #expect(object.reason == "Fatal error")
         #expect(object.date == crash.date)
         #expect(object.crashID != nil)
-        #expect(object.value(forKey: "installID") as? UUID == crash.installID)
-        #expect(object.value(forKey: "launchID") as? UUID == crash.launchID)
+        #expect(object.installID == crash.installID)
+        #expect(object.launchID == crash.launchID)
     }
 
     @Test("Encodes stack trace as JSON data")


### PR DESCRIPTION
Replace setValue(forKey:) calls with direct property assignments for installID and launchID in LogCrash to override values set by awakeFromInsert using the crash-captured IDs. Update tests to assert the properties directly instead of using KVC. This makes the assignment type-safe and clearer.