### PR TITLE
Hide the History section for events without a device

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -89,9 +89,8 @@ extension EventView {
         let event: Event
 
         var body: some View {
-            Header(title: "History")
-
             if let deviceID = event.deviceID {
+                Header(title: "History")
                 timelineRow(deviceID: deviceID)
             }
         }


### PR DESCRIPTION
The `HistorySection` only ever shows a `Timeline` link, and that link requires the event's `deviceID`. Previously the section still rendered its "History" header even when `deviceID` was `nil`, leaving an empty section with nothing actionable underneath it.

Now the whole section — header included — is rendered only when the event has a `deviceID`, mirroring how `ParamSection` is already shown conditionally. Events without a device no longer display an empty History section.