### PR TITLE
Document Scout coding conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,7 @@ Never remove or rename fields, record types, or index modifiers (`QUERYABLE`/`SE
 Scout UI strings must always render in source English: use `Text(verbatim: …)` for literals (or `.navigationTitle(en: …)` for titles) so they don't resolve through the host app's `LocalizedStringKey` catalog.
 
 Sample data in app code is named `sample` (a `static var` for fixed instances, a `static func sample(...)` when parameters are needed), placed in an extension at the end of the type's main file (e.g. `Device.swift`), and built directly via the struct initializer. Tests use a different naming convention — `make<Name>(...)` factory functions.
+
+`guard` statements with multiple conditions or pattern matching (`case .x = y`) should keep the conditions on a single line but expand the `else` block to multiple lines (`else {` / body / `}`). Single-condition simple guards (`guard let x = y else { return }`, `guard !x else { return }`) stay fully inline.
+
+Function/method signatures should be written on a single line, even with many parameters or default values — do not wrap parameters onto separate lines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,5 @@ Multi-line doc comments (`///`) must end with a trailing empty `///` line. Singl
 Never remove or rename fields, record types, or index modifiers (`QUERYABLE`/`SEARCHABLE`/`SORTABLE`) in the CloudKit `Schema` file — Production schemas are append-only and `cktool import-schema` will reject removals with `cannot remove field … which exists in active production type …`. To deprecate a field, stop writing it in code but keep its declaration in `Schema`.
 
 Scout UI strings must always render in source English: use `Text(verbatim: …)` for literals (or `.navigationTitle(en: …)` for titles) so they don't resolve through the host app's `LocalizedStringKey` catalog.
+
+Sample data in app code is named `sample` (a `static var` for fixed instances, a `static func sample(...)` when parameters are needed), placed in an extension at the end of the type's main file (e.g. `Device.swift`), and built directly via the struct initializer. Tests use a different naming convention — `make<Name>(...)` factory functions.


### PR DESCRIPTION
- Add sample data naming convention: `sample` (a `static var`, or `static func sample(...)` when parameters are needed) in app code, placed in an extension at the end of the type's main file; tests use `make<Name>(...)` factory functions instead
- Document `guard` formatting (multi-condition/pattern-matching guards keep conditions on one line but expand the `else` block; simple single-condition guards stay fully inline) and require function/method signatures to be written on a single line
