### PR TITLE
Make remaining UUID properties non-optional

### DIFF
--- a/Sources/Scout/Core/Activity/UserActivityObject.swift
+++ b/Sources/Scout/Core/Activity/UserActivityObject.swift
@@ -13,7 +13,7 @@ final class UserActivityObject: TrackedObject, Syncable {
     @NSManaged var dayCount: Int32
     @NSManaged var monthCount: Int32
     @NSManaged var period: String?
-    @NSManaged var userActivityID: UUID?
+    @NSManaged var userActivityID: UUID
     @NSManaged var weekCount: Int32
 
     static func group(in context: NSManagedObjectContext) throws -> [UserActivityObject]? {

--- a/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
@@ -11,7 +11,7 @@ import CoreData
 @objc(CrashObject)
 final class CrashObject: NamedObject, Syncable {
     static let recordType = "Crash"
-    @NSManaged var crashID: UUID?
+    @NSManaged var crashID: UUID
     @NSManaged var reason: String?
     @NSManaged var stackTrace: Data?
 
@@ -26,14 +26,14 @@ final class CrashObject: NamedObject, Syncable {
 
 extension CrashObject: CKRepresentable {
     var toRecord: CKRecord {
-        let recordID = CKRecord.ID(recordName: crashID!.uuidString)
+        let recordID = CKRecord.ID(recordName: crashID.uuidString)
         let record = CKRecord(recordType: Self.recordType, recordID: recordID)
 
         record["name"] = name
         record["reason"] = reason
         record["stack_trace"] = stackTrace
         record["date"] = date
-        record["uuid"] = crashID?.uuidString
+        record["uuid"] = crashID.uuidString
 
         record.setValuesForKeys(metadata)
 

--- a/Sources/Scout/Core/Diagnostics/Log/EventObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Log/EventObject.swift
@@ -11,7 +11,7 @@ import CoreData
 @objc(EventObject)
 final class EventObject: NamedObject, Syncable {
     static let recordType = "Event"
-    @NSManaged var eventID: UUID?
+    @NSManaged var eventID: UUID
     @NSManaged var level: String?
     @NSManaged var paramCount: Int64
     @NSManaged var params: Data?
@@ -27,7 +27,7 @@ final class EventObject: NamedObject, Syncable {
 
 extension EventObject: CKRepresentable {
     var toRecord: CKRecord {
-        let recordID = CKRecord.ID(recordName: eventID!.uuidString)
+        let recordID = CKRecord.ID(recordName: eventID.uuidString)
         let record = CKRecord(recordType: Self.recordType, recordID: recordID)
 
         record["name"] = name
@@ -35,7 +35,7 @@ extension EventObject: CKRepresentable {
         record["params"] = params
         record["param_count"] = paramCount
         record["date"] = date
-        record["uuid"] = eventID?.uuidString
+        record["uuid"] = eventID.uuidString
         record["session_id"] = sessionID.uuidString
 
         record.setValuesForKeys(metadata)

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
@@ -35,7 +35,6 @@ struct LogCrashTests {
         #expect(object.name == "SIGABRT")
         #expect(object.reason == "Fatal error")
         #expect(object.date == crash.date)
-        #expect(object.crashID != nil)
         #expect(object.installID == crash.installID)
         #expect(object.launchID == crash.launchID)
     }

--- a/Tests/ScoutTests/Core/Diagnostics/Log/LogTest.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Log/LogTest.swift
@@ -42,7 +42,6 @@ private func makeEvent(
     #expect(event.date == date)
     #expect(event.hour == date.startOfHour)
     #expect(event.week == date.startOfWeek)
-    #expect(event.eventID != nil)
     #expect(event.installID == IDs.install)
     #expect(event.paramCount == 1)
 

--- a/Tests/ScoutTests/Core/Sync/StableRecordIDTests.swift
+++ b/Tests/ScoutTests/Core/Sync/StableRecordIDTests.swift
@@ -50,7 +50,7 @@ struct StableRecordIDTests {
     @Test("EventObject.toRecord is stable across calls")
     func eventStable() {
         let event = EventObject.stub(name: "test", date: date, in: context)
-        let expected = event.eventID!.uuidString
+        let expected = event.eventID.uuidString
         #expect(event.toRecord.recordID == event.toRecord.recordID)
         #expect(event.toRecord.recordID.recordName == expected)
     }


### PR DESCRIPTION
- Make `EventObject.eventID`, `CrashObject.crashID`, and `UserActivityObject.userActivityID` non-optional in Swift to match the Core Data model (they were already required there)
- Drops the remaining `!` force-unwraps in `toRecord` for Event/Crash and the corresponding `!= nil` checks in tests that no longer compile
- Completes the alignment started in PR #443 for `sessionID`/`launchID`/`installID`/`deviceID`
