### PR TITLE
Move session ID generation to SessionObject

### DIFF
--- a/Sources/Scout/Core/Bootstrap/ActionTable.AppState.swift
+++ b/Sources/Scout/Core/Bootstrap/ActionTable.AppState.swift
@@ -10,7 +10,6 @@ import UIKit
 extension ActionTable {
     static let appState = ActionTable(actions: [
         UIApplication.willEnterForegroundNotification: {
-            IDs.session = UUID()
             try await persistentContainer.performBackgroundTasks(
                 SessionObject.trigger,
                 UserActivityObject.trigger

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
@@ -9,6 +9,8 @@ import CoreData
 
 extension SessionObject: Monitor {
     static func trigger(in context: NSManagedObjectContext) throws {
+        IDs.session = UUID()
+
         let entity = NSEntityDescription.entity(forEntityName: "SessionObject", in: context)!
         let session = SessionObject(entity: entity, insertInto: context)
         session.date = Date()


### PR DESCRIPTION
Move the assignment of IDs.session out of the willEnterForegroundNotification action and into SessionObject.trigger. This ensures the session UUID is created when a SessionObject is instantiated in the Core Data background context, removing the redundant assignment from the app-state action.