### PR TITLE
Throw instead of crashing on malformed matrix cell keys

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Metrics/MetricsObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Metrics/MetricsObject.swift
@@ -33,12 +33,12 @@ class MetricsObject: TrackedObject {
             date: week,
             name: name,
             category: telemetry,
-            cells: T.parse(of: batch)
+            cells: try T.parse(of: batch)
         )
     }
 
-    static func parse<T: MetricsValued>(of batch: [T]) -> [T.Cell] {
-        batch.grouped(by: \.hour).mapValues { items in
+    static func parse<T: MetricsValued>(of batch: [T]) throws -> [T.Cell] {
+        try batch.grouped(by: \.hour).mapValues { items in
             items.reduce(.zero) { $0 + $1.value }
         }
         .map(T.Cell.init)

--- a/Sources/Scout/Core/Matrix/Batch/GridBatch.swift
+++ b/Sources/Scout/Core/Matrix/Batch/GridBatch.swift
@@ -29,7 +29,7 @@ extension GridBatch where Self: DateObject {
             recordType: Int.recordType,
             date: week,
             name: Self.recordType,
-            cells: parse(of: batch)
+            cells: try parse(of: batch)
         )
     }
 }

--- a/Sources/Scout/Core/Matrix/Batch/MatrixBatch.swift
+++ b/Sources/Scout/Core/Matrix/Batch/MatrixBatch.swift
@@ -31,7 +31,7 @@ struct MatrixPropertyError: LocalizedError {
 
 /// Groups records by hour-of-week and counts them into `GridCell<Int>`.
 extension MatrixBatch where Self: DateObject, Cell == GridCell<Int> {
-    static func parse(of batch: [Self]) -> [GridCell<Int>] {
-        batch.grouped(by: \.hour).mapValues(\.count).map(GridCell.init)
+    static func parse(of batch: [Self]) throws -> [GridCell<Int>] {
+        try batch.grouped(by: \.hour).mapValues(\.count).map(GridCell.init)
     }
 }

--- a/Sources/Scout/Core/Matrix/Batch/NamedObject.swift
+++ b/Sources/Scout/Core/Matrix/Batch/NamedObject.swift
@@ -28,7 +28,7 @@ class NamedObject: TrackedObject, MatrixBatch {
             recordType: Int.recordType,
             date: week,
             name: name,
-            cells: parse(of: batch)
+            cells: try parse(of: batch)
         )
     }
 }

--- a/Sources/Scout/Core/Matrix/Cell/CellProtocol.swift
+++ b/Sources/Scout/Core/Matrix/Cell/CellProtocol.swift
@@ -14,7 +14,27 @@ protocol CellProtocol: Combining, Sendable, Equatable {
     var key: String { get }
     var value: Scalar { get }
 
-    init(key: String, value: Scalar)
+    init(key: String, value: Scalar) throws
+}
+
+/// An unparseable cell key from a CloudKit record.
+///
+/// Thrown for a malformed or hostile record in the public database, and
+/// surfaced through `Matrix.init(record:)` so callers can reject the record
+/// instead of crashing the host app.
+///
+enum CellKeyError: LocalizedError {
+    case malformed(String)
+    case invalidComponent(field: String, value: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .malformed(let key):
+            "Malformed cell key: \(key)"
+        case .invalidComponent(let field, let value):
+            "Invalid \(field) in cell key: \(value)"
+        }
+    }
 }
 
 extension Int {

--- a/Sources/Scout/Core/Matrix/Cell/GridCell.swift
+++ b/Sources/Scout/Core/Matrix/Cell/GridCell.swift
@@ -22,17 +22,17 @@ extension GridCell: CellProtocol {
         "cell_\(row)_\(column.leadingZero)"
     }
 
-    init(key: String, value: T) {
+    init(key: String, value: T) throws {
         let parts = key.components(separatedBy: "_")
 
         guard parts.count == 3 else {
-            fatalError("Invalid key format")
+            throw CellKeyError.malformed(key)
         }
         guard let row = Int(parts[1]) else {
-            fatalError("Invalid row index")
+            throw CellKeyError.invalidComponent(field: "row", value: parts[1])
         }
         guard let column = Int(parts[2]) else {
-            fatalError("Invalid column index")
+            throw CellKeyError.invalidComponent(field: "column", value: parts[2])
         }
 
         self.init(row: row, column: column, value: value)

--- a/Sources/Scout/Core/Matrix/Cell/PeriodCell.swift
+++ b/Sources/Scout/Core/Matrix/Cell/PeriodCell.swift
@@ -22,17 +22,17 @@ extension PeriodCell: CellProtocol {
         "cell_\(period.rawValue)_\((day + 1).leadingZero)"
     }
 
-    init(key: String, value: T) {
+    init(key: String, value: T) throws {
         let parts = key.components(separatedBy: "_")
 
         guard parts.count == 3 else {
-            fatalError("Invalid key format")
+            throw CellKeyError.malformed(key)
         }
         guard let period = ActivityPeriod(rawValue: String(parts[1])) else {
-            fatalError("Invalid period")
+            throw CellKeyError.invalidComponent(field: "period", value: parts[1])
         }
         guard let day = Int(parts[2]) else {
-            fatalError("Invalid day")
+            throw CellKeyError.invalidComponent(field: "day", value: parts[2])
         }
 
         self.init(period: period, day: day - 1, value: value)

--- a/Sources/Scout/Core/Matrix/Matrix+CKPersistable.swift
+++ b/Sources/Scout/Core/Matrix/Matrix+CKPersistable.swift
@@ -32,7 +32,7 @@ extension Matrix: CKInitializable {
             throw MapError.invalidCells
         }
 
-        self.cells = cellDict.map(T.init)
+        self.cells = try cellDict.map(T.init)
     }
 }
 

--- a/Tests/ScoutTests/Core/Diagnostics/Log/EventObjectTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Log/EventObjectTests.swift
@@ -24,7 +24,7 @@ struct EventObjectTests {
             .stub(name: "name", date: date.addingHour(), in: context),
         ]
 
-        let cells = EventObject.parse(of: batch)
+        let cells = try EventObject.parse(of: batch)
 
         let counts = cells.map(\.value)
         #expect(counts.contains(2))

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
@@ -24,7 +24,7 @@ struct LaunchObjectTests {
             .stub(date: week.addingHour(), synced: false, in: context),
         ]
 
-        let cells = LaunchObject.parse(of: batch)
+        let cells = try LaunchObject.parse(of: batch)
 
         #expect(
             cells.sorted() == [

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
@@ -24,7 +24,7 @@ struct SessionObjectTests {
             .stub(date: week.addingHour(), synced: false, in: context),
         ]
 
-        let cells = SessionObject.parse(of: batch)
+        let cells = try SessionObject.parse(of: batch)
 
         #expect(
             cells.sorted() == [

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
@@ -24,7 +24,7 @@ struct VersionObjectTests {
             .stub(date: week.addingHour(), synced: false, in: context),
         ]
 
-        let cells = VersionObject.parse(of: batch)
+        let cells = try VersionObject.parse(of: batch)
 
         #expect(
             cells.sorted() == [

--- a/Tests/ScoutTests/Core/Matrix/Batch/NamedObjectTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/Batch/NamedObjectTests.swift
@@ -24,7 +24,7 @@ struct NamedObjectTests {
             try .stub(name: "crash", date: date.addingHour(), in: context),
         ]
 
-        let cells = NamedObject.parse(of: batch)
+        let cells = try NamedObject.parse(of: batch)
 
         #expect(cells.count == 2)
         #expect(cells.map(\.value).reduce(0, +) == 3)

--- a/Tests/ScoutTests/Core/Matrix/Cell/GridCellTest.swift
+++ b/Tests/ScoutTests/Core/Matrix/Cell/GridCellTest.swift
@@ -16,3 +16,14 @@ import Testing
 
     #expect(c == GridCell(row: 1, column: 2, value: 7))
 }
+
+@Test("GridCell parses a valid key") func testValidKey() throws {
+    let cell = try GridCell<Int>(key: "cell_1_02", value: 5)
+    #expect(cell == GridCell(row: 1, column: 2, value: 5))
+}
+
+@Test("GridCell throws on a malformed key instead of crashing") func testMalformedKey() {
+    #expect(throws: CellKeyError.self) { try GridCell<Int>(key: "cell_1", value: 5) }
+    #expect(throws: CellKeyError.self) { try GridCell<Int>(key: "cell_x_02", value: 5) }
+    #expect(throws: CellKeyError.self) { try GridCell<Int>(key: "cell_1_zz", value: 5) }
+}

--- a/Tests/ScoutTests/Core/Matrix/Cell/PeriodCellTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/Cell/PeriodCellTests.swift
@@ -33,27 +33,40 @@ struct PeriodCellTests {
     // MARK: - Key Parsing
 
     @Test("Init from key parses correctly")
-    func initFromKey() {
-        let cell = PeriodCell<Int>(key: "cell_d_05", value: 10)
+    func initFromKey() throws {
+        let cell = try PeriodCell<Int>(key: "cell_d_05", value: 10)
         #expect(cell.period == .daily)
         #expect(cell.day == 4)
         #expect(cell.value == 10)
     }
 
     @Test("Init from key parses weekly")
-    func initFromKeyWeekly() {
-        let cell = PeriodCell<Int>(key: "cell_w_01", value: 3)
+    func initFromKeyWeekly() throws {
+        let cell = try PeriodCell<Int>(key: "cell_w_01", value: 3)
         #expect(cell.period == .weekly)
         #expect(cell.day == 0)
         #expect(cell.value == 3)
     }
 
+    @Test("Init throws on a malformed key instead of crashing")
+    func initRejectsMalformedKey() {
+        #expect(throws: CellKeyError.self) {
+            try PeriodCell<Int>(key: "cell_d", value: 1)
+        }
+        #expect(throws: CellKeyError.self) {
+            try PeriodCell<Int>(key: "cell_x_01", value: 1)
+        }
+        #expect(throws: CellKeyError.self) {
+            try PeriodCell<Int>(key: "cell_d_zz", value: 1)
+        }
+    }
+
     // MARK: - Round-trip
 
     @Test("Key round-trips through init")
-    func keyRoundTrip() {
+    func keyRoundTrip() throws {
         let original = PeriodCell<Int>(period: .monthly, day: 6, value: 42)
-        let restored = PeriodCell<Int>(key: original.key, value: original.value)
+        let restored = try PeriodCell<Int>(key: original.key, value: original.value)
 
         #expect(restored.period == original.period)
         #expect(restored.day == original.day)


### PR DESCRIPTION
The cell decoders for `GridCell` and `PeriodCell` parsed a CloudKit record's cell keys with `fatalError` whenever the key had an unexpected shape. Since matrix records live in a public, world-writable CloudKit database, a single malformed or hostile record would crash the host app uncatchably, and the bad key could reach the decoder through chart rendering, `lookupExisting`, or the conflict-merge path during upload.

This makes `CellProtocol.init(key:value:)` throwing and introduces a `CellKeyError` so the failure flows through the existing `do`/`catch` in `Matrix.init(record:)`, which now rejects the bad record instead of terminating the process. The `throws` is propagated through the internal `parse(of:)` helpers, whose keys are always well-formed and therefore never actually throw. New tests cover the throwing behavior for both cell types.