### PR TITLE
Show a directional chevron on the timeline recenter button

### DIFF
--- a/Sources/Scout/UI/Timeline/Item/TimelineItem.swift
+++ b/Sources/Scout/UI/Timeline/Item/TimelineItem.swift
@@ -24,3 +24,17 @@ struct TimelineItem: Identifiable {
         }
     }
 }
+
+extension TimelineItem: ScrollCursor {
+    static func < (lhs: TimelineItem, rhs: TimelineItem) -> Bool {
+        lhs.date < rhs.date
+    }
+
+    static func == (lhs: TimelineItem, rhs: TimelineItem) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/Sources/Scout/UI/Timeline/View/AnchoredScroll.swift
+++ b/Sources/Scout/UI/Timeline/View/AnchoredScroll.swift
@@ -7,24 +7,30 @@
 
 import SwiftUI
 
-struct AnchoredScroll<ID: Hashable>: ViewModifier {
-    let anchorID: ID?
+/// A position in an always-sorted list that `AnchoredScroll` tracks:
+/// identified by `id`, ordered by `<`.
+///
+/// Because the list stays sorted, comparing two cursors tells which one sits
+/// above the other, so direction needs no index lookup.
+///
+protocol ScrollCursor: Comparable, Hashable {
+    associatedtype ID: Hashable
+    var id: ID { get }
+}
 
-    @State private var scrollID: ID?
+struct AnchoredScroll<Cursor: ScrollCursor>: ViewModifier {
+    let cursor: Cursor?
 
-    init(anchorID: ID?) {
-        self.anchorID = anchorID
-        self._scrollID = State(wrappedValue: anchorID)
-    }
+    @State private var scroll: Cursor?
 
     func body(content: Content) -> some View {
         if #available(iOS 17.0, *) {
             ScrollView {
-                content.scrollTargetLayout()
+                content
             }
-            .scrollPosition(id: $scrollID, anchor: .center)
+            .scrollPosition(id: $scroll, anchor: .center)
             .overlay(alignment: .bottomTrailing) { recenterButton }
-            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: scrollID)
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: scroll)
         } else {
             ScrollView { content }
         }
@@ -32,11 +38,11 @@ struct AnchoredScroll<ID: Hashable>: ViewModifier {
 
     @ViewBuilder
     private var recenterButton: some View {
-        if let anchorID, scrollID != anchorID {
+        if let pointsUp {
             Button {
-                scrollID = anchorID
+                scroll = cursor
             } label: {
-                let icon = Image(systemName: "scope")
+                let icon = Image(systemName: pointsUp ? "chevron.up" : "chevron.down")
                     .font(.title3)
                     .padding(12)
                 #if compiler(>=6.2)
@@ -53,34 +59,75 @@ struct AnchoredScroll<ID: Hashable>: ViewModifier {
             .transition(.scale.combined(with: .opacity))
         }
     }
+
+    /// Whether the recenter chevron points up, or `nil` when there is no
+    /// centered row to compare against — in which case the button stays hidden.
+    ///
+    private var pointsUp: Bool? {
+        guard let cursor, let scroll, scroll != cursor else {
+            return nil
+        }
+        return cursor < scroll
+    }
 }
 
 extension View {
-    func anchoredScroll<ID: Hashable>(anchorID: ID?) -> some View {
-        modifier(AnchoredScroll(anchorID: anchorID))
+    /// Scrolls the content while tracking the centered row, showing a button
+    /// that recenters on `cursor`.
+    ///
+    /// The content's row container must apply `scrollTargetLayoutIfAvailable()`
+    /// so the centered row can be resolved.
+    ///
+    func anchoredScroll<Cursor: ScrollCursor>(cursor: Cursor?) -> some View {
+        modifier(AnchoredScroll(cursor: cursor))
+    }
+
+    /// Marks this layout's subviews as scroll targets on iOS 17+, so a sibling
+    /// `scrollPosition(id:)` can report the centered row; a no-op below iOS 17.
+    ///
+    @ViewBuilder
+    func scrollTargetLayoutIfAvailable() -> some View {
+        if #available(iOS 17.0, *) {
+            scrollTargetLayout()
+        } else {
+            self
+        }
     }
 }
 
 @available(iOS 17.0, *)
 #Preview {
-    @Previewable @State var anchorID = 5
+    @Previewable @State var cursor = CursorItem(id: 5)
+
+    let items = (0..<40).map(CursorItem.init)
 
     LazyVStack(spacing: 0) {
-        ForEach(0..<40, id: \.self) { i in
+        ForEach(items, id: \.self) { item in
             HStack {
-                Text("Row \(i)").monospaced()
+                Text("Row \(item.id)").monospaced()
                 Spacer()
-                if i == anchorID {
+                if item == cursor {
                     Text("anchor").foregroundStyle(.tint).font(.caption)
                 }
             }
             .padding()
-            .background(i == anchorID ? Color.accentColor.opacity(0.12) : .clear)
+            .background(item == cursor ? Color.accentColor.opacity(0.12) : .clear)
         }
     }
-    .anchoredScroll(anchorID: anchorID)
+    .scrollTargetLayoutIfAvailable()
+    .anchoredScroll(cursor: cursor)
     .task {
         await Task.yield()
-        anchorID = 30
+        cursor = CursorItem(id: 30)
     }
 }
+
+#if DEBUG
+    private struct CursorItem: ScrollCursor {
+        let id: Int
+
+        static func < (lhs: CursorItem, rhs: CursorItem) -> Bool {
+            lhs.id < rhs.id
+        }
+    }
+#endif

--- a/Sources/Scout/UI/Timeline/View/Timeline.swift
+++ b/Sources/Scout/UI/Timeline/View/Timeline.swift
@@ -63,17 +63,19 @@ struct Timeline: View {
     }
 
     private func list(for rail: Rail) -> some View {
-        VStack(spacing: 0) {
+        let items = TimelineItem.items(from: rail)
+
+        return VStack(spacing: 0) {
             if showLegend {
                 Legend(kinds: LegendKind.allCases, expanded: $expandedKind)
             }
             TimelineList(
-                items: TimelineItem.items(from: rail),
+                items: items,
                 highlightedID: event?.id,
                 older: { RailPagination(lane: provider.older, result: $provider.result) },
                 newer: { RailPagination(lane: provider.newer, result: $provider.result) }
             )
-            .anchoredScroll(anchorID: event?.id)
+            .anchoredScroll(cursor: items.first { $0.id == event?.id })
         }
     }
 

--- a/Sources/Scout/UI/Timeline/View/TimelineList.swift
+++ b/Sources/Scout/UI/Timeline/View/TimelineList.swift
@@ -21,7 +21,7 @@ struct TimelineList<Pagination: View>: View {
         LazyVStack(spacing: 0) {
             older()
 
-            ForEach(Array(items.enumerated()), id: \.element.id) { index, row in
+            ForEach(Array(items.enumerated()), id: \.element) { index, row in
                 TimelineRow(
                     color: .primary,
                     name: row.name,
@@ -55,6 +55,7 @@ struct TimelineList<Pagination: View>: View {
 
             newer()
         }
+        .scrollTargetLayoutIfAvailable()
         .padding(16)
     }
 }


### PR DESCRIPTION
The timeline's recenter button showed a static `scope` icon and only disappeared when tapped, because `scrollTargetLayout()` was applied to the composite content instead of the rows' `LazyVStack`, so `scrollPosition(id:)` never reported the centered row. This moves `scrollTargetLayout` onto the row container so the centered row resolves, and adds a `ScrollCursor` protocol (`Comparable` + `Hashable` + `id`) that lets the button derive its chevron direction by comparing the anchor against the centered row in the always-sorted list. The button now points up or down toward the anchor, hides when the anchor re-centers, and stays hidden when there is no determinable direction. The start anchor is no longer seeded, so the timeline opens at the top and the recenter control appears once the anchor event loads.