### PR TITLE
Extract metadata into DateObject; override in IDObject

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Base/IDObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/IDObject.swift
@@ -26,12 +26,8 @@ class IDObject: DateObject {
         launchID = IDs.launch
     }
 
-    var metadata: [String: Any] {
-        var fields: [String: Any] = [:]
-        fields["hour"] = hour
-        fields["day"] = day
-        fields["week"] = week
-        fields["month"] = month
+    override var metadata: [String: Any] {
+        var fields = super.metadata
         fields["device_id"] = deviceID.uuidString
         fields["install_id"] = installID.uuidString
         fields["launch_id"] = launchID.uuidString

--- a/Sources/Scout/Core/Utilities/Date/DateObject.swift
+++ b/Sources/Scout/Core/Utilities/Date/DateObject.swift
@@ -35,4 +35,13 @@ class DateObject: NSManagedObject, Identifiable {
             month = newValue?.startOfMonth
         }
     }
+
+    var metadata: [String: Any] {
+        var fields: [String: Any] = [:]
+        fields["hour"] = hour
+        fields["day"] = day
+        fields["week"] = week
+        fields["month"] = month
+        return fields
+    }
 }


### PR DESCRIPTION
Move the date-related metadata (hour, day, week, month) out of IDObject into a new metadata property on DateObject. IDObject now overrides metadata to start from super.metadata and adds device_id, install_id and launch_id. This centralizes date fields for reuse and removes duplication.