### PR TITLE
Add CLAUDE.md rule for maintaining folder structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@ When pushing new commits to an existing PR, update its title and description to 
 
 Always create commits using the repository's git `user.name`/`user.email` identity. Never set the author or committer to "Claude <noreply@anthropic.com>" or any other bot identity, and do not add "Co-Authored-By" trailers.
 
+# Project structure
+
+Keep an eye on the folder and file structure as the codebase evolves, and reorganize it when needed: when a folder accumulates too many files at one level, group related files into subfolders following the conventions already present nearby (e.g. `UI/Chart` groups files into `Model`, `Scale`, `View`, `Comparison`, `Picker`, `Range`). Move files as-is without code changes, and ship structure-only reorganizations as their own PR, separate from functional changes.
+
 # Swift code style
 
 Multi-line doc comments (`///`) must end with a trailing empty `///` line, except when they document a single-line property declaration (a stored `let`/`var` written on one line), where the trailing empty `///` is omitted. Single-line doc comments never need it.


### PR DESCRIPTION
Adds a `Project structure` section to `CLAUDE.md` instructing Claude to watch the folder and file layout as the codebase grows and reorganize it when a folder gets too crowded. Reorganizations should follow the grouping conventions already present nearby, move files without code changes, and ship as their own structure-only PR.