### PR TITLE
Report code coverage in CI test runs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -53,6 +53,7 @@ jobs:
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
+            -enableCodeCoverage YES \
             build-for-testing
 
       - name: Test
@@ -60,4 +61,15 @@ jobs:
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
+            -enableCodeCoverage YES \
+            -resultBundlePath TestResults.xcresult \
             test-without-building
+
+      - name: Report coverage
+        run: |
+          {
+            echo "### Coverage (iOS ${{ matrix.ios }})"
+            echo '```'
+            xcrun xccov view --report --only-targets TestResults.xcresult
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Enables code coverage in the `Swift` workflow by passing `-enableCodeCoverage YES` to the build and test steps, and adds a step that renders the per-target coverage table from the `.xcresult` bundle via `xccov` into the job summary. Each matrix leg now shows its coverage numbers directly on the workflow run page, with no external services involved.