### PR TITLE
Make lifecycle UUID properties non-optional

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Log/EventObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Log/EventObject.swift
@@ -35,7 +35,7 @@ extension EventObject: CKRepresentable {
         record["param_count"] = paramCount
         record["date"] = date
         record["uuid"] = eventID?.uuidString
-        record["session_id"] = sessionID?.uuidString
+        record["session_id"] = sessionID.uuidString
 
         record.setValuesForKeys(metadata)
 

--- a/Sources/Scout/Core/Lifecycle/Base/IDObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/IDObject.swift
@@ -15,9 +15,9 @@ import CoreData
 ///
 @objc(IDObject)
 class IDObject: DateObject {
-    @NSManaged var deviceID: UUID?
-    @NSManaged var installID: UUID?
-    @NSManaged var launchID: UUID?
+    @NSManaged var deviceID: UUID
+    @NSManaged var installID: UUID
+    @NSManaged var launchID: UUID
 
     override func awakeFromInsert() {
         super.awakeFromInsert()
@@ -32,9 +32,9 @@ class IDObject: DateObject {
         fields["day"] = day
         fields["week"] = week
         fields["month"] = month
-        fields["device_id"] = deviceID?.uuidString
-        fields["install_id"] = installID?.uuidString
-        fields["launch_id"] = launchID?.uuidString
+        fields["device_id"] = deviceID.uuidString
+        fields["install_id"] = installID.uuidString
+        fields["launch_id"] = launchID.uuidString
         fields["version"] = 1
         return fields
     }

--- a/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
@@ -17,7 +17,7 @@ import CoreData
 ///
 @objc(TrackedObject)
 class TrackedObject: SyncableObject {
-    @NSManaged var sessionID: UUID?
+    @NSManaged var sessionID: UUID
 
     override func awakeFromInsert() {
         super.awakeFromInsert()

--- a/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
@@ -14,7 +14,7 @@ final class DeviceObject: SyncableObject, Syncable, GridBatch {
 
     func installs(in context: NSManagedObjectContext) throws -> [InstallObject] {
         let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
-        request.predicate = NSPredicate(format: "deviceID == %@", deviceID! as CVarArg)
+        request.predicate = NSPredicate(format: "deviceID == %@", deviceID as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
         return try context.fetch(request)
     }
@@ -25,7 +25,7 @@ extension DeviceObject {
         let record = CKRecord(recordType: Self.recordType)
 
         record["date"] = date
-        record["device_id"] = deviceID?.uuidString
+        record["device_id"] = deviceID.uuidString
 
         record.setValuesForKeys(metadata)
 

--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
@@ -14,7 +14,7 @@ final class InstallObject: SyncableObject, Syncable, GridBatch {
 
     func versions(in context: NSManagedObjectContext) throws -> [VersionObject] {
         let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        request.predicate = NSPredicate(format: "installID == %@", installID! as CVarArg)
+        request.predicate = NSPredicate(format: "installID == %@", installID as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
         return try context.fetch(request)
     }

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+CompleteStale.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+CompleteStale.swift
@@ -32,8 +32,6 @@ extension LaunchObject {
     }
 
     private func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
-        guard let launchID else { return nil }
-
         let request = NSFetchRequest<IDObject>(entityName: "IDObject")
         request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
@@ -16,14 +16,14 @@ final class LaunchObject: SyncableObject, Syncable, GridBatch {
 
     func sessions(in context: NSManagedObjectContext) throws -> [SessionObject] {
         let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
-        request.predicate = NSPredicate(format: "launchID == %@", launchID! as CVarArg)
+        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
         return try context.fetch(request)
     }
 
     func version(in context: NSManagedObjectContext) throws -> VersionObject? {
         let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        request.predicate = NSPredicate(format: "launchID == %@", launchID! as CVarArg)
+        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
         request.fetchLimit = 1
         return try context.fetch(request).first
     }
@@ -35,7 +35,7 @@ extension LaunchObject {
 
         record["start_date"] = date
         record["end_date"] = endDate
-        record["launch_id"] = launchID?.uuidString
+        record["launch_id"] = launchID.uuidString
 
         record.setValuesForKeys(metadata)
 

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject+CompleteStale.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject+CompleteStale.swift
@@ -32,8 +32,6 @@ extension SessionObject {
     }
 
     private func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
-        guard let sessionID else { return nil }
-
         let request = NSFetchRequest<TrackedObject>(entityName: "TrackedObject")
         request.predicate = NSPredicate(format: "sessionID == %@", sessionID as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
@@ -16,7 +16,7 @@ final class SessionObject: TrackedObject, Syncable, GridBatch {
 
     func launch(in context: NSManagedObjectContext) throws -> LaunchObject? {
         let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
-        request.predicate = NSPredicate(format: "launchID == %@", launchID! as CVarArg)
+        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
         request.fetchLimit = 1
         return try context.fetch(request).first
     }
@@ -28,8 +28,8 @@ extension SessionObject {
 
         record["start_date"] = date
         record["end_date"] = endDate
-        record["session_id"] = sessionID?.uuidString
-        record["launch_id"] = launchID?.uuidString
+        record["session_id"] = sessionID.uuidString
+        record["launch_id"] = launchID.uuidString
 
         record.setValuesForKeys(metadata)
 

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
@@ -17,7 +17,7 @@ final class VersionObject: SyncableObject, Syncable, GridBatch {
 
     func install(in context: NSManagedObjectContext) throws -> InstallObject? {
         let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
-        request.predicate = NSPredicate(format: "installID == %@", installID! as CVarArg)
+        request.predicate = NSPredicate(format: "installID == %@", installID as CVarArg)
         request.fetchLimit = 1
         return try context.fetch(request).first
     }
@@ -42,7 +42,7 @@ extension VersionObject {
         record["date"] = date
         record["app_version"] = appVersion
         record["build_number"] = buildNumber
-        record["launch_id"] = launchID?.uuidString
+        record["launch_id"] = launchID.uuidString
 
         record.setValuesForKeys(metadata)
 

--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -50,7 +50,7 @@
         <attribute name="syncAttempts" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
-        <attribute name="sessionID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="sessionID" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
     <entity name="VersionObject" representedClassName="VersionObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
         <attribute name="appVersion" optional="YES" attributeType="String"/>

--- a/Tests/ScoutTests/Core/Lifecycle/Device/DeviceObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Device/DeviceObjectTests.swift
@@ -19,7 +19,7 @@ struct DeviceObjectTests {
     @Test("installs(in:) returns installs matching deviceID")
     func testInstalls() throws {
         let device = DeviceObject.stub(date: week, in: context)
-        let deviceID = device.deviceID!
+        let deviceID = device.deviceID
 
         let i1 = InstallObject.stub(date: week, in: context)
         i1.deviceID = deviceID

--- a/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
@@ -19,7 +19,7 @@ struct InstallObjectTests {
     @Test("versions(in:) returns versions matching installID")
     func testVersions() throws {
         let install = InstallObject.stub(date: week, in: context)
-        let installID = install.installID!
+        let installID = install.installID
 
         let v1 = VersionObject.stub(date: week, appVersion: "1.0", in: context)
         v1.installID = installID

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
@@ -36,7 +36,7 @@ struct LaunchObjectTests {
     @Test("sessions(in:) returns sessions matching launchID")
     func testSessions() throws {
         let launch = LaunchObject.stub(date: week, in: context)
-        let launchID = launch.launchID!
+        let launchID = launch.launchID
 
         let session1 = SessionObject.stub(date: week, in: context)
         session1.launchID = launchID
@@ -58,7 +58,7 @@ struct LaunchObjectTests {
     @Test("version(in:) returns version matching launchID")
     func testVersion() throws {
         let launch = LaunchObject.stub(date: week, in: context)
-        let launchID = launch.launchID!
+        let launchID = launch.launchID
 
         let version = VersionObject.stub(date: week, appVersion: "2.0", in: context)
         version.launchID = launchID

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
@@ -36,7 +36,7 @@ struct SessionObjectTests {
     @Test("launch(in:) returns launch matching launchID")
     func testLaunch() throws {
         let session = SessionObject.stub(date: week, in: context)
-        let launchID = session.launchID!
+        let launchID = session.launchID
 
         let launch = LaunchObject.stub(date: week, in: context)
         launch.launchID = launchID

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
@@ -68,7 +68,7 @@ struct VersionObjectTests {
     @Test("install(in:) returns install matching installID")
     func testInstall() throws {
         let version = VersionObject.stub(date: week, appVersion: "2.0", in: context)
-        let installID = version.installID!
+        let installID = version.installID
 
         let install = InstallObject.stub(date: week, in: context)
         install.installID = installID


### PR DESCRIPTION
Convert lifecycle UUID properties (deviceID, installID, launchID, sessionID) from Optional to non-optional across Core model objects and the CoreData model. Update fetch predicates and CKRecord population to use the non-optional UUIDs (remove force-unwraps and optional chaining) and remove redundant guard-let checks in inferred end-date helpers. Adjust the xcdatamodel contents to mark sessionID non-optional and update unit tests to reflect the new non-optional properties. These changes tighten model invariants and simplify lookup/serialization code.