### PR TITLE
Add Dependabot config for GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Adds a `dependabot.yml` that checks the `github-actions` ecosystem monthly, so action versions used in the workflows (such as `actions/checkout`) stay up to date without manual tracking.