### PR TITLE
Capture sessionID in CrashInfo

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/CrashInfo.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashInfo.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
+/// Snapshot of the identifiers captured at crash time.
+///
+/// Persisted to disk before the process dies and replayed on the next
+/// process start by `logCrash`. The IDs it carries (`installID`,
+/// `launchID`, `sessionID`) must be those of the **crashed** process —
+/// not the recovery process that eventually inserts the `CrashObject`.
+///
 struct CrashInfo: Codable {
     let name: String
     let reason: String?
@@ -14,6 +21,7 @@ struct CrashInfo: Codable {
     let date: Date
     let installID: UUID
     let launchID: UUID
+    let sessionID: UUID
 
     init(name: String, reason: String?, stackTrace: [String]) {
         self.name = name
@@ -22,5 +30,6 @@ struct CrashInfo: Codable {
         self.date = Date()
         self.installID = IDs.install
         self.launchID = IDs.launch
+        self.sessionID = IDs.session
     }
 }

--- a/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
@@ -20,6 +20,7 @@ func logCrash(_ crash: CrashInfo, context: NSManagedObjectContext) throws {
     // Override IDs set by awakeFromInsert with values captured at crash time
     object.installID = crash.installID
     object.launchID = crash.launchID
+    object.sessionID = crash.sessionID
 
     try context.save()
 }

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
@@ -38,6 +38,25 @@ struct LogCrashTests {
         #expect(object.crashID != nil)
         #expect(object.installID == crash.installID)
         #expect(object.launchID == crash.launchID)
+        #expect(object.sessionID == crash.sessionID)
+    }
+
+    @Test("Preserves sessionID captured at crash time, not the recovery session")
+    func preservesCapturedSessionID() throws {
+        // Phase 1: "crashed" process captures its sessionID.
+        let crashedSessionID = UUID()
+        IDs.session = crashedSessionID
+        let crash = makeCrashInfo(name: "SIGSEGV", reason: nil, stackTrace: [])
+
+        // Phase 2: recovery process has a fresh sessionID — awakeFromInsert
+        // would use this unless logCrash overrides it.
+        IDs.session = UUID()
+        #expect(IDs.session != crashedSessionID)
+
+        try logCrash(crash, context: context)
+
+        let object = try #require(try context.fetch(NSFetchRequest<CrashObject>(entityName: "CrashObject")).first)
+        #expect(object.sessionID == crashedSessionID)
     }
 
     @Test("Encodes stack trace as JSON data")


### PR DESCRIPTION
- Add `sessionID` to `CrashInfo` so the value is captured at crash time alongside `installID` and `launchID`, not rebuilt from the recovery process's `IDs.session`
- Override `CrashObject.sessionID` in `logCrash` with the captured value (the managed property otherwise defaults to `IDs.session` via `TrackedObject.awakeFromInsert`)
- Add a regression test that rotates `IDs.session` between crash capture and replay and asserts the original sessionID is preserved on the resulting `CrashObject`
