### PR TITLE
Add comparison mode for charts

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -26,8 +26,16 @@ struct ActivityView: View {
                 RangeControl(extent: $extent)
 
                 List {
-                    chart(data: data)
-                        .listRowSeparator(.hidden)
+                    let points = data.points(on: extent.period)
+
+                    ComparableChart(
+                        segment: extent.segment(from: points),
+                        points: points,
+                        extent: extent,
+                        color: .green,
+                        isComparing: isComparing
+                    )
+                    .listRowSeparator(.hidden)
 
                     ComparisonToggle(isOn: $isComparing)
                 }
@@ -36,22 +44,6 @@ struct ActivityView: View {
             }
         }
         .navigationTitle(en: "Active Users")
-    }
-
-    @ViewBuilder func chart(data: [ActivityMatrix]) -> some View {
-        let points = data.points(on: extent.period)
-
-        if isComparing {
-            ComparisonChartView(
-                segment: extent.segment(from: points),
-                reference: extent.referenceSegment(from: points),
-                timing: extent,
-                color: .green
-            )
-        } else {
-            ChartView(segment: extent.segment(from: points), timing: extent)
-                .foregroundStyle(.green)
-        }
     }
 }
 

--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct ActivityView: View {
     @State var extent: ChartExtent<ActivityPeriod>
+    @State private var isComparing = false
     @ObservedObject var activity: ActivityProvider
 
     init(activity: ActivityProvider, period: ActivityPeriod) {
@@ -25,11 +26,10 @@ struct ActivityView: View {
                 RangeControl(extent: $extent)
 
                 List {
-                    let segment = extent.segment(from: data)
-
-                    ChartView(segment: segment, timing: extent)
-                        .foregroundStyle(.green)
+                    chart(data: data)
                         .listRowSeparator(.hidden)
+
+                    ComparisonToggle(isOn: $isComparing)
                 }
                 .listStyle(.plain)
                 .scrollDisabled(true)
@@ -37,11 +37,21 @@ struct ActivityView: View {
         }
         .navigationTitle(en: "Active Users")
     }
-}
 
-extension ChartExtent<ActivityPeriod> {
-    fileprivate func segment(from matrices: [ActivityMatrix]) -> [ChartPoint<Int>] {
-        segment(from: matrices.points(on: period))
+    @ViewBuilder func chart(data: [ActivityMatrix]) -> some View {
+        let points = data.points(on: extent.period)
+
+        if isComparing {
+            ComparisonChartView(
+                segment: extent.segment(from: points),
+                reference: extent.referenceSegment(from: points),
+                timing: extent,
+                color: .green
+            )
+        } else {
+            ChartView(segment: extent.segment(from: points), timing: extent)
+                .foregroundStyle(.green)
+        }
     }
 }
 

--- a/Sources/Scout/UI/Chart/ChartPlaceholder.swift
+++ b/Sources/Scout/UI/Chart/ChartPlaceholder.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+/// "No results" placeholder shown over an empty chart's plot area.
+struct ChartPlaceholder: View {
+    var body: some View {
+        Text(verbatim: "No results")
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundStyle(.gray.opacity(0.7))
+    }
+}

--- a/Sources/Scout/UI/Chart/ChartTiming.swift
+++ b/Sources/Scout/UI/Chart/ChartTiming.swift
@@ -12,6 +12,32 @@ protocol ChartTiming {
     var tickValues: [Date]? { get }
 }
 
+/// The time slot a bucket occupies on the x axis.
+///
+/// `BarMark` bins dates with the local calendar, so charts derive their bar
+/// slots, domains, and ticks from the same bins to stay pixel-aligned with
+/// the binned marks.
+///
+func binRange(of date: Date, unit: Calendar.Component) -> Range<Date> {
+    let interval = Calendar.autoupdatingCurrent.dateInterval(of: unit, for: date)!
+    return interval.start..<interval.end
+}
+
+extension ChartTiming {
+    /// Explicit x-axis ticks for `segment`: the scale's own `tickValues`
+    /// when defined, otherwise bucket bin starts thinned to at most four —
+    /// the dates the automatic axis picks for binned bar charts.
+    ///
+    func tickDates<T: ChartNumeric>(for segment: [ChartPoint<T>]) -> [Date] {
+        if let values = tickValues {
+            return values
+        }
+        let starts = segment.map { binRange(of: $0.date, unit: unit).lowerBound }.sorted()
+        let step = max(1, (starts.count + 3) / 4)
+        return stride(from: 0, to: starts.count, by: step).map { starts[$0] }
+    }
+}
+
 extension ChartExtent: ChartTiming {
     var unit: Calendar.Component {
         period.pointComponent

--- a/Sources/Scout/UI/Chart/ChartView.swift
+++ b/Sources/Scout/UI/Chart/ChartView.swift
@@ -8,6 +8,14 @@
 import Charts
 import SwiftUI
 
+/// Fraction of its slot a bar occupies.
+///
+/// Pinned explicitly on both the plain bar marks and the comparison chart's
+/// geometry, so the two modes render identical bars regardless of the
+/// framework's default width.
+///
+let chartBarRatio: Double = 0.7
+
 struct ChartView<T: ChartNumeric>: View {
     let segment: [ChartPoint<T>]
     let timing: ChartTiming
@@ -18,21 +26,16 @@ struct ChartView<T: ChartNumeric>: View {
         Chart(segment, id: \.date) { point in
             BarMark(
                 x: .value("X", point.date, unit: unit),
-                y: .value("Y", point.count)
+                y: .value("Y", point.count),
+                width: .ratio(chartBarRatio)
             )
         }
         .chartXAxis {
-            if let values = timing.tickValues {
-                AxisMarks(format: unit.chartFormat, values: values)
-            } else {
-                AxisMarks(format: unit.chartFormat)
-            }
+            AxisMarks(format: unit.chartFormat, values: timing.tickDates(for: segment))
         }
         .chartBackground { _ in
             if segment.total == .zero {
-                Text(verbatim: "No results")
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundStyle(.gray.opacity(0.7))
+                ChartPlaceholder()
             }
         }
         .aspectRatio(4 / 3, contentMode: .fit)

--- a/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
@@ -14,12 +14,16 @@ extension ChartExtent {
     }
 
     /// Buckets `points` into the previous window and places the results on
-    /// the current window's bucket dates, so each previous value lines up
-    /// with the bucket it should be compared against.
+    /// the bucket dates of `segment`, pairing buckets by their offset from
+    /// the period's end.
     ///
-    func referenceSegment<U: ChartNumeric>(from points: [ChartPoint<U>]) -> [ChartPoint<U>] {
-        let current = segment(from: points)
+    /// `segment` is the current window's segment, which callers have already
+    /// computed. When the previous window spans fewer buckets (calendar
+    /// months differ in length), the oldest current buckets have no
+    /// counterpart and are omitted; the chart draws no reference for them.
+    ///
+    func referenceSegment<U: ChartNumeric>(from points: [ChartPoint<U>], alignedTo segment: [ChartPoint<U>]) -> [ChartPoint<U>] {
         let previous = points.bucket(in: previousDomain, component: period.pointComponent)
-        return zip(current, previous).map { ChartPoint(date: $0.date, count: $1.count) }
+        return zip(segment, previous).map { ChartPoint(date: $0.date, count: $1.count) }
     }
 }

--- a/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension ChartExtent {
+    /// The same window one `rangeComponent` earlier than the current domain.
+    var previousDomain: Range<Date> {
+        domain.moved(by: period.rangeComponent, value: -1)
+    }
+
+    /// Buckets `points` into the previous window and places the results on
+    /// the current window's bucket dates, so each previous value lines up
+    /// with the bucket it should be compared against.
+    ///
+    func referenceSegment<U: ChartNumeric>(from points: [ChartPoint<U>]) -> [ChartPoint<U>] {
+        let current = segment(from: points)
+        let previous = points.bucket(in: previousDomain, component: period.pointComponent)
+        return zip(current, previous).map { ChartPoint(date: $0.date, count: $1.count) }
+    }
+}

--- a/Sources/Scout/UI/Chart/Comparison/ComparableChart.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparableChart.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+/// Chart row that switches between the plain bar chart and the comparison
+/// overlay; pairs with `ComparisonToggle` driving `isComparing`.
+///
+/// `points` is the full data set the reference segment is bucketed from,
+/// while `segment` is the already-computed current-window slice of it.
+///
+struct ComparableChart<T: ChartNumeric, S: ChartTimeScale>: View {
+    let segment: [ChartPoint<T>]
+    let points: [ChartPoint<T>]
+    let extent: ChartExtent<S>
+    let color: Color
+    let isComparing: Bool
+
+    var body: some View {
+        if isComparing {
+            ComparisonChartView(
+                segment: segment,
+                reference: extent.referenceSegment(from: points, alignedTo: segment),
+                timing: extent,
+                color: color
+            )
+        } else {
+            ChartView(segment: segment, timing: extent)
+                .foregroundStyle(color)
+        }
+    }
+}

--- a/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
@@ -8,26 +8,11 @@
 import Charts
 import SwiftUI
 
-/// Horizontal portion of each bucket slot occupied by a bar.
+/// Horizontal portion of each bucket slot occupied by a bar, derived from
+/// `chartBarRatio` and shared by the marks and the `ReferenceOverlay` so the
+/// reference marks match the bars exactly.
 ///
-/// Shared by the marks and the overlay so the reference marks match the bars
-/// exactly. The centered 70% of the slot matches the default `BarMark` width,
-/// keeping bars the same size as in the plain `ChartView`.
-///
-private let barSlot: ClosedRange<Double> = 0.15...0.85
-
-private let referenceDash = StrokeStyle(lineWidth: 1.5, dash: [4, 4])
-
-/// The time slot a bucket occupies on the x axis.
-///
-/// `BarMark` bins dates with the local calendar, so the comparison chart
-/// derives its bar slots, domain, and ticks from the same bins to keep the
-/// two modes pixel-aligned.
-///
-private func binRange(of date: Date, unit: Calendar.Component) -> Range<Date> {
-    let interval = Calendar.autoupdatingCurrent.dateInterval(of: unit, for: date)!
-    return interval.start..<interval.end
-}
+let barSlot: ClosedRange<Double> = (0.5 - chartBarRatio / 2)...(0.5 + chartBarRatio / 2)
 
 /// A bar chart of the current period with the previous period's per-bucket
 /// levels drawn on top of it.
@@ -38,8 +23,8 @@ private func binRange(of date: Date, unit: Calendar.Component) -> Range<Date> {
 ///   previous level and the missing slice is tinted.
 ///
 /// `reference` is expected to sit on the same bucket dates as `segment`
-/// (see `ChartExtent.referenceSegment(from:)`); buckets missing from it are
-/// treated as zero.
+/// (see `ChartExtent.referenceSegment(from:alignedTo:)`); buckets missing
+/// from it have no comparison data and draw no reference marks.
 ///
 /// The y scale covers both periods, rounded up to a nice axis value the same
 /// way plain bar charts round their maximum — so reference contours always
@@ -52,15 +37,14 @@ struct ComparisonChartView<T: ChartNumeric>: View {
     let color: Color
 
     var body: some View {
-        let unit = timing.unit
+        let pairs = self.pairs
 
         Chart(pairs) { pair in
-            bar(for: pair)
-            scaleAnchor(for: pair)
+            marks(for: pair)
         }
-        .chartXScale(domain: xDomain)
+        .chartXScale(domain: xDomain(of: pairs))
         .chartXAxis {
-            AxisMarks(format: unit.chartFormat, values: timing.tickValues ?? tickDates)
+            AxisMarks(format: timing.unit.chartFormat, values: timing.tickDates(for: segment))
         }
         .chartOverlay { proxy in
             GeometryReader { geo in
@@ -68,16 +52,13 @@ struct ComparisonChartView<T: ChartNumeric>: View {
                     pairs: pairs,
                     proxy: proxy,
                     plotFrame: geo[proxy.plotAreaFrame],
-                    unit: unit,
                     color: color
                 )
             }
         }
         .chartBackground { _ in
             if segment.total == .zero && reference.total == .zero {
-                Text(verbatim: "No results")
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundStyle(.gray.opacity(0.7))
+                ChartPlaceholder()
             }
         }
         .aspectRatio(4 / 3, contentMode: .fit)
@@ -89,164 +70,64 @@ struct ComparisonChartView<T: ChartNumeric>: View {
     var pairs: [ComparisonPair<T>] {
         let counts = Dictionary(reference.map { ($0.date, $0.count) }, uniquingKeysWith: +)
         return segment.map { point in
-            ComparisonPair(date: point.date, count: point.count, reference: counts[point.date] ?? .zero)
+            ComparisonPair(
+                date: point.date,
+                bin: binRange(of: point.date, unit: timing.unit),
+                count: point.count,
+                reference: counts[point.date]
+            )
         }
     }
 
     /// Full bucket bands, so the edge bars are inset from the plot edges the
     /// same way binned `BarMark` charts are.
     ///
-    var xDomain: ClosedRange<Date> {
-        let dates = segment.map(\.date)
-        guard let first = dates.min(), let last = dates.max() else {
+    func xDomain(of pairs: [ComparisonPair<T>]) -> ClosedRange<Date> {
+        guard let first = pairs.map(\.bin.lowerBound).min(), let last = pairs.map(\.bin.upperBound).max() else {
             return Date().startOfDay...Date().startOfDay.addingDay()
         }
-        return binRange(of: first, unit: timing.unit).lowerBound...binRange(of: last, unit: timing.unit).upperBound
+        return first...last
     }
 
-    /// Bucket bin starts thinned to at most four ticks — the same dates the
-    /// default axis of a binned `BarMark` chart picks.
+    /// The bar for the current value, plus an invisible mark at the previous
+    /// level so the y scale grows to a rounded maximum that fits reference
+    /// contours rising above the bars.
     ///
-    var tickDates: [Date] {
-        let starts = segment.map { binRange(of: $0.date, unit: timing.unit).lowerBound }.sorted()
-        let step = max(1, (starts.count + 3) / 4)
-        return stride(from: 0, to: starts.count, by: step).map { starts[$0] }
-    }
-
-    func bar(for pair: ComparisonPair<T>) -> some ChartContent {
-        let bin = binRange(of: pair.date, unit: timing.unit)
-        let length = bin.upperBound.timeIntervalSince(bin.lowerBound)
-        let start: PlottableValue<Date> = .value("Start", bin.lowerBound.addingTimeInterval(length * barSlot.lowerBound))
-        let end: PlottableValue<Date> = .value("End", bin.lowerBound.addingTimeInterval(length * barSlot.upperBound))
+    @ChartContentBuilder func marks(for pair: ComparisonPair<T>) -> some ChartContent {
+        let length = pair.bin.upperBound.timeIntervalSince(pair.bin.lowerBound)
+        let start: PlottableValue<Date> = .value("Start", pair.bin.lowerBound.addingTimeInterval(length * barSlot.lowerBound))
+        let end: PlottableValue<Date> = .value("End", pair.bin.lowerBound.addingTimeInterval(length * barSlot.upperBound))
         let zero: PlottableValue<T> = .value("Zero", .zero)
         let count: PlottableValue<T> = .value("Count", pair.count)
 
-        return RectangleMark(xStart: start, xEnd: end, yStart: zero, yEnd: count)
+        RectangleMark(xStart: start, xEnd: end, yStart: zero, yEnd: count)
             .foregroundStyle(color)
             .cornerRadius(3)
-    }
 
-    /// An invisible mark at the previous level, so the y scale grows to a
-    /// rounded maximum that fits reference contours rising above the bars.
-    ///
-    func scaleAnchor(for pair: ComparisonPair<T>) -> some ChartContent {
-        let bin = binRange(of: pair.date, unit: timing.unit)
-        let center: PlottableValue<Date> = .value("Center", bin.lowerBound.addingTimeInterval(bin.upperBound.timeIntervalSince(bin.lowerBound) / 2))
-        let reference: PlottableValue<T> = .value("Reference", pair.reference)
+        if let reference = pair.reference {
+            let center: PlottableValue<Date> = .value("Center", pair.bin.lowerBound.addingTimeInterval(length / 2))
+            let level: PlottableValue<T> = .value("Reference", reference)
 
-        return PointMark(x: center, y: reference)
-            .opacity(0)
+            PointMark(x: center, y: level)
+                .opacity(0)
+        }
     }
 }
 
 /// One bucket of the comparison: the current value and the previous-period
 /// value it is compared against, both on the current bucket's date.
 ///
+/// `reference` is nil when the previous window has no counterpart bucket —
+/// calendar months differ in length, so the oldest buckets of a longer
+/// current window have nothing to compare against.
+///
 struct ComparisonPair<T: ChartNumeric>: Identifiable {
     let date: Date
+    let bin: Range<Date>
     let count: T
-    let reference: T
+    let reference: T?
 
     var id: Date { date }
-}
-
-// MARK: - Overlay
-
-/// Draws the previous-period levels over the plot area using chart-proxy
-/// coordinates, since bar marks cannot render dashed strokes.
-///
-private struct ReferenceOverlay<T: ChartNumeric>: View {
-    let pairs: [ComparisonPair<T>]
-    let proxy: ChartProxy
-    let plotFrame: CGRect
-    let unit: Calendar.Component
-    let color: Color
-
-    var body: some View {
-        ZStack {
-            slices { $0.reference <= $0.count }
-                .fill(.white.opacity(0.25))
-            slices { $0.reference > $0.count }
-                .fill(color.opacity(0.12))
-            referenceLines()
-                .stroke(style: referenceDash)
-                .foregroundStyle(.white)
-            referenceContours()
-                .stroke(style: referenceDash)
-                .foregroundStyle(color)
-        }
-    }
-
-    /// Rectangles between the two periods' levels for the matching buckets.
-    func slices(where matches: (ComparisonPair<T>) -> Bool) -> Path {
-        Path { path in
-            for pair in pairs where matches(pair) && !isEmpty(pair) {
-                guard let frame = frame(for: pair) else { continue }
-                let top = min(frame.count, frame.reference)
-                let bottom = max(frame.count, frame.reference)
-                path.addRect(
-                    CGRect(
-                        x: frame.x.lowerBound,
-                        y: top,
-                        width: frame.x.upperBound - frame.x.lowerBound,
-                        height: bottom - top
-                    )
-                )
-            }
-        }
-    }
-
-    /// White dashed lines across the bars where the value grew.
-    func referenceLines() -> Path {
-        Path { path in
-            for pair in pairs where pair.reference <= pair.count && !isEmpty(pair) {
-                guard let frame = frame(for: pair) else { continue }
-                path.move(to: CGPoint(x: frame.x.lowerBound, y: frame.reference))
-                path.addLine(to: CGPoint(x: frame.x.upperBound, y: frame.reference))
-            }
-        }
-    }
-
-    /// Dashed contours rising above the bars where the value dropped.
-    ///
-    /// A contour clipped by the plot's top edge is left without its cap to
-    /// show that the previous level lies beyond the visible scale.
-    ///
-    func referenceContours() -> Path {
-        Path { path in
-            for pair in pairs where pair.reference > pair.count {
-                guard let frame = frame(for: pair) else { continue }
-                path.move(to: CGPoint(x: frame.x.lowerBound, y: frame.count))
-                path.addLine(to: CGPoint(x: frame.x.lowerBound, y: frame.reference))
-                if frame.isClamped {
-                    path.move(to: CGPoint(x: frame.x.upperBound, y: frame.reference))
-                } else {
-                    path.addLine(to: CGPoint(x: frame.x.upperBound, y: frame.reference))
-                }
-                path.addLine(to: CGPoint(x: frame.x.upperBound, y: frame.count))
-            }
-        }
-    }
-
-    func isEmpty(_ pair: ComparisonPair<T>) -> Bool {
-        pair.count == .zero && pair.reference == .zero
-    }
-
-    /// Bar-aligned geometry for one bucket, in overlay coordinates.
-    func frame(for pair: ComparisonPair<T>) -> (x: ClosedRange<CGFloat>, count: CGFloat, reference: CGFloat, isClamped: Bool)? {
-        let bin = binRange(of: pair.date, unit: unit)
-        guard let slotStart = proxy.position(forX: bin.lowerBound), let slotEnd = proxy.position(forX: bin.upperBound) else {
-            return nil
-        }
-        guard let countY = proxy.position(forY: pair.count), let referenceY = proxy.position(forY: pair.reference) else {
-            return nil
-        }
-        let width = slotEnd - slotStart
-        let lower = plotFrame.minX + slotStart + width * barSlot.lowerBound
-        let upper = plotFrame.minX + slotStart + width * barSlot.upperBound
-        let reference = plotFrame.minY + referenceY
-        return (lower...upper, plotFrame.minY + countY, max(reference, plotFrame.minY), isClamped: reference < plotFrame.minY)
-    }
 }
 
 // MARK: - Previews
@@ -258,12 +139,13 @@ private struct ReferenceOverlay<T: ChartNumeric>: View {
     let points = counts.enumerated().map { i, count in
         ChartPoint(date: today.addingDay(-i - 1), count: count)
     }
+    let segment = extent.segment(from: points)
 
     return VStack(alignment: .leading, spacing: 24) {
         Text(verbatim: "With Data").font(.headline)
         ComparisonChartView(
-            segment: extent.segment(from: points),
-            reference: extent.referenceSegment(from: points),
+            segment: segment,
+            reference: extent.referenceSegment(from: points, alignedTo: segment),
             timing: extent,
             color: .blue
         )

--- a/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
@@ -1,0 +1,275 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Charts
+import SwiftUI
+
+/// Horizontal portion of each bucket slot occupied by a bar.
+///
+/// Shared by the marks and the overlay so the reference marks match the bars
+/// exactly. The centered 70% of the slot matches the default `BarMark` width,
+/// keeping bars the same size as in the plain `ChartView`.
+///
+private let barSlot: ClosedRange<Double> = 0.15...0.85
+
+private let referenceDash = StrokeStyle(lineWidth: 1.5, dash: [4, 4])
+
+/// The time slot a bucket occupies on the x axis.
+///
+/// `BarMark` bins dates with the local calendar, so the comparison chart
+/// derives its bar slots, domain, and ticks from the same bins to keep the
+/// two modes pixel-aligned.
+///
+private func binRange(of date: Date, unit: Calendar.Component) -> Range<Date> {
+    let interval = Calendar.autoupdatingCurrent.dateInterval(of: unit, for: date)!
+    return interval.start..<interval.end
+}
+
+/// A bar chart of the current period with the previous period's per-bucket
+/// levels drawn on top of it.
+///
+/// - where the value grew, a white dashed line marks the previous level and
+///   the slice of the bar above it is lightened;
+/// - where the value dropped, a dashed contour rises above the bar to the
+///   previous level and the missing slice is tinted.
+///
+/// `reference` is expected to sit on the same bucket dates as `segment`
+/// (see `ChartExtent.referenceSegment(from:)`); buckets missing from it are
+/// treated as zero.
+///
+/// The y scale covers both periods, rounded up to a nice axis value the same
+/// way plain bar charts round their maximum — so reference contours always
+/// fit and the axis keeps regular tick values.
+///
+struct ComparisonChartView<T: ChartNumeric>: View {
+    let segment: [ChartPoint<T>]
+    let reference: [ChartPoint<T>]
+    let timing: ChartTiming
+    let color: Color
+
+    var body: some View {
+        let unit = timing.unit
+
+        Chart(pairs) { pair in
+            bar(for: pair)
+            scaleAnchor(for: pair)
+        }
+        .chartXScale(domain: xDomain)
+        .chartXAxis {
+            AxisMarks(format: unit.chartFormat, values: timing.tickValues ?? tickDates)
+        }
+        .chartOverlay { proxy in
+            GeometryReader { geo in
+                ReferenceOverlay(
+                    pairs: pairs,
+                    proxy: proxy,
+                    plotFrame: geo[proxy.plotAreaFrame],
+                    unit: unit,
+                    color: color
+                )
+            }
+        }
+        .chartBackground { _ in
+            if segment.total == .zero && reference.total == .zero {
+                Text(verbatim: "No results")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(.gray.opacity(0.7))
+            }
+        }
+        .aspectRatio(4 / 3, contentMode: .fit)
+        .padding()
+        .padding(.bottom)
+        .listRowInsets(EdgeInsets())
+    }
+
+    var pairs: [ComparisonPair<T>] {
+        let counts = Dictionary(reference.map { ($0.date, $0.count) }, uniquingKeysWith: +)
+        return segment.map { point in
+            ComparisonPair(date: point.date, count: point.count, reference: counts[point.date] ?? .zero)
+        }
+    }
+
+    /// Full bucket bands, so the edge bars are inset from the plot edges the
+    /// same way binned `BarMark` charts are.
+    ///
+    var xDomain: ClosedRange<Date> {
+        let dates = segment.map(\.date)
+        guard let first = dates.min(), let last = dates.max() else {
+            return Date().startOfDay...Date().startOfDay.addingDay()
+        }
+        return binRange(of: first, unit: timing.unit).lowerBound...binRange(of: last, unit: timing.unit).upperBound
+    }
+
+    /// Bucket bin starts thinned to at most four ticks — the same dates the
+    /// default axis of a binned `BarMark` chart picks.
+    ///
+    var tickDates: [Date] {
+        let starts = segment.map { binRange(of: $0.date, unit: timing.unit).lowerBound }.sorted()
+        let step = max(1, (starts.count + 3) / 4)
+        return stride(from: 0, to: starts.count, by: step).map { starts[$0] }
+    }
+
+    func bar(for pair: ComparisonPair<T>) -> some ChartContent {
+        let bin = binRange(of: pair.date, unit: timing.unit)
+        let length = bin.upperBound.timeIntervalSince(bin.lowerBound)
+        let start: PlottableValue<Date> = .value("Start", bin.lowerBound.addingTimeInterval(length * barSlot.lowerBound))
+        let end: PlottableValue<Date> = .value("End", bin.lowerBound.addingTimeInterval(length * barSlot.upperBound))
+        let zero: PlottableValue<T> = .value("Zero", .zero)
+        let count: PlottableValue<T> = .value("Count", pair.count)
+
+        return RectangleMark(xStart: start, xEnd: end, yStart: zero, yEnd: count)
+            .foregroundStyle(color)
+            .cornerRadius(3)
+    }
+
+    /// An invisible mark at the previous level, so the y scale grows to a
+    /// rounded maximum that fits reference contours rising above the bars.
+    ///
+    func scaleAnchor(for pair: ComparisonPair<T>) -> some ChartContent {
+        let bin = binRange(of: pair.date, unit: timing.unit)
+        let center: PlottableValue<Date> = .value("Center", bin.lowerBound.addingTimeInterval(bin.upperBound.timeIntervalSince(bin.lowerBound) / 2))
+        let reference: PlottableValue<T> = .value("Reference", pair.reference)
+
+        return PointMark(x: center, y: reference)
+            .opacity(0)
+    }
+}
+
+/// One bucket of the comparison: the current value and the previous-period
+/// value it is compared against, both on the current bucket's date.
+///
+struct ComparisonPair<T: ChartNumeric>: Identifiable {
+    let date: Date
+    let count: T
+    let reference: T
+
+    var id: Date { date }
+}
+
+// MARK: - Overlay
+
+/// Draws the previous-period levels over the plot area using chart-proxy
+/// coordinates, since bar marks cannot render dashed strokes.
+///
+private struct ReferenceOverlay<T: ChartNumeric>: View {
+    let pairs: [ComparisonPair<T>]
+    let proxy: ChartProxy
+    let plotFrame: CGRect
+    let unit: Calendar.Component
+    let color: Color
+
+    var body: some View {
+        ZStack {
+            slices { $0.reference <= $0.count }
+                .fill(.white.opacity(0.25))
+            slices { $0.reference > $0.count }
+                .fill(color.opacity(0.12))
+            referenceLines()
+                .stroke(style: referenceDash)
+                .foregroundStyle(.white)
+            referenceContours()
+                .stroke(style: referenceDash)
+                .foregroundStyle(color)
+        }
+    }
+
+    /// Rectangles between the two periods' levels for the matching buckets.
+    func slices(where matches: (ComparisonPair<T>) -> Bool) -> Path {
+        Path { path in
+            for pair in pairs where matches(pair) && !isEmpty(pair) {
+                guard let frame = frame(for: pair) else { continue }
+                let top = min(frame.count, frame.reference)
+                let bottom = max(frame.count, frame.reference)
+                path.addRect(
+                    CGRect(
+                        x: frame.x.lowerBound,
+                        y: top,
+                        width: frame.x.upperBound - frame.x.lowerBound,
+                        height: bottom - top
+                    )
+                )
+            }
+        }
+    }
+
+    /// White dashed lines across the bars where the value grew.
+    func referenceLines() -> Path {
+        Path { path in
+            for pair in pairs where pair.reference <= pair.count && !isEmpty(pair) {
+                guard let frame = frame(for: pair) else { continue }
+                path.move(to: CGPoint(x: frame.x.lowerBound, y: frame.reference))
+                path.addLine(to: CGPoint(x: frame.x.upperBound, y: frame.reference))
+            }
+        }
+    }
+
+    /// Dashed contours rising above the bars where the value dropped.
+    ///
+    /// A contour clipped by the plot's top edge is left without its cap to
+    /// show that the previous level lies beyond the visible scale.
+    ///
+    func referenceContours() -> Path {
+        Path { path in
+            for pair in pairs where pair.reference > pair.count {
+                guard let frame = frame(for: pair) else { continue }
+                path.move(to: CGPoint(x: frame.x.lowerBound, y: frame.count))
+                path.addLine(to: CGPoint(x: frame.x.lowerBound, y: frame.reference))
+                if frame.isClamped {
+                    path.move(to: CGPoint(x: frame.x.upperBound, y: frame.reference))
+                } else {
+                    path.addLine(to: CGPoint(x: frame.x.upperBound, y: frame.reference))
+                }
+                path.addLine(to: CGPoint(x: frame.x.upperBound, y: frame.count))
+            }
+        }
+    }
+
+    func isEmpty(_ pair: ComparisonPair<T>) -> Bool {
+        pair.count == .zero && pair.reference == .zero
+    }
+
+    /// Bar-aligned geometry for one bucket, in overlay coordinates.
+    func frame(for pair: ComparisonPair<T>) -> (x: ClosedRange<CGFloat>, count: CGFloat, reference: CGFloat, isClamped: Bool)? {
+        let bin = binRange(of: pair.date, unit: unit)
+        guard let slotStart = proxy.position(forX: bin.lowerBound), let slotEnd = proxy.position(forX: bin.upperBound) else {
+            return nil
+        }
+        guard let countY = proxy.position(forY: pair.count), let referenceY = proxy.position(forY: pair.reference) else {
+            return nil
+        }
+        let width = slotEnd - slotStart
+        let lower = plotFrame.minX + slotStart + width * barSlot.lowerBound
+        let upper = plotFrame.minX + slotStart + width * barSlot.upperBound
+        let reference = plotFrame.minY + referenceY
+        return (lower...upper, plotFrame.minY + countY, max(reference, plotFrame.minY), isClamped: reference < plotFrame.minY)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("ComparisonChartView – Week") {
+    let extent = ChartExtent(period: Period.week)
+    let today = Date().startOfDay
+    let counts = [14, 25, 17, 22, 9, 18, 12, 12, 16, 10, 19, 11, 15, 8]
+    let points = counts.enumerated().map { i, count in
+        ChartPoint(date: today.addingDay(-i - 1), count: count)
+    }
+
+    return VStack(alignment: .leading, spacing: 24) {
+        Text(verbatim: "With Data").font(.headline)
+        ComparisonChartView(
+            segment: extent.segment(from: points),
+            reference: extent.referenceSegment(from: points),
+            timing: extent,
+            color: .blue
+        )
+
+        Text(verbatim: "Empty State").font(.headline)
+        ComparisonChartView(segment: .empty, reference: .empty, timing: extent, color: .blue)
+    }
+    .padding()
+}

--- a/Sources/Scout/UI/Chart/Comparison/ComparisonToggle.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonToggle.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+/// List row with the switch that turns the previous-period overlay on.
+struct ComparisonToggle: View {
+    @Binding var isOn: Bool
+
+    var body: some View {
+        Toggle(isOn: $isOn) {
+            Text(verbatim: "Compare with previous period")
+        }
+        .listRowSeparator(.hidden)
+    }
+}
+
+#Preview("ComparisonToggle") {
+    List {
+        ComparisonToggle(isOn: .constant(true))
+        ComparisonToggle(isOn: .constant(false))
+    }
+    .listStyle(.plain)
+}

--- a/Sources/Scout/UI/Chart/Comparison/ReferenceOverlay.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ReferenceOverlay.swift
@@ -1,0 +1,125 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Charts
+import SwiftUI
+
+private let referenceDash = StrokeStyle(lineWidth: 1.5, dash: [4, 4])
+
+/// Bar-aligned geometry of one bucket's reference level, in overlay
+/// coordinates.
+///
+struct ReferenceLevel {
+    let x: ClosedRange<CGFloat>
+    let count: CGFloat
+    let reference: CGFloat
+    let isClamped: Bool
+
+    /// Whether the previous level lies above the bar (the value dropped).
+    var isDrop: Bool { reference < count }
+}
+
+/// Draws the previous-period levels over the plot area using chart-proxy
+/// coordinates, since bar marks cannot render dashed strokes.
+///
+struct ReferenceOverlay<T: ChartNumeric>: View {
+    let pairs: [ComparisonPair<T>]
+    let proxy: ChartProxy
+    let plotFrame: CGRect
+    let color: Color
+
+    var body: some View {
+        let levels = pairs.compactMap(level(for:))
+        let gains = levels.filter { !$0.isDrop }
+        let drops = levels.filter(\.isDrop)
+
+        ZStack {
+            slices(for: gains)
+                .fill(.white.opacity(0.25))
+            slices(for: drops)
+                .fill(color.opacity(0.12))
+            lines(for: gains)
+                .stroke(style: referenceDash)
+                .foregroundStyle(.white)
+            contours(for: drops)
+                .stroke(style: referenceDash)
+                .foregroundStyle(color)
+        }
+    }
+
+    /// Rectangles between the two periods' levels.
+    func slices(for levels: [ReferenceLevel]) -> Path {
+        Path { path in
+            for level in levels {
+                let top = min(level.count, level.reference)
+                let bottom = max(level.count, level.reference)
+                path.addRect(
+                    CGRect(
+                        x: level.x.lowerBound,
+                        y: top,
+                        width: level.x.upperBound - level.x.lowerBound,
+                        height: bottom - top
+                    )
+                )
+            }
+        }
+    }
+
+    /// White dashed lines across the bars where the value grew.
+    func lines(for levels: [ReferenceLevel]) -> Path {
+        Path { path in
+            for level in levels {
+                path.move(to: CGPoint(x: level.x.lowerBound, y: level.reference))
+                path.addLine(to: CGPoint(x: level.x.upperBound, y: level.reference))
+            }
+        }
+    }
+
+    /// Dashed contours rising above the bars where the value dropped.
+    ///
+    /// A contour clipped by the plot's top edge is left without its cap to
+    /// show that the previous level lies beyond the visible scale.
+    ///
+    func contours(for levels: [ReferenceLevel]) -> Path {
+        Path { path in
+            for level in levels {
+                path.move(to: CGPoint(x: level.x.lowerBound, y: level.count))
+                path.addLine(to: CGPoint(x: level.x.lowerBound, y: level.reference))
+                if level.isClamped {
+                    path.move(to: CGPoint(x: level.x.upperBound, y: level.reference))
+                } else {
+                    path.addLine(to: CGPoint(x: level.x.upperBound, y: level.reference))
+                }
+                path.addLine(to: CGPoint(x: level.x.upperBound, y: level.count))
+            }
+        }
+    }
+
+    /// Geometry for one bucket; nil for buckets without comparison data,
+    /// empty in both periods, or falling outside the plot.
+    ///
+    func level(for pair: ComparisonPair<T>) -> ReferenceLevel? {
+        guard let referenceCount = pair.reference else { return nil }
+        guard pair.count != .zero || referenceCount != .zero else { return nil }
+
+        guard let slotStart = proxy.position(forX: pair.bin.lowerBound), let slotEnd = proxy.position(forX: pair.bin.upperBound) else {
+            return nil
+        }
+        guard let countY = proxy.position(forY: pair.count), let referenceY = proxy.position(forY: referenceCount) else {
+            return nil
+        }
+        let width = slotEnd - slotStart
+        let reference = plotFrame.minY + referenceY
+
+        return ReferenceLevel(
+            x: (plotFrame.minX + slotStart + width * barSlot.lowerBound)...(plotFrame.minX + slotStart + width * barSlot.upperBound),
+            count: plotFrame.minY + countY,
+            reference: max(reference, plotFrame.minY),
+            isClamped: reference < plotFrame.minY
+        )
+    }
+}

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -13,6 +13,7 @@ struct MetricsView<T: ChartNumeric>: View {
     let formatter: KeyPath<T, String>
 
     @State var extent: ChartExtent<Period>
+    @State private var isComparing = false
 
     init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period) {
         self.group = group
@@ -34,16 +35,29 @@ struct MetricsView<T: ChartNumeric>: View {
         RangeControl(extent: $extent)
 
         List {
-            let segment = extent.segment(from: group.points)
-
-            ChartView(segment: segment, timing: extent)
+            chart(segment: extent.segment(from: group.points))
                 .chartYAxis(content: { formattedMarks })
-                .foregroundStyle(.blue)
                 .listRowSeparator(.hidden)
+
+            ComparisonToggle(isOn: $isComparing)
         }
         .listStyle(.plain)
         .navigationTitle(group.name)
         .scrollDisabled(true)
+    }
+
+    @ViewBuilder func chart(segment: [ChartPoint<T>]) -> some View {
+        if isComparing {
+            ComparisonChartView(
+                segment: segment,
+                reference: extent.referenceSegment(from: group.points),
+                timing: extent,
+                color: .blue
+            )
+        } else {
+            ChartView(segment: segment, timing: extent)
+                .foregroundStyle(.blue)
+        }
     }
 
     private var formattedMarks: some AxisContent {

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -35,29 +35,21 @@ struct MetricsView<T: ChartNumeric>: View {
         RangeControl(extent: $extent)
 
         List {
-            chart(segment: extent.segment(from: group.points))
-                .chartYAxis(content: { formattedMarks })
-                .listRowSeparator(.hidden)
+            ComparableChart(
+                segment: extent.segment(from: group.points),
+                points: group.points,
+                extent: extent,
+                color: .blue,
+                isComparing: isComparing
+            )
+            .chartYAxis(content: { formattedMarks })
+            .listRowSeparator(.hidden)
 
             ComparisonToggle(isOn: $isComparing)
         }
         .listStyle(.plain)
         .navigationTitle(group.name)
         .scrollDisabled(true)
-    }
-
-    @ViewBuilder func chart(segment: [ChartPoint<T>]) -> some View {
-        if isComparing {
-            ComparisonChartView(
-                segment: segment,
-                reference: extent.referenceSegment(from: group.points),
-                timing: extent,
-                color: .blue
-            )
-        } else {
-            ChartView(segment: segment, timing: extent)
-                .foregroundStyle(.blue)
-        }
     }
 
     private var formattedMarks: some AxisContent {

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -28,7 +28,7 @@ struct StatView: View {
                     let points = data.flatMap(\.points)
                     let segment = extent.segment(from: points)
 
-                    chart(segment: segment, points: points)
+                    ComparableChart(segment: segment, points: points, extent: extent, color: color, isComparing: isComparing)
                         .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
 
                     ComparisonToggle(isOn: $isComparing)
@@ -43,20 +43,6 @@ struct StatView: View {
         }
         .onAppear {
             tint.value = nil
-        }
-    }
-
-    @ViewBuilder func chart(segment: [ChartPoint<Int>], points: [ChartPoint<Int>]) -> some View {
-        if isComparing {
-            ComparisonChartView(
-                segment: segment,
-                reference: extent.referenceSegment(from: points),
-                timing: extent,
-                color: color
-            )
-        } else {
-            ChartView(segment: segment, timing: extent)
-                .foregroundStyle(color)
         }
     }
 

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -12,6 +12,7 @@ struct StatView: View {
     let showList: Bool
 
     @State var extent: ChartExtent<Period>
+    @State private var isComparing = false
     @ObservedObject var stat: StatProvider
     @EnvironmentObject var tint: Tint
     @Environment(\.chartColor) var color
@@ -27,9 +28,10 @@ struct StatView: View {
                     let points = data.flatMap(\.points)
                     let segment = extent.segment(from: points)
 
-                    ChartView(segment: segment, timing: extent)
-                        .foregroundStyle(color)
+                    chart(segment: segment, points: points)
                         .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
+
+                    ComparisonToggle(isOn: $isComparing)
 
                     if showList {
                         total(count: segment.total)
@@ -41,6 +43,20 @@ struct StatView: View {
         }
         .onAppear {
             tint.value = nil
+        }
+    }
+
+    @ViewBuilder func chart(segment: [ChartPoint<Int>], points: [ChartPoint<Int>]) -> some View {
+        if isComparing {
+            ComparisonChartView(
+                segment: segment,
+                reference: extent.referenceSegment(from: points),
+                timing: extent,
+                color: color
+            )
+        } else {
+            ChartView(segment: segment, timing: extent)
+                .foregroundStyle(color)
         }
     }
 

--- a/Tests/ScoutTests/UI/ChartComparisonTests.swift
+++ b/Tests/ScoutTests/UI/ChartComparisonTests.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct ChartComparisonTests {
+    @Test("Previous domain precedes the current one") func testPreviousDomain() {
+        let extent = ChartExtent(period: Period.week)
+
+        #expect(extent.previousDomain.upperBound == extent.domain.lowerBound)
+        #expect(extent.previousDomain.lowerBound == extent.domain.lowerBound.addingWeek(-1))
+    }
+
+    @Test("Reference segment aligns previous counts to current buckets") func testReferenceSegment() {
+        let extent = ChartExtent(period: Period.week)
+        let points = makePoints(in: extent.domain, count: 2) + makePoints(in: extent.previousDomain, count: 5)
+
+        let segment = extent.segment(from: points)
+        let reference = extent.referenceSegment(from: points)
+
+        #expect(reference.count == segment.count)
+        #expect(reference.map(\.date) == segment.map(\.date))
+        #expect(reference.allSatisfy { $0.count == 5 })
+        #expect(segment.allSatisfy { $0.count == 2 })
+    }
+
+    @Test("Reference segment is zero without previous data") func testEmptyReference() {
+        let extent = ChartExtent(period: Period.week)
+        let points = makePoints(in: extent.domain, count: 3)
+
+        let reference = extent.referenceSegment(from: points)
+
+        #expect(reference.count == extent.segment(from: points).count)
+        #expect(reference.allSatisfy { $0.count == 0 })
+    }
+
+    func makePoints(in range: Range<Date>, count: Int) -> [ChartPoint<Int>] {
+        var points: [ChartPoint<Int>] = []
+        var date = range.lowerBound
+
+        while date < range.upperBound {
+            points.append(ChartPoint(date: date, count: count))
+            date.addDay()
+        }
+
+        return points
+    }
+}

--- a/Tests/ScoutTests/UI/ChartComparisonTests.swift
+++ b/Tests/ScoutTests/UI/ChartComparisonTests.swift
@@ -23,7 +23,7 @@ struct ChartComparisonTests {
         let points = makePoints(in: extent.domain, count: 2) + makePoints(in: extent.previousDomain, count: 5)
 
         let segment = extent.segment(from: points)
-        let reference = extent.referenceSegment(from: points)
+        let reference = extent.referenceSegment(from: points, alignedTo: segment)
 
         #expect(reference.count == segment.count)
         #expect(reference.map(\.date) == segment.map(\.date))
@@ -31,13 +31,28 @@ struct ChartComparisonTests {
         #expect(segment.allSatisfy { $0.count == 2 })
     }
 
+    @Test("Reference segment pairs buckets by offset across month lengths") func testMonthLengthMismatch() {
+        let domain = Date(year: 2026, month: 5, day: 10)..<Date(year: 2026, month: 6, day: 10)
+        let extent = ChartExtent(period: Period.month, domain: domain)
+        let points = makePoints(in: extent.domain, count: 2) + makePoints(in: extent.previousDomain, count: 5)
+
+        let segment = extent.segment(from: points)
+        let reference = extent.referenceSegment(from: points, alignedTo: segment)
+
+        #expect(segment.count == 31)
+        #expect(reference.count == 30)
+        #expect(reference.map(\.date) == segment.prefix(30).map(\.date))
+        #expect(reference.allSatisfy { $0.count == 5 })
+    }
+
     @Test("Reference segment is zero without previous data") func testEmptyReference() {
         let extent = ChartExtent(period: Period.week)
         let points = makePoints(in: extent.domain, count: 3)
 
-        let reference = extent.referenceSegment(from: points)
+        let segment = extent.segment(from: points)
+        let reference = extent.referenceSegment(from: points, alignedTo: segment)
 
-        #expect(reference.count == extent.segment(from: points).count)
+        #expect(reference.count == segment.count)
         #expect(reference.allSatisfy { $0.count == 0 })
     }
 


### PR DESCRIPTION
Adds a comparison mode to the stats, metrics, and activity charts: a `Compare with previous period` toggle overlays the previous period's per-bucket levels on the current bars, closing #223. Where a value grew, a white dashed line marks the previous level inside the bar; where it dropped, a dashed contour rises above the bar with the missing slice tinted. The previous window is computed locally by `ChartExtent.referenceSegment` from data the providers already fetch, so toggling needs no extra CloudKit requests.

To keep the two modes visually interchangeable, the bar width and x-axis ticks are now pinned explicitly on both charts through a shared `chartBarRatio` constant and `ChartTiming.tickDates`, instead of relying on the framework's undocumented defaults — bars, ticks, and scales match pixel-for-pixel when switching. Buckets whose previous window has no counterpart (calendar months differ in length) draw no reference rather than a misleading zero.