### PR TITLE
Mark Scout as set up only after setup() succeeds

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -28,7 +28,6 @@ public func setup(container: CKContainer) async throws {
     guard !isSetup else {
         throw SetupError()
     }
-    isSetup = true
 
     installExceptionHandler()
     installSignalHandler()
@@ -57,4 +56,6 @@ public func setup(container: CKContainer) async throws {
         CKLogHandler(sync: sync, label: label)
     }
     MetricsSystem.bootstrap(TelemetryFactory(sync: sync))
+
+    isSetup = true
 }


### PR DESCRIPTION
- `isSetup` was set to `true` at the start of `setup()`, so a throw from `CrashArchive.flush()` or `persistentContainer.performBackgroundTasks(...)` left the flag latched while `LoggingSystem`, `MetricsSystem`, and the sync controller were never bootstrapped.
- A subsequent retry would then fail with `SetupError("Scout is already setup")` even though Scout was effectively uninitialized. Move the assignment to the end so callers can retry after a transient failure while a fully successful setup still rejects duplicate calls.