### PR TITLE
Revert "Log sync job failures instead of silently swallowing them"

### DIFF
--- a/Sources/Scout/Core/Sync/SyncController.swift
+++ b/Sources/Scout/Core/Sync/SyncController.swift
@@ -6,9 +6,6 @@
 // https://opensource.org/licenses/MIT.
 
 import CloudKit
-import os
-
-private let logger = Logger(subsystem: "Scout", category: "Sync")
 
 typealias SyncAction = @MainActor () async throws -> Void
 
@@ -39,7 +36,6 @@ typealias SyncAction = @MainActor () async throws -> Void
                 } catch let error where Task.isCancelled {
                     throw error
                 } catch {
-                    logger.error("Sync job failed: \(error.localizedDescription, privacy: .public)")
                     continue
                 }
             }


### PR DESCRIPTION
- Reverts commit b457cf3 which added os.Logger error logging in the sync job catch block
- Returns the catch block to its previous behavior of silently continuing past per-job errors