### PR TITLE
Require swift-format lint after Swift edits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,5 @@ When pushing new commits to an existing PR, update its title and description to 
 Multi-line doc comments (`///`) must end with a trailing empty `///` line. Single-line doc comments do not need this.
 
 Never remove or rename fields, record types, or index modifiers (`QUERYABLE`/`SEARCHABLE`/`SORTABLE`) in the CloudKit `Schema` file — Production schemas are append-only and `cktool import-schema` will reject removals with `cannot remove field … which exists in active production type …`. To deprecate a field, stop writing it in code but keep its declaration in `Schema`.
+
+After modifying any Swift source, run `xcrun swift-format lint --strict --recursive Sources Tests` and resolve every reported violation before committing.


### PR DESCRIPTION
Adds a CLAUDE.md instruction to run `xcrun swift-format lint --strict --recursive Sources Tests` after modifying any Swift source, and resolve every violation before committing — so we don't push lint-broken commits like the ones that surfaced on PR #467.