### PR TITLE
Add model version guard for Scout.xcdatamodeld

### DIFF
--- a/.github/workflows/coredata.yml
+++ b/.github/workflows/coredata.yml
@@ -1,0 +1,45 @@
+name: Core Data
+
+on:
+  pull_request:
+    paths: [ 'Sources/Scout/Scout.xcdatamodeld/**' ]
+
+permissions:
+  contents: read
+
+jobs:
+  model-versions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check model version rules
+        run: |
+          git diff --name-status --no-renames \
+            "origin/${{ github.base_ref }}"...HEAD \
+            -- Sources/Scout/Scout.xcdatamodeld > /tmp/model-changes
+          cat /tmp/model-changes
+
+          touched=$(awk -F'\t' '$1 != "A" && $2 !~ /\.xccurrentversion$/' /tmp/model-changes)
+          if [ -n "$touched" ]; then
+            echo
+            echo "Model versions in Scout.xcdatamodeld are immutable once they are on ${{ github.base_ref }}:"
+            echo "a store created by a shipped version can only be opened by migrating to a newer one."
+            echo "Add a new model version (Xcode: Editor > Add Model Version) instead of editing or deleting these:"
+            echo "$touched"
+            exit 1
+          fi
+
+          added=$(awk -F'\t' '$1 == "A" && $2 ~ /\.xcdatamodel\//' /tmp/model-changes)
+          current=$(awk -F'\t' '$2 ~ /\.xccurrentversion$/' /tmp/model-changes)
+          if [ -n "$added" ] && [ -z "$current" ]; then
+            echo
+            echo "A new model version was added, but .xccurrentversion was not updated,"
+            echo "so the app would still build against the previous version."
+            echo "Mark the new version as current (Xcode: File Inspector > Model Version > Current)."
+            exit 1
+          fi


### PR DESCRIPTION
Adds a `Core Data` workflow that runs on pull requests touching `Scout.xcdatamodeld` and enforces the versioned-migration policy introduced with the removal of the store reset: model versions that are already on main are immutable, so editing or deleting one fails the check, and a newly added model version must be marked as current via `.xccurrentversion`. This makes the policy from `CLAUDE.md` mechanical instead of relying on review discipline.