### PR TITLE
Add comparison mode for charts

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -23,13 +23,18 @@ struct ActivityView: View {
 
             ProviderView(provider: activity) { data in
                 RangeControl(extent: $extent)
+                CompareControl(extent: $extent)
 
                 List {
                     let segment = extent.segment(from: data)
 
-                    ChartView(segment: segment, timing: extent)
-                        .foregroundStyle(.green)
-                        .listRowSeparator(.hidden)
+                    ChartView(
+                        segment: segment,
+                        timing: extent,
+                        comparison: extent.comparison(from: data)
+                    )
+                    .foregroundStyle(.green)
+                    .listRowSeparator(.hidden)
                 }
                 .listStyle(.plain)
                 .scrollDisabled(true)
@@ -42,6 +47,10 @@ struct ActivityView: View {
 extension ChartExtent<ActivityPeriod> {
     fileprivate func segment(from matrices: [ActivityMatrix]) -> [ChartPoint<Int>] {
         segment(from: matrices.points(on: period))
+    }
+
+    fileprivate func comparison(from matrices: [ActivityMatrix]) -> [ChartPoint<Int>]? {
+        comparison(from: matrices.points(on: period))
     }
 }
 

--- a/Sources/Scout/UI/Chart/ChartExtent.swift
+++ b/Sources/Scout/UI/Chart/ChartExtent.swift
@@ -12,6 +12,7 @@ struct ChartExtent<T: ChartTimeScale> {
         didSet { domain = period.initialRange }
     }
     var domain: Range<Date>
+    var isComparing = false
 }
 
 extension ChartExtent {

--- a/Sources/Scout/UI/Chart/ChartView.swift
+++ b/Sources/Scout/UI/Chart/ChartView.swift
@@ -11,15 +11,30 @@ import SwiftUI
 struct ChartView<T: ChartNumeric>: View {
     let segment: [ChartPoint<T>]
     let timing: ChartTiming
+    var comparison: [ChartPoint<T>]? = nil
 
     var body: some View {
         let unit = timing.unit
 
-        Chart(segment, id: \.date) { point in
-            BarMark(
-                x: .value("X", point.date, unit: unit),
-                y: .value("Y", point.count)
-            )
+        Chart {
+            ForEach(segment, id: \.date) { point in
+                BarMark(
+                    x: .value("X", point.date, unit: unit),
+                    y: .value("Y", point.count)
+                )
+            }
+
+            if let comparison {
+                ForEach(comparison, id: \.date) { point in
+                    LineMark(
+                        x: .value("X", point.date, unit: unit),
+                        y: .value("Y", point.count)
+                    )
+                    .foregroundStyle(.gray)
+                    .lineStyle(StrokeStyle(lineWidth: 2))
+                    .symbol(.circle)
+                }
+            }
         }
         .chartXAxis {
             if let values = timing.tickValues {
@@ -29,7 +44,7 @@ struct ChartView<T: ChartNumeric>: View {
             }
         }
         .chartBackground { _ in
-            if segment.total == .zero {
+            if segment.total == .zero, (comparison ?? []).total == .zero {
                 Text(verbatim: "No results")
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(.gray.opacity(0.7))
@@ -50,5 +65,26 @@ struct ChartView<T: ChartNumeric>: View {
         Text(verbatim: "Empty State").font(.headline)
         ChartView(segment: .empty, timing: ChartExtent(period: Period.month))
     }
+    .padding()
+}
+
+#Preview("ChartView – Comparison") {
+    let extent = ChartExtent(
+        period: Period.week,
+        domain: Period.week.initialRange,
+        isComparing: true
+    )
+    let end = Date()
+    let points = (0..<336).compactMap { i in
+        Calendar.utc.date(byAdding: .hour, value: -i, to: end).map {
+            ChartPoint(date: $0, count: Int.random(in: 0...20))
+        }
+    }
+
+    ChartView(
+        segment: extent.segment(from: points),
+        timing: extent,
+        comparison: extent.comparison(from: points)
+    )
     .padding()
 }

--- a/Sources/Scout/UI/Chart/Compare/ChartExtent+Compare.swift
+++ b/Sources/Scout/UI/Chart/Compare/ChartExtent+Compare.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+extension ChartExtent {
+    /// The date range immediately preceding the visible domain, one period back.
+    var previousDomain: Range<Date> {
+        domain.moved(by: period.rangeComponent, value: -1)
+    }
+
+    /// A comparison series for the period preceding the visible domain.
+    ///
+    /// Buckets the points into the previous period and shifts the result forward
+    /// by one period so both series align on the current domain's axis.
+    /// Returns `nil` when comparison is turned off.
+    ///
+    func comparison<U: ChartNumeric>(from points: [ChartPoint<U>]) -> [ChartPoint<U>]? {
+        guard isComparing else { return nil }
+
+        return points.bucket(in: previousDomain, component: period.pointComponent).map { point in
+            ChartPoint(date: point.date.adding(period.rangeComponent), count: point.count)
+        }
+    }
+}

--- a/Sources/Scout/UI/Chart/Compare/CompareControl.swift
+++ b/Sources/Scout/UI/Chart/Compare/CompareControl.swift
@@ -1,0 +1,69 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct CompareControl<T: ChartTimeScale>: View {
+    @Binding var extent: ChartExtent<T>
+
+    let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    var body: some View {
+        HStack {
+            Button {
+                extent.isComparing.toggle()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.left.arrow.right")
+                    Text(verbatim: "Compare")
+                }
+                .font(.system(size: 14, weight: .medium))
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.capsule)
+            .controlSize(.small)
+            .tint(extent.isComparing ? .blue : .secondary)
+
+            Spacer()
+
+            if extent.isComparing {
+                Text(verbatim: "vs \(extent.previousDomain.label(using: formatter))")
+                    .font(.system(size: 14))
+                    .monospaced()
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.top, 8)
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    VStack(spacing: 16) {
+        CompareControl(
+            extent: .constant(ChartExtent(period: Period.week))
+        )
+
+        CompareControl(
+            extent: .constant(
+                ChartExtent(
+                    period: Period.week,
+                    domain: Period.week.initialRange,
+                    isComparing: true
+                )
+            )
+        )
+    }
+}

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -32,14 +32,19 @@ struct MetricsView<T: ChartNumeric>: View {
         .pickerStyle(.segmented)
 
         RangeControl(extent: $extent)
+        CompareControl(extent: $extent)
 
         List {
             let segment = extent.segment(from: group.points)
 
-            ChartView(segment: segment, timing: extent)
-                .chartYAxis(content: { formattedMarks })
-                .foregroundStyle(.blue)
-                .listRowSeparator(.hidden)
+            ChartView(
+                segment: segment,
+                timing: extent,
+                comparison: extent.comparison(from: group.points)
+            )
+            .chartYAxis(content: { formattedMarks })
+            .foregroundStyle(.blue)
+            .listRowSeparator(.hidden)
         }
         .listStyle(.plain)
         .navigationTitle(group.name)

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -22,14 +22,19 @@ struct StatView: View {
 
             ProviderView(provider: stat) { data in
                 RangeControl(extent: $extent)
+                CompareControl(extent: $extent)
 
                 List {
                     let points = data.flatMap(\.points)
                     let segment = extent.segment(from: points)
 
-                    ChartView(segment: segment, timing: extent)
-                        .foregroundStyle(color)
-                        .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
+                    ChartView(
+                        segment: segment,
+                        timing: extent,
+                        comparison: extent.comparison(from: points)
+                    )
+                    .foregroundStyle(color)
+                    .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
 
                     if showList {
                         total(count: segment.total)

--- a/Tests/ScoutTests/UI/ChartExtentCompareTests.swift
+++ b/Tests/ScoutTests/UI/ChartExtentCompareTests.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct ChartExtentCompareTests {
+    let date = Date()
+
+    @Test("Previous domain") func testPreviousDomain() {
+        let interval: Double = 3600 * 24 * 7
+        let range = date..<date.addingTimeInterval(interval)
+        let model = ChartExtent(period: Period.week, domain: range)
+
+        let expectedRange = date.addingTimeInterval(-interval)..<date
+        #expect(model.previousDomain == expectedRange)
+    }
+
+    @Test("Comparison is nil when not comparing") func testComparisonOff() {
+        let range = date..<date.addingTimeInterval(3600 * 24 * 7)
+        let model = ChartExtent(period: Period.week, domain: range)
+
+        let point = ChartPoint(date: date.addingTimeInterval(-3600), count: 5)
+        #expect(model.comparison(from: [point]) == nil)
+    }
+
+    @Test("Comparison shifts previous period onto current domain") func testComparisonShift() {
+        let interval: Double = 3600 * 24 * 7
+        let range = date..<date.addingTimeInterval(interval)
+        var model = ChartExtent(period: Period.week, domain: range)
+        model.isComparing = true
+
+        let point = ChartPoint(date: date.addingTimeInterval(-3600), count: 5)
+        let comparison = model.comparison(from: [point])
+
+        let expectedPoint = ChartPoint(
+            date: date.addingTimeInterval(interval - 3600 * 24),
+            count: 5
+        )
+        #expect(comparison?.first == expectedPoint)
+        #expect(comparison?.count == 7)
+        #expect(comparison?.total == 5)
+    }
+
+    @Test("Comparison points fall within current domain") func testComparisonAlignment() {
+        let range = date..<date.addingTimeInterval(3600 * 24 * 7)
+        var model = ChartExtent(period: Period.week, domain: range)
+        model.isComparing = true
+
+        let points = (0..<14).map { i in
+            ChartPoint(date: date.addingTimeInterval(Double(-3600 * 24 * i)), count: 1)
+        }
+        let comparison = model.comparison(from: points)
+
+        #expect(comparison?.allSatisfy { range.contains($0.date) } == true)
+    }
+}


### PR DESCRIPTION
Adds a comparison mode that overlays the previous period on a chart as a gray line with point markers, so e.g. this week can be compared against last week at a glance. A new `Compare` toggle sits below `RangeControl` and, when active, shows the previous date range next to it.

The implementation builds on `ChartExtent`: a new `previousDomain` shifts the visible domain one period back, and `comparison(from:)` buckets points into that range and shifts them forward onto the current axis. `ChartView` renders the optional comparison series as a `LineMark` over the existing bars. The mode is available on the stats, metrics, and activity screens.

Closes #223