### PR TITLE
Log sync job failures instead of silently swallowing them

### DIFF
--- a/Sources/Scout/Core/Sync/SyncController.swift
+++ b/Sources/Scout/Core/Sync/SyncController.swift
@@ -6,6 +6,9 @@
 // https://opensource.org/licenses/MIT.
 
 import CloudKit
+import os
+
+private let logger = Logger(subsystem: "Scout", category: "Sync")
 
 typealias SyncAction = @MainActor () async throws -> Void
 
@@ -36,6 +39,7 @@ typealias SyncAction = @MainActor () async throws -> Void
                 } catch let error where Task.isCancelled {
                     throw error
                 } catch {
+                    logger.error("Sync job failed: \(error.localizedDescription, privacy: .public)")
                     continue
                 }
             }


### PR DESCRIPTION
- The per-job ` catch { continue }` in `SyncController.synchronize` skipped every non-cancellation error without a trace, hiding sync regressions in a logging library.
- Emit failures via `os.Logger` so they surface in Console while still letting the loop continue. Use `os.Logger` rather than swift-log to avoid feeding the failure back through `CKLogHandler` and Core Data.