### PR TITLE
Seed both timeline lanes before showing the list

### DIFF
--- a/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
+++ b/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
@@ -29,7 +29,17 @@ final class TimelineProvider: ObservableObject {
             older.pendingInstalls = split.older
             newer.pendingInstalls = split.newer
 
-            result = .success(rail)
+            // Seed the first chunk of both lanes before showing the list, so the
+            // user goes straight from the loading spinner to events instead of
+            // flashing an empty list while the pagination footers self-load.
+            var seeded = rail
+
+            for lane in [older, newer] where !lane.pendingInstalls.isEmpty {
+                let (sessions, events) = try await lane.loadMore(in: feed.database)
+                seeded = seeded.merged(sessions: sessions, events: events)
+            }
+
+            result = .success(seeded)
         } catch {
             result = .failure(error)
         }


### PR DESCRIPTION
The multi-rail timeline loaded the device, installs, and launches first and only fetched the actual events afterward, driven by the pagination footers self-loading once they appeared on screen. Because of that two-phase load there was an intermediate state where the central spinner had already disappeared but no events had arrived yet, so the user briefly saw an empty list with a pagination loader before events showed up.

This change prefetches the first chunk of both the `older` and `newer` lanes inside `TimelineProvider.start` and merges them into the `rail` before publishing the result. As a result the screen goes straight from the loading spinner to events, without the empty-list flash. Later chunks still load on demand through the pagination footers exactly as before, since the lane cursors are already advanced after the initial `loadMore`.
