### PR TITLE
Fix release build by removing the AnchoredScroll preview's DEBUG guard

### DIFF
--- a/Sources/Scout/UI/Timeline/View/AnchoredScroll.swift
+++ b/Sources/Scout/UI/Timeline/View/AnchoredScroll.swift
@@ -122,12 +122,10 @@ extension View {
     }
 }
 
-#if DEBUG
-    private struct CursorItem: ScrollCursor {
-        let id: Int
+private struct CursorItem: ScrollCursor {
+    let id: Int
 
-        static func < (lhs: CursorItem, rhs: CursorItem) -> Bool {
-            lhs.id < rhs.id
-        }
+    static func < (lhs: CursorItem, rhs: CursorItem) -> Bool {
+        lhs.id < rhs.id
     }
-#endif
+}


### PR DESCRIPTION
The `#Preview` in `AnchoredScroll.swift` referenced `CursorItem`, a helper that was only defined inside an `#if DEBUG` block. Release builds such as the TestFlight archive strip `CursorItem` but still compile the preview body, which broke the build with "cannot find 'CursorItem' in scope". Rather than guard the preview too, this drops the `#if DEBUG` entirely so `CursorItem` always compiles alongside the preview, matching every other preview in the codebase where the supporting sample helpers are not DEBUG-guarded.