### PR TITLE
Persist syncAttempts before upload

### DIFF
--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -18,6 +18,9 @@ struct SyncEngine: @unchecked Sendable {
                 object.syncAttempts += 1
             }
 
+            // Persist attempt counters so cleanup can retire records that keep failing.
+            try context.save()
+
             if let objects = batch as? [CKRepresentable] {
                 try await database.write(
                     records: objects.map(\.toRecord)

--- a/Tests/ScoutTests/Core/Sync/SyncEngineTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncEngineTests.swift
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("SyncEngine")
+struct SyncEngineTests {
+    let database = InMemoryDatabase()
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("Persists syncAttempts when upload fails")
+    func persistsSyncAttemptsOnFailure() async throws {
+        let event = EventObject.stub(name: "x", in: context)
+        event.eventID = UUID()
+        try context.save()
+
+        database.writeErrors.append(CKError(.networkFailure))
+
+        let engine = SyncEngine(database: database, context: context)
+
+        await #expect(throws: (any Error).self) {
+            try await engine.send(type: EventObject.self)
+        }
+
+        #expect(event.syncAttempts == 1)
+        #expect(!context.hasChanges)
+    }
+}


### PR DESCRIPTION
- Move `context.save()` in `SyncEngine.send` to right after the `syncAttempts` increment so the counter persists even when the upload fails
- Without this, a record that always fails to upload keeps `syncAttempts = 0` on disk forever, so `SyncableObject.cleanup` never retires it via the `syncAttempts > 10` threshold
- New unit test: inject a CK error into `InMemoryDatabase.writeErrors`, run `SyncEngine.send`, assert the event's `syncAttempts == 1` and the context has no pending changes
