### PR TITLE
Infer endDate from latest child record

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+CompleteStale.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+CompleteStale.swift
@@ -11,16 +11,34 @@ extension LaunchObject {
     /// Closes launches from previous app runs that were not properly
     /// completed — typically because the app crashed.
     ///
+    /// `endDate` is set to the most recent timestamp of any IDObject
+    /// sharing the launch's `launchID` (sessions, events, crashes, metrics,
+    /// activity, version, or the launch itself). This approximates the real
+    /// launch length from the last signal emitted before the crash instead
+    /// of collapsing it to zero. Launches with no child records fall back
+    /// to their start date.
+    ///
     static func completeStale(in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
         request.predicate = NSPredicate(format: "endDate == nil AND launchID != %@", IDs.launch as CVarArg)
 
         for launch in try context.fetch(request) {
-            launch.endDate = launch.date
+            launch.endDate = try launch.inferredEndDate(in: context)
         }
 
         if context.hasChanges {
             try context.save()
         }
+    }
+
+    private func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
+        guard let launchID else { return nil }
+
+        let request = NSFetchRequest<IDObject>(entityName: "IDObject")
+        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
+        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
+        request.fetchLimit = 1
+
+        return try context.fetch(request).first?.date
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject+CompleteStale.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject+CompleteStale.swift
@@ -11,16 +11,34 @@ extension SessionObject {
     /// Closes sessions from previous launches that were not properly
     /// completed — typically because the app crashed.
     ///
+    /// `endDate` is set to the most recent timestamp of any TrackedObject
+    /// sharing the session's `sessionID` (events, crashes, metrics,
+    /// activity, or the session itself). This approximates the real session
+    /// length from the last signal emitted before the crash instead of
+    /// collapsing it to zero. Sessions with no child records fall back to
+    /// their start date.
+    ///
     static func completeStale(in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
         request.predicate = NSPredicate(format: "endDate == nil AND launchID != %@", IDs.launch as CVarArg)
 
         for session in try context.fetch(request) {
-            session.endDate = session.date
+            session.endDate = try session.inferredEndDate(in: context)
         }
 
         if context.hasChanges {
             try context.save()
         }
+    }
+
+    private func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
+        guard let sessionID else { return nil }
+
+        let request = NSFetchRequest<TrackedObject>(entityName: "TrackedObject")
+        request.predicate = NSPredicate(format: "sessionID == %@", sessionID as CVarArg)
+        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
+        request.fetchLimit = 1
+
+        return try context.fetch(request).first?.date
     }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Base/CompleteStaleTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Base/CompleteStaleTests.swift
@@ -48,6 +48,20 @@ struct CompleteStaleSessionTests {
 
         #expect(session.endDate == endDate)
     }
+
+    @Test("Uses latest child event date as endDate")
+    func endDateFromChildEvent() throws {
+        let session = SessionObject.stub(date: date, in: context)
+        session.launchID = UUID()
+
+        let latest = date.addingTimeInterval(120)
+        EventObject.stub(name: "x", date: latest, in: context)
+
+        try context.save()
+        try SessionObject.completeStale(in: context)
+
+        #expect(session.endDate == latest)
+    }
 }
 
 @MainActor
@@ -87,5 +101,24 @@ struct CompleteStaleLaunchTests {
         try LaunchObject.completeStale(in: context)
 
         #expect(launch.endDate == endDate)
+    }
+
+    @Test("Uses latest child timestamp as endDate")
+    func endDateFromChild() throws {
+        let staleLaunchID = UUID()
+        let launch = LaunchObject.stub(date: date, in: context)
+        launch.launchID = staleLaunchID
+
+        let session = SessionObject.stub(date: date.addingTimeInterval(10), in: context)
+        session.launchID = staleLaunchID
+
+        let latest = date.addingTimeInterval(300)
+        let event = EventObject.stub(name: "x", date: latest, in: context)
+        event.launchID = staleLaunchID
+
+        try context.save()
+        try LaunchObject.completeStale(in: context)
+
+        #expect(launch.endDate == latest)
     }
 }


### PR DESCRIPTION
Update stale-completion logic for LaunchObject and SessionObject to set endDate to the most recent timestamp of their child records instead of collapsing to the start date. Adds private inferredEndDate(in:) helpers that fetch the latest IDObject/TrackedObject by date and return its date, and uses these helpers when completing stale launches/sessions. Tests updated to verify endDate is derived from the latest child event/timestamp.