### PR TITLE
Unify code chip style and add Swift syntax highlighting

### DIFF
--- a/Sources/Scout/UI/Controls/Placeholder.swift
+++ b/Sources/Scout/UI/Controls/Placeholder.swift
@@ -35,11 +35,14 @@ struct Placeholder: View {
 
             if let code {
                 Text(code)
-                    .font(.system(size: 13, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundStyle(.primary)
                     .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.3), lineWidth: 1))
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.gray.opacity(0.12))
+                    )
             }
         }
         .padding()

--- a/Sources/Scout/UI/Controls/Placeholder.swift
+++ b/Sources/Scout/UI/Controls/Placeholder.swift
@@ -34,15 +34,7 @@ struct Placeholder: View {
             }
 
             if let code {
-                Text(code)
-                    .font(.system(size: 14, design: .monospaced))
-                    .foregroundStyle(.primary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color.gray.opacity(0.12))
-                    )
+                Text(code).codeChipStyle()
             }
         }
         .padding()

--- a/Sources/Scout/UI/Controls/Placeholder.swift
+++ b/Sources/Scout/UI/Controls/Placeholder.swift
@@ -34,7 +34,7 @@ struct Placeholder: View {
             }
 
             if let code {
-                Text(code).codeChipStyle()
+                Text(code.swiftSyntax).codeChipStyle()
             }
         }
         .padding()

--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -62,7 +62,7 @@ struct SetupPage: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
                 }
-                Text(code)
+                Text(code.swiftSyntax)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .codeChipStyle()
                     .padding(.leading, 32)

--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -63,15 +63,8 @@ struct SetupPage: View {
                         .fontWeight(.medium)
                 }
                 Text(code)
-                    .font(.system(size: 14, design: .monospaced))
-                    .foregroundStyle(.primary)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color.gray.opacity(0.12))
-                    )
+                    .codeChipStyle()
                     .padding(.leading, 32)
             }
         }

--- a/Sources/Scout/UI/Utilities/String+SwiftSyntax.swift
+++ b/Sources/Scout/UI/Utilities/String+SwiftSyntax.swift
@@ -1,0 +1,59 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+private let keywords: Set<String> = [
+    "async", "await", "class", "else", "enum", "extension", "false",
+    "func", "if", "import", "init", "let", "nil", "return", "self",
+    "struct", "throws", "true", "try", "var",
+]
+
+extension String {
+    var swiftSyntax: AttributedString {
+        var result = AttributedString()
+        var index = startIndex
+
+        while index < endIndex {
+            let character = self[index]
+
+            if character == "\"" {
+                let start = index
+                index = self.index(after: index)
+                while index < endIndex && self[index] != "\"" {
+                    index = self.index(after: index)
+                }
+                if index < endIndex {
+                    index = self.index(after: index)
+                }
+                var segment = AttributedString(self[start..<index])
+                segment.foregroundColor = .red
+                result += segment
+            } else if character.isLetter || character == "_" {
+                let start = index
+                while index < endIndex,
+                    self[index].isLetter || self[index].isNumber || self[index] == "_"
+                {
+                    index = self.index(after: index)
+                }
+                let word = String(self[start..<index])
+                var segment = AttributedString(word)
+                if keywords.contains(word) {
+                    segment.foregroundColor = .pink
+                } else if word.first?.isUppercase == true {
+                    segment.foregroundColor = .purple
+                }
+                result += segment
+            } else {
+                result += AttributedString(String(character))
+                index = self.index(after: index)
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/Scout/UI/Utilities/View+CodeChip.swift
+++ b/Sources/Scout/UI/Utilities/View+CodeChip.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    func codeChipStyle() -> some View {
+        font(.system(size: 14, design: .monospaced))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.12))
+            )
+    }
+}


### PR DESCRIPTION
- Match the `Placeholder` code chip style to `SetupPage` so empty-state and onboarding code snippets render identically.
- Extract the shared chip styling into a reusable `codeChipStyle()` view modifier in `UI/Utilities/`.
- Add a `String.swiftSyntax` extension that returns an `AttributedString` with Swift keywords, type names, and string literals colored, and use it in both call sites.