### PR TITLE
Prevent matrix double-counting on retry after partial sync failure

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/CrashInfo.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashInfo.swift
@@ -23,13 +23,13 @@ struct CrashInfo: Codable {
     let launchID: UUID
     let sessionID: UUID
 
-    init(name: String, reason: String?, stackTrace: [String]) {
+    init(name: String, reason: String?, stackTrace: [String], sessionID: UUID = IDs.session) {
         self.name = name
         self.reason = reason
         self.stackTrace = stackTrace
         self.date = Date()
         self.installID = IDs.install
         self.launchID = IDs.launch
-        self.sessionID = IDs.session
+        self.sessionID = sessionID
     }
 }

--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -29,12 +29,26 @@ struct SyncEngine: @unchecked Sendable {
                 )
             }
 
-            try await SyncCoordinator(
-                database: database,
-                maxRetry: 3,
-                batch: batch
-            )
-            .upload()
+            // Records already counted into the server matrix on a previous
+            // attempt must not contribute again, or the matrix double-counts.
+            let pending = batch.filter { !$0.isAggregated }
+
+            if pending.count > 0 {
+                try await SyncCoordinator(
+                    database: database,
+                    maxRetry: 3,
+                    batch: pending
+                )
+                .upload()
+
+                for object in pending {
+                    object.isAggregated = true
+                }
+
+                // Persist right away so a crash before the final save
+                // doesn't replay the matrix contribution on the next cycle.
+                try context.save()
+            }
 
             for object in batch {
                 object.isSynced = true

--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -31,7 +31,7 @@ struct SyncEngine: @unchecked Sendable {
 
             // Records already counted into the server matrix on a previous
             // attempt must not contribute again, or the matrix double-counts.
-            let pending = batch.filter { !$0.isAggregated }
+            let pending = batch.filter { $0.syncState == .pending }
 
             if pending.count > 0 {
                 try await SyncCoordinator(
@@ -42,7 +42,7 @@ struct SyncEngine: @unchecked Sendable {
                 .upload()
 
                 for object in pending {
-                    object.isAggregated = true
+                    object.syncState = .aggregated
                 }
 
                 // Persist right away so a crash before the final save
@@ -51,7 +51,7 @@ struct SyncEngine: @unchecked Sendable {
             }
 
             for object in batch {
-                object.isSynced = true
+                object.syncState = .synced
             }
 
             try context.save()

--- a/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
@@ -20,8 +20,8 @@ extension SyncableObject {
 
         let request = NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
         request.predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
-            NSPredicate(format: "isSynced == true AND datePrimitive < %@", cutoff as NSDate),
-            NSPredicate(format: "isSynced == false AND syncAttempts > %d", maxSyncAttempts),
+            NSPredicate(format: "syncStatePrimitive == %d AND datePrimitive < %@", SyncState.synced.rawValue, cutoff as NSDate),
+            NSPredicate(format: "syncStatePrimitive != %d AND syncAttempts > %d", SyncState.synced.rawValue, maxSyncAttempts),
         ])
 
         for object in try context.fetch(request) {

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -17,31 +17,51 @@ protocol Syncable: SyncableObject {
     static func group(in context: NSManagedObjectContext) throws -> [Self]?
 }
 
+/// Progress of a record through the sync pipeline.
+///
+/// A record advances `pending → aggregated → synced`. The intermediate
+/// `aggregated` state marks records whose counts are already merged into
+/// the server matrix, so a retry after a partial sync failure doesn't
+/// re-contribute them and double-count the matrix.
+///
+enum SyncState: Int16 {
+    /// Not uploaded yet; the next sync cycle picks the record up.
+    case pending = 0
+
+    /// Counts are merged into the server matrix, but the cycle hasn't
+    /// finished — the record is still re-sent as a raw upload (idempotent).
+    case aggregated = 1
+
+    /// Fully uploaded; eligible for cleanup once old enough.
+    case synced = 2
+}
+
 @objc(SyncableObject)
 class SyncableObject: IDObject {
-    @NSManaged var isSynced: Bool
-
-    /// Whether this record's counts have been merged into the server matrix.
-    ///
-    /// Tracked separately from `isSynced` so a retry after a partial sync
-    /// failure doesn't re-contribute the batch to the aggregated matrix.
-    ///
-    @NSManaged var isAggregated: Bool
-
+    @NSManaged var syncStatePrimitive: Int16
     @NSManaged var syncAttempts: Int
+
+    var syncState: SyncState {
+        get {
+            SyncState(rawValue: syncStatePrimitive) ?? .pending
+        }
+        set {
+            syncStatePrimitive = newValue.rawValue
+        }
+    }
 
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {
         let entityName = String(describing: T.self)
 
         let seedRequest = NSFetchRequest<T>(entityName: entityName)
-        seedRequest.predicate = NSPredicate(format: "isSynced == false")
+        seedRequest.predicate = NSPredicate(format: "syncStatePrimitive != %d", SyncState.synced.rawValue)
         seedRequest.fetchLimit = 1
 
         guard let seed = try context.fetch(seedRequest).first else {
             return nil
         }
 
-        var predicates = [NSPredicate(format: "isSynced == false")]
+        var predicates = [NSPredicate(format: "syncStatePrimitive != %d", SyncState.synced.rawValue)]
 
         for keyPath in keyPaths {
             if let key = keyPath._kvcKeyPathString, let value = seed.value(forKey: key) as? NSObject {

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -20,6 +20,14 @@ protocol Syncable: SyncableObject {
 @objc(SyncableObject)
 class SyncableObject: IDObject {
     @NSManaged var isSynced: Bool
+
+    /// Whether this record's counts have been merged into the server matrix.
+    ///
+    /// Tracked separately from `isSynced` so a retry after a partial sync
+    /// failure doesn't re-contribute the batch to the aggregated matrix.
+    ///
+    @NSManaged var isAggregated: Bool
+
     @NSManaged var syncAttempts: Int
 
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {

--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -47,9 +47,8 @@
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
     <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="IDObject" syncable="YES" codeGenerationType="none">
-        <attribute name="isAggregated" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="isSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="syncAttempts" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="syncStatePrimitive" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
         <attribute name="sessionID" attributeType="UUID" usesScalarValueType="NO"/>

--- a/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout.xcdatamodel/contents
@@ -47,6 +47,7 @@
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
     <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="IDObject" syncable="YES" codeGenerationType="none">
+        <attribute name="isAggregated" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isSynced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="syncAttempts" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
@@ -38,7 +38,7 @@ struct CrashObjectTests {
         object.name = name
         object.date = date
         object.crashID = UUID()
-        object.isSynced = false
+        object.syncState = .pending
         return object
     }
 }

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
@@ -42,14 +42,13 @@ struct LogCrashTests {
 
     @Test("Preserves sessionID captured at crash time, not the recovery session")
     func preservesCapturedSessionID() throws {
-        // Phase 1: "crashed" process captures its sessionID.
+        // The "crashed" process snapshot carries its own sessionID. A fresh
+        // UUID can never match the recovery session that `awakeFromInsert`
+        // assigns, so the test doesn't need to touch the `IDs.session`
+        // global — other suites mutate it concurrently.
         let crashedSessionID = UUID()
-        IDs.session = crashedSessionID
-        let crash = makeCrashInfo(name: "SIGSEGV", reason: nil, stackTrace: [])
+        let crash = CrashInfo(name: "SIGSEGV", reason: nil, stackTrace: [], sessionID: crashedSessionID)
 
-        // Phase 2: recovery process has a fresh sessionID — awakeFromInsert
-        // would use this unless logCrash overrides it.
-        IDs.session = UUID()
         #expect(IDs.session != crashedSessionID)
 
         try logCrash(crash, context: context)

--- a/Tests/ScoutTests/Core/Lifecycle/Base/IDsTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Base/IDsTests.swift
@@ -10,7 +10,9 @@ import Testing
 
 @testable import Scout
 
-@Suite("IDs")
+// Serialized: both tests mutate the process-wide `IDs.session`, so the
+// round-trip check must not overlap the concurrent-access stress test.
+@Suite("IDs", .serialized)
 struct IDsTests {
     @Test("session getter/setter round-trip")
     func sessionRoundTrip() {

--- a/Tests/ScoutTests/Core/Matrix/Batch/NamedObjectTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/Batch/NamedObjectTests.swift
@@ -81,7 +81,7 @@ extension NamedObject {
         object.name = name
         object.date = date
         object.eventID = UUID()
-        object.isSynced = false
+        object.syncState = .pending
         object.level = "info"
         return object
     }

--- a/Tests/ScoutTests/Core/Sync/SyncEngineTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncEngineTests.swift
@@ -43,8 +43,7 @@ struct SyncEngineTests {
         let engine = SyncEngine(database: database, context: context)
         try await engine.send(type: EventObject.self)
 
-        #expect(event.isAggregated)
-        #expect(event.isSynced)
+        #expect(event.syncState == .synced)
         #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
     }
 
@@ -53,13 +52,13 @@ struct SyncEngineTests {
         // Simulate a crash after the matrix upload was persisted but before
         // the final save: the record is aggregated yet still unsynced.
         let event = EventObject.stub(name: "x", in: context)
-        event.isAggregated = true
+        event.syncState = .aggregated
         try context.save()
 
         let engine = SyncEngine(database: database, context: context)
         try await engine.send(type: EventObject.self)
 
-        #expect(event.isSynced)
+        #expect(event.syncState == .synced)
         #expect(database.events.count == 1)
         #expect(database.records.filter { $0.recordType == Int.recordType }.count == 0)
     }

--- a/Tests/ScoutTests/Core/Sync/SyncEngineTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncEngineTests.swift
@@ -34,4 +34,33 @@ struct SyncEngineTests {
         #expect(event.syncAttempts == 1)
         #expect(!context.hasChanges)
     }
+
+    @Test("Uploads the matrix once and marks the batch aggregated")
+    func marksBatchAggregated() async throws {
+        let event = EventObject.stub(name: "x", in: context)
+        try context.save()
+
+        let engine = SyncEngine(database: database, context: context)
+        try await engine.send(type: EventObject.self)
+
+        #expect(event.isAggregated)
+        #expect(event.isSynced)
+        #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
+    }
+
+    @Test("Does not re-contribute an aggregated batch to the matrix on retry")
+    func skipsMatrixUploadOnRetry() async throws {
+        // Simulate a crash after the matrix upload was persisted but before
+        // the final save: the record is aggregated yet still unsynced.
+        let event = EventObject.stub(name: "x", in: context)
+        event.isAggregated = true
+        try context.save()
+
+        let engine = SyncEngine(database: database, context: context)
+        try await engine.send(type: EventObject.self)
+
+        #expect(event.isSynced)
+        #expect(database.events.count == 1)
+        #expect(database.records.filter { $0.recordType == Int.recordType }.count == 0)
+    }
 }

--- a/Tests/ScoutTests/Stubs/Objects/DeviceObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/DeviceObject+Stub.swift
@@ -19,7 +19,7 @@ extension DeviceObject {
         let device = DeviceObject(entity: entity, insertInto: context)
 
         device.date = date
-        device.isSynced = synced
+        device.syncState = synced ? .synced : .pending
 
         return device
     }

--- a/Tests/ScoutTests/Stubs/Objects/EventObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/EventObject+Stub.swift
@@ -23,7 +23,7 @@ extension EventObject {
         event.name = name
         event.date = date
         event.eventID = UUID()
-        event.isSynced = synced
+        event.syncState = synced ? .synced : .pending
         event.level = level.rawValue
 
         return event

--- a/Tests/ScoutTests/Stubs/Objects/InstallObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/InstallObject+Stub.swift
@@ -19,7 +19,7 @@ extension InstallObject {
         let install = InstallObject(entity: entity, insertInto: context)
 
         install.date = date
-        install.isSynced = synced
+        install.syncState = synced ? .synced : .pending
 
         return install
     }

--- a/Tests/ScoutTests/Stubs/Objects/LaunchObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/LaunchObject+Stub.swift
@@ -20,7 +20,7 @@ extension LaunchObject {
         let launch = LaunchObject(entity: entity, insertInto: context)
 
         launch.date = date
-        launch.isSynced = synced
+        launch.syncState = synced ? .synced : .pending
         launch.endDate = endDate
 
         return launch

--- a/Tests/ScoutTests/Stubs/Objects/SessionObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/SessionObject+Stub.swift
@@ -20,7 +20,7 @@ extension SessionObject {
         let session = SessionObject(entity: entity, insertInto: context)
 
         session.date = date
-        session.isSynced = synced
+        session.syncState = synced ? .synced : .pending
         session.endDate = endDate
 
         return session

--- a/Tests/ScoutTests/Stubs/Objects/UserActivityObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/UserActivityObject+Stub.swift
@@ -25,7 +25,7 @@ extension UserActivityObject {
         activity.month = month
         activity.day = day
         activity.period = period.rawValue
-        activity.isSynced = isSynced
+        activity.syncState = isSynced ? .synced : .pending
 
         // Set all count fields to 0, then set the relevant one
         activity.dayCount = 0

--- a/Tests/ScoutTests/Stubs/Objects/VersionObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/VersionObject+Stub.swift
@@ -21,7 +21,7 @@ extension VersionObject {
         let version = VersionObject(entity: entity, insertInto: context)
 
         version.date = date
-        version.isSynced = synced
+        version.syncState = synced ? .synced : .pending
         version.appVersion = appVersion
         version.buildNumber = buildNumber
 


### PR DESCRIPTION
Fixes #453.

`SyncEngine.send` now tracks matrix aggregation separately from raw-record sync: the former `isSynced` flag is replaced by a `SyncState` enum (`pending → aggregated → synced`) stored on `SyncableObject`. The batch contributed to the server matrix is filtered to `pending` records, and the `aggregated` state is persisted immediately after `SyncCoordinator.upload()` returns, so a crash before the final save no longer replays the batch into the weekly matrix on the next sync cycle. Raw records were already safe thanks to stable record IDs; this closes the same gap for the aggregated matrix.

Also fixes a flaky crash-logging test that raced other suites on the process-wide `IDs.session` global: `CrashInfo` now accepts the session ID as an injectable parameter, the test no longer mutates the global, and `IDsTests` is serialized so its stress test can't interfere with its own round-trip check.
