### PR TITLE
Filter InstallObject.trigger by current IDs.install

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject+Monitor.swift
@@ -10,6 +10,7 @@ import CoreData
 extension InstallObject: PartialMonitor {
     static func trigger(in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
+        request.predicate = NSPredicate(format: "installID == %@", IDs.install as CVarArg)
         request.fetchLimit = 1
 
         guard try context.fetch(request).isEmpty else {

--- a/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectMonitorTests.swift
@@ -1,0 +1,49 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("InstallObject+Monitor")
+struct InstallObjectMonitorTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("trigger creates an InstallObject on empty store")
+    func createsFirst() throws {
+        try InstallObject.trigger(in: context)
+
+        let installs = try context.fetch(NSFetchRequest<InstallObject>(entityName: "InstallObject"))
+        #expect(installs.count == 1)
+        #expect(installs.first?.installID == IDs.install)
+    }
+
+    @Test("trigger is a no-op when an InstallObject for the current install already exists")
+    func skipsWhenExists() throws {
+        try InstallObject.trigger(in: context)
+        try InstallObject.trigger(in: context)
+        try InstallObject.trigger(in: context)
+
+        let installs = try context.fetch(NSFetchRequest<InstallObject>(entityName: "InstallObject"))
+        #expect(installs.count == 1)
+    }
+
+    @Test("trigger creates a new InstallObject when existing records belong to a different install")
+    func createsWhenInstallChanged() throws {
+        let prior = InstallObject.stub(date: Date(), in: context)
+        prior.installID = UUID()
+        try context.save()
+
+        try InstallObject.trigger(in: context)
+
+        let installs = try context.fetch(NSFetchRequest<InstallObject>(entityName: "InstallObject"))
+        #expect(installs.count == 2)
+        #expect(installs.contains { $0.installID == IDs.install })
+    }
+}


### PR DESCRIPTION
- Scope `InstallObject.trigger`'s existence check to `installID == IDs.install`
- Without the predicate, any pre-existing `InstallObject` (e.g. from a wiped `UserDefaults` + new `IDs.install`) suppressed creation for the current install, leaving subsequent records with an `installID` that had no matching `InstallObject`
- Matches the pattern already used by `DeviceObject.trigger`
- Unit tests cover: first-time creation, idempotent no-op on repeat triggers, and new creation when prior records belong to a different install
