### PR TITLE
Guard cutoff date in SyncableObject cleanup

### DIFF
--- a/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
@@ -14,11 +14,13 @@ extension SyncableObject {
     /// exceeded the sync attempt limit.
     ///
     static func cleanup(in context: NSManagedObjectContext) throws {
-        let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: Date())! as NSDate
+        guard let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: Date()) else {
+            return
+        }
 
         let request = NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
         request.predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
-            NSPredicate(format: "isSynced == true AND datePrimitive < %@", cutoff),
+            NSPredicate(format: "isSynced == true AND datePrimitive < %@", cutoff as NSDate),
             NSPredicate(format: "isSynced == false AND syncAttempts > %d", maxSyncAttempts),
         ])
 


### PR DESCRIPTION
- Replace `Calendar.current.date(byAdding:value:to:)!` with a `guard let` so cleanup skips a pass instead of trapping if the calendar ever fails to compute the cutoff.
- Practical crash risk is ~zero for `Date() - 7 days`, but the force-unwrap was the only one left on the sync path; cleaner to remove the trap than to rely on the invariant.