### PR TITLE
Drop double-animation on recenter in AnchoredScroll

### DIFF
--- a/Sources/Scout/UI/Timeline/View/AnchoredScroll.swift
+++ b/Sources/Scout/UI/Timeline/View/AnchoredScroll.swift
@@ -34,7 +34,7 @@ struct AnchoredScroll<ID: Hashable>: ViewModifier {
     private var recenterButton: some View {
         if let anchorID, scrollID != anchorID {
             Button {
-                withAnimation { scrollID = anchorID }
+                scrollID = anchorID
             } label: {
                 let icon = Image(systemName: "scope")
                     .font(.title3)


### PR DESCRIPTION
The recenter button in `AnchoredScroll` wrapped its `scrollID` assignment in `withAnimation`, but the outer `.animation(.spring..., value: scrollID)` on the `ScrollView` already animates the scroll-position change for the same value. The two combined produced overlapping animations on tap. Dropping the inner `withAnimation` leaves a single, consistent spring transition driven by the view-level modifier.