### PR TITLE
Run cleanup early and tolerate job errors

### DIFF
--- a/Sources/Scout/Core/Sync/SyncController.swift
+++ b/Sources/Scout/Core/Sync/SyncController.swift
@@ -24,14 +24,20 @@ typealias SyncAction = @MainActor () async throws -> Void
             throw NotLoggedInError()
         }
 
+        try SyncableObject.cleanup(in: persistentContainer.viewContext)
+
         let engine = SyncEngine(database: container.publicCloudDatabase, context: persistentContainer.viewContext)
         let jobPlan = SyncJobPlan(engine: engine)
 
-        try SyncableObject.cleanup(in: persistentContainer.viewContext)
         try await dispatcher.performEnsuringBackground {
             for job in jobPlan.jobs.shuffled() {
-                try Task.checkCancellation()
-                try await job()
+                do {
+                    try await job()
+                } catch let error where Task.isCancelled {
+                    throw error
+                } catch {
+                    continue
+                }
             }
         }
     }


### PR DESCRIPTION
Move SyncableObject.cleanup to run before creating the sync engine, and wrap each sync job in a do/catch. Task cancellations are rethrown to stop the operation, while other job errors are swallowed (continue) so a single failing job doesn't abort the whole dispatch loop.