### PR TITLE
Inline Text(verbatim:) wrapper at relativeString call sites

### DIFF
--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -55,7 +55,7 @@ struct CrashListView: View {
                 Spacer()
 
                 if let date = crash.date {
-                    date.relativeText
+                    Text(verbatim: date.relativeString)
                         .font(.system(size: 15))
                         .foregroundStyle(Color.gray)
                 }

--- a/Sources/Scout/UI/Event/EventList.swift
+++ b/Sources/Scout/UI/Event/EventList.swift
@@ -53,7 +53,7 @@ struct EventList: View {
 
                 if let date = event.date {
                     TimelineView(.periodic(from: timeline, by: 1)) { _ in
-                        date.relativeText
+                        Text(verbatim: date.relativeString)
                     }
                     .font(.system(size: 15))
                     .foregroundStyle(Color.gray)

--- a/Sources/Scout/UI/Utilities/Date+RelativeString.swift
+++ b/Sources/Scout/UI/Utilities/Date+RelativeString.swift
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import SwiftUI
+import Foundation
 
 extension Date {
     var relativeString: String {
@@ -14,10 +14,6 @@ extension Date {
         } else {
             "recently"
         }
-    }
-
-    var relativeText: Text {
-        Text(verbatim: relativeString)
     }
 }
 


### PR DESCRIPTION
Drops the `Date.relativeText: Text` helper and inlines `Text(verbatim: date.relativeString)` at the two call sites (`CrashListView`, `EventList`). Source file renamed `Date+RelativeText.swift` → `Date+RelativeString.swift` and switched `import SwiftUI` → `import Foundation`.