### PR TITLE
Introduce SetupOptions for opt-in features and tuning

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -17,7 +17,7 @@ struct SetupError: LocalizedError {
 
 @MainActor private var isSetup = false
 
-/// Initializes Scout's global infrastructure.
+/// Initializes Scout's global infrastructure with the default options.
 ///
 /// - Parameter container: The CloudKit container for all operations.
 /// - Throws: An error if initialization fails or if called more than once.
@@ -25,15 +25,32 @@ struct SetupError: LocalizedError {
 ///
 @MainActor
 public func setup(container: CKContainer) async throws {
+    try await setup(container: container, options: SetupOptions())
+}
+
+/// Initializes Scout's global infrastructure with custom options.
+///
+/// - Parameters:
+///   - container: The CloudKit container for all operations.
+///   - options: Feature gates and tuning values; defaults preserve the
+///     behavior of ``setup(container:)``.
+/// - Throws: An error if initialization fails or if called more than once.
+/// - Important: Call from the main actor during app startup.
+///
+@MainActor
+public func setup(container: CKContainer, options: SetupOptions) async throws {
     guard !isSetup else {
         throw SetupError()
     }
-    isSetup = true
 
-    installExceptionHandler()
-    installSignalHandler()
+    activeSetupOptions = options
 
-    await CrashArchive.system.flush()
+    if case .enabled = options.crashReporting {
+        installExceptionHandler()
+        installSignalHandler()
+        await CrashArchive.system.flush()
+    }
+
     try await persistentContainer.performBackgroundTasks(
         SessionObject.completeStale,
         LaunchObject.completeStale,
@@ -53,8 +70,14 @@ public func setup(container: CKContainer) async throws {
         UserActivityObject.trigger
     )
 
-    LoggingSystem.bootstrap { label in
-        CKLogHandler(sync: sync, label: label)
+    if case .enabled = options.logging {
+        LoggingSystem.bootstrap { label in
+            CKLogHandler(sync: sync, label: label)
+        }
     }
-    MetricsSystem.bootstrap(TelemetryFactory(sync: sync))
+    if case .enabled = options.metrics {
+        MetricsSystem.bootstrap(TelemetryFactory(sync: sync))
+    }
+
+    isSetup = true
 }

--- a/Sources/Scout/Core/Bootstrap/SetupOptions.swift
+++ b/Sources/Scout/Core/Bootstrap/SetupOptions.swift
@@ -1,0 +1,100 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+/// Configuration passed to ``setup(container:options:)``.
+///
+/// Defaults preserve the behavior of the parameter-less ``setup(container:)``
+/// overload. Tune individual fields to opt out of features or adjust limits.
+///
+public struct SetupOptions: Sendable {
+    public var crashReporting: CrashReporting
+    public var metrics: Metrics
+    public var logging: Logging
+    public var sync: SyncOptions
+    public var retention: RetentionPolicy
+
+    public init(
+        crashReporting: CrashReporting = .enabled,
+        metrics: Metrics = .enabled,
+        logging: Logging = .enabled,
+        sync: SyncOptions = SyncOptions(),
+        retention: RetentionPolicy = RetentionPolicy()
+    ) {
+        self.crashReporting = crashReporting
+        self.metrics = metrics
+        self.logging = logging
+        self.sync = sync
+        self.retention = retention
+    }
+}
+
+extension SetupOptions {
+    public enum CrashReporting: Sendable, Equatable {
+        case enabled
+        case disabled
+    }
+
+    public enum Metrics: Sendable, Equatable {
+        case enabled
+        case disabled
+    }
+
+    public enum Logging: Sendable, Equatable {
+        case enabled
+        case disabled
+    }
+}
+
+/// CloudKit sync tuning.
+///
+public struct SyncOptions: Sendable {
+    /// Minimum remaining background time required before a CloudKit operation runs.
+    public var backgroundTimeThreshold: TimeInterval
+
+    /// Per-request and per-resource timeout for CloudKit operations.
+    public var requestTimeout: TimeInterval
+
+    /// Maximum number of retries when CloudKit reports `serverRecordChanged`.
+    public var maxConflictRetries: Int
+
+    public init(
+        backgroundTimeThreshold: TimeInterval = 15,
+        requestTimeout: TimeInterval = 10,
+        maxConflictRetries: Int = 3
+    ) {
+        self.backgroundTimeThreshold = backgroundTimeThreshold
+        self.requestTimeout = requestTimeout
+        self.maxConflictRetries = maxConflictRetries
+    }
+}
+
+/// Retention policy for locally persisted records awaiting sync.
+///
+public struct RetentionPolicy: Sendable {
+    /// How long synced records are kept locally before cleanup deletes them.
+    public var syncedRecordLifetime: TimeInterval
+
+    /// How many failed sync attempts a record may accumulate before cleanup retires it.
+    public var maxSyncAttempts: Int
+
+    public init(
+        syncedRecordLifetime: TimeInterval = 7 * 24 * 60 * 60,
+        maxSyncAttempts: Int = 10
+    ) {
+        self.syncedRecordLifetime = syncedRecordLifetime
+        self.maxSyncAttempts = maxSyncAttempts
+    }
+}
+
+/// Active configuration consulted by sync, retention and runner code paths.
+///
+/// Written once by ``setup(container:options:)`` before any sync work runs;
+/// readers from background contexts therefore observe a stable value.
+///
+nonisolated(unsafe) var activeSetupOptions = SetupOptions()

--- a/Sources/Scout/Core/Database/CKDatabase+Runner.swift
+++ b/Sources/Scout/Core/Database/CKDatabase+Runner.swift
@@ -10,13 +10,15 @@ import UIKit
 
 extension CKDatabase {
     @discardableResult func runner<R>(body: @Sendable (CKDatabase) async throws -> R) async throws -> R {
-        guard await UIApplication.shared.backgroundTimeRemaining > 15 else {
+        let sync = activeSetupOptions.sync
+
+        guard await UIApplication.shared.backgroundTimeRemaining > sync.backgroundTimeThreshold else {
             throw RunnerError()
         }
 
         let configuration = CKOperation.Configuration()
-        configuration.timeoutIntervalForRequest = 10
-        configuration.timeoutIntervalForResource = 10
+        configuration.timeoutIntervalForRequest = sync.requestTimeout
+        configuration.timeoutIntervalForResource = sync.requestTimeout
 
         return try await configuredWith(configuration: configuration, body: body)
     }

--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -31,7 +31,7 @@ struct SyncEngine: @unchecked Sendable {
 
             try await SyncCoordinator(
                 database: database,
-                maxRetry: 3,
+                maxRetry: activeSetupOptions.sync.maxConflictRetries,
                 batch: batch
             )
             .upload()

--- a/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
@@ -7,21 +7,18 @@
 
 import CoreData
 
-private let maxSyncAttempts = 10
-
 extension SyncableObject {
-    /// Deletes synced objects older than 7 days and objects that
-    /// exceeded the sync attempt limit.
+    /// Deletes synced objects older than ``RetentionPolicy/syncedRecordLifetime``
+    /// and objects that exceeded ``RetentionPolicy/maxSyncAttempts``.
     ///
     static func cleanup(in context: NSManagedObjectContext) throws {
-        guard let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: Date()) else {
-            return
-        }
+        let retention = activeSetupOptions.retention
+        let cutoff = Date().addingTimeInterval(-retention.syncedRecordLifetime)
 
         let request = NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
         request.predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
             NSPredicate(format: "isSynced == true AND datePrimitive < %@", cutoff as NSDate),
-            NSPredicate(format: "isSynced == false AND syncAttempts > %d", maxSyncAttempts),
+            NSPredicate(format: "isSynced == false AND syncAttempts > %d", retention.maxSyncAttempts),
         ])
 
         for object in try context.fetch(request) {

--- a/Tests/ScoutTests/Core/Bootstrap/SetupOptionsTests.swift
+++ b/Tests/ScoutTests/Core/Bootstrap/SetupOptionsTests.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Testing
+
+@testable import Scout
+
+@Suite("SetupOptions defaults")
+struct SetupOptionsTests {
+    @Test("Defaults match the legacy hard-coded values")
+    func defaultsMatchLegacy() {
+        let options = SetupOptions()
+
+        #expect(options.crashReporting == .enabled)
+        #expect(options.metrics == .enabled)
+        #expect(options.logging == .enabled)
+
+        #expect(options.sync.backgroundTimeThreshold == 15)
+        #expect(options.sync.requestTimeout == 10)
+        #expect(options.sync.maxConflictRetries == 3)
+
+        #expect(options.retention.syncedRecordLifetime == 7 * 24 * 60 * 60)
+        #expect(options.retention.maxSyncAttempts == 10)
+    }
+}


### PR DESCRIPTION
Draft for design review of the public configuration API. Defaults preserve the behavior of the existing parameter-less `setup(container:)`, which now forwards to `setup(container:options:)` with default options.

- Public `SetupOptions` with nested `SyncOptions` and `RetentionPolicy` (Variant B from the discussion). Nested groups give discoverable namespaces and room to grow without breaking ABI.
- Per-feature gates: `crashReporting`, `metrics`, `logging` toggles. Crash reporting now skips both signal/exception handler installation and the `CrashArchive.flush` migration when disabled.
- Tuning values previously hard-coded:
  - `SyncOptions.backgroundTimeThreshold` (was 15)
  - `SyncOptions.requestTimeout` (was 10)
  - `SyncOptions.maxConflictRetries` (was 3, in `SyncEngine.send`)
  - `RetentionPolicy.syncedRecordLifetime` (was 7 days)
  - `RetentionPolicy.maxSyncAttempts` (was 10)
- Active configuration lives in a single `nonisolated(unsafe)` global, written once during `setup(...)` before any sync work runs. Matches the existing `persistentContainer` global pattern.
- Also defers `isSetup = true` to the end of `setup(...)` so a transient failure during bootstrap leaves the flag clear and the caller can retry. Overlaps with #475; rebase will need a small touch on that file.

Open questions:
- Naming: `RetentionPolicy.syncedRecordLifetime` vs `retainSyncedFor`. `SyncOptions` plain or `CloudKitSyncOptions` for symmetry with hypothetical future non-CK transports.
- Should `SetupOptions.loggingOnly` / `.crashOnly` static presets ship in the same PR?
- Should the parameter-less `setup(container:)` be deprecated in favor of the explicit overload?
