### PR TITLE
Fix the always-empty crash count on the Home screen

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
@@ -9,19 +9,12 @@ import CloudKit
 import CoreData
 
 @objc(CrashObject)
-final class CrashObject: NamedObject, Syncable {
+final class CrashObject: TrackedObject, Syncable, GridBatch {
     static let recordType = "Crash"
+    @NSManaged var name: String?
     @NSManaged var crashID: UUID
     @NSManaged var reason: String?
     @NSManaged var stackTrace: Data?
-
-    static func group(in context: NSManagedObjectContext) throws -> [CrashObject]? {
-        try batch(in: context, matching: [\.name, \.week])
-    }
-
-    static func matrix(of batch: [CrashObject]) throws -> GridMatrix<Int> {
-        try NamedObject.matrix(of: batch)
-    }
 }
 
 extension CrashObject: CKRepresentable {

--- a/Sources/Scout/Core/Matrix/Batch/NamedObject.swift
+++ b/Sources/Scout/Core/Matrix/Batch/NamedObject.swift
@@ -10,8 +10,8 @@ import CoreData
 /// `TrackedObject` with a user-facing `name` attribute and a shared
 /// `matrix(of:)` that groups records by their own `name`.
 ///
-/// Base for `EventObject` and `CrashObject` — both aggregate by event name
-/// (e.g. "login", "fatal") rather than by `recordType`.
+/// Base for `EventObject`, which aggregates by event name (e.g. "login")
+/// rather than by `recordType`.
 ///
 @objc(NamedObject)
 class NamedObject: TrackedObject, MatrixBatch {

--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="CrashObject" representedClassName="CrashObject" parentEntity="NamedObject" syncable="YES" codeGenerationType="none">
+    <entity name="CrashObject" representedClassName="CrashObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
         <attribute name="crashID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
         <attribute name="reason" optional="YES" attributeType="String"/>
         <attribute name="stackTrace" optional="YES" attributeType="Binary"/>
     </entity>

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("CrashObject")
+struct CrashObjectTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let date = Date(year: 2025, month: 1, day: 6)
+
+    @Test("matrix(of:) aggregates every crash into a single \"Crash\" matrix")
+    func testMatrixAggregatesByRecordType() throws {
+        let batch: [CrashObject] = [
+            makeCrashObject(name: "SIGABRT", date: date),
+            makeCrashObject(name: "SIGSEGV", date: date),
+            makeCrashObject(name: "SIGSEGV", date: date.addingHour()),
+        ]
+
+        let matrix = try CrashObject.matrix(of: batch)
+
+        #expect(matrix.recordType == Int.recordType)
+        #expect(matrix.name == CrashObject.recordType)
+        #expect(matrix.date == date.startOfWeek)
+        #expect(matrix.cells.map(\.value).reduce(0, +) == 3)
+    }
+
+    private func makeCrashObject(name: String, date: Date) -> CrashObject {
+        let entity = NSEntityDescription.entity(forEntityName: "CrashObject", in: context)!
+        let object = CrashObject(entity: entity, insertInto: context)
+        object.name = name
+        object.date = date
+        object.crashID = UUID()
+        object.isSynced = false
+        return object
+    }
+}


### PR DESCRIPTION
The crash summary on the Home screen always showed an empty count. It fetches a `DateIntMatrix` record named `"Crash"`, but `CrashObject` inherited from `NamedObject` and so produced a separate matrix for each individual crash name (`SIGABRT`, `SIGSEGV`, and so on) rather than one aggregate. No record named `"Crash"` ever existed, so the query returned nothing, and those per-name crash matrices were never read by any view.

This makes `CrashObject` a `GridBatch` like `SessionObject`, so every crash in a week rolls up into a single matrix named after the record type — which is exactly what the summary query looks for. `CrashObject` is reparented from `NamedObject` to `TrackedObject` and now declares its own `name` attribute, which is still used for the individual crash list. A regression test covers that crashes with different names aggregate into one `"Crash"` matrix.

Note that existing per-name crash matrices already synced to CloudKit will not be rolled up retroactively, so the summary populates from newly synced crashes forward. The CloudKit schema is unchanged.