### PR TITLE
Unify UI text handling and enforce English localization standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,5 @@ Multi-line doc comments (`///`) must end with a trailing empty `///` line. Singl
 Never remove or rename fields, record types, or index modifiers (`QUERYABLE`/`SEARCHABLE`/`SORTABLE`) in the CloudKit `Schema` file — Production schemas are append-only and `cktool import-schema` will reject removals with `cannot remove field … which exists in active production type …`. To deprecate a field, stop writing it in code but keep its declaration in `Schema`.
 
 After modifying any Swift source, run `xcrun swift-format lint --strict --recursive Sources Tests` and resolve every reported violation before committing.
+
+Scout UI strings must always render in source English: use `Text(verbatim: …)` for literals (or `.navigationTitle(en: …)` for titles) so they don't resolve through the host app's `LocalizedStringKey` catalog.

--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -35,7 +35,7 @@ struct ActivityView: View {
                 .scrollDisabled(true)
             }
         }
-        .navigationTitle(Text(verbatim: "Active Users"))
+        .navigationTitle(en: "Active Users")
     }
 }
 

--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -35,7 +35,7 @@ struct ActivityView: View {
                 .scrollDisabled(true)
             }
         }
-        .navigationTitle("Active Users")
+        .navigationTitle(Text(verbatim: "Active Users"))
     }
 }
 

--- a/Sources/Scout/UI/Chart/ChartFormat.swift
+++ b/Sources/Scout/UI/Chart/ChartFormat.swift
@@ -10,6 +10,7 @@ import Foundation
 extension Calendar.Component {
     var chartFormat: Date.FormatStyle {
         var style = Date.FormatStyle()
+        style.locale = Locale(identifier: "en_US")
         style.timeZone = TimeZone(secondsFromGMT: 0)!
 
         return switch self {

--- a/Sources/Scout/UI/Chart/ChartView.swift
+++ b/Sources/Scout/UI/Chart/ChartView.swift
@@ -30,7 +30,7 @@ struct ChartView<T: ChartNumeric>: View {
         }
         .chartBackground { _ in
             if segment.total == .zero {
-                Text("No results")
+                Text(verbatim: "No results")
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(.gray.opacity(0.7))
             }
@@ -44,10 +44,10 @@ struct ChartView<T: ChartNumeric>: View {
 
 #Preview("ChartView – Month") {
     VStack(alignment: .leading, spacing: 24) {
-        Text("With Data").font(.headline)
+        Text(verbatim: "With Data").font(.headline)
         ChartView(segment: .sample, timing: ChartExtent(period: Period.month))
 
-        Text("Empty State").font(.headline)
+        Text(verbatim: "Empty State").font(.headline)
         ChartView(segment: .empty, timing: ChartExtent(period: Period.month))
     }
     .padding()

--- a/Sources/Scout/UI/Controls/Header.swift
+++ b/Sources/Scout/UI/Controls/Header.swift
@@ -24,7 +24,7 @@ struct Header: View {
                 Spacer()
 
                 Button(action: action) {
-                    Text("See all").foregroundStyle(.blue)
+                    Text(verbatim: "See all").foregroundStyle(.blue)
                 }
                 .buttonStyle(.plain)
             }

--- a/Sources/Scout/UI/Controls/Row.swift
+++ b/Sources/Scout/UI/Controls/Row.swift
@@ -36,11 +36,11 @@ struct Row<Content: View, Destination: View>: View {
     NavigationStack {
         List {
             Row {
-                Text("Label")
+                Text(verbatim: "Label")
                 Spacer()
-                Text("Value")
+                Text(verbatim: "Value")
             } destination: {
-                Text("Detail")
+                Text(verbatim: "Detail")
             }
         }
     }

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -41,7 +41,7 @@ struct CrashDetailView: View {
             }
 
             if let reason = crash.reason {
-                Text("REASON:   ").fontWeight(.bold)
+                Text(verbatim: "REASON:   ").fontWeight(.bold)
                     + Text(reason).fontWeight(.bold).foregroundColor(.red)
             }
         }

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -38,7 +38,7 @@ struct CrashListView: View {
                 ProgressView().frame(maxHeight: .infinity)
             }
         }
-        .navigationTitle("Crashes")
+        .navigationTitle(Text(verbatim: "Crashes"))
         .task {
             await provider.fetch(in: database)
         }
@@ -89,6 +89,6 @@ struct CrashListView: View {
             systemImage: "checkmark.shield",
             description: "No crash reports have been recorded"
         )
-        .navigationTitle("Crashes")
+        .navigationTitle(Text(verbatim: "Crashes"))
     }
 }

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -38,7 +38,7 @@ struct CrashListView: View {
                 ProgressView().frame(maxHeight: .infinity)
             }
         }
-        .navigationTitle(Text(verbatim: "Crashes"))
+        .navigationTitle(en: "Crashes")
         .task {
             await provider.fetch(in: database)
         }
@@ -89,6 +89,6 @@ struct CrashListView: View {
             systemImage: "checkmark.shield",
             description: "No crash reports have been recorded"
         )
-        .navigationTitle(Text(verbatim: "Crashes"))
+        .navigationTitle(en: "Crashes")
     }
 }

--- a/Sources/Scout/UI/Database/Provider/ErrorView.swift
+++ b/Sources/Scout/UI/Database/Provider/ErrorView.swift
@@ -19,7 +19,7 @@ struct ErrorView: View {
                 .font(.system(size: 48))
                 .foregroundColor(.yellow)
 
-            Text("An error occurred")
+            Text(verbatim: "An error occurred")
                 .font(.title2)
                 .bold()
 
@@ -29,7 +29,7 @@ struct ErrorView: View {
 
             if let retry {
                 Button(action: retry) {
-                    Text("Retry")
+                    Text(verbatim: "Retry")
                         .bold()
                         .padding()
                         .frame(maxWidth: .infinity)
@@ -50,7 +50,7 @@ struct ErrorView: View {
 #Preview("ErrorView") {
     ErrorView(
         description: Text(
-            "This is a sample error message that is intentionally made very long to test how the ErrorView handles multiline text display. It should properly wrap and be readable without any issues."
+            verbatim: "This is a sample error message that is intentionally made very long to test how the ErrorView handles multiline text display. It should properly wrap and be readable without any issues."
         ),
         retry: {}
     )

--- a/Sources/Scout/UI/Database/Provider/ErrorView.swift
+++ b/Sources/Scout/UI/Database/Provider/ErrorView.swift
@@ -50,7 +50,9 @@ struct ErrorView: View {
 #Preview("ErrorView") {
     ErrorView(
         description: Text(
-            verbatim: "This is a sample error message that is intentionally made very long to test how the ErrorView handles multiline text display. It should properly wrap and be readable without any issues."
+            verbatim: "This is a sample error message that is intentionally made very long "
+                + "to test how the ErrorView handles multiline text display. "
+                + "It should properly wrap and be readable without any issues."
         ),
         retry: {}
     )

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -50,7 +50,7 @@ struct AnalyticsView: View {
         .onChange(of: filter.text) { _ in
             search.events?.removeAll()
         }
-        .navigationTitle(Text(verbatim: "Events"))
+        .navigationTitle(en: "Events")
         .onAppear {
             tint.value = nil
         }

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -24,7 +24,7 @@ struct AnalyticsView: View {
                 eventList
             }
         }
-        .searchable(text: $filter.text, placement: .navigationBarDrawer(displayMode: .always))
+        .searchable(text: $filter.text, placement: .navigationBarDrawer(displayMode: .always), prompt: Text(verbatim: "Search"))
         .autocorrectionDisabled(true)  // stop keyboard suggestions
         .keyboardType(.alphabet)  // stop keyboard suggestions
         .searchSuggestions {
@@ -50,7 +50,7 @@ struct AnalyticsView: View {
         .onChange(of: filter.text) { _ in
             search.events?.removeAll()
         }
-        .navigationTitle("Events")
+        .navigationTitle(Text(verbatim: "Events"))
         .onAppear {
             tint.value = nil
         }

--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -86,7 +86,7 @@ extension EventView {
                         extent: ChartExtent(period: period),
                         stat: stat
                     )
-                    .navigationTitle(Text(verbatim: "Stats"))
+                    .navigationTitle(en: "Stats")
                 }
             }
         }

--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -86,7 +86,7 @@ extension EventView {
                         extent: ChartExtent(period: period),
                         stat: stat
                     )
-                    .navigationTitle("Stats")
+                    .navigationTitle(Text(verbatim: "Stats"))
                 }
             }
         }

--- a/Sources/Scout/UI/Event/EventView.swift
+++ b/Sources/Scout/UI/Event/EventView.swift
@@ -60,7 +60,7 @@ extension EventView {
 
                 if let level = event.level {
                     Group {
-                        Text("LEVEL:   ") + level.descriptionText
+                        Text(verbatim: "LEVEL:   ") + level.descriptionText
                     }
                     .fontWeight(.bold)
                 }

--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -37,15 +37,19 @@ struct FilterView: View {
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Reset") {
+                    Button {
                         criteria.reset()
+                    } label: {
+                        Text(verbatim: "Reset")
                     }
                     .disabled(!criteria.isResetEnabled)
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("Apply") {
+                    Button {
                         criteria.apply()
                         dismiss()
+                    } label: {
+                        Text(verbatim: "Apply")
                     }
                     .disabled(!criteria.isApplyEnabled)
                     .fontWeight(.semibold)
@@ -54,7 +58,7 @@ struct FilterView: View {
             .padding(.top)
             .listStyle(.plain)
             .scrollDisabled(true)
-            .navigationTitle("Filter")
+            .navigationTitle(Text(verbatim: "Filter"))
             .navigationBarTitleDisplayMode(.inline)
         }
     }
@@ -66,8 +70,10 @@ struct FilterButton: View {
     @State private var isFilterPresented = false
 
     var body: some View {
-        Button("Filter") {
+        Button {
             isFilterPresented = true
+        } label: {
+            Text(verbatim: "Filter")
         }
         .sheet(isPresented: $isFilterPresented) {
             FilterView(selected: $levels).presentationDetents([.height(392)])

--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -58,7 +58,7 @@ struct FilterView: View {
             .padding(.top)
             .listStyle(.plain)
             .scrollDisabled(true)
-            .navigationTitle(Text(verbatim: "Filter"))
+            .navigationTitle(en: "Filter")
             .navigationBarTitleDisplayMode(.inline)
         }
     }

--- a/Sources/Scout/UI/Event/History/HistoryView.swift
+++ b/Sources/Scout/UI/Event/History/HistoryView.swift
@@ -62,7 +62,7 @@ struct HistoryView: View {
                 await fetch()
             }
         }
-        .navigationTitle("History")
+        .navigationTitle(Text(verbatim: "History"))
     }
 
     func fetch() async {

--- a/Sources/Scout/UI/Event/History/HistoryView.swift
+++ b/Sources/Scout/UI/Event/History/HistoryView.swift
@@ -62,7 +62,7 @@ struct HistoryView: View {
                 await fetch()
             }
         }
-        .navigationTitle(Text(verbatim: "History"))
+        .navigationTitle(en: "History")
     }
 
     func fetch() async {

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -20,7 +20,7 @@ struct ParamList: View {
             }
         }
         .listStyle(.plain)
-        .navigationTitle("Params")
+        .navigationTitle(Text(verbatim: "Params"))
         .onAppear {
             tint.value = nil
         }

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -20,7 +20,7 @@ struct ParamList: View {
             }
         }
         .listStyle(.plain)
-        .navigationTitle(Text(verbatim: "Params"))
+        .navigationTitle(en: "Params")
         .onAppear {
             tint.value = nil
         }

--- a/Sources/Scout/UI/Home/Dismissable.swift
+++ b/Sources/Scout/UI/Home/Dismissable.swift
@@ -19,8 +19,10 @@ private struct DismissableModifier: ViewModifier {
     func body(content: Content) -> some View {
         content.toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button("Close") {
+                Button {
                     dismiss()
+                } label: {
+                    Text(verbatim: "Close")
                 }
             }
         }

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -37,7 +37,7 @@ struct HomeContent: View {
                     Text(verbatim: "Metrics")
                     Spacer()
                 } destination: {
-                    MetricsList().navigationTitle(Text(verbatim: "Metrics"))
+                    MetricsList().navigationTitle(en: "Metrics")
                 }
             }
             .foregroundStyle(.blue)
@@ -60,7 +60,7 @@ struct HomeContent: View {
                         stat: crashStat
                     )
                     .environment(\.chartColor, .red)
-                    .navigationTitle(Text(verbatim: "Crashes"))
+                    .navigationTitle(en: "Crashes")
                 }
             }
 
@@ -108,7 +108,7 @@ struct HomeContent: View {
                         stat: sessionStat
                     )
                     .environment(\.chartColor, .purple)
-                    .navigationTitle(Text(verbatim: "Sessions"))
+                    .navigationTitle(en: "Sessions")
                 }
             }
         } header: {

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -28,16 +28,16 @@ struct HomeContent: View {
         Section {
             Group {
                 Row {
-                    Text("Events")
+                    Text(verbatim: "Events")
                     Spacer()
                 } destination: {
                     AnalyticsView()
                 }
                 Row {
-                    Text("Metrics")
+                    Text(verbatim: "Metrics")
                     Spacer()
                 } destination: {
-                    MetricsList().navigationTitle("Metrics")
+                    MetricsList().navigationTitle(Text(verbatim: "Metrics"))
                 }
             }
             .foregroundStyle(.blue)
@@ -60,12 +60,12 @@ struct HomeContent: View {
                         stat: crashStat
                     )
                     .environment(\.chartColor, .red)
-                    .navigationTitle("Crashes")
+                    .navigationTitle(Text(verbatim: "Crashes"))
                 }
             }
 
             Row {
-                Text("All")
+                Text(verbatim: "All")
                 Spacer()
             } destination: {
                 CrashListView()
@@ -108,7 +108,7 @@ struct HomeContent: View {
                         stat: sessionStat
                     )
                     .environment(\.chartColor, .purple)
-                    .navigationTitle("Sessions")
+                    .navigationTitle(Text(verbatim: "Sessions"))
                 }
             }
         } header: {

--- a/Sources/Scout/UI/Home/ICloudWarning.swift
+++ b/Sources/Scout/UI/Home/ICloudWarning.swift
@@ -35,7 +35,7 @@ private struct ICloudWarningModifier: ViewModifier {
                 }
             }
             .alert(Text(verbatim: "iCloud Unavailable"), isPresented: $isAlertPresented) {
-                Button(role: .cancel) {} label: {
+                Button(role: .cancel, action: {}) {
                     Text(verbatim: "OK")
                 }
             } message: {

--- a/Sources/Scout/UI/Home/ICloudWarning.swift
+++ b/Sources/Scout/UI/Home/ICloudWarning.swift
@@ -34,10 +34,12 @@ private struct ICloudWarningModifier: ViewModifier {
                     }
                 }
             }
-            .alert("iCloud Unavailable", isPresented: $isAlertPresented) {
-                Button("OK", role: .cancel) {}
+            .alert(Text(verbatim: "iCloud Unavailable"), isPresented: $isAlertPresented) {
+                Button(role: .cancel) {} label: {
+                    Text(verbatim: "OK")
+                }
             } message: {
-                Text("Sign in to iCloud to sync data.")
+                Text(verbatim: "Sign in to iCloud to sync data.")
             }
             .task {
                 await verify()

--- a/Sources/Scout/UI/Home/Onboarding/ReadyPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/ReadyPage.swift
@@ -20,11 +20,11 @@ struct ReadyPage: View {
                 .font(.system(size: 64))
                 .foregroundStyle(.green)
 
-            Text("You're all set")
+            Text(verbatim: "You're all set")
                 .font(.title)
                 .bold()
 
-            Text("Run your app and come back here to see your data.")
+            Text(verbatim: "Run your app and come back here to see your data.")
                 .font(.body)
                 .kerning(0.3)
                 .foregroundStyle(.secondary)
@@ -34,7 +34,7 @@ struct ReadyPage: View {
             Button {
                 dismiss()
             } label: {
-                Text("Get Started")
+                Text(verbatim: "Get Started")
                     .bold()
                     .frame(maxWidth: .infinity)
                     .padding()

--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -14,7 +14,7 @@ struct SetupPage: View {
             Spacer()
             Spacer()
 
-            Text("Quick Setup")
+            Text(verbatim: "Quick Setup")
                 .font(.title)
                 .bold()
 

--- a/Sources/Scout/UI/Home/Onboarding/WelcomePage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/WelcomePage.swift
@@ -14,7 +14,7 @@ struct WelcomePage: View {
             Spacer()
             Spacer()
 
-            Text("Welcome to Scout")
+            Text(verbatim: "Welcome to Scout")
                 .font(.title)
                 .bold()
 

--- a/Sources/Scout/UI/Home/SchemaWarning.swift
+++ b/Sources/Scout/UI/Home/SchemaWarning.swift
@@ -35,7 +35,7 @@ private struct SchemaWarningModifier: ViewModifier {
                 }
             }
             .alert(Text(verbatim: "Schema Outdated"), isPresented: $isAlertPresented) {
-                Button(role: .cancel) {} label: {
+                Button(role: .cancel, action: {}) {
                     Text(verbatim: "OK")
                 }
             } message: {

--- a/Sources/Scout/UI/Home/SchemaWarning.swift
+++ b/Sources/Scout/UI/Home/SchemaWarning.swift
@@ -34,8 +34,10 @@ private struct SchemaWarningModifier: ViewModifier {
                     }
                 }
             }
-            .alert("Schema Outdated", isPresented: $isAlertPresented) {
-                Button("OK", role: .cancel) {}
+            .alert(Text(verbatim: "Schema Outdated"), isPresented: $isAlertPresented) {
+                Button(role: .cancel) {} label: {
+                    Text(verbatim: "OK")
+                }
             } message: {
                 if let schemaError {
                     Text(schemaError.errorDescription ?? "")

--- a/Sources/Scout/UI/Message/MessageView.Presenter.swift
+++ b/Sources/Scout/UI/Message/MessageView.Presenter.swift
@@ -79,7 +79,7 @@ extension MessageView {
             }
             .disabled(message == nil)
         }
-        .navigationTitle(Text(verbatim: "Message Presenter"))
+        .navigationTitle(en: "Message Presenter")
         .navigationBarTitleDisplayMode(.inline)
     }
     .message($message)

--- a/Sources/Scout/UI/Message/MessageView.Presenter.swift
+++ b/Sources/Scout/UI/Message/MessageView.Presenter.swift
@@ -54,26 +54,32 @@ extension MessageView {
 
     NavigationStack {
         VStack(spacing: 32) {
-            Button("Show Info") {
+            Button {
                 message = Message(
                     Message.Level.info.text,
                     level: .info
                 )
+            } label: {
+                Text(verbatim: "Show Info")
             }
 
-            Button("Show Multiline Warning") {
+            Button {
                 message = Message(
                     Message.Level.warning.longText,
                     level: .warning
                 )
+            } label: {
+                Text(verbatim: "Show Multiline Warning")
             }
 
-            Button("Hide") {
+            Button {
                 message = nil
+            } label: {
+                Text(verbatim: "Hide")
             }
             .disabled(message == nil)
         }
-        .navigationTitle("Message Presenter")
+        .navigationTitle(Text(verbatim: "Message Presenter"))
         .navigationBarTitleDisplayMode(.inline)
     }
     .message($message)

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -76,6 +76,6 @@ struct MetricsContent<T: ChartNumeric>: View {
             description: "Metrics will appear here once your app records data",
             code: "Counter(label: \"api_calls\").increment()"
         )
-        .navigationTitle("Metrics")
+        .navigationTitle(Text(verbatim: "Metrics"))
     }
 }

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -76,6 +76,6 @@ struct MetricsContent<T: ChartNumeric>: View {
             description: "Metrics will appear here once your app records data",
             code: "Counter(label: \"api_calls\").increment()"
         )
-        .navigationTitle(Text(verbatim: "Metrics"))
+        .navigationTitle(en: "Metrics")
     }
 }

--- a/Sources/Scout/UI/Metrics/MetricsList.swift
+++ b/Sources/Scout/UI/Metrics/MetricsList.swift
@@ -67,6 +67,6 @@ struct MetricsList: View {
 #Preview("Metrics List") {
     NavigationStack {
         MetricsList()
-            .navigationTitle(Text(verbatim: "Metrics"))
+            .navigationTitle(en: "Metrics")
     }
 }

--- a/Sources/Scout/UI/Metrics/MetricsList.swift
+++ b/Sources/Scout/UI/Metrics/MetricsList.swift
@@ -20,19 +20,23 @@ struct MetricsList: View {
     @State private var scope: Scope = .int
 
     var body: some View {
-        Picker("Period", selection: $period) {
+        Picker(selection: $period) {
             ForEach(Period.allCases) { period in
                 Text(period.shortTitle.uppercased())
             }
+        } label: {
+            Text(verbatim: "Period")
         }
         .padding(.horizontal)
         .padding(.bottom)
         .pickerStyle(.segmented)
 
-        Picker("Scope", selection: $scope) {
+        Picker(selection: $scope) {
             ForEach(Scope.allCases) { scope in
                 Text(scope.rawValue.uppercased())
             }
+        } label: {
+            Text(verbatim: "Scope")
         }
         .padding(.horizontal)
         .pickerStyle(.segmented)
@@ -63,6 +67,6 @@ struct MetricsList: View {
 #Preview("Metrics List") {
     NavigationStack {
         MetricsList()
-            .navigationTitle("Metrics")
+            .navigationTitle(Text(verbatim: "Metrics"))
     }
 }

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -21,10 +21,12 @@ struct MetricsView<T: ChartNumeric>: View {
     }
 
     var body: some View {
-        Picker("Period", selection: $extent.period) {
+        Picker(selection: $extent.period) {
             ForEach(Period.allCases) { period in
                 Text(period.shortTitle.uppercased())
             }
+        } label: {
+            Text(verbatim: "Period")
         }
         .padding(.horizontal)
         .pickerStyle(.segmented)

--- a/Sources/Scout/UI/Stats/StatRow.swift
+++ b/Sources/Scout/UI/Stats/StatRow.swift
@@ -44,7 +44,7 @@ struct StatRow<Destination: View>: View {
                 period: .today,
                 stat: StatProvider(eventName: "event_name", periods: Period.allCases)
             ) {
-                Text("Detail")
+                Text(verbatim: "Detail")
             }
         }
     }

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -47,7 +47,7 @@ struct StatView: View {
     func total(count: Int) -> some View {
         ZStack {
             HStack {
-                Text("Events")
+                Text(verbatim: "Events")
                 Spacer()
                 Text(count == 0 ? "—" : "\(count)")
             }
@@ -80,7 +80,7 @@ extension EnvironmentValues {
             extent: ChartExtent(period: .yesterday),
             stat: stat
         )
-        .navigationTitle("App Launch")
+        .navigationTitle(Text(verbatim: "App Launch"))
         .environmentObject(Tint())
     }
 }

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -80,7 +80,7 @@ extension EnvironmentValues {
             extent: ChartExtent(period: .yesterday),
             stat: stat
         )
-        .navigationTitle(Text(verbatim: "App Launch"))
+        .navigationTitle(en: "App Launch")
         .environmentObject(Tint())
     }
 }

--- a/Sources/Scout/UI/Utilities/Date+RelativeText.swift
+++ b/Sources/Scout/UI/Utilities/Date+RelativeText.swift
@@ -8,12 +8,16 @@
 import SwiftUI
 
 extension Date {
-    var relativeText: Text {
+    var relativeString: String {
         if timeIntervalSinceNow < -60 {
-            Text(relativeFormatter.localizedString(for: self, relativeTo: Date()))
+            relativeFormatter.localizedString(for: self, relativeTo: Date())
         } else {
-            Text(verbatim: "recently")
+            "recently"
         }
+    }
+
+    var relativeText: Text {
+        Text(verbatim: relativeString)
     }
 }
 

--- a/Sources/Scout/UI/Utilities/Date+RelativeText.swift
+++ b/Sources/Scout/UI/Utilities/Date+RelativeText.swift
@@ -12,7 +12,7 @@ extension Date {
         if timeIntervalSinceNow < -60 {
             Text(relativeFormatter.localizedString(for: self, relativeTo: Date()))
         } else {
-            Text("recently")
+            Text(verbatim: "recently")
         }
     }
 }

--- a/Sources/Scout/UI/Utilities/View+NavigationTitle.swift
+++ b/Sources/Scout/UI/Utilities/View+NavigationTitle.swift
@@ -1,0 +1,15 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    /// English-only navigation title; bypasses host-app `LocalizedStringKey` resolution.
+    func navigationTitle(en title: String) -> some View {
+        navigationTitle(Text(verbatim: title))
+    }
+}

--- a/Tests/ScoutTests/UI/RelativeStringTests.swift
+++ b/Tests/ScoutTests/UI/RelativeStringTests.swift
@@ -5,37 +5,33 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import SwiftUI
+import Foundation
 import Testing
 
 @testable import Scout
 
-struct RelativeTextTests {
+struct RelativeStringTests {
     @Test("Old date shows relative string")
     func oldDate() {
         let date = Date(timeIntervalSinceNow: -3600)
-        let text = date.relativeText
-        #expect(text != Text("recently"))
+        #expect(date.relativeString != "recently")
     }
 
     @Test("Recent date shows 'recently'")
     func recentDate() {
         let date = Date(timeIntervalSinceNow: -30)
-        let text = date.relativeText
-        #expect(text == Text("recently"))
+        #expect(date.relativeString == "recently")
     }
 
     @Test("Future date shows 'recently'")
     func futureDate() {
         let date = Date(timeIntervalSinceNow: 100)
-        let text = date.relativeText
-        #expect(text == Text("recently"))
+        #expect(date.relativeString == "recently")
     }
 
     @Test("Boundary at exactly 60 seconds")
     func boundary() {
         let date = Date(timeIntervalSinceNow: -59)
-        let text = date.relativeText
-        #expect(text == Text("recently"))
+        #expect(date.relativeString == "recently")
     }
 }


### PR DESCRIPTION
This pull request standardizes UI string handling across the Scout app to ensure all interface text is always rendered in source English, regardless of localization settings. The changes primarily update all user-facing string literals in SwiftUI views to use `Text(verbatim:)` or `.navigationTitle(en:)`, preventing them from being resolved through the host app’s localization system. Additionally, date formatting in charts is now explicitly set to use the US English locale.

The most important changes include:

**UI String Standardization:**

* Updated all `Text` literals in UI components to use `Text(verbatim: ...)` for English source rendering, ensuring strings are not passed through the host app's `LocalizedStringKey` catalog. This affects labels, buttons, alerts, and other text elements throughout the app. [[1]](diffhunk://#diff-c2624a65edf346ee93ebbde6e270b7c053952f439eab8094e0ac9ecc223003fdL33-R33) [[2]](diffhunk://#diff-c2624a65edf346ee93ebbde6e270b7c053952f439eab8094e0ac9ecc223003fdL47-R50) [[3]](diffhunk://#diff-8688e86a4724740f8e9862e985f9a6aa8d0c846dabfe256bdb686959c8b716b6L27-R27) [[4]](diffhunk://#diff-e5c12da89d0920e9e29ca9547804bb8ad5b4d0a2f627db61ffd8b055b859935fL39-R43) [[5]](diffhunk://#diff-50f080ed6533479aa1797890124972fc10c210c56557787a7ffc4141335d81d3L44-R44) [[6]](diffhunk://#diff-78dec34bdc8b01a2c3e42dce07832816c3485f16fede9c55f939fe6ddfafb434L22-R22) [[7]](diffhunk://#diff-78dec34bdc8b01a2c3e42dce07832816c3485f16fede9c55f939fe6ddfafb434L32-R32) [[8]](diffhunk://#diff-78dec34bdc8b01a2c3e42dce07832816c3485f16fede9c55f939fe6ddfafb434L53-R53) [[9]](diffhunk://#diff-764fccc4e8ebf4ac01b5ea8ae35d5f826a3f4b69ea390584d5d20c1c0ddfa35dL27-R27) [[10]](diffhunk://#diff-8e62290335d0ed3db10ed3cbf6de74d2e32ef199d767ade6b1859f127c1d56bbL63-R63) [[11]](diffhunk://#diff-c5617b20688adfd1abbcdc74b637e4bcc812629c2623590ae605d6baccff07f8L40-R52) [[12]](diffhunk://#diff-c5617b20688adfd1abbcdc74b637e4bcc812629c2623590ae605d6baccff07f8L69-R76) [[13]](diffhunk://#diff-74ee625b173fb2d0992a9024b6fba61213ea7e01ec6966bc6e1511e614f2d822L22-R25) [[14]](diffhunk://#diff-7def4a81f7b7e6d75942a689a04427bdbc370892b7968f25572d2de9e00a70b2L31-R40) [[15]](diffhunk://#diff-7def4a81f7b7e6d75942a689a04427bdbc370892b7968f25572d2de9e00a70b2L63-R68) [[16]](diffhunk://#diff-7def4a81f7b7e6d75942a689a04427bdbc370892b7968f25572d2de9e00a70b2L111-R111) [[17]](diffhunk://#diff-5747209de1322531f9595612555168b200eeb7fceefd07465b0f534358bc2c53L37-R42) [[18]](diffhunk://#diff-d45a5dfdb244ededeab3ef5c258ebe300c5bb2b57d464d132a2397e950773537L23-R27) [[19]](diffhunk://#diff-d45a5dfdb244ededeab3ef5c258ebe300c5bb2b57d464d132a2397e950773537L37-R37) [[20]](diffhunk://#diff-cf79553a04315b144e74cc49cf6177133df031f78db029fad384287b83eeb8faL17-R17)

* Changed all navigation titles to use `.navigationTitle(en: ...)` to enforce English titles in navigation bars. [[1]](diffhunk://#diff-7608e61d448839ecdd15d39edaae705de9a3e569729667a8720895eab73eb73bL38-R38) [[2]](diffhunk://#diff-3088ff97a44b6f0589dfc71867310cb1452ca1d5a7727003bb516e1f8b1d00a1L41-R41) [[3]](diffhunk://#diff-3088ff97a44b6f0589dfc71867310cb1452ca1d5a7727003bb516e1f8b1d00a1L92-R92) [[4]](diffhunk://#diff-764fccc4e8ebf4ac01b5ea8ae35d5f826a3f4b69ea390584d5d20c1c0ddfa35dL53-R53) [[5]](diffhunk://#diff-eabaa968472a7cf4c7fc592517dcdb1fe30808e48cddef10f2a9607373082c0cL89-R89) [[6]](diffhunk://#diff-c5617b20688adfd1abbcdc74b637e4bcc812629c2623590ae605d6baccff07f8L57-R61) [[7]](diffhunk://#diff-0c4d1a3a7529e5cabe704b255eb2f9a391b727887597c8687d07d278acfc92d1L65-R65) [[8]](diffhunk://#diff-dd1857ee6b4a70d73629b473d2d19d26d9269ac1b369ed5a6b0b198d554eeba1L23-R23) [[9]](diffhunk://#diff-7def4a81f7b7e6d75942a689a04427bdbc370892b7968f25572d2de9e00a70b2L31-R40) [[10]](diffhunk://#diff-7def4a81f7b7e6d75942a689a04427bdbc370892b7968f25572d2de9e00a70b2L63-R68) [[11]](diffhunk://#diff-7def4a81f7b7e6d75942a689a04427bdbc370892b7968f25572d2de9e00a70b2L111-R111)

**Chart and Date Formatting:**

* Set the chart date formatting locale explicitly to US English (`en_US`) to ensure consistent date presentation in charts.

**Documentation:**

* Added a note to the `CLAUDE.md` documentation specifying the requirement to render Scout UI strings in source English using `Text(verbatim: ...)` or `.navigationTitle(en: ...)`.