### PR TITLE
Coalesce pending sync runs in QueueDispatcher

### DIFF
--- a/Sources/Scout/Core/Utilities/Dispatcher/QueueDispatcher.swift
+++ b/Sources/Scout/Core/Utilities/Dispatcher/QueueDispatcher.swift
@@ -5,12 +5,19 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+/// Runs work items one at a time, coalescing submissions that arrive mid-run.
+///
+/// Callers submit work that processes everything accumulated so far (a sync run),
+/// so keeping more than one pending item is pointless: while a run is in flight,
+/// each new submission replaces the pending one, and at most one follow-up run
+/// executes after the current run finishes.
+///
 actor QueueDispatcher: Dispatcher {
-    private var queue: [Work] = []
+    private var pending: Work?
     private var isRunning = false
 
     func perform(_ work: @escaping Work) async throws {
-        queue.append(work)
+        pending = work
 
         guard !isRunning else { return }
 
@@ -18,13 +25,13 @@ actor QueueDispatcher: Dispatcher {
 
         defer { isRunning = false }
 
-        while let next = queue.first {
-            queue.removeFirst()
+        while let next = pending {
+            pending = nil
 
             do {
                 try await next()
             } catch {
-                queue.removeAll()
+                pending = nil
                 throw error
             }
         }

--- a/Tests/ScoutTests/Core/Utilities/Dispatcher/QueueDispatcherTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/Dispatcher/QueueDispatcherTests.swift
@@ -63,4 +63,25 @@ struct QueueDispatcherTests {
 
         #expect(box.value == 3)
     }
+
+    @Test("Work submitted mid-run coalesces into a single follow-up run")
+    func testCoalescesPendingWork() async throws {
+        let dispatcher = QueueDispatcher()
+        let box = Box([Int]())
+
+        let first = Task {
+            try await dispatcher.perform {
+                box.value.append(1)
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+        }
+
+        // Let the first work item start, then pile up two submissions behind it.
+        try? await Task.sleep(for: .milliseconds(20))
+        try await dispatcher.perform { box.value.append(2) }
+        try await dispatcher.perform { box.value.append(3) }
+        try await first.value
+
+        #expect(box.value == [1, 3])
+    }
 }


### PR DESCRIPTION
Every run dispatched through `QueueDispatcher` synchronizes everything accumulated up to that point, so queuing more than one follow-up run never does useful work — a burst of log writes used to enqueue a closure per write and replay them all one by one after the current run finished. The dispatcher now keeps a single `pending` work item that each mid-run submission replaces, so any burst collapses into exactly one follow-up run. Error semantics are unchanged: a failing run still clears whatever was pending and rethrows to the caller driving the loop. Covered by a new test that piles two submissions behind an in-flight run and checks only the latest one executes.