### PR TITLE
Run cleanup before iCloud account check

### DIFF
--- a/Sources/Scout/Core/Sync/SyncController.swift
+++ b/Sources/Scout/Core/Sync/SyncController.swift
@@ -20,11 +20,11 @@ typealias SyncAction = @MainActor () async throws -> Void
     }
 
     func synchronize() async throws {
+        try SyncableObject.cleanup(in: persistentContainer.viewContext)
+
         guard try await container.accountStatus() == .available else {
             throw NotLoggedInError()
         }
-
-        try SyncableObject.cleanup(in: persistentContainer.viewContext)
 
         let engine = SyncEngine(database: container.publicCloudDatabase, context: persistentContainer.viewContext)
         let jobPlan = SyncJobPlan(engine: engine)


### PR DESCRIPTION
- Move `SyncableObject.cleanup` ahead of the `accountStatus` guard so stale records are pruned even when the user is signed out of iCloud
- Cleanup is a local Core Data operation and does not require an iCloud account, so gating it on availability prevented stale rows from being collected in the signed-out edge case