### PR TITLE
Extract comparison chart computations into model types

### DIFF
--- a/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
@@ -8,12 +8,6 @@
 import Charts
 import SwiftUI
 
-/// Horizontal portion of each bucket slot occupied by a bar, derived from
-/// `chartBarRatio` and shared by the marks and the `ReferenceOverlay` so the
-/// reference marks match the bars exactly.
-///
-let barSlot: ClosedRange<Double> = (0.5 - chartBarRatio / 2)...(0.5 + chartBarRatio / 2)
-
 /// A bar chart of the current period with the previous period's per-bucket
 /// levels drawn on top of it.
 ///
@@ -37,12 +31,12 @@ struct ComparisonChartView<T: ChartNumeric>: View {
     let color: Color
 
     var body: some View {
-        let pairs = self.pairs
+        let pairs = segment.paired(with: reference, unit: timing.unit)
 
         Chart(pairs) { pair in
             marks(for: pair)
         }
-        .chartXScale(domain: xDomain(of: pairs))
+        .chartXScale(domain: pairs.xDomain())
         .chartXAxis {
             AxisMarks(format: timing.unit.chartFormat, values: timing.tickDates(for: segment))
         }
@@ -67,67 +61,25 @@ struct ComparisonChartView<T: ChartNumeric>: View {
         .listRowInsets(EdgeInsets())
     }
 
-    var pairs: [ComparisonPair<T>] {
-        let counts = Dictionary(reference.map { ($0.date, $0.count) }, uniquingKeysWith: +)
-        return segment.map { point in
-            ComparisonPair(
-                date: point.date,
-                bin: binRange(of: point.date, unit: timing.unit),
-                count: point.count,
-                reference: counts[point.date]
-            )
-        }
-    }
-
-    /// Full bucket bands, so the edge bars are inset from the plot edges the
-    /// same way binned `BarMark` charts are.
-    ///
-    func xDomain(of pairs: [ComparisonPair<T>]) -> ClosedRange<Date> {
-        guard let first = pairs.map(\.bin.lowerBound).min(), let last = pairs.map(\.bin.upperBound).max() else {
-            return Date().startOfDay...Date().startOfDay.addingDay()
-        }
-        return first...last
-    }
-
     /// The bar for the current value, plus an invisible mark at the previous
     /// level so the y scale grows to a rounded maximum that fits reference
     /// contours rising above the bars.
     ///
     @ChartContentBuilder func marks(for pair: ComparisonPair<T>) -> some ChartContent {
-        let length = pair.bin.upperBound.timeIntervalSince(pair.bin.lowerBound)
-        let start: PlottableValue<Date> = .value("Start", pair.bin.lowerBound.addingTimeInterval(length * barSlot.lowerBound))
-        let end: PlottableValue<Date> = .value("End", pair.bin.lowerBound.addingTimeInterval(length * barSlot.upperBound))
-        let zero: PlottableValue<T> = .value("Zero", .zero)
-        let count: PlottableValue<T> = .value("Count", pair.count)
-
-        RectangleMark(xStart: start, xEnd: end, yStart: zero, yEnd: count)
-            .foregroundStyle(color)
-            .cornerRadius(3)
+        RectangleMark(
+            xStart: .value("Start", pair.barStart),
+            xEnd: .value("End", pair.barEnd),
+            yStart: .value("Zero", T.zero),
+            yEnd: .value("Count", pair.count)
+        )
+        .foregroundStyle(color)
+        .cornerRadius(3)
 
         if let reference = pair.reference {
-            let center: PlottableValue<Date> = .value("Center", pair.bin.lowerBound.addingTimeInterval(length / 2))
-            let level: PlottableValue<T> = .value("Reference", reference)
-
-            PointMark(x: center, y: level)
+            PointMark(x: .value("Center", pair.binCenter), y: .value("Reference", reference))
                 .opacity(0)
         }
     }
-}
-
-/// One bucket of the comparison: the current value and the previous-period
-/// value it is compared against, both on the current bucket's date.
-///
-/// `reference` is nil when the previous window has no counterpart bucket —
-/// calendar months differ in length, so the oldest buckets of a longer
-/// current window have nothing to compare against.
-///
-struct ComparisonPair<T: ChartNumeric>: Identifiable {
-    let date: Date
-    let bin: Range<Date>
-    let count: T
-    let reference: T?
-
-    var id: Date { date }
 }
 
 // MARK: - Previews

--- a/Sources/Scout/UI/Chart/Comparison/ComparisonPair.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonPair.swift
@@ -1,0 +1,79 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+/// Horizontal portion of each bucket slot occupied by a bar, derived from
+/// `chartBarRatio` and applied through `barStart`/`barEnd`, so the marks and
+/// the `ReferenceOverlay` place bar edges identically.
+///
+let barSlot: ClosedRange<Double> = (0.5 - chartBarRatio / 2)...(0.5 + chartBarRatio / 2)
+
+/// One bucket of the comparison: the current value and the previous-period
+/// value it is compared against, both on the current bucket's date.
+///
+/// `reference` is nil when the previous window has no counterpart bucket —
+/// calendar months differ in length, so the oldest buckets of a longer
+/// current window have nothing to compare against.
+///
+struct ComparisonPair<T: ChartNumeric>: Identifiable {
+    let date: Date
+    let bin: Range<Date>
+    let count: T
+    let reference: T?
+
+    var id: Date { date }
+}
+
+// MARK: - Bar Geometry
+
+extension ComparisonPair {
+    /// Date of the bar's leading edge within the bucket slot.
+    var barStart: Date { slotDate(at: barSlot.lowerBound) }
+
+    /// Date of the bar's trailing edge within the bucket slot.
+    var barEnd: Date { slotDate(at: barSlot.upperBound) }
+
+    /// Date at the center of the bucket slot.
+    var binCenter: Date { slotDate(at: 0.5) }
+
+    /// The date lying at `fraction` of the way across the bucket slot.
+    private func slotDate(at fraction: Double) -> Date {
+        let length = bin.upperBound.timeIntervalSince(bin.lowerBound)
+        return bin.lowerBound.addingTimeInterval(length * fraction)
+    }
+}
+
+// MARK: - Pairing
+
+extension Collection {
+    /// Pairs each bucket of the current segment with the reference value
+    /// sitting on the same date; buckets missing from `reference` get a nil
+    /// reference and draw no comparison marks.
+    ///
+    func paired<T>(with reference: [ChartPoint<T>], unit: Calendar.Component) -> [ComparisonPair<T>] where Element == ChartPoint<T> {
+        let counts = Dictionary(reference.map { ($0.date, $0.count) }, uniquingKeysWith: +)
+        return map { point in
+            ComparisonPair(
+                date: point.date,
+                bin: binRange(of: point.date, unit: unit),
+                count: point.count,
+                reference: counts[point.date]
+            )
+        }
+    }
+
+    /// Full bucket bands, so the edge bars are inset from the plot edges the
+    /// same way binned `BarMark` charts are.
+    ///
+    func xDomain<T>() -> ClosedRange<Date> where Element == ComparisonPair<T> {
+        guard let first = map(\.bin.lowerBound).min(), let last = map(\.bin.upperBound).max() else {
+            return Date().startOfDay...Date().startOfDay.addingDay()
+        }
+        return first...last
+    }
+}

--- a/Sources/Scout/UI/Chart/Comparison/ReferenceLevel.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ReferenceLevel.swift
@@ -1,0 +1,114 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Charts
+import SwiftUI
+
+/// Bar-aligned geometry of one bucket's reference level, in overlay
+/// coordinates.
+///
+struct ReferenceLevel {
+    let x: ClosedRange<CGFloat>
+    let count: CGFloat
+    let reference: CGFloat
+    let isClamped: Bool
+
+    /// Whether the previous level lies above the bar (the value dropped).
+    var isDrop: Bool { reference < count }
+}
+
+// MARK: - Projection
+
+extension ReferenceLevel {
+    /// Geometry for one bucket; nil for buckets without comparison data,
+    /// empty in both periods, or falling outside the plot.
+    ///
+    init?<T: ChartNumeric>(pair: ComparisonPair<T>, proxy: ChartProxy, plotFrame: CGRect) {
+        guard let referenceCount = pair.reference else {
+            return nil
+        }
+        guard pair.count != .zero || referenceCount != .zero else {
+            return nil
+        }
+        guard let barStartX = proxy.position(forX: pair.barStart), let barEndX = proxy.position(forX: pair.barEnd) else {
+            return nil
+        }
+        guard let countY = proxy.position(forY: pair.count), let referenceY = proxy.position(forY: referenceCount) else {
+            return nil
+        }
+
+        let reference = plotFrame.minY + referenceY
+
+        self.init(
+            x: (plotFrame.minX + barStartX)...(plotFrame.minX + barEndX),
+            count: plotFrame.minY + countY,
+            reference: max(reference, plotFrame.minY),
+            isClamped: reference < plotFrame.minY
+        )
+    }
+}
+
+// MARK: - Paths
+
+extension [ReferenceLevel] {
+    /// Levels where the value grew or held its ground.
+    var gains: Self { filter { !$0.isDrop } }
+
+    /// Levels where the value dropped below the previous period.
+    var drops: Self { filter(\.isDrop) }
+
+    /// Rectangles between the two periods' levels.
+    var slices: Path {
+        Path { path in
+            for level in self {
+                let top = Swift.min(level.count, level.reference)
+                let bottom = Swift.max(level.count, level.reference)
+                path.addRect(
+                    CGRect(
+                        x: level.x.lowerBound,
+                        y: top,
+                        width: level.x.upperBound - level.x.lowerBound,
+                        height: bottom - top
+                    )
+                )
+            }
+        }
+    }
+
+    /// Lines across the bars at the previous level, for buckets where the
+    /// value grew.
+    ///
+    var lines: Path {
+        Path { path in
+            for level in self {
+                path.move(to: CGPoint(x: level.x.lowerBound, y: level.reference))
+                path.addLine(to: CGPoint(x: level.x.upperBound, y: level.reference))
+            }
+        }
+    }
+
+    /// Contours rising above the bars to the previous level, for buckets
+    /// where the value dropped.
+    ///
+    /// A contour clipped by the plot's top edge is left without its cap to
+    /// show that the previous level lies beyond the visible scale.
+    ///
+    var contours: Path {
+        Path { path in
+            for level in self {
+                path.move(to: CGPoint(x: level.x.lowerBound, y: level.count))
+                path.addLine(to: CGPoint(x: level.x.lowerBound, y: level.reference))
+                if level.isClamped {
+                    path.move(to: CGPoint(x: level.x.upperBound, y: level.reference))
+                } else {
+                    path.addLine(to: CGPoint(x: level.x.upperBound, y: level.reference))
+                }
+                path.addLine(to: CGPoint(x: level.x.upperBound, y: level.count))
+            }
+        }
+    }
+}

--- a/Sources/Scout/UI/Chart/Comparison/ReferenceOverlay.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ReferenceOverlay.swift
@@ -10,19 +10,6 @@ import SwiftUI
 
 private let referenceDash = StrokeStyle(lineWidth: 1.5, dash: [4, 4])
 
-/// Bar-aligned geometry of one bucket's reference level, in overlay
-/// coordinates.
-///
-struct ReferenceLevel {
-    let x: ClosedRange<CGFloat>
-    let count: CGFloat
-    let reference: CGFloat
-    let isClamped: Bool
-
-    /// Whether the previous level lies above the bar (the value dropped).
-    var isDrop: Bool { reference < count }
-}
-
 /// Draws the previous-period levels over the plot area using chart-proxy
 /// coordinates, since bar marks cannot render dashed strokes.
 ///
@@ -33,93 +20,21 @@ struct ReferenceOverlay<T: ChartNumeric>: View {
     let color: Color
 
     var body: some View {
-        let levels = pairs.compactMap(level(for:))
-        let gains = levels.filter { !$0.isDrop }
-        let drops = levels.filter(\.isDrop)
+        let levels = pairs.compactMap { ReferenceLevel(pair: $0, proxy: proxy, plotFrame: plotFrame) }
+        let gains = levels.gains
+        let drops = levels.drops
 
         ZStack {
-            slices(for: gains)
+            gains.slices
                 .fill(.white.opacity(0.25))
-            slices(for: drops)
+            drops.slices
                 .fill(color.opacity(0.12))
-            lines(for: gains)
+            gains.lines
                 .stroke(style: referenceDash)
                 .foregroundStyle(.white)
-            contours(for: drops)
+            drops.contours
                 .stroke(style: referenceDash)
                 .foregroundStyle(color)
         }
-    }
-
-    /// Rectangles between the two periods' levels.
-    func slices(for levels: [ReferenceLevel]) -> Path {
-        Path { path in
-            for level in levels {
-                let top = min(level.count, level.reference)
-                let bottom = max(level.count, level.reference)
-                path.addRect(
-                    CGRect(
-                        x: level.x.lowerBound,
-                        y: top,
-                        width: level.x.upperBound - level.x.lowerBound,
-                        height: bottom - top
-                    )
-                )
-            }
-        }
-    }
-
-    /// White dashed lines across the bars where the value grew.
-    func lines(for levels: [ReferenceLevel]) -> Path {
-        Path { path in
-            for level in levels {
-                path.move(to: CGPoint(x: level.x.lowerBound, y: level.reference))
-                path.addLine(to: CGPoint(x: level.x.upperBound, y: level.reference))
-            }
-        }
-    }
-
-    /// Dashed contours rising above the bars where the value dropped.
-    ///
-    /// A contour clipped by the plot's top edge is left without its cap to
-    /// show that the previous level lies beyond the visible scale.
-    ///
-    func contours(for levels: [ReferenceLevel]) -> Path {
-        Path { path in
-            for level in levels {
-                path.move(to: CGPoint(x: level.x.lowerBound, y: level.count))
-                path.addLine(to: CGPoint(x: level.x.lowerBound, y: level.reference))
-                if level.isClamped {
-                    path.move(to: CGPoint(x: level.x.upperBound, y: level.reference))
-                } else {
-                    path.addLine(to: CGPoint(x: level.x.upperBound, y: level.reference))
-                }
-                path.addLine(to: CGPoint(x: level.x.upperBound, y: level.count))
-            }
-        }
-    }
-
-    /// Geometry for one bucket; nil for buckets without comparison data,
-    /// empty in both periods, or falling outside the plot.
-    ///
-    func level(for pair: ComparisonPair<T>) -> ReferenceLevel? {
-        guard let referenceCount = pair.reference else { return nil }
-        guard pair.count != .zero || referenceCount != .zero else { return nil }
-
-        guard let slotStart = proxy.position(forX: pair.bin.lowerBound), let slotEnd = proxy.position(forX: pair.bin.upperBound) else {
-            return nil
-        }
-        guard let countY = proxy.position(forY: pair.count), let referenceY = proxy.position(forY: referenceCount) else {
-            return nil
-        }
-        let width = slotEnd - slotStart
-        let reference = plotFrame.minY + referenceY
-
-        return ReferenceLevel(
-            x: (plotFrame.minX + slotStart + width * barSlot.lowerBound)...(plotFrame.minX + slotStart + width * barSlot.upperBound),
-            count: plotFrame.minY + countY,
-            reference: max(reference, plotFrame.minY),
-            isClamped: reference < plotFrame.minY
-        )
     }
 }

--- a/Tests/ScoutTests/UI/ComparisonChartViewTests.swift
+++ b/Tests/ScoutTests/UI/ComparisonChartViewTests.swift
@@ -1,0 +1,59 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+import Testing
+import UIKit
+
+@testable import Scout
+
+/// Render smoke tests: drawing the chart through `ImageRenderer` exercises
+/// the whole pipeline — pairing, the marks, and the reference overlay
+/// projecting levels through a live `ChartProxy`.
+///
+struct ComparisonChartViewTests {
+    @Test("Renders bars with the reference overlay") @MainActor func testRender() {
+        let extent = ChartExtent(period: Period.week)
+        let points = makePoints(in: extent.domain, count: 2) + makePoints(in: extent.previousDomain, count: 5)
+        let segment = extent.segment(from: points)
+
+        let renderer = ImageRenderer(
+            content: ComparisonChartView(
+                segment: segment,
+                reference: extent.referenceSegment(from: points, alignedTo: segment),
+                timing: extent,
+                color: .blue
+            )
+            .frame(width: 400, height: 300)
+        )
+
+        #expect(renderer.uiImage?.size == CGSize(width: 400, height: 300))
+    }
+
+    @Test("Renders the placeholder when both periods are empty") @MainActor func testEmptyRender() {
+        let extent = ChartExtent(period: Period.week)
+
+        let renderer = ImageRenderer(
+            content: ComparisonChartView(segment: .empty, reference: .empty, timing: extent, color: .blue)
+                .frame(width: 400, height: 300)
+        )
+
+        #expect(renderer.uiImage?.size == CGSize(width: 400, height: 300))
+    }
+
+    func makePoints(in range: Range<Date>, count: Int) -> [ChartPoint<Int>] {
+        var points: [ChartPoint<Int>] = []
+        var date = range.lowerBound
+
+        while date < range.upperBound {
+            points.append(ChartPoint(date: date, count: count))
+            date.addDay()
+        }
+
+        return points
+    }
+}

--- a/Tests/ScoutTests/UI/ComparisonPairTests.swift
+++ b/Tests/ScoutTests/UI/ComparisonPairTests.swift
@@ -1,0 +1,70 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct ComparisonPairTests {
+    @Test("Pairing matches reference counts to segment dates") func testPairing() {
+        let segment = makeSegment(days: 3, count: 2)
+        let reference = [
+            ChartPoint(date: segment[0].date, count: 7),
+            ChartPoint(date: segment[1].date, count: 4),
+        ]
+
+        let pairs = segment.paired(with: reference, unit: .day)
+
+        #expect(pairs.map(\.date) == segment.map(\.date))
+        #expect(pairs.map(\.count) == [2, 2, 2])
+        #expect(pairs.map(\.reference) == [7, 4, nil])
+        #expect(pairs.allSatisfy { $0.bin.contains($0.date) })
+    }
+
+    @Test("Pairing sums reference points sharing a date") func testDuplicateReferenceDates() {
+        let segment = makeSegment(days: 1, count: 2)
+        let reference = [
+            ChartPoint(date: segment[0].date, count: 3),
+            ChartPoint(date: segment[0].date, count: 4),
+        ]
+
+        let pairs = segment.paired(with: reference, unit: .day)
+
+        #expect(pairs.map(\.reference) == [7])
+    }
+
+    @Test("Domain spans the full bucket bands") func testXDomain() {
+        let pairs = makeSegment(days: 3, count: 1).paired(with: [], unit: .day)
+
+        let domain = pairs.xDomain()
+
+        #expect(domain.lowerBound == pairs.map(\.bin.lowerBound).min())
+        #expect(domain.upperBound == pairs.map(\.bin.upperBound).max())
+    }
+
+    @Test("Empty domain falls back to a single day band") func testEmptyXDomain() {
+        let domain = [ComparisonPair<Int>]().xDomain()
+
+        #expect(domain.upperBound == domain.lowerBound.addingDay())
+    }
+
+    @Test("Bar edges split the bucket slot by the bar ratio") func testBarGeometry() {
+        let pair = makeSegment(days: 1, count: 1).paired(with: [], unit: .day)[0]
+        let length = pair.bin.upperBound.timeIntervalSince(pair.bin.lowerBound)
+
+        #expect(abs(pair.barStart.timeIntervalSince(pair.bin.lowerBound) - length * barSlot.lowerBound) < 0.001)
+        #expect(abs(pair.barEnd.timeIntervalSince(pair.bin.lowerBound) - length * barSlot.upperBound) < 0.001)
+        #expect(abs(pair.binCenter.timeIntervalSince(pair.bin.lowerBound) - length / 2) < 0.001)
+        #expect(abs(pair.barEnd.timeIntervalSince(pair.barStart) - length * chartBarRatio) < 0.001)
+    }
+
+    func makeSegment(days: Int, count: Int) -> [ChartPoint<Int>] {
+        let base = Date(year: 2026, month: 6, day: 1, hour: 12)
+        return (0..<days).map { ChartPoint(date: base.addingDay($0), count: count) }
+    }
+}

--- a/Tests/ScoutTests/UI/ReferenceLevelTests.swift
+++ b/Tests/ScoutTests/UI/ReferenceLevelTests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+import Testing
+
+@testable import Scout
+
+struct ReferenceLevelTests {
+    @Test("Drop means the previous level lies above the bar") func testIsDrop() {
+        #expect(makeLevel(reference: 50).isDrop)
+        #expect(!makeLevel(reference: 120).isDrop)
+        #expect(!makeLevel(reference: 80).isDrop)
+    }
+
+    @Test("Gains and drops partition the levels") func testPartition() {
+        let levels = [makeLevel(reference: 50), makeLevel(reference: 120)]
+
+        #expect(levels.drops.map(\.reference) == [50])
+        #expect(levels.gains.map(\.reference) == [120])
+    }
+
+    @Test("Slices fill between the two periods' levels") func testSlices() {
+        #expect([makeLevel(reference: 50)].slices.boundingRect == CGRect(x: 10, y: 50, width: 20, height: 30))
+        #expect([makeLevel(reference: 120)].slices.boundingRect == CGRect(x: 10, y: 80, width: 20, height: 40))
+    }
+
+    @Test("Lines run across the bar at the previous level") func testLines() {
+        let path = [makeLevel(reference: 50)].lines
+
+        #expect(path.elements == [.move(to: CGPoint(x: 10, y: 50)), .line(to: CGPoint(x: 30, y: 50))])
+    }
+
+    @Test("Contours rise to the previous level and cap the top") func testContours() {
+        let path = [makeLevel(reference: 50)].contours
+
+        #expect(
+            path.elements == [
+                .move(to: CGPoint(x: 10, y: 80)),
+                .line(to: CGPoint(x: 10, y: 50)),
+                .line(to: CGPoint(x: 30, y: 50)),
+                .line(to: CGPoint(x: 30, y: 80)),
+            ]
+        )
+    }
+
+    @Test("Clamped contours leave the top cap open") func testClampedContours() {
+        let path = [makeLevel(reference: 0, isClamped: true)].contours
+
+        #expect(
+            path.elements == [
+                .move(to: CGPoint(x: 10, y: 80)),
+                .line(to: CGPoint(x: 10, y: 0)),
+                .move(to: CGPoint(x: 30, y: 0)),
+                .line(to: CGPoint(x: 30, y: 80)),
+            ]
+        )
+    }
+
+    func makeLevel(reference: CGFloat, isClamped: Bool = false) -> ReferenceLevel {
+        ReferenceLevel(
+            x: 10...30,
+            count: 80,
+            reference: reference,
+            isClamped: isClamped
+        )
+    }
+}
+
+extension Path {
+    fileprivate var elements: [Element] {
+        var elements: [Element] = []
+        forEach { elements.append($0) }
+        return elements
+    }
+}


### PR DESCRIPTION
`ComparisonChartView` and `ReferenceOverlay` carried most of the comparison chart's data preparation and geometry inline, which made the views hard to read and the logic impossible to test. This change moves that logic into two new model files: `ComparisonPair` now owns pairing the current segment with the previous-period reference, the x-axis domain, and the bar-edge dates, while `ReferenceLevel` owns projecting a pair into overlay coordinates and building the slice, line, and contour paths. The overlay now derives bar edges from the same `barStart`/`barEnd` dates the marks use instead of repeating the slot math in pixel space, so the two stay aligned by construction.

The views are left with declarative markup only, and behavior is unchanged — verified by rendering the chart before and after. The extracted logic is covered by new unit tests for pairing, domains, and path geometry (including the clamped-contour case), plus `ImageRenderer` smoke tests that exercise the full render pipeline with a live `ChartProxy`.