### PR TITLE
Increase filter sheet height to fit all log levels

### DIFF
--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -76,7 +76,7 @@ struct FilterButton: View {
             Text(verbatim: "Filter")
         }
         .sheet(isPresented: $isFilterPresented) {
-            FilterView(selected: $levels).presentationDetents([.height(392)])
+            FilterView(selected: $levels).presentationDetents([.height(440)])
         }
         .tint(.blue)
     }


### PR DESCRIPTION
- Increase presentation detent height from 392 to 440 so all 7 log levels are visible without clipping