### PR TITLE
Unify and document the matrix create/update logic in SyncCoordinator

### DIFF
--- a/Sources/Scout/Core/Sync/SyncCoordinator.swift
+++ b/Sources/Scout/Core/Sync/SyncCoordinator.swift
@@ -22,6 +22,9 @@ extension SyncCoordinator {
 }
 
 extension SyncCoordinator {
+    /// Merges into the bucket's existing record when one exists,
+    /// otherwise creates a new one.
+    ///
     func upload() async throws {
         if let existing = try await matrix.lookupExisting(in: database) {
             try await upload(snapshot: matrix + existing)
@@ -30,14 +33,21 @@ extension SyncCoordinator {
         }
     }
 
+    /// On a `serverRecordChanged` conflict, merges the server's counts with
+    /// ours and retries; once retries run out, or no server record is
+    /// provided, writes a new matrix instead.
+    ///
+    /// Duplicates are harmless — reads sum a bucket's records via
+    /// `mergeDuplicates`.
+    ///
     func upload(snapshot: Matrix<T>, retry: Int = 1) async throws {
         do {
             try await database.write(record: snapshot.toRecord)
         } catch let error as CKError where error.code == CKError.serverRecordChanged {
-            if retry > maxRetry {
-                try await upload(snapshot: matrix, retry: 1)
-            } else if let serverRecord = error.userInfo[CKRecordChangedErrorServerRecordKey] as? CKRecord {
+            if retry <= maxRetry, let serverRecord = error.userInfo[CKRecordChangedErrorServerRecordKey] as? CKRecord {
                 try await upload(snapshot: try Matrix(record: serverRecord) + matrix, retry: retry + 1)
+            } else {
+                try await upload(snapshot: matrix, retry: 1)
             }
         }
     }

--- a/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncCoordinatorTests.swift
@@ -55,6 +55,15 @@ struct SyncCoordinatorTests {
 
         #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
     }
+
+    @Test("Upload creates a new matrix when the conflict carries no server record")
+    func testUploadConflictWithoutServerRecordCreatesNewMatrix() async throws {
+        database.writeErrors.append(CKError(.serverRecordChanged))
+
+        try await coordinator.upload()
+
+        #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
+    }
 }
 
 private let now = Date()


### PR DESCRIPTION
`SyncCoordinator.upload` merges a batch's matrix into the bucket's existing CloudKit record and, when merging keeps losing the `serverRecordChanged` race, falls back to writing the local delta as a fresh matrix. That fallback is intentional — every dashboard read sums all of a bucket's records through `QueryProvider.fetch`'s `mergeDuplicates` (`Matrix.isDuplicate` matches by bucket, `Matrix.+` sums cells), so duplicate records always reconcile to the correct total.

The conflict handling had a gap, though: a `serverRecordChanged` error that carried no server record in its `userInfo` matched neither branch, so `upload` returned without writing anything and `SyncEngine.send` then marked the batch `isSynced`, dropping its counts. This collapses the two non-mergeable cases — retries exhausted, or no server record — into the same create-a-new-matrix fallback so nothing is silently lost, and documents the update-versus-create logic in both `upload` overloads.