### PR TITLE
Move ParamList navigation destination outside the lazy List

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -13,24 +13,13 @@ extension EventView {
     struct ParamSection: View {
         let count: Int
 
-        @State private var isParamPresented = false
-
-        @StateObject var param: ParamProvider
+        @ObservedObject var param: ParamProvider
+        @Binding var isParamPresented: Bool
         @Environment(\.database) var database
-
-        init(count: Int, param: ParamProvider) {
-            self.count = count
-            self._param = StateObject(wrappedValue: param)
-        }
 
         var body: some View {
             Header(title: "Params", action: seeAll).task {
                 await param.fetchIfNeeded(in: database)
-            }
-            .navigationDestination(isPresented: $isParamPresented) {
-                if let items = try? param.result?.get() {
-                    ParamList(items: items)
-                }
             }
 
             if let items = try? param.result?.get() {

--- a/Sources/Scout/UI/Event/EventView.swift
+++ b/Sources/Scout/UI/Event/EventView.swift
@@ -12,6 +12,13 @@ struct EventView: View {
     let event: Event
 
     @EnvironmentObject var tint: Tint
+    @StateObject private var param: ParamProvider
+    @State private var isParamPresented = false
+
+    init(event: Event) {
+        self.event = event
+        _param = StateObject(wrappedValue: ParamProvider(recordID: event.id))
+    }
 
     var body: some View {
         let color = event.level?.color
@@ -22,7 +29,8 @@ struct EventView: View {
             if let paramCount = event.paramCount, paramCount > 0 {
                 ParamSection(
                     count: paramCount,
-                    param: ParamProvider(recordID: event.id)
+                    param: param,
+                    isParamPresented: $isParamPresented
                 )
             }
 
@@ -39,6 +47,11 @@ struct EventView: View {
         .toolbarBackground(color?.opacity(0.12) ?? .clear, for: .navigationBar)
         .toolbarBackground(color == nil ? .automatic : .visible, for: .navigationBar)
         .navigationTitle(event.name)
+        .navigationDestination(isPresented: $isParamPresented) {
+            if let items = try? param.result?.get() {
+                ParamList(items: items)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
`navigationDestination(isPresented:destination:)` was attached to the `Header` row inside `EventView`'s `List`. Because `List` only realises its rows on demand, SwiftUI logs a runtime warning that the modifier may be ignored once the row is recycled. Hoisting it onto the `List` itself keeps the destination visible to the navigation stack.

`ParamSection` now takes its presentation state and `ParamProvider` as inputs from `EventView`, so the section stays presentation-only.