### PR TITLE
Make LaunchObject a PartialMonitor and add tests

### DIFF
--- a/Sources/Scout/Core/Bootstrap/ActionTable.AppState.swift
+++ b/Sources/Scout/Core/Bootstrap/ActionTable.AppState.swift
@@ -18,7 +18,6 @@ extension ActionTable {
         UIApplication.didEnterBackgroundNotification: {
             try await persistentContainer.performBackgroundTasks(
                 SessionObject.complete,
-                LaunchObject.complete,
                 UserActivityObject.trigger
             )
         },

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Monitor.swift
@@ -8,8 +8,9 @@
 import CoreData
 
 extension LaunchObject: PartialMonitor {
-    /// A launch represents the lifetime of the current process. It is
-    /// created once during `setup()` and finalised only on the next
+    /// A launch represents the lifetime of the current process.
+    ///
+    /// Created once during `setup()` and finalised only on the next
     /// process start via `completeStale`, which sets `endDate` from the
     /// latest signal recorded under this `launchID` — the OS provides no
     /// reliable hook for "process about to die".

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Monitor.swift
@@ -7,25 +7,17 @@
 
 import CoreData
 
-extension LaunchObject: Monitor {
+extension LaunchObject: PartialMonitor {
+    /// A launch represents the lifetime of the current process. It is
+    /// created once during `setup()` and finalised only on the next
+    /// process start via `completeStale`, which sets `endDate` from the
+    /// latest signal recorded under this `launchID` — the OS provides no
+    /// reliable hook for "process about to die".
+    ///
     static func trigger(in context: NSManagedObjectContext) throws {
         let entity = NSEntityDescription.entity(forEntityName: "LaunchObject", in: context)!
         let launch = LaunchObject(entity: entity, insertInto: context)
         launch.date = Date()
-        try context.save()
-    }
-
-    static func complete(in context: NSManagedObjectContext) throws {
-        let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
-        request.predicate = NSPredicate(format: "launchID == %@", IDs.launch as CVarArg)
-        request.fetchLimit = 1
-
-        guard let launch = try context.fetch(request).first else {
-            throw MonitorError.notFound
-        }
-
-        launch.endDate = Date()
         try context.save()
     }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectMonitorTests.swift
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("LaunchObject+Monitor")
+struct LaunchObjectMonitorTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("trigger creates a LaunchObject")
+    func createsLaunch() throws {
+        try LaunchObject.trigger(in: context)
+
+        let launches = try context.fetch(NSFetchRequest<LaunchObject>(entityName: "LaunchObject"))
+        #expect(launches.count == 1)
+        #expect(launches.first?.launchID == IDs.launch)
+        #expect(launches.first?.endDate == nil)
+    }
+
+    @Test("Launch stays open when a session inside it is completed")
+    func launchRemainsOpenAfterSessionComplete() throws {
+        try LaunchObject.trigger(in: context)
+        try SessionObject.trigger(in: context)
+        try SessionObject.complete(in: context)
+
+        let launches = try context.fetch(NSFetchRequest<LaunchObject>(entityName: "LaunchObject"))
+        #expect(launches.first?.endDate == nil)
+    }
+}


### PR DESCRIPTION
Change LaunchObject from a full Monitor to a PartialMonitor and remove its in-context complete implementation (finalization is handled elsewhere, e.g. via completeStale on next process start). Stop invoking LaunchObject.complete during app backgrounding in ActionTable to avoid prematurely ending the process-level launch. Add unit tests to verify trigger behavior and that a launch remains open when a session inside it is completed.