### PR TITLE
Run CloudKit requests in parallel under a global 8-slot limiter

### DIFF
--- a/Sources/Scout/Core/Bootstrap/ParallelismCheck.swift
+++ b/Sources/Scout/Core/Bootstrap/ParallelismCheck.swift
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import CloudKit
+import Foundation
+
+/// How often debug builds re-validate `RequestLimiter.requestLimit` against CloudKit.
+private let parallelismCheckInterval: TimeInterval = 7 * 24 * 60 * 60
+
+/// In debug builds, re-runs `verifyCloudKitParallelism` once `parallelismCheckInterval`
+/// has passed since the last check, so a change in CloudKit's server-side limits shows
+/// up in the console during development instead of going unnoticed.
+///
+@MainActor func verifyParallelismIfDue(container: CKContainer) {
+    #if DEBUG
+        let key = "scout.parallelismCheckDate"
+        let lastCheck = UserDefaults.standard.object(forKey: key) as? Date
+
+        if let lastCheck, Date().timeIntervalSince(lastCheck) < parallelismCheckInterval {
+            return
+        }
+
+        Task {
+            await verifyCloudKitParallelism(container: container)
+            UserDefaults.standard.set(Date(), forKey: key)
+        }
+    #endif
+}

--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -57,4 +57,6 @@ public func setup(container: CKContainer) async throws {
     MetricsSystem.bootstrap(TelemetryFactory(sync: sync))
 
     isSetup = true
+
+    verifyParallelismIfDue(container: container)
 }

--- a/Sources/Scout/Core/Database/CKDatabase+Runner.swift
+++ b/Sources/Scout/Core/Database/CKDatabase+Runner.swift
@@ -14,11 +14,9 @@ extension CKDatabase {
             throw RunnerError()
         }
 
-        let configuration = CKOperation.Configuration()
-        configuration.timeoutIntervalForRequest = 10
-        configuration.timeoutIntervalForResource = 10
-
-        return try await configuredWith(configuration: configuration, body: body)
+        return try await requestLimiter.withSlot {
+            try await configuredWith(configuration: .scout, body: body)
+        }
     }
 
     struct RunnerError: LocalizedError {
@@ -26,5 +24,15 @@ extension CKDatabase {
         let failureReason: String? = "Not enough background time remaining."
         let helpAnchor: String? = "https://developer.apple.com/documentation/uikit/uiapplication/backgroundtimeremaining"
         let recoverySuggestion: String? = "Try again later."
+    }
+}
+
+extension CKOperation.Configuration {
+    /// The configuration for every Scout CloudKit request, measurement requests included.
+    static var scout: CKOperation.Configuration {
+        let configuration = CKOperation.Configuration()
+        configuration.timeoutIntervalForRequest = 10
+        configuration.timeoutIntervalForResource = 10
+        return configuration
     }
 }

--- a/Sources/Scout/Core/Database/CloudKitParallelismBenchmark.swift
+++ b/Sources/Scout/Core/Database/CloudKitParallelismBenchmark.swift
@@ -1,0 +1,203 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+// Maintenance tooling for `RequestLimiter.requestLimit`. Both functions talk to
+// CloudKit directly, bypassing the limiter, so concurrency levels above the
+// configured limit are actually exercised. Not used in production flows.
+//
+
+import CloudKit
+import Foundation
+
+/// Measures how CloudKit query latency scales with the number of in-flight requests.
+///
+/// Runs a warm-up request first, then for each concurrency level in `counts` executes
+/// that many identical queries in parallel, `rounds` times. Prints the batch wall-clock
+/// time, the effective per-request time, and throttle errors (`serviceUnavailable` /
+/// `requestRateLimited`) if they occur. With perfect parallelism the batch time stays
+/// flat as the level grows; the level where it starts climbing is the practical ceiling.
+///
+/// Holds every `RequestLimiter` slot for the duration, so regular Scout traffic neither
+/// skews the measurements nor competes with them — library requests queue up and resume
+/// once the sweep is done.
+///
+/// June 2026 baseline: 1 → 409 ms, 2 → 562 ms, 4 → 652 ms, 8 → 751 ms, 16 → 1406 ms,
+/// no throttling — the ceiling `RequestLimiter.requestLimit` is based on.
+///
+public func benchmarkCloudKitParallelism(container: CKContainer, recordType: String = "Event", counts: [Int] = [1, 2, 4, 8, 16], rounds: Int = 2) async {
+    let counts = counts.filter { $0 > 0 }
+
+    print("[CKBench] concurrency sweep \(counts), \(rounds) round(s) each, record type \(recordType)")
+
+    await requestLimiter.withAllSlots {
+        await runSweep(container.publicCloudDatabase, recordType: recordType, counts: counts, rounds: rounds)
+    }
+}
+
+private func runSweep(_ database: CKDatabase, recordType: String, counts: [Int], rounds: Int) async {
+    do {
+        let warmup = try await rawBatch(database, recordType: recordType, count: 1)
+        print("[CKBench] warm-up: \(warmup.wholeMilliseconds) ms")
+    } catch {
+        print("[CKBench] warm-up failed: \(describe(error))")
+        return
+    }
+
+    var summary: [(count: Int, average: Int)] = []
+
+    for count in counts {
+        var durations: [Duration] = []
+        for round in 1...rounds {
+            do {
+                let duration = try await rawBatch(database, recordType: recordType, count: count)
+                durations.append(duration)
+                print("[CKBench] \(count) in flight, round \(round): \(duration.wholeMilliseconds) ms")
+            } catch {
+                print("[CKBench] \(count) in flight, round \(round) FAILED: \(describe(error))")
+            }
+        }
+        if durations.count > 0 {
+            let batch = average(durations).wholeMilliseconds
+            summary.append((count: count, average: batch))
+            print("[CKBench] \(count) in flight: avg \(batch) ms per batch, \(batch / count) ms effective per request")
+        }
+    }
+
+    guard summary.count > 0 else {
+        print("[CKBench] no successful batches — see errors above")
+        return
+    }
+
+    print("[CKBench] RESULT (count → batch ms → effective ms/request):")
+    for entry in summary {
+        print("[CKBench]   \(entry.count) → \(entry.average) ms → \(entry.average / entry.count) ms")
+    }
+}
+
+/// Re-validates that `RequestLimiter.requestLimit` still matches CloudKit's behavior.
+///
+/// Compares the latency of a single request against a batch of `requestLimit` parallel
+/// requests and a batch of twice that. Returns `true` when the limit still looks right:
+/// the batch at the limit stays within ×3 of a single request and nothing gets throttled.
+/// Prints a FAIL with lowering advice when scaling broke down, and a NOTE with raising
+/// advice when twice the limit also scales cleanly.
+///
+/// CloudKit's server-side behavior can change without notice, so run this occasionally —
+/// from a nightly performance job, or manually in a debug build after iOS/CloudKit
+/// updates. Costs about `3 × requestLimit + 3` requests per run. Holds every
+/// `RequestLimiter` slot for the duration, so regular Scout traffic neither skews the
+/// measurements nor competes with them — library requests queue up and resume after.
+///
+@discardableResult public func verifyCloudKitParallelism(container: CKContainer, recordType: String = "Event") async -> Bool {
+    print("[CKVerify] checking that \(RequestLimiter.requestLimit) in-flight CloudKit requests is still the right limit")
+
+    return await requestLimiter.withAllSlots {
+        await runVerification(container.publicCloudDatabase, recordType: recordType)
+    }
+}
+
+private func runVerification(_ database: CKDatabase, recordType: String) async -> Bool {
+    let limit = RequestLimiter.requestLimit
+
+    do {
+        try await rawRead(database, recordType: recordType)
+
+        let single = try await rawBatch(database, recordType: recordType, count: 1, rounds: 2)
+        let atLimit = try await rawBatch(database, recordType: recordType, count: limit, rounds: 2)
+        print("[CKVerify] 1 in flight: \(single.wholeMilliseconds) ms, \(limit) in flight: \(atLimit.wholeMilliseconds) ms")
+
+        guard atLimit < single * 3 else {
+            let factor = String(format: "%.1f", Double(atLimit.wholeMilliseconds) / Double(single.wholeMilliseconds))
+            print(
+                "[CKVerify] FAIL: \(limit) parallel requests cost ×\(factor) of a single one — "
+                    + "scaling degraded, consider lowering RequestLimiter.requestLimit "
+                    + "(run benchmarkCloudKitParallelism for the full picture)")
+            return false
+        }
+
+        let beyond = try await rawBatch(database, recordType: recordType, count: limit * 2)
+        print("[CKVerify] \(limit * 2) in flight: \(beyond.wholeMilliseconds) ms")
+
+        if beyond < atLimit * 3 / 2 {
+            print(
+                "[CKVerify] NOTE: \(limit * 2) in flight still scales cleanly — "
+                    + "consider raising RequestLimiter.requestLimit "
+                    + "(run benchmarkCloudKitParallelism for the full picture)")
+        } else {
+            print("[CKVerify] OK: scaling stops past \(limit) in flight, limit confirmed")
+        }
+        return true
+    } catch {
+        print(
+            "[CKVerify] FAIL: \(describe(error)) — a throttle error here means CloudKit "
+                + "no longer tolerates \(RequestLimiter.requestLimit * 2) in-flight requests; "
+                + "consider lowering RequestLimiter.requestLimit")
+        return false
+    }
+}
+
+private let resultsLimit = 20
+
+private func makeQuery(_ recordType: String) -> CKQuery {
+    let query = CKQuery(recordType: recordType, predicate: NSPredicate(value: true))
+    query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+    return query
+}
+
+/// A single query against CloudKit, bypassing `RequestLimiter` (but with the same
+/// operation configuration as `CKDatabase.runner`).
+private func rawRead(_ database: CKDatabase, recordType: String) async throws {
+    _ = try await database.configuredWith(configuration: .scout) { database in
+        try await database.records(
+            matching: makeQuery(recordType),
+            desiredKeys: [],
+            resultsLimit: resultsLimit
+        )
+    }
+}
+
+private func rawBatch(_ database: CKDatabase, recordType: String, count: Int, rounds: Int = 1) async throws -> Duration {
+    var durations: [Duration] = []
+    for _ in 0..<rounds {
+        let duration = try await measure {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for _ in 0..<count {
+                    group.addTask {
+                        try await rawRead(database, recordType: recordType)
+                    }
+                }
+                try await group.waitForAll()
+            }
+        }
+        durations.append(duration)
+    }
+    return average(durations)
+}
+
+private func measure(_ body: () async throws -> Void) async rethrows -> Duration {
+    try await ContinuousClock().measure {
+        try await body()
+    }
+}
+
+private func average(_ durations: [Duration]) -> Duration {
+    durations.reduce(.zero, +) / durations.count
+}
+
+extension Duration {
+    fileprivate var wholeMilliseconds: Int {
+        Int(self / .milliseconds(1))
+    }
+}
+
+private func describe(_ error: Error) -> String {
+    guard let ckError = error as? CKError else {
+        return String(describing: error)
+    }
+    let retryAfter = ckError.retryAfterSeconds.map { ", retry after \($0)s" } ?? ""
+    return "CKError \(ckError.code.rawValue): \(ckError.localizedDescription)\(retryAfter)"
+}

--- a/Sources/Scout/Core/Database/RequestLimiter.swift
+++ b/Sources/Scout/Core/Database/RequestLimiter.swift
@@ -1,0 +1,119 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+/// The process-wide limiter that every `CKDatabase.runner` call goes through.
+let requestLimiter = RequestLimiter(limit: RequestLimiter.requestLimit)
+
+/// An asynchronous semaphore that caps the number of CloudKit requests in flight.
+///
+/// Measured in June 2026 (see `benchmarkCloudKitParallelism`): CloudKit query latency
+/// scales near-perfectly up to 8 concurrent requests (×4.4 over sequential) and degrades
+/// beyond that — 16 in flight doubles batch latency with no throughput gain. The limit
+/// keeps Scout inside the well-scaling range no matter how many call sites fan out at
+/// once. Re-validate with `verifyCloudKitParallelism` if CloudKit behavior changes.
+///
+actor RequestLimiter {
+    /// The measured CloudKit parallelism ceiling; `verifyCloudKitParallelism` re-checks it.
+    static let requestLimit = 8
+
+    private let limit: Int
+    private var running = 0
+    private var isDraining = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var drainWaiters: [CheckedContinuation<Void, Never>] = []
+    private var drained: CheckedContinuation<Void, Never>?
+
+    init(limit: Int) {
+        self.limit = limit
+    }
+
+    /// Waits until a request slot is free and claims it; pair with `release()`.
+    func acquire() async {
+        if !isDraining && running < limit {
+            running += 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    /// Frees the slot, handing it to the longest-waiting request if any.
+    func release() {
+        running -= 1
+        if isDraining {
+            if running == 0 {
+                drained?.resume()
+                drained = nil
+            }
+            return
+        }
+        resumeWaiters()
+    }
+
+    /// Claims every slot at once, giving measurement code exclusive access to CloudKit.
+    ///
+    /// Waits out in-flight requests and blocks new ones until `releaseAll()`. Drains are
+    /// atomic — concurrent callers queue up instead of deadlocking on each other's
+    /// partially claimed slots.
+    ///
+    func acquireAll() async {
+        while isDraining {
+            await withCheckedContinuation { continuation in
+                drainWaiters.append(continuation)
+            }
+        }
+        isDraining = true
+        if running > 0 {
+            await withCheckedContinuation { continuation in
+                drained = continuation
+            }
+        }
+        running = limit
+    }
+
+    /// Releases all slots claimed by `acquireAll()`.
+    func releaseAll() {
+        running = 0
+        isDraining = false
+        if drainWaiters.count > 0 {
+            drainWaiters.removeFirst().resume()
+            return
+        }
+        resumeWaiters()
+    }
+
+    private func resumeWaiters() {
+        while running < limit, waiters.count > 0 {
+            running += 1
+            waiters.removeFirst().resume()
+        }
+    }
+
+    /// Runs `body` while holding one request slot.
+    nonisolated func withSlot<R>(body: () async throws -> R) async rethrows -> R {
+        try await holding({ await acquire() }, until: { await release() }, body: body)
+    }
+
+    /// Runs `body` while holding every slot, giving it exclusive access to CloudKit.
+    nonisolated func withAllSlots<R>(body: () async throws -> R) async rethrows -> R {
+        try await holding({ await acquireAll() }, until: { await releaseAll() }, body: body)
+    }
+
+    nonisolated private func holding<R>(_ claim: () async -> Void, until free: () async -> Void, body: () async throws -> R) async rethrows -> R {
+        await claim()
+        do {
+            let result = try await body()
+            await free()
+            return result
+        } catch {
+            await free()
+            throw error
+        }
+    }
+}

--- a/Sources/Scout/Core/Database/Schema/CKContainer+Verify.swift
+++ b/Sources/Scout/Core/Database/Schema/CKContainer+Verify.swift
@@ -49,7 +49,9 @@ extension CKContainer {
             let query = CKQuery(recordType: recordType, predicate: NSPredicate(value: true))
 
             do {
-                _ = try await publicCloudDatabase.records(matching: query, resultsLimit: 1)
+                try await publicCloudDatabase.runner { database in
+                    _ = try await database.records(matching: query, resultsLimit: 1)
+                }
             } catch let error as CKError where error.isSchemaError {
                 print("[Scout] Schema error for '\(recordType)': \(error.localizedDescription)")
                 invalid.append(recordType)

--- a/Sources/Scout/Core/Sync/SyncController.swift
+++ b/Sources/Scout/Core/Sync/SyncController.swift
@@ -30,15 +30,14 @@ typealias SyncAction = @MainActor () async throws -> Void
         let jobPlan = SyncJobPlan(engine: engine)
 
         try await dispatcher.performEnsuringBackground {
-            for job in jobPlan.jobs.shuffled() {
-                do {
-                    try await job()
-                } catch let error where Task.isCancelled {
-                    throw error
-                } catch {
-                    continue
+            await withTaskGroup(of: Void.self) { group in
+                for job in jobPlan.jobs.shuffled() {
+                    group.addTask {
+                        try? await job()
+                    }
                 }
             }
+            try Task.checkCancellation()
         }
     }
 

--- a/Sources/Scout/Core/Sync/SyncJobPlan.swift
+++ b/Sources/Scout/Core/Sync/SyncJobPlan.swift
@@ -6,7 +6,7 @@
 // https://opensource.org/licenses/MIT.
 
 struct SyncJobPlan: Sendable {
-    typealias Job = () async throws -> Void
+    typealias Job = @Sendable () async throws -> Void
 
     let engine: SyncEngine
 

--- a/Sources/Scout/UI/Database/Record/RecordLookup.swift
+++ b/Sources/Scout/UI/Database/Record/RecordLookup.swift
@@ -13,6 +13,8 @@ protocol RecordLookup {
 
 extension CKDatabase: RecordLookup {
     func lookup(id: CKRecord.ID) async throws -> CKRecord {
-        try await record(for: id)
+        try await runner { database in
+            try await database.record(for: id)
+        }
     }
 }

--- a/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
+++ b/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
@@ -52,10 +52,16 @@ final class TimelineProvider: ObservableObject {
                     break
                 }
 
-                for lane in lanes {
-                    let chunk = try await lane.loadMore(in: feed.database)
-                    sessions += chunk.sessions
-                    events += chunk.events
+                try await withThrowingTaskGroup(of: (sessions: [Session], events: [Event]).self) { group in
+                    for lane in lanes {
+                        group.addTask {
+                            try await lane.loadMore(in: feed.database)
+                        }
+                    }
+                    for try await chunk in group {
+                        sessions += chunk.sessions
+                        events += chunk.events
+                    }
                 }
             }
 
@@ -74,10 +80,13 @@ final class TimelineProvider: ObservableObject {
 
 extension TimelineFeed {
     fileprivate func rail() async throws -> Rail {
-        try await Rail(
-            device: device(),
-            installs: installs(),
-            launches: launches()
+        async let device = self.device()
+        async let installs = self.installs()
+        async let launches = self.launches()
+        return try await Rail(
+            device: device,
+            installs: installs,
+            launches: launches
         )
     }
 }

--- a/Tests/ScoutTests/Core/Database/RequestLimiterTests.swift
+++ b/Tests/ScoutTests/Core/Database/RequestLimiterTests.swift
@@ -1,0 +1,125 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Testing
+
+@testable import Scout
+
+@Suite("RequestLimiter")
+struct RequestLimiterTests {
+    @Test("Acquires up to the limit without suspending")
+    func testAcquiresUpToLimit() async {
+        let limiter = RequestLimiter(limit: 3)
+
+        // Would hang here if the limiter blocked before reaching its limit.
+        for _ in 0..<3 {
+            await limiter.acquire()
+        }
+
+        await limiter.releaseAll()
+    }
+
+    @Test("Never exceeds the limit under contention")
+    func testCapsConcurrency() async {
+        let limiter = RequestLimiter(limit: 3)
+        let tracker = Tracker()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<20 {
+                group.addTask {
+                    await limiter.acquire()
+                    await tracker.enter()
+                    try? await Task.sleep(for: .milliseconds(5))
+                    await tracker.exit()
+                    await limiter.release()
+                }
+            }
+        }
+
+        #expect(await tracker.maxConcurrent <= 3)
+        #expect(await tracker.total == 20)
+    }
+
+    @Test("Release hands the slot to a waiter")
+    func testWaiterResumes() async {
+        let limiter = RequestLimiter(limit: 1)
+        await limiter.acquire()
+
+        let waiter = Task {
+            await limiter.acquire()
+            return true
+        }
+
+        try? await Task.sleep(for: .milliseconds(50))
+        await limiter.release()
+
+        #expect(await waiter.value)
+        await limiter.release()
+    }
+
+    @Test("acquireAll blocks new requests until releaseAll")
+    func testAcquireAllBlocksUntilReleaseAll() async {
+        let limiter = RequestLimiter(limit: 2)
+        await limiter.acquireAll()
+
+        let entered = Box(false)
+        let waiter = Task {
+            await limiter.acquire()
+            entered.value = true
+            await limiter.release()
+        }
+
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(!entered.value)
+
+        await limiter.releaseAll()
+        await waiter.value
+
+        #expect(entered.value)
+    }
+
+    @Test("Concurrent acquireAll calls serialize instead of deadlocking")
+    func testConcurrentAcquireAllSerializes() async {
+        let limiter = RequestLimiter(limit: 4)
+        await limiter.acquire()
+
+        let drains = [
+            Task {
+                await limiter.withAllSlots { true }
+            },
+            Task {
+                await limiter.withAllSlots { true }
+            },
+        ]
+
+        // Both drains are now waiting for the held slot; with per-slot
+        // acquisition they would deadlock on each other's partial claims.
+        try? await Task.sleep(for: .milliseconds(50))
+        await limiter.release()
+
+        for drain in drains {
+            #expect(await drain.value)
+        }
+    }
+}
+
+private actor Tracker {
+    private var current = 0
+
+    var maxConcurrent = 0
+    var total = 0
+
+    func enter() {
+        current += 1
+        total += 1
+        maxConcurrent = max(maxConcurrent, current)
+    }
+
+    func exit() {
+        current -= 1
+    }
+}

--- a/Tests/ScoutTests/Core/Utilities/Dispatcher/QueueDispatcherTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/Dispatcher/QueueDispatcherTests.swift
@@ -64,11 +64,3 @@ struct QueueDispatcherTests {
         #expect(box.value == 3)
     }
 }
-
-private final class Box<T>: @unchecked Sendable {
-    var value: T
-
-    init(_ value: T) {
-        self.value = value
-    }
-}

--- a/Tests/ScoutTests/Utilities/Box.swift
+++ b/Tests/ScoutTests/Utilities/Box.swift
@@ -1,0 +1,15 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+/// A mutable reference cell for observing side effects of `Sendable` closures in tests.
+final class Box<T>: @unchecked Sendable {
+    var value: T
+
+    init(_ value: T) {
+        self.value = value
+    }
+}


### PR DESCRIPTION
Scout previously issued CloudKit requests one at a time, based on the assumption that CloudKit serializes them. Benchmarking disproved that: latency scales near-perfectly up to 8 in-flight requests (×4.4 over sequential) and degrades beyond. This change introduces a `RequestLimiter` actor wired into `CKDatabase.runner` so every CloudKit call — reads, writes, lookups, and schema verification — shares a global cap of 8 concurrent requests, and parallelizes the independent call sites: timeline rail queries via `async let`, lane loading and sync jobs via task groups.

The measurement tooling stays in the codebase: `benchmarkCloudKitParallelism` runs a full concurrency sweep and `verifyCloudKitParallelism` re-validates the configured limit against live CloudKit behavior, draining the limiter first so regular traffic neither skews the numbers nor competes with them. Debug builds re-run the verification weekly from `setup()`, so a server-side change in CloudKit throttling surfaces in the console during development.

Worth knowing for review: `acquireAll` drains atomically (concurrent drains queue up rather than deadlock on each other's partial claims), sync jobs remain mutually exclusive across runs via `QueueDispatcher` while running concurrently within a run, and cursor pagination stays sequential by nature. Covered by new `RequestLimiter` unit tests, including the concurrent-drain case.