### PR TITLE
Use stable CKRecord IDs; add tests

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
@@ -26,7 +26,8 @@ final class CrashObject: NamedObject, Syncable {
 
 extension CrashObject: CKRepresentable {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: Self.recordType)
+        let recordID = CKRecord.ID(recordName: crashID!.uuidString)
+        let record = CKRecord(recordType: Self.recordType, recordID: recordID)
 
         record["name"] = name
         record["reason"] = reason

--- a/Sources/Scout/Core/Diagnostics/Log/EventObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Log/EventObject.swift
@@ -27,7 +27,8 @@ final class EventObject: NamedObject, Syncable {
 
 extension EventObject: CKRepresentable {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: Self.recordType)
+        let recordID = CKRecord.ID(recordName: eventID!.uuidString)
+        let record = CKRecord(recordType: Self.recordType, recordID: recordID)
 
         record["name"] = name
         record["level"] = level

--- a/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
@@ -22,7 +22,8 @@ final class DeviceObject: SyncableObject, Syncable, GridBatch {
 
 extension DeviceObject {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: Self.recordType)
+        let recordID = CKRecord.ID(recordName: deviceID.uuidString)
+        let record = CKRecord(recordType: Self.recordType, recordID: recordID)
 
         record["date"] = date
         record["device_id"] = deviceID.uuidString

--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
@@ -22,7 +22,8 @@ final class InstallObject: SyncableObject, Syncable, GridBatch {
 
 extension InstallObject {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: Self.recordType)
+        let recordID = CKRecord.ID(recordName: installID.uuidString)
+        let record = CKRecord(recordType: Self.recordType, recordID: recordID)
 
         record["date"] = date
 

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
@@ -31,7 +31,8 @@ final class LaunchObject: SyncableObject, Syncable, GridBatch {
 
 extension LaunchObject {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: Self.recordType)
+        let recordID = CKRecord.ID(recordName: launchID.uuidString)
+        let record = CKRecord(recordType: Self.recordType, recordID: recordID)
 
         record["start_date"] = date
         record["end_date"] = endDate

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
@@ -24,7 +24,8 @@ final class SessionObject: TrackedObject, Syncable, GridBatch {
 
 extension SessionObject {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: Self.recordType)
+        let recordID = CKRecord.ID(recordName: sessionID.uuidString)
+        let record = CKRecord(recordType: Self.recordType, recordID: recordID)
 
         record["start_date"] = date
         record["end_date"] = endDate

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
@@ -37,7 +37,9 @@ final class VersionObject: SyncableObject, Syncable, GridBatch {
 
 extension VersionObject {
     var toRecord: CKRecord {
-        let record = CKRecord(recordType: Self.recordType)
+        let recordName = "\(installID.uuidString)-\(appVersion ?? "")-\(buildNumber ?? "")"
+        let recordID = CKRecord.ID(recordName: recordName)
+        let record = CKRecord(recordType: Self.recordType, recordID: recordID)
 
         record["date"] = date
         record["app_version"] = appVersion

--- a/Tests/ScoutTests/Core/Sync/StableRecordIDTests.swift
+++ b/Tests/ScoutTests/Core/Sync/StableRecordIDTests.swift
@@ -1,0 +1,76 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("Stable CKRecord IDs")
+struct StableRecordIDTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let date = Date(timeIntervalSince1970: 1_724_457_600)
+
+    @Test("DeviceObject.toRecord is stable across calls")
+    func deviceStable() {
+        let device = DeviceObject.stub(date: date, in: context)
+        #expect(device.toRecord.recordID == device.toRecord.recordID)
+        #expect(device.toRecord.recordID.recordName == device.deviceID.uuidString)
+    }
+
+    @Test("InstallObject.toRecord is stable across calls")
+    func installStable() {
+        let install = InstallObject.stub(date: date, in: context)
+        #expect(install.toRecord.recordID == install.toRecord.recordID)
+        #expect(install.toRecord.recordID.recordName == install.installID.uuidString)
+    }
+
+    @Test("LaunchObject.toRecord is stable across calls")
+    func launchStable() {
+        let launch = LaunchObject.stub(date: date, in: context)
+        launch.launchID = UUID()
+        #expect(launch.toRecord.recordID == launch.toRecord.recordID)
+        #expect(launch.toRecord.recordID.recordName == launch.launchID.uuidString)
+    }
+
+    @Test("SessionObject.toRecord is stable across calls")
+    func sessionStable() {
+        let session = SessionObject.stub(date: date, in: context)
+        session.sessionID = UUID()
+        #expect(session.toRecord.recordID == session.toRecord.recordID)
+        #expect(session.toRecord.recordID.recordName == session.sessionID.uuidString)
+    }
+
+    @Test("EventObject.toRecord is stable across calls")
+    func eventStable() {
+        let event = EventObject.stub(name: "test", date: date, in: context)
+        let expected = event.eventID!.uuidString
+        #expect(event.toRecord.recordID == event.toRecord.recordID)
+        #expect(event.toRecord.recordID.recordName == expected)
+    }
+
+    @Test("VersionObject.toRecord is stable across calls")
+    func versionStable() {
+        let version = VersionObject.stub(date: date, appVersion: "1.2.3", in: context)
+        version.buildNumber = "42"
+        let expected = "\(version.installID.uuidString)-1.2.3-42"
+        #expect(version.toRecord.recordID == version.toRecord.recordID)
+        #expect(version.toRecord.recordID.recordName == expected)
+    }
+
+    @Test("Different objects of the same type produce different recordIDs")
+    func uniqueness() {
+        let launch1 = LaunchObject.stub(date: date, in: context)
+        launch1.launchID = UUID()
+        let launch2 = LaunchObject.stub(date: date, in: context)
+        launch2.launchID = UUID()
+
+        #expect(launch1.toRecord.recordID != launch2.toRecord.recordID)
+    }
+}


### PR DESCRIPTION
Create CKRecord instances with explicit CKRecord.IDs derived from each object's UUIDs (crashID, eventID, deviceID, installID, launchID, sessionID) and use a composite recordName for VersionObject (installID-appVersion-buildNumber). This ensures stable recordIDs across repeated toRecord conversions for reliable deduplication and lookup. Add StableRecordIDTests.swift to verify stability across calls and uniqueness between different objects.