### PR TITLE
Skip creating VersionObject when unchanged

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject+Monitor.swift
@@ -9,11 +9,29 @@ import CoreData
 
 extension VersionObject: PartialMonitor {
     static func trigger(in context: NSManagedObjectContext) throws {
+        try trigger(
+            appVersion: Bundle.main.marketingVersion,
+            buildNumber: Bundle.main.buildNumber,
+            in: context
+        )
+    }
+
+    static func trigger(appVersion: String?, buildNumber: String?, in context: NSManagedObjectContext) throws {
+        let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
+        request.predicate = NSPredicate(format: "installID == %@", IDs.install as CVarArg)
+        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
+        request.fetchLimit = 1
+        let latest = try context.fetch(request).first
+
+        if latest?.appVersion == appVersion && latest?.buildNumber == buildNumber {
+            return
+        }
+
         let entity = NSEntityDescription.entity(forEntityName: "VersionObject", in: context)!
         let version = VersionObject(entity: entity, insertInto: context)
         version.date = Date()
-        version.appVersion = Bundle.main.marketingVersion
-        version.buildNumber = Bundle.main.buildNumber
+        version.appVersion = appVersion
+        version.buildNumber = buildNumber
         try context.save()
     }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectMonitorTests.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("VersionObject+Monitor")
+struct VersionObjectMonitorTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("trigger creates a VersionObject on first call")
+    func firstTrigger() throws {
+        try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
+
+        let versions = try context.fetch(NSFetchRequest<VersionObject>(entityName: "VersionObject"))
+        #expect(versions.count == 1)
+        #expect(versions.first?.appVersion == "1.0")
+        #expect(versions.first?.buildNumber == "1")
+    }
+
+    @Test("trigger is a no-op when version and build are unchanged")
+    func noopOnUnchanged() throws {
+        try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
+        try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
+        try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
+
+        let versions = try context.fetch(NSFetchRequest<VersionObject>(entityName: "VersionObject"))
+        #expect(versions.count == 1)
+    }
+
+    @Test("trigger creates a new VersionObject when appVersion changes")
+    func appVersionChange() throws {
+        try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
+        try VersionObject.trigger(appVersion: "2.0", buildNumber: "1", in: context)
+
+        let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
+        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        let versions = try context.fetch(request)
+
+        #expect(versions.count == 2)
+        #expect(versions.map(\.appVersion) == ["1.0", "2.0"])
+    }
+
+    @Test("trigger creates a new VersionObject when buildNumber changes")
+    func buildNumberChange() throws {
+        try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
+        try VersionObject.trigger(appVersion: "1.0", buildNumber: "2", in: context)
+
+        let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
+        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        let versions = try context.fetch(request)
+
+        #expect(versions.count == 2)
+        #expect(versions.map(\.buildNumber) == ["1", "2"])
+    }
+
+    @Test("trigger ignores VersionObjects from other installs")
+    func ignoresOtherInstalls() throws {
+        let other = VersionObject.stub(date: Date(), appVersion: "1.0", buildNumber: "1", in: context)
+        other.installID = UUID()
+        try context.save()
+
+        try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
+
+        let versions = try context.fetch(NSFetchRequest<VersionObject>(entityName: "VersionObject"))
+        #expect(versions.count == 2)
+    }
+}

--- a/Tests/ScoutTests/Stubs/VersionObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/VersionObject+Stub.swift
@@ -14,6 +14,7 @@ extension VersionObject {
         date: Date,
         synced: Bool = false,
         appVersion: String = "1.0",
+        buildNumber: String? = nil,
         in context: NSManagedObjectContext
     ) -> VersionObject {
         let entity = NSEntityDescription.entity(forEntityName: "VersionObject", in: context)!
@@ -22,6 +23,7 @@ extension VersionObject {
         version.date = date
         version.isSynced = synced
         version.appVersion = appVersion
+        version.buildNumber = buildNumber
 
         return version
     }


### PR DESCRIPTION
Add an overloaded trigger(appVersion:buildNumber:in:) that checks the latest VersionObject for the current install and returns early if appVersion and buildNumber are unchanged. The original trigger() now calls the new overload with Bundle values. Add tests (VersionObjectMonitorTests) to verify creation on first trigger, no-op when unchanged, creation on appVersion/buildNumber changes, and ignoring other installs. Update the test stub to accept and set buildNumber. This prevents unnecessary inserts and saves when the version/build haven't changed.