### PR TITLE
Disable comparison toggle when both periods have no results

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -27,9 +27,10 @@ struct ActivityView: View {
 
                 List {
                     let points = data.points(on: extent.period)
+                    let segment = extent.segment(from: points)
 
                     ComparableChart(
-                        segment: extent.segment(from: points),
+                        segment: segment,
                         points: points,
                         extent: extent,
                         color: .green,
@@ -38,6 +39,7 @@ struct ActivityView: View {
                     .listRowSeparator(.hidden)
 
                     ComparisonToggle(isOn: $isComparing)
+                        .disabled(!extent.canCompare(points: points, segment: segment))
                 }
                 .listStyle(.plain)
                 .scrollDisabled(true)

--- a/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
@@ -26,9 +26,10 @@ extension ChartExtent {
         zip(segment, previousSegment(from: points)).map { ChartPoint(date: $0.date, count: $1.count) }
     }
 
-    /// Whether the comparison overlay has anything to show: true when the
-    /// current or the previous window holds any data. When both are empty
-    /// the comparison toggle is shown disabled.
+    /// Whether the comparison overlay has anything to show.
+    ///
+    /// True when the current or the previous window holds any data; when
+    /// both are empty the comparison toggle is shown disabled.
     ///
     /// `segment` is the current window's segment, which callers have already
     /// computed.

--- a/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ChartExtent+Comparison.swift
@@ -23,7 +23,22 @@ extension ChartExtent {
     /// counterpart and are omitted; the chart draws no reference for them.
     ///
     func referenceSegment<U: ChartNumeric>(from points: [ChartPoint<U>], alignedTo segment: [ChartPoint<U>]) -> [ChartPoint<U>] {
-        let previous = points.bucket(in: previousDomain, component: period.pointComponent)
-        return zip(segment, previous).map { ChartPoint(date: $0.date, count: $1.count) }
+        zip(segment, previousSegment(from: points)).map { ChartPoint(date: $0.date, count: $1.count) }
+    }
+
+    /// Whether the comparison overlay has anything to show: true when the
+    /// current or the previous window holds any data. When both are empty
+    /// the comparison toggle is shown disabled.
+    ///
+    /// `segment` is the current window's segment, which callers have already
+    /// computed.
+    ///
+    func canCompare<U: ChartNumeric>(points: [ChartPoint<U>], segment: [ChartPoint<U>]) -> Bool {
+        segment.total != .zero || previousSegment(from: points).total != .zero
+    }
+
+    /// Buckets `points` into the previous window.
+    private func previousSegment<U: ChartNumeric>(from points: [ChartPoint<U>]) -> [ChartPoint<U>] {
+        points.bucket(in: previousDomain, component: period.pointComponent)
     }
 }

--- a/Sources/Scout/UI/Chart/Comparison/ComparisonToggle.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonToggle.swift
@@ -23,6 +23,8 @@ struct ComparisonToggle: View {
     List {
         ComparisonToggle(isOn: .constant(true))
         ComparisonToggle(isOn: .constant(false))
+        ComparisonToggle(isOn: .constant(false))
+            .disabled(true)
     }
     .listStyle(.plain)
 }

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -35,8 +35,10 @@ struct MetricsView<T: ChartNumeric>: View {
         RangeControl(extent: $extent)
 
         List {
+            let segment = extent.segment(from: group.points)
+
             ComparableChart(
-                segment: extent.segment(from: group.points),
+                segment: segment,
                 points: group.points,
                 extent: extent,
                 color: .blue,
@@ -46,6 +48,7 @@ struct MetricsView<T: ChartNumeric>: View {
             .listRowSeparator(.hidden)
 
             ComparisonToggle(isOn: $isComparing)
+                .disabled(!extent.canCompare(points: group.points, segment: segment))
         }
         .listStyle(.plain)
         .navigationTitle(group.name)

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -32,6 +32,7 @@ struct StatView: View {
                         .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
 
                     ComparisonToggle(isOn: $isComparing)
+                        .disabled(!extent.canCompare(points: points, segment: segment))
 
                     if showList {
                         total(count: segment.total)


### PR DESCRIPTION
The `Compare with previous period` row used to stay active even when the chart had nothing to compare. Now, when both the current and the previous window are empty, the toggle stays visible but is disabled. A new `canCompare(points:segment:)` helper on `ChartExtent` decides this, and the previous-window bucketing it shares with `referenceSegment` is extracted into `previousSegment(from:)`. Applied on all three screens with the toggle: `StatView`, `ActivityView`, and `MetricsView`.