### PR TITLE
Don't create duplicate matrix records when sync retries are exhausted

### DIFF
--- a/Sources/Scout/Core/Sync/SyncCoordinator.swift
+++ b/Sources/Scout/Core/Sync/SyncCoordinator.swift
@@ -35,7 +35,10 @@ extension SyncCoordinator {
             try await database.write(record: snapshot.toRecord)
         } catch let error as CKError where error.code == CKError.serverRecordChanged {
             if retry > maxRetry {
-                try await upload(snapshot: matrix, retry: 1)
+                // Give up instead of writing `matrix`: it has no backing
+                // CKRecord, so a write would mint a fresh recordID and create a
+                // duplicate for this bucket. Stay unsynced and retry next cycle.
+                throw error
             } else if let serverRecord = error.userInfo[CKRecordChangedErrorServerRecordKey] as? CKRecord {
                 try await upload(snapshot: try Matrix(record: serverRecord) + matrix, retry: retry + 1)
             }

--- a/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
@@ -46,14 +46,16 @@ struct SyncCoordinatorTests {
         #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
     }
 
-    @Test("Upload falls back to newMatrix after max retries")
-    func testUploadMaxRetryFallback() async throws {
+    @Test("Upload gives up without writing a duplicate after max retries")
+    func testUploadMaxRetryThrows() async throws {
         for _ in 0..<(coordinator.maxRetry + 1) {
             database.writeErrors.append(createMergeError())
         }
-        try await coordinator.upload()
 
-        #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
+        await #expect(throws: CKError.self) {
+            try await coordinator.upload()
+        }
+        #expect(database.records.filter { $0.recordType == Int.recordType }.count == 0)
     }
 }
 


### PR DESCRIPTION
When a matrix upload kept losing a `serverRecordChanged` race, `SyncCoordinator.upload` eventually gave up by recursing with `upload(snapshot: matrix, retry: 1)`. The batch's local `matrix` carries no backing `CKRecord`, so `toRecord` minted a fresh record ID and that give-up path silently wrote a duplicate record for the same bucket while discarding the merged server counts, splitting the aggregate across two records that never reconcile. The `maxRetry` cap was effectively defeated by its own reset.

This throws the conflict error instead of writing a duplicate. The batch stays unsynced and is retried on the next sync cycle, and `syncAttempts` still advances toward the cleanup retirement limit, so a permanently-conflicting batch is eventually dropped rather than endlessly duplicated. The retry-exhaustion test is updated to assert that no duplicate is written.