### PR TITLE
Make SessionObject.complete idempotent

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
@@ -17,6 +17,13 @@ extension SessionObject: Monitor {
         try context.save()
     }
 
+    /// Marks the latest session for the current launch as ended.
+    ///
+    /// Idempotent — returns without changes when the session is already
+    /// closed. Background-entry notifications can fire repeatedly
+    /// (scene lifecycle, state restoration), and a no-op on the second
+    /// call preserves the first observed end time.
+    ///
     static func complete(in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
         request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
@@ -26,12 +33,10 @@ extension SessionObject: Monitor {
         guard let session = try context.fetch(request).first else {
             throw MonitorError.notFound
         }
-        if let endDate = session.endDate {
-            throw MonitorError.alreadyCompleted(endDate)
-        }
 
-        let date = Date()
-        session.endDate = date
-        try context.save()
+        if session.endDate == nil {
+            session.endDate = Date()
+            try context.save()
+        }
     }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
@@ -1,0 +1,52 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("SessionObject+Monitor")
+struct SessionObjectMonitorTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("complete sets endDate on an open session")
+    func completeOpenSession() throws {
+        try SessionObject.trigger(in: context)
+
+        try SessionObject.complete(in: context)
+
+        let sessions = try context.fetch(NSFetchRequest<SessionObject>(entityName: "SessionObject"))
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.endDate != nil)
+    }
+
+    @Test("complete is a no-op when the session is already closed")
+    func completeTwiceIsNoop() throws {
+        try SessionObject.trigger(in: context)
+        try SessionObject.complete(in: context)
+
+        let firstEndDate = try #require(try context
+            .fetch(NSFetchRequest<SessionObject>(entityName: "SessionObject"))
+            .first?.endDate)
+
+        try SessionObject.complete(in: context)
+
+        let session = try #require(try context
+            .fetch(NSFetchRequest<SessionObject>(entityName: "SessionObject"))
+            .first)
+        #expect(session.endDate == firstEndDate)
+    }
+
+    @Test("complete throws notFound when no session exists for the current launch")
+    func completeWithoutSessionThrows() throws {
+        #expect(throws: MonitorError.notFound) {
+            try SessionObject.complete(in: context)
+        }
+    }
+}

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
@@ -31,15 +31,12 @@ struct SessionObjectMonitorTests {
         try SessionObject.trigger(in: context)
         try SessionObject.complete(in: context)
 
-        let firstEndDate = try #require(try context
-            .fetch(NSFetchRequest<SessionObject>(entityName: "SessionObject"))
-            .first?.endDate)
+        let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
+        let firstEndDate = try #require(try context.fetch(request).first?.endDate)
 
         try SessionObject.complete(in: context)
 
-        let session = try #require(try context
-            .fetch(NSFetchRequest<SessionObject>(entityName: "SessionObject"))
-            .first)
+        let session = try #require(try context.fetch(request).first)
         #expect(session.endDate == firstEndDate)
     }
 


### PR DESCRIPTION
Update SessionObject.complete to be idempotent: instead of throwing MonitorError.alreadyCompleted when an endDate exists, the method now returns no-op and preserves the original endDate. Added documentation explaining repeated background-entry notifications and rationale. Also added unit tests (SessionObjectMonitorTests) to verify setting endDate on open sessions, no-op behavior when called twice, and notFound when no session exists.