### PR TITLE
Fix chart hour labels using 24-hour format

### DIFF
--- a/Sources/Scout/UI/Chart/ChartFormat.swift
+++ b/Sources/Scout/UI/Chart/ChartFormat.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Calendar.Component {
     var chartFormat: Date.FormatStyle {
         var style = Date.FormatStyle()
-        style.locale = Locale(identifier: "en_US")
+        style.locale = Locale(identifier: "en_GB")
         style.timeZone = TimeZone(secondsFromGMT: 0)!
 
         return switch self {


### PR DESCRIPTION
- Switch chart format locale from `en_US` to `en_GB` so hour labels display in 24-hour format (00, 06, 12, 18) instead of ambiguous 12-hour values (12, 06, 12, 06)