### PR TITLE
Move iCloud & schema warnings into NavigationStack

### DIFF
--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -22,11 +22,11 @@ public struct HomeView: View {
         NavigationStack {
             HomeContent()
                 .navigationBarTitle("Home")
+                .iCloudWarning(container: container)
+                .schemaWarning(container: container)
+                .dismissable()
         }
-        .dismissable()
         .onboardingSheet()
-        .iCloudWarning(container: container)
-        .schemaWarning(container: container)
         .tint(tint.value)
         .environmentObject(tint)
         .environment(\.database, container.publicCloudDatabase)


### PR DESCRIPTION
Apply .iCloudWarning(container:), .schemaWarning(container:) and .dismissable() directly to HomeContent inside the NavigationStack instead of the outer view. This changes the modifier scope/order so the warnings and dismiss behavior are scoped to the navigation content; onboardingSheet, tint and environment modifiers remain on the outer view.