### PR TITLE
Drop swift-format lint instruction from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,4 @@ Multi-line doc comments (`///`) must end with a trailing empty `///` line. Singl
 
 Never remove or rename fields, record types, or index modifiers (`QUERYABLE`/`SEARCHABLE`/`SORTABLE`) in the CloudKit `Schema` file — Production schemas are append-only and `cktool import-schema` will reject removals with `cannot remove field … which exists in active production type …`. To deprecate a field, stop writing it in code but keep its declaration in `Schema`.
 
-After modifying any Swift source, run `xcrun swift-format lint --strict --recursive Sources Tests` and resolve every reported violation before committing.
-
 Scout UI strings must always render in source English: use `Text(verbatim: …)` for literals (or `.navigationTitle(en: …)` for titles) so they don't resolve through the host app's `LocalizedStringKey` catalog.


### PR DESCRIPTION
- Removes the rule requiring `xcrun swift-format lint --strict --recursive Sources Tests` after every Swift source change.