### PR TITLE
Make IDs.session thread-safe and add tests

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Base/IDs.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/IDs.swift
@@ -8,7 +8,19 @@
 import Foundation
 
 enum IDs {
-    nonisolated(unsafe) static var session = UUID()
+    private static let sessionQueue = DispatchQueue(label: "scout.ids.session")
+
+    nonisolated(unsafe) private static var sessionStorage = UUID()
+
+    /// Rotates on every `SessionObject.trigger`. `TrackedObject.awakeFromInsert`
+    /// reads it from arbitrary Core Data background contexts, so access is
+    /// serialised through a dispatch queue to avoid torn reads when rotation
+    /// races with concurrent inserts.
+    ///
+    static var session: UUID {
+        get { sessionQueue.sync { sessionStorage } }
+        set { sessionQueue.sync { sessionStorage = newValue } }
+    }
 
     static let launch = UUID()
 

--- a/Tests/ScoutTests/Core/Lifecycle/Base/IDsTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Base/IDsTests.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("IDs")
+struct IDsTests {
+    @Test("session getter/setter round-trip")
+    func sessionRoundTrip() {
+        let uuid = UUID()
+        IDs.session = uuid
+        #expect(IDs.session == uuid)
+    }
+
+    @Test("concurrent session reads and writes are safe")
+    func concurrentAccess() async {
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<500 {
+                group.addTask { _ = IDs.session }
+                group.addTask { IDs.session = UUID() }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Serialize access to IDs.session by introducing a private DispatchQueue and private storage, exposing a computed static var that syncs get/set through the queue. This avoids torn reads when the session UUID is rotated (e.g. on SessionObject.trigger) and concurrently read from Core Data background contexts. Also add unit tests to verify getter/setter round-trip and concurrent read/write safety.