### PR TITLE
Comparison mode for charts

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct ActivityView: View {
     @State var extent: ChartExtent<ActivityPeriod>
+    @State var comparison: ChartComparison?
     @ObservedObject var activity: ActivityProvider
 
     init(activity: ActivityProvider, period: ActivityPeriod) {
@@ -23,25 +24,20 @@ struct ActivityView: View {
 
             ProviderView(provider: activity) { data in
                 RangeControl(extent: $extent)
+                ComparisonPicker(comparison: $comparison)
 
                 List {
-                    let segment = extent.segment(from: data)
+                    let points = data.points(on: extent.period)
 
-                    ChartView(segment: segment, timing: extent)
+                    ComparisonChartView(points: points, extent: extent, comparison: comparison)
                         .foregroundStyle(.green)
                         .listRowSeparator(.hidden)
                 }
                 .listStyle(.plain)
-                .scrollDisabled(true)
+                .scrollDisabled(comparison == nil)
             }
         }
         .navigationTitle(en: "Active Users")
-    }
-}
-
-extension ChartExtent<ActivityPeriod> {
-    fileprivate func segment(from matrices: [ActivityMatrix]) -> [ChartPoint<Int>] {
-        segment(from: matrices.points(on: period))
     }
 }
 

--- a/Sources/Scout/UI/Chart/ChartView.swift
+++ b/Sources/Scout/UI/Chart/ChartView.swift
@@ -10,16 +10,29 @@ import SwiftUI
 
 struct ChartView<T: ChartNumeric>: View {
     let segment: [ChartPoint<T>]
+    var comparison: [ChartPoint<T>]? = nil
+    var aspectRatio: CGFloat = 4 / 3
     let timing: ChartTiming
 
     var body: some View {
         let unit = timing.unit
 
-        Chart(segment, id: \.date) { point in
-            BarMark(
-                x: .value("X", point.date, unit: unit),
-                y: .value("Y", point.count)
-            )
+        Chart {
+            ForEach(segment, id: \.date) { point in
+                BarMark(
+                    x: .value("X", point.date, unit: unit),
+                    y: .value("Y", point.count)
+                )
+            }
+            if let comparison {
+                ForEach(comparison, id: \.date) { point in
+                    LineMark(
+                        x: .value("X", point.date, unit: unit),
+                        y: .value("Y", point.count)
+                    )
+                    .foregroundStyle(.gray)
+                }
+            }
         }
         .chartXAxis {
             if let values = timing.tickValues {
@@ -29,13 +42,13 @@ struct ChartView<T: ChartNumeric>: View {
             }
         }
         .chartBackground { _ in
-            if segment.total == .zero {
+            if segment.total == .zero, (comparison ?? []).total == .zero {
                 Text(verbatim: "No results")
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(.gray.opacity(0.7))
             }
         }
-        .aspectRatio(4 / 3, contentMode: .fit)
+        .aspectRatio(aspectRatio, contentMode: .fit)
         .padding()
         .padding(.bottom)
         .listRowInsets(EdgeInsets())

--- a/Sources/Scout/UI/Chart/Comparison/ChartComparison.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ChartComparison.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+/// A display option for comparing the visible time window with the one before it.
+enum ChartComparison: String, CaseIterable, Identifiable {
+    case overlay
+    case split
+
+    var id: Self { self }
+}
+
+extension ChartComparison {
+    var title: String {
+        switch self {
+        case .overlay:
+            "Overlay"
+        case .split:
+            "Split"
+        }
+    }
+}

--- a/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension ChartExtent {
+    /// The time window immediately preceding the visible domain.
+    var previousDomain: Range<Date> {
+        domain.moved(by: period.rangeComponent, value: -1)
+    }
+
+    /// A copy of the extent that looks at the previous time window.
+    var previousExtent: ChartExtent {
+        ChartExtent(period: period, domain: previousDomain)
+    }
+
+    /// Groups points that fall inside the previous time window into buckets.
+    func previousSegment<U: ChartNumeric>(from points: [ChartPoint<U>]) -> [ChartPoint<U>] {
+        points.bucket(in: previousDomain, component: period.pointComponent)
+    }
+
+    /// Re-dates the previous window's buckets onto the current domain so that
+    /// both periods share the x-axis in overlay mode.
+    ///
+    /// Both segments are built from the newest bucket backwards, so pairing by
+    /// position matches every bucket with its counterpart one period earlier.
+    /// Buckets of the previous window without a counterpart are dropped.
+    ///
+    func overlaySegment<U: ChartNumeric>(from points: [ChartPoint<U>]) -> [ChartPoint<U>] {
+        zip(segment(from: points), previousSegment(from: points)).map { current, previous in
+            ChartPoint(date: current.date, count: previous.count)
+        }
+    }
+}

--- a/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
@@ -1,0 +1,129 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Charts
+import SwiftUI
+
+/// Renders a chart for the visible time window, optionally comparing it with
+/// the previous window using the selected ``ChartComparison`` display option.
+///
+/// Without a comparison the view falls back to a plain ``ChartView``.
+///
+struct ComparisonChartView<S: ChartTimeScale, T: ChartNumeric>: View {
+    let points: [ChartPoint<T>]
+    let extent: ChartExtent<S>
+    let comparison: ChartComparison?
+
+    let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    var body: some View {
+        switch comparison {
+        case nil:
+            ChartView(segment: extent.segment(from: points), timing: extent)
+        case .overlay:
+            overlay
+        case .split:
+            split
+        }
+    }
+
+    var overlay: some View {
+        VStack(spacing: 0) {
+            legend
+
+            ChartView(
+                segment: extent.segment(from: points),
+                comparison: extent.overlaySegment(from: points),
+                timing: extent
+            )
+        }
+        .listRowInsets(EdgeInsets())
+    }
+
+    var split: some View {
+        VStack(spacing: 0) {
+            label(for: extent.domain)
+            ChartView(segment: extent.segment(from: points), aspectRatio: 2, timing: extent)
+
+            label(for: extent.previousDomain)
+            ChartView(
+                segment: extent.previousSegment(from: points),
+                aspectRatio: 2,
+                timing: extent.previousExtent
+            )
+            .foregroundStyle(.gray)
+        }
+        .listRowInsets(EdgeInsets())
+    }
+
+    var legend: some View {
+        HStack(spacing: 16) {
+            HStack(spacing: 6) {
+                RoundedRectangle(cornerRadius: 2)
+                    .frame(width: 10, height: 10)
+                Text(extent.domain.label(using: formatter))
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 6) {
+                Capsule()
+                    .fill(.gray)
+                    .frame(width: 10, height: 3)
+                Text(extent.previousDomain.label(using: formatter))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .font(.footnote)
+        .monospaced()
+        .padding(.horizontal)
+        .padding(.top)
+    }
+
+    func label(for range: Range<Date>) -> some View {
+        Text(range.label(using: formatter))
+            .font(.footnote)
+            .monospaced()
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal)
+            .padding(.top)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("ComparisonChartView") {
+    let sample: [ChartPoint<Int>] = .sample
+    let shifted = sample.map { point in
+        ChartPoint(date: point.date.addingWeek(-1), count: point.count)
+    }
+    let points = sample + shifted
+
+    return List {
+        ComparisonChartView(
+            points: points,
+            extent: ChartExtent(period: Period.week),
+            comparison: .overlay
+        )
+        .foregroundStyle(.blue)
+
+        ComparisonChartView(
+            points: points,
+            extent: ChartExtent(period: Period.week),
+            comparison: .split
+        )
+        .foregroundStyle(.blue)
+    }
+    .listStyle(.plain)
+}

--- a/Sources/Scout/UI/Chart/Comparison/ComparisonPicker.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonPicker.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct ComparisonPicker: View {
+    @Binding var comparison: ChartComparison?
+
+    var body: some View {
+        Picker(selection: $comparison) {
+            Text(verbatim: "Off").tag(ChartComparison?.none)
+            ForEach(ChartComparison.allCases) { comparison in
+                Text(verbatim: comparison.title).tag(ChartComparison?.some(comparison))
+            }
+        } label: {
+            Text(verbatim: "Compare")
+        }
+        .padding(.horizontal)
+        .pickerStyle(.segmented)
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    ComparisonPicker(comparison: .constant(.overlay))
+}

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -13,6 +13,7 @@ struct MetricsView<T: ChartNumeric>: View {
     let formatter: KeyPath<T, String>
 
     @State var extent: ChartExtent<Period>
+    @State var comparison: ChartComparison?
 
     init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period) {
         self.group = group
@@ -32,18 +33,17 @@ struct MetricsView<T: ChartNumeric>: View {
         .pickerStyle(.segmented)
 
         RangeControl(extent: $extent)
+        ComparisonPicker(comparison: $comparison)
 
         List {
-            let segment = extent.segment(from: group.points)
-
-            ChartView(segment: segment, timing: extent)
+            ComparisonChartView(points: group.points, extent: extent, comparison: comparison)
                 .chartYAxis(content: { formattedMarks })
                 .foregroundStyle(.blue)
                 .listRowSeparator(.hidden)
         }
         .listStyle(.plain)
         .navigationTitle(group.name)
-        .scrollDisabled(true)
+        .scrollDisabled(comparison == nil)
     }
 
     private var formattedMarks: some AxisContent {

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -12,6 +12,7 @@ struct StatView: View {
     let showList: Bool
 
     @State var extent: ChartExtent<Period>
+    @State var comparison: ChartComparison? = nil
     @ObservedObject var stat: StatProvider
     @EnvironmentObject var tint: Tint
     @Environment(\.chartColor) var color
@@ -22,21 +23,21 @@ struct StatView: View {
 
             ProviderView(provider: stat) { data in
                 RangeControl(extent: $extent)
+                ComparisonPicker(comparison: $comparison)
 
                 List {
                     let points = data.flatMap(\.points)
-                    let segment = extent.segment(from: points)
 
-                    ChartView(segment: segment, timing: extent)
+                    ComparisonChartView(points: points, extent: extent, comparison: comparison)
                         .foregroundStyle(color)
                         .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
 
                     if showList {
-                        total(count: segment.total)
+                        total(count: extent.segment(from: points).total)
                     }
                 }
                 .listStyle(.plain)
-                .scrollDisabled(true)
+                .scrollDisabled(comparison == nil)
             }
         }
         .onAppear {

--- a/Tests/ScoutTests/UI/ChartComparisonTests.swift
+++ b/Tests/ScoutTests/UI/ChartComparisonTests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct ChartComparisonTests {
+    let date = Date()
+
+    @Test("Previous domain") func testPreviousDomain() {
+        let interval: Double = 3600 * 24 * 7
+        let range = date..<date.addingTimeInterval(interval)
+        let model = ChartExtent(period: Period.week, domain: range)
+
+        let expectedRange = date.addingTimeInterval(-interval)..<date
+        #expect(model.previousDomain == expectedRange)
+    }
+
+    @Test("Previous extent") func testPreviousExtent() {
+        let model = ChartExtent(period: Period.week)
+        let previous = model.previousExtent
+
+        #expect(previous.period == .week)
+        #expect(previous.domain == model.previousDomain)
+    }
+
+    @Test("Previous segment") func testPreviousSegment() {
+        let upper = Date().startOfDay
+        let model = ChartExtent(period: Period.week, domain: upper.addingWeek(-1)..<upper)
+
+        let points = [
+            ChartPoint(date: upper.addingDay(-1), count: 3),
+            ChartPoint(date: upper.addingDay(-8), count: 5),
+        ]
+
+        #expect(model.segment(from: points).total == 3)
+        #expect(model.previousSegment(from: points).total == 5)
+    }
+
+    @Test("Overlay segment alignment") func testOverlaySegment() {
+        let upper = Date().startOfDay
+        let model = ChartExtent(period: Period.week, domain: upper.addingWeek(-1)..<upper)
+
+        let points = [
+            ChartPoint(date: upper.addingDay(-1), count: 3),
+            ChartPoint(date: upper.addingDay(-8), count: 5),
+        ]
+        let overlay = model.overlaySegment(from: points)
+
+        #expect(overlay.map(\.date) == model.segment(from: points).map(\.date))
+        #expect(overlay.first == ChartPoint(date: upper.addingDay(-1), count: 5))
+        #expect(overlay.total == 5)
+    }
+
+    @Test("Overlay segment truncation") func testOverlayTruncation() {
+        // 2026-03-15 UTC: the current month window spans 28 days, the previous one 31.
+        let upper = Date(timeIntervalSince1970: 1_773_532_800)
+        let model = ChartExtent(period: Period.month, domain: upper.addingMonth(-1)..<upper)
+
+        let points: [ChartPoint<Int>] = []
+
+        #expect(model.segment(from: points).count == 28)
+        #expect(model.overlaySegment(from: points).count == 28)
+    }
+}


### PR DESCRIPTION
Adds a comparison mode that lets the stats, activity, and metrics charts compare the visible time window with the one immediately before it, e.g. this week against last week. A new `ComparisonPicker` below the range control switches between off, overlay, and split: overlay draws the previous period as a gray line over the current bars on a shared x-axis, while split stacks two charts with their date ranges labeled. The feature builds on `ChartExtent`, which gains `previousDomain`, `previousExtent`, and segment helpers that re-date the previous window's buckets onto the current domain, covered by new tests.

Closes #223