### PR TITLE
Split Monitor into PartialMonitor and RecoveryMonitor

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Base/Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/Monitor.swift
@@ -19,3 +19,11 @@ protocol Monitor: PartialMonitor {
 protocol PartialMonitor {
     static func trigger(in context: NSManagedObjectContext) throws
 }
+
+/// Marker for types that need to finalise records left open by a prior
+/// process — crashes, OS kills, swipe-terminations — at the next process
+/// start.
+///
+protocol RecoveryMonitor {
+    static func completeStale(in context: NSManagedObjectContext) throws
+}

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Recovery.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Recovery.swift
@@ -7,7 +7,7 @@
 
 import CoreData
 
-extension LaunchObject {
+extension LaunchObject: RecoveryMonitor {
     /// Closes launches from previous app runs that were not properly
     /// completed — typically because the app crashed.
     ///

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject+Recovery.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject+Recovery.swift
@@ -7,7 +7,7 @@
 
 import CoreData
 
-extension SessionObject {
+extension SessionObject: RecoveryMonitor {
     /// Closes sessions from previous launches that were not properly
     /// completed — typically because the app crashed.
     ///

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectRecoveryTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectRecoveryTests.swift
@@ -11,65 +11,8 @@ import Testing
 @testable import Scout
 
 @MainActor
-@Suite("SessionObject.completeStale")
-struct CompleteStaleSessionTests {
-    let context = NSManagedObjectContext.inMemoryContext()
-    let date = Date(timeIntervalSince1970: 1_724_457_600)
-
-    @Test("Closes sessions from previous launches")
-    func closesStale() throws {
-        let session = SessionObject.stub(date: date, in: context)
-        session.launchID = UUID()
-
-        try context.save()
-        try SessionObject.completeStale(in: context)
-
-        #expect(session.endDate == date)
-    }
-
-    @Test("Does not close sessions from current launch")
-    func skipsCurrent() throws {
-        let session = SessionObject.stub(date: date, in: context)
-
-        try context.save()
-        try SessionObject.completeStale(in: context)
-
-        #expect(session.endDate == nil)
-    }
-
-    @Test("Does not modify already completed sessions")
-    func skipsCompleted() throws {
-        let endDate = date.addingTimeInterval(60)
-        let session = SessionObject.stub(date: date, endDate: endDate, in: context)
-        session.launchID = UUID()
-
-        try context.save()
-        try SessionObject.completeStale(in: context)
-
-        #expect(session.endDate == endDate)
-    }
-
-    @Test("Uses latest child event date as endDate")
-    func endDateFromChildEvent() throws {
-        let staleSessionID = UUID()
-        let session = SessionObject.stub(date: date, in: context)
-        session.launchID = UUID()
-        session.sessionID = staleSessionID
-
-        let latest = date.addingTimeInterval(120)
-        let event = EventObject.stub(name: "x", date: latest, in: context)
-        event.sessionID = staleSessionID
-
-        try context.save()
-        try SessionObject.completeStale(in: context)
-
-        #expect(session.endDate == latest)
-    }
-}
-
-@MainActor
-@Suite("LaunchObject.completeStale")
-struct CompleteStaleLaunchTests {
+@Suite("LaunchObject+Recovery")
+struct LaunchObjectRecoveryTests {
     let context = NSManagedObjectContext.inMemoryContext()
     let date = Date(timeIntervalSince1970: 1_724_457_600)
 

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectRecoveryTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectRecoveryTests.swift
@@ -1,0 +1,68 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("SessionObject+Recovery")
+struct SessionObjectRecoveryTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let date = Date(timeIntervalSince1970: 1_724_457_600)
+
+    @Test("Closes sessions from previous launches")
+    func closesStale() throws {
+        let session = SessionObject.stub(date: date, in: context)
+        session.launchID = UUID()
+
+        try context.save()
+        try SessionObject.completeStale(in: context)
+
+        #expect(session.endDate == date)
+    }
+
+    @Test("Does not close sessions from current launch")
+    func skipsCurrent() throws {
+        let session = SessionObject.stub(date: date, in: context)
+
+        try context.save()
+        try SessionObject.completeStale(in: context)
+
+        #expect(session.endDate == nil)
+    }
+
+    @Test("Does not modify already completed sessions")
+    func skipsCompleted() throws {
+        let endDate = date.addingTimeInterval(60)
+        let session = SessionObject.stub(date: date, endDate: endDate, in: context)
+        session.launchID = UUID()
+
+        try context.save()
+        try SessionObject.completeStale(in: context)
+
+        #expect(session.endDate == endDate)
+    }
+
+    @Test("Uses latest child event date as endDate")
+    func endDateFromChildEvent() throws {
+        let staleSessionID = UUID()
+        let session = SessionObject.stub(date: date, in: context)
+        session.launchID = UUID()
+        session.sessionID = staleSessionID
+
+        let latest = date.addingTimeInterval(120)
+        let event = EventObject.stub(name: "x", date: latest, in: context)
+        event.sessionID = staleSessionID
+
+        try context.save()
+        try SessionObject.completeStale(in: context)
+
+        #expect(session.endDate == latest)
+    }
+}


### PR DESCRIPTION
- Introduce a `RecoveryMonitor` marker protocol alongside `Monitor` / `PartialMonitor` for types that need to finalise records left open by a prior process (crashes, OS kills, swipe-terminations)
- Both `SessionObject` and `LaunchObject` conform — the protocol requires a single `static func completeStale(in:)` entry point
- Rename the extension files `+CompleteStale.swift` → `+Recovery.swift` to match the `+Monitor` naming convention
- Split the joint `CompleteStaleTests.swift` into per-type files (`SessionObjectRecoveryTests.swift`, `LaunchObjectRecoveryTests.swift`) co-located with their sources; suite names become `SessionObject+Recovery` / `LaunchObject+Recovery` matching the `+Monitor` pattern
