### PR TITLE
Cancel work on background task expiration

### DIFF
--- a/Sources/Scout/Core/Utilities/Dispatcher/Dispatcher.swift
+++ b/Sources/Scout/Core/Utilities/Dispatcher/Dispatcher.swift
@@ -16,13 +16,15 @@ extension Dispatcher {
 }
 
 extension Dispatcher {
+    /// Cancels `work` on expiration rather than letting iOS silently revoke background time.
     func performEnsuringBackground(_ work: @escaping Work) async throws {
         try await perform { @MainActor in
-            let task = UIApplication.shared.beginBackgroundTask()
+            let work = Task(operation: work)
+            let task = UIApplication.shared.beginBackgroundTask(withName: "scout.sync", expirationHandler: work.cancel)
 
             defer { UIApplication.shared.endBackgroundTask(task) }
 
-            try await work()
+            try await work.value
         }
     }
 }


### PR DESCRIPTION
Wrap the provided work in a Task and register its cancel handler with UIApplication.beginBackgroundTask(withName:expirationHandler:). This ensures the work is cancelled when the background task expires (rather than iOS silently revoking background time). Also adds a task name "scout.sync" and awaits the Task's value instead of calling the work directly.