### PR TITLE
Seed the timeline to 50 events and open centered on the anchor

### DIFF
--- a/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
+++ b/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
@@ -10,6 +10,10 @@ import SwiftUI
 
 @MainActor
 final class TimelineProvider: ObservableObject {
+    /// How many events to seed before revealing the list, so it opens already
+    /// populated and scrollable around the anchor instead of near-empty.
+    private static let seedTarget = 50
+
     @Published var result: Result<Rail, Error>?
     @Published private(set) var older = RailLane()
     @Published private(set) var newer = RailLane()
@@ -29,14 +33,24 @@ final class TimelineProvider: ObservableObject {
             older.pendingInstalls = split.older
             newer.pendingInstalls = split.newer
 
-            // Seed the first chunk of both lanes before showing the list, so the
-            // user goes straight from the loading spinner to events instead of
-            // flashing an empty list while the pagination footers self-load.
+            // Seed events into both lanes before showing the list, so the user
+            // goes straight from the loading spinner to a populated, scrollable
+            // timeline instead of flashing a near-empty list while the
+            // pagination footers self-load. Keep pulling chunks from both lanes
+            // until the timeline holds `seedTarget` events or both lanes run dry.
             var seeded = rail
 
-            for lane in [older, newer] where !lane.pendingInstalls.isEmpty {
-                let (sessions, events) = try await lane.loadMore(in: feed.database)
-                seeded = seeded.merged(sessions: sessions, events: events)
+            while TimelineItem.items(from: seeded).count < Self.seedTarget {
+                let lanes = [older, newer].filter { !$0.pendingInstalls.isEmpty }
+
+                guard !lanes.isEmpty else {
+                    break
+                }
+
+                for lane in lanes {
+                    let (sessions, events) = try await lane.loadMore(in: feed.database)
+                    seeded = seeded.merged(sessions: sessions, events: events)
+                }
             }
 
             result = .success(seeded)

--- a/Sources/Scout/UI/Timeline/View/AnchoredScroll.swift
+++ b/Sources/Scout/UI/Timeline/View/AnchoredScroll.swift
@@ -23,6 +23,11 @@ struct AnchoredScroll<Cursor: ScrollCursor>: ViewModifier {
 
     @State private var scroll: Cursor?
 
+    init(cursor: Cursor?) {
+        self.cursor = cursor
+        _scroll = State(initialValue: cursor)
+    }
+
     func body(content: Content) -> some View {
         if #available(iOS 17.0, *) {
             ScrollView {
@@ -97,7 +102,7 @@ extension View {
 
 @available(iOS 17.0, *)
 #Preview {
-    @Previewable @State var cursor = CursorItem(id: 5)
+    let cursor = CursorItem(id: 20)
 
     let items = (0..<40).map(CursorItem.init)
 
@@ -116,10 +121,6 @@ extension View {
     }
     .scrollTargetLayoutIfAvailable()
     .anchoredScroll(cursor: cursor)
-    .task {
-        await Task.yield()
-        cursor = CursorItem(id: 30)
-    }
 }
 
 private struct CursorItem: ScrollCursor {


### PR DESCRIPTION
The timeline previously revealed its list after seeding only a single page from each lane, so it could appear with just a handful of rows around the anchor and then grow as the pagination footers self-loaded. It now keeps pulling chunks from both lanes while the loading spinner is still showing, until the list holds at least 50 events or both lanes are exhausted, so it opens already populated and scrollable.

It also opens centered on the anchor event: `AnchoredScroll` now seeds its tracked scroll position with the anchor on first appear, so the list lands with the anchor in the middle instead of scrolled to the top. The recenter button stays hidden until the user scrolls away, and its animated appearance is unchanged.

Verified by compiling for the iOS simulator and rendering the `AnchoredScroll` preview, which shows a mid-list anchor opening centered.