### PR TITLE
Check for Task cancellation during sync

### DIFF
--- a/Sources/Scout/Core/Sync/SyncController.swift
+++ b/Sources/Scout/Core/Sync/SyncController.swift
@@ -30,6 +30,7 @@ typealias SyncAction = @MainActor () async throws -> Void
         try SyncableObject.cleanup(in: persistentContainer.viewContext)
         try await dispatcher.performEnsuringBackground {
             for job in jobPlan.jobs.shuffled() {
+                try Task.checkCancellation()
                 try await job()
             }
         }

--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -14,6 +14,8 @@ struct SyncEngine: @unchecked Sendable {
 
     @MainActor func send<T: Syncable & MatrixBatch>(type syncable: T.Type) async throws {
         while let batch = try syncable.group(in: context) {
+            try Task.checkCancellation()
+
             for object in batch {
                 object.syncAttempts += 1
             }


### PR DESCRIPTION
Add cooperative cancellation checks to long-running sync loops so work can be aborted promptly. Inserted try Task.checkCancellation() in SyncController's job loop (jobPlan.jobs.shuffled()) and in SyncEngine's batch sending loop (while let batch = ...). This avoids unnecessary work and keeps the sync system responsive when tasks are cancelled.