### PR TITLE
Pin sessionID in completeStale child-event test

### DIFF
--- a/Tests/ScoutTests/Core/Lifecycle/Base/CompleteStaleTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Base/CompleteStaleTests.swift
@@ -51,11 +51,14 @@ struct CompleteStaleSessionTests {
 
     @Test("Uses latest child event date as endDate")
     func endDateFromChildEvent() throws {
+        let staleSessionID = UUID()
         let session = SessionObject.stub(date: date, in: context)
         session.launchID = UUID()
+        session.sessionID = staleSessionID
 
         let latest = date.addingTimeInterval(120)
-        EventObject.stub(name: "x", date: latest, in: context)
+        let event = EventObject.stub(name: "x", date: latest, in: context)
+        event.sessionID = staleSessionID
 
         try context.save()
         try SessionObject.completeStale(in: context)


### PR DESCRIPTION
- Pin sessionID explicitly on both session and event in the completeStale child-event test
- Removes a flake on iOS 26 where parallel suites rotated `IDs.session` between the two stub() calls, leaving them with mismatched sessionIDs
- iOS 18 was unaffected because its test scheduling didn't trigger the interleave
