### PR TITLE
Expand swift-format rule set

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -7,11 +7,19 @@
   "rules": {
     "AlwaysUseLiteralForEmptyCollectionInit": true,
     "BeginDocumentationCommentWithOneLineSummary": true,
+    "GroupNumericLiterals": true,
     "NeverUseImplicitlyUnwrappedOptionals": true,
+    "NoAccessLevelOnExtensionDeclaration": true,
+    "NoBlockComments": true,
     "NoEmptyLinesOpeningClosingBraces": true,
     "NoLeadingUnderscores": true,
     "OmitExplicitReturns": true,
+    "OneCasePerLine": true,
+    "OrderedImports": true,
+    "ReturnVoidInsteadOfEmptyTuple": true,
     "UseEarlyExits": true,
+    "UseShorthandTypeNames": true,
+    "UseSynthesizedInitializer": true,
     "UseWhereClausesInForLoops": true,
     "ValidateDocumentationComments": true
   }


### PR DESCRIPTION
- Enable 8 additional swift-format rules: OrderedImports, UseShorthandTypeNames, UseSynthesizedInitializer, ReturnVoidInsteadOfEmptyTuple, NoAccessLevelOnExtensionDeclaration, GroupNumericLiterals, OneCasePerLine, NoBlockComments.
- Existing code already passes the expanded rule set (`xcrun swift-format lint --strict --recursive Sources Tests` exits 0).