### PR TITLE
Run guard workflows on every PR so they can be required checks

### DIFF
--- a/.github/workflows/coredata.yml
+++ b/.github/workflows/coredata.yml
@@ -1,8 +1,10 @@
 name: Core Data
 
+# No paths filter: this is a required status check, and a required check that
+# never runs blocks the merge. With no model changes the diff is empty and the
+# job passes in seconds.
 on:
   pull_request:
-    paths: [ 'Sources/Scout/Scout.xcdatamodeld/**' ]
 
 permissions:
   contents: read

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -1,8 +1,10 @@
 name: Schema
 
+# No paths filter: this is a required status check, and a required check that
+# never runs blocks the merge. With no Schema changes the diff is empty and the
+# job passes in seconds.
 on:
   pull_request:
-    paths: [ Schema ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes the `paths` filters from the `Schema` and `Core Data` guard workflows so the `append-only` and `model-versions` jobs run on every pull request. Both are being promoted to required status checks, and a required check that never runs blocks the merge indefinitely — with this change a PR that doesn't touch the guarded files just gets an empty diff and the jobs pass in seconds.