### PR TITLE
Add leading SF Symbol icons to Home rows

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityRow.swift
+++ b/Sources/Scout/UI/Activity/ActivityRow.swift
@@ -9,12 +9,18 @@ import SwiftUI
 
 struct ActivityRow: View {
     let period: ActivityPeriod
+    var systemImage: String? = nil
 
     @ObservedObject var activity: ActivityProvider
 
     var body: some View {
         Row {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .frame(width: 24)
+            }
             Text(period.title)
+                .foregroundColor(.primary)
             Spacer()
 
             let count = try? activity.result?.get()

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -26,21 +26,24 @@ struct HomeContent: View {
 
     private var logSection: some View {
         Section {
-            Group {
-                Row {
-                    Text(verbatim: "Events")
-                    Spacer()
-                } destination: {
-                    AnalyticsView()
-                }
-                Row {
-                    Text(verbatim: "Metrics")
-                    Spacer()
-                } destination: {
-                    MetricsList().navigationTitle(en: "Metrics")
-                }
+            Row {
+                Image(systemName: "list.bullet")
+                    .foregroundColor(.blue)
+                    .frame(width: 24)
+                Text(verbatim: "Events")
+                Spacer()
+            } destination: {
+                AnalyticsView()
             }
-            .foregroundStyle(.blue)
+            Row {
+                Image(systemName: "chart.bar")
+                    .foregroundColor(.blue)
+                    .frame(width: 24)
+                Text(verbatim: "Metrics")
+                Spacer()
+            } destination: {
+                MetricsList().navigationTitle(en: "Metrics")
+            }
         } header: {
             Header(title: "Log")
         }
@@ -52,6 +55,7 @@ struct HomeContent: View {
                 StatRow(
                     color: .red,
                     period: period,
+                    systemImage: "exclamationmark.triangle",
                     stat: crashStat
                 ) {
                     StatView(
@@ -65,12 +69,14 @@ struct HomeContent: View {
             }
 
             Row {
+                Image(systemName: "tray.full")
+                    .foregroundColor(.red)
+                    .frame(width: 24)
                 Text(verbatim: "All")
                 Spacer()
             } destination: {
                 CrashListView()
             }
-            .foregroundStyle(.red)
         } header: {
             Header(title: "Crashes").task {
                 await crashStat.fetchIfNeeded(in: database)
@@ -83,6 +89,7 @@ struct HomeContent: View {
             ForEach(ActivityPeriod.allCases) { period in
                 ActivityRow(
                     period: period,
+                    systemImage: "person.2",
                     activity: activity
                 )
             }
@@ -100,6 +107,7 @@ struct HomeContent: View {
                 StatRow(
                     color: .purple,
                     period: period,
+                    systemImage: "clock",
                     stat: sessionStat
                 ) {
                     StatView(
@@ -116,5 +124,11 @@ struct HomeContent: View {
                 await sessionStat.fetchIfNeeded(in: database)
             }
         }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HomeContent()
     }
 }

--- a/Sources/Scout/UI/Stats/StatRow.swift
+++ b/Sources/Scout/UI/Stats/StatRow.swift
@@ -10,24 +10,29 @@ import SwiftUI
 struct StatRow<Destination: View>: View {
     let color: Color
     let period: Period
+    var systemImage: String? = nil
 
     @ObservedObject var stat: StatProvider
     @ViewBuilder let destination: () -> Destination
 
     var body: some View {
         Row {
-            Group {
-                Text(period.title)
-                Spacer()
-
-                let count = try? stat.result?.get()
-                    .flatMap(\.points)
-                    .bucket(on: period)
-                    .total
-
-                RedactedText(count: count)
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .foregroundColor(color)
+                    .frame(width: 24)
             }
-            .foregroundColor(color)
+            Text(period.title)
+                .foregroundColor(systemImage == nil ? color : .primary)
+            Spacer()
+
+            let count = try? stat.result?.get()
+                .flatMap(\.points)
+                .bucket(on: period)
+                .total
+
+            RedactedText(count: count)
+                .foregroundColor(color)
         } destination: {
             destination()
         }


### PR DESCRIPTION
- Add an SF Symbol on the left of every row in HomeContent (Events/Metrics, Crashes incl. "All", Users, Sessions) for quicker scanning
- Tint only the icon and the trailing value with the section color; keep the row title `.primary` so it remains readable in dark mode
- Pin each icon to a 24pt-wide frame so titles align vertically across rows
- Extend `StatRow` and `ActivityRow` with an optional `systemImage` parameter (defaults to `nil`, so `EventView.Sections` is unchanged)