### PR TITLE
Inline SyncController into setup

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -38,8 +38,7 @@ public func setup(container: CKContainer) async throws {
         LaunchObject.completeStale,
     )
 
-    let syncController = SyncController(container: container)
-    let sync = syncController.synchronize
+    let sync = SyncController(container: container).synchronize
 
     ActionTable.appState.startListening(completion: sync)
 


### PR DESCRIPTION
- Remove intermediate `syncController` variable and construct `SyncController` inline when extracting the `synchronize` method reference