### PR TITLE
Add area mini-charts to Home rows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Always create commits using the repository's git `user.name`/`user.email` identi
 
 Keep an eye on the folder and file structure as the codebase evolves, and reorganize it when needed: when a folder accumulates too many files at one level, group related files into subfolders following the conventions already present nearby (e.g. `UI/Chart` groups files into `Model`, `Scale`, `View`, `Comparison`, `Picker`, `Range`). Move files as-is without code changes, and ship structure-only reorganizations as their own PR, separate from functional changes.
 
+# Code organization
+
+Minimize code duplication. Extract logic and computations out of SwiftUI views into separate types covered by unit tests. Keep views from bloating: when a view accumulates non-trivial logic, computations, or repeated layout, extract them into model types or subviews.
+
 # Swift code style
 
 Multi-line doc comments (`///`) must end with a trailing empty `///` line, except when they document a single-line property declaration (a stored `let`/`var` written on one line), where the trailing empty `///` is omitted. Single-line doc comments never need it.

--- a/Sources/Scout/UI/Activity/ActivityMatrix+Sample.swift
+++ b/Sources/Scout/UI/Activity/ActivityMatrix+Sample.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import CloudKit
+
+extension Matrix where T == PeriodCell<Int> {
+    static var sampleRecords: [CKRecord] {
+        let calendar = Calendar.utc
+        let today = Date().startOfDay
+
+        return (-52...0).compactMap { weekOffset in
+            guard let weekStart = calendar.date(byAdding: .weekOfYear, value: weekOffset, to: today) else {
+                return nil
+            }
+
+            let record = CKRecord(recordType: PeriodCell<Int>.recordType)
+            record["date"] = weekStart
+            record["name"] = "ActiveUser"
+
+            for day in 1...7 {
+                record["cell_d_\(day.leadingZero)"] = Int.random(in: 20...80)
+                record["cell_w_\(day.leadingZero)"] = Int.random(in: 100...300)
+                record["cell_m_\(day.leadingZero)"] = Int.random(in: 400...900)
+            }
+
+            return record
+        }
+    }
+}

--- a/Sources/Scout/UI/Activity/ActivityRow.swift
+++ b/Sources/Scout/UI/Activity/ActivityRow.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ActivityRow: View {
     let period: ActivityPeriod
+    let color: Color
     var systemImage: String? = nil
 
     @ObservedObject var activity: ActivityProvider
@@ -17,22 +18,32 @@ struct ActivityRow: View {
         Row {
             if let systemImage {
                 Image(systemName: systemImage)
+                    .foregroundColor(color)
                     .frame(width: 24)
             }
             Text(period.title)
                 .foregroundColor(.primary)
             Spacer()
 
-            let count = try? activity.result?.get()
-                .points(on: period)
-                .bucket(on: period)
-                .max()?
-                .count
-
-            RedactedText(count: count)
+            RowSummary(series: series, count: count, color: color)
         } destination: {
             ActivityView(activity: activity, period: period)
         }
+    }
+
+    /// Daily activity values; `nil` while the provider is still loading.
+    private var days: [ChartPoint<Int>]? {
+        try? activity.result?.get()
+            .points(on: period)
+            .bucket(on: period)
+    }
+
+    private var series: MiniChartSeries? {
+        days.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .latest) }
+    }
+
+    private var count: Int? {
+        days?.max()?.count
     }
 }
 
@@ -43,6 +54,7 @@ struct ActivityRow: View {
         List {
             ActivityRow(
                 period: .daily,
+                color: .green,
                 activity: ActivityProvider()
             )
         }

--- a/Sources/Scout/UI/Chart/Model/ChartComposing.swift
+++ b/Sources/Scout/UI/Chart/Model/ChartComposing.swift
@@ -17,7 +17,9 @@ protocol ChartComposing: CellProtocol {
 
 extension PeriodCell: ChartComposing {
     var secondsSinceBase: Int {
-        (day - 1) * 86_400
+        // `day` is 0-based (unlike GridCell's 1-based `row`), so the first
+        // day of the period lands exactly on the matrix base date.
+        day * 86_400
     }
 }
 

--- a/Sources/Scout/UI/Chart/Model/MiniChartSeries.swift
+++ b/Sources/Scout/UI/Chart/Model/MiniChartSeries.swift
@@ -1,0 +1,67 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+/// The points of a Home row's period compressed into a fixed number of
+/// equal time slices, ready to be drawn as an inline mini-chart.
+///
+struct MiniChartSeries: Equatable {
+    /// Number of slices a mini-chart compresses its period into.
+    static let sliceCount = 7
+
+    /// One aggregated value per slice, oldest first.
+    let values: [Int]
+}
+
+extension MiniChartSeries {
+    /// How the points of one slice collapse into its single value.
+    enum Aggregation {
+        /// Sum of all counts — for additive series like event totals.
+        case total
+
+        /// Count of the newest point — for level series like active users.
+        case latest
+    }
+
+    /// Splits `range` into `sliceCount` equal time slices and aggregates the
+    /// points that fall into each one. Points outside `range` are ignored;
+    /// a point exactly on a slice boundary belongs to the later slice.
+    ///
+    init(points: [ChartPoint<Int>], range: Range<Date>, aggregation: Aggregation) {
+        let step = range.upperBound.timeIntervalSince(range.lowerBound) / Double(Self.sliceCount)
+
+        guard step > 0 else {
+            values = Array(repeating: .zero, count: Self.sliceCount)
+            return
+        }
+
+        var slices = [[ChartPoint<Int>]](repeating: [], count: Self.sliceCount)
+
+        for point in points where range.contains(point.date) {
+            let index = Int(point.date.timeIntervalSince(range.lowerBound) / step)
+            slices[min(index, Self.sliceCount - 1)].append(point)
+        }
+
+        values = slices.map { slice in
+            switch aggregation {
+            case .total:
+                slice.total
+            case .latest:
+                slice.max()?.count ?? .zero
+            }
+        }
+    }
+}
+
+// MARK: - Placeholder
+
+extension MiniChartSeries {
+    /// A gentle wave drawn under redaction while the real series loads.
+    static let placeholder = MiniChartSeries(values: [3, 5, 4, 6, 5, 7, 6])
+}

--- a/Sources/Scout/UI/Chart/Model/MiniChartSeries.swift
+++ b/Sources/Scout/UI/Chart/Model/MiniChartSeries.swift
@@ -29,9 +29,11 @@ extension MiniChartSeries {
         case latest
     }
 
-    /// Splits `range` into `sliceCount` equal time slices and aggregates the
-    /// points that fall into each one. Points outside `range` are ignored;
-    /// a point exactly on a slice boundary belongs to the later slice.
+    /// Splits `range` into `sliceCount` equal time slices and aggregates
+    /// the points that fall into each one.
+    ///
+    /// Points outside `range` are ignored; a point exactly on a slice
+    /// boundary belongs to the later slice.
     ///
     init(points: [ChartPoint<Int>], range: Range<Date>, aggregation: Aggregation) {
         let step = range.upperBound.timeIntervalSince(range.lowerBound) / Double(Self.sliceCount)

--- a/Sources/Scout/UI/Chart/View/MiniChart.swift
+++ b/Sources/Scout/UI/Chart/View/MiniChart.swift
@@ -1,0 +1,81 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Charts
+import SwiftUI
+
+/// An inline sparkline for Home rows: the period's slice values drawn as a
+/// smooth line over a gradient fill fading to the baseline. While the series
+/// is loading, a redacted placeholder of the same size keeps rows stable.
+///
+struct MiniChart: View {
+    /// Pinned size so charts and placeholders align across Home rows.
+    static let size = CGSize(width: 56, height: 22)
+
+    let series: MiniChartSeries?
+    let color: Color
+
+    var body: some View {
+        Group {
+            if let series {
+                chart(for: series, tint: color)
+            } else {
+                chart(for: .placeholder, tint: Color(.systemGray3))
+                    .redacted(reason: .placeholder)
+            }
+        }
+        .frame(width: Self.size.width, height: Self.size.height)
+    }
+
+    private func chart(for series: MiniChartSeries, tint: Color) -> some View {
+        Chart(series.values.indices, id: \.self) { index in
+            AreaMark(x: .value("X", index), y: .value("Y", series.values[index]))
+                .interpolationMethod(.catmullRom)
+                .foregroundStyle(gradient(of: tint))
+            LineMark(x: .value("X", index), y: .value("Y", series.values[index]))
+                .interpolationMethod(.catmullRom)
+                .lineStyle(StrokeStyle(lineWidth: 1.5))
+                .foregroundStyle(tint)
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+    }
+
+    private func gradient(of tint: Color) -> LinearGradient {
+        LinearGradient(
+            colors: [tint.opacity(0.35), tint.opacity(0.02)],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    NavigationStack {
+        List {
+            HStack {
+                Text(verbatim: "Loaded")
+                Spacer()
+                MiniChart(series: MiniChartSeries(values: [2, 4, 3, 7, 6, 11, 16]), color: .red)
+            }
+            HStack {
+                Text(verbatim: "Loading")
+                Spacer()
+                MiniChart(series: nil, color: .red)
+            }
+            HStack {
+                Text(verbatim: "Empty")
+                Spacer()
+                MiniChart(series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)), color: .red)
+            }
+        }
+        .listStyle(.plain)
+    }
+}

--- a/Sources/Scout/UI/Chart/View/MiniChart.swift
+++ b/Sources/Scout/UI/Chart/View/MiniChart.swift
@@ -10,8 +10,10 @@ import Charts
 import SwiftUI
 
 /// An inline sparkline for Home rows: the period's slice values drawn as a
-/// smooth line over a gradient fill fading to the baseline. While the series
-/// is loading, a redacted placeholder of the same size keeps rows stable.
+/// smooth line over a gradient fill fading to the baseline.
+///
+/// While the series is loading, a redacted placeholder of the same size
+/// keeps rows stable.
 ///
 struct MiniChart: View {
     /// Pinned size so charts and placeholders align across Home rows.

--- a/Sources/Scout/UI/Database/Record/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/Record/DefaultDatabase.swift
@@ -16,6 +16,8 @@ struct DefaultDatabase: AppDatabase {
             records = Crash.sampleRecords
         case Int.recordType:
             records = GridMatrix<Int>.sampleRecords
+        case PeriodCell<Int>.recordType:
+            records = ActivityMatrix.sampleRecords
         default:
             records = Event.sampleRecords
         }

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -89,11 +89,11 @@ struct HomeContent: View {
             ForEach(ActivityPeriod.allCases) { period in
                 ActivityRow(
                     period: period,
+                    color: .green,
                     systemImage: "person.2",
                     activity: activity
                 )
             }
-            .foregroundStyle(.green)
         } header: {
             Header(title: "Users").task {
                 await activity.fetchIfNeeded(in: database)

--- a/Sources/Scout/UI/Primitives/Controls/RowSummary.swift
+++ b/Sources/Scout/UI/Primitives/Controls/RowSummary.swift
@@ -1,0 +1,62 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+/// The trailing summary of a Home row: a mini-chart next to the period's
+/// count, both tinted with the row's color. The chart's fixed size and the
+/// count's minimum width stack the summaries into aligned columns.
+///
+struct RowSummary: View {
+    /// Minimum count width: rows whose counts fit it get their charts and
+    /// counts stacked into aligned columns; wider counts push their chart left.
+    static let countWidth: CGFloat = 56
+
+    let series: MiniChartSeries?
+    let count: Int?
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 32) {
+            MiniChart(series: series, color: color)
+            RedactedText(count: count)
+                .foregroundColor(color)
+                .frame(minWidth: Self.countWidth, alignment: .trailing)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    NavigationStack {
+        List {
+            HStack {
+                Text(verbatim: "Loaded")
+                Spacer()
+                RowSummary(series: MiniChartSeries(values: [2, 4, 3, 7, 6, 11, 16]), count: 49, color: .red)
+            }
+            HStack {
+                Text(verbatim: "Wide count")
+                Spacer()
+                RowSummary(series: MiniChartSeries(values: [3, 1, 4, 1, 5, 9, 2]), count: 19_989, color: .green)
+            }
+            HStack {
+                Text(verbatim: "Loading")
+                Spacer()
+                RowSummary(series: nil, count: nil, color: .purple)
+            }
+            HStack {
+                Text(verbatim: "Empty")
+                Spacer()
+                RowSummary(series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)), count: 0, color: .blue)
+            }
+        }
+        .listStyle(.plain)
+    }
+}

--- a/Sources/Scout/UI/Primitives/Controls/RowSummary.swift
+++ b/Sources/Scout/UI/Primitives/Controls/RowSummary.swift
@@ -9,8 +9,10 @@
 import SwiftUI
 
 /// The trailing summary of a Home row: a mini-chart next to the period's
-/// count, both tinted with the row's color. The chart's fixed size and the
-/// count's minimum width stack the summaries into aligned columns.
+/// count, both tinted with the row's color.
+///
+/// The chart's fixed size and the count's minimum width stack the
+/// summaries into aligned columns.
 ///
 struct RowSummary: View {
     /// Minimum count width: rows whose counts fit it get their charts and

--- a/Sources/Scout/UI/Stats/StatRow.swift
+++ b/Sources/Scout/UI/Stats/StatRow.swift
@@ -26,16 +26,23 @@ struct StatRow<Destination: View>: View {
                 .foregroundColor(systemImage == nil ? color : .primary)
             Spacer()
 
-            let count = try? stat.result?.get()
-                .flatMap(\.points)
-                .bucket(on: period)
-                .total
-
-            RedactedText(count: count)
-                .foregroundColor(color)
+            RowSummary(series: series, count: count, color: color)
         } destination: {
             destination()
         }
+    }
+
+    /// All fetched points; `nil` while the provider is still loading.
+    private var points: [ChartPoint<Int>]? {
+        try? stat.result?.get().flatMap(\.points)
+    }
+
+    private var series: MiniChartSeries? {
+        points.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .total) }
+    }
+
+    private var count: Int? {
+        points?.bucket(on: period).total
     }
 }
 

--- a/Tests/ScoutTests/Core/Matrix/Cell/PeriodCellTests.swift
+++ b/Tests/ScoutTests/Core/Matrix/Cell/PeriodCellTests.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import Foundation
 import Testing
 
 @testable import Scout
@@ -71,6 +72,28 @@ struct PeriodCellTests {
         #expect(restored.period == original.period)
         #expect(restored.day == original.day)
         #expect(restored.value == original.value)
+    }
+
+    // MARK: - Chart Mapping
+
+    @Test("First day maps onto the matrix base date")
+    func firstDayChartPoint() {
+        let base = Date(year: 2026, month: 6, day: 1)
+        let cell = PeriodCell<Int>(period: .daily, day: 0, value: 5)
+        let point = cell.point(baseDate: base)
+
+        #expect(point.date == base)
+        #expect(point.count == 5)
+    }
+
+    @Test("Later days advance from the base date by whole days")
+    func laterDayChartPoint() {
+        let base = Date(year: 2026, month: 6, day: 1)
+        let cell = PeriodCell<Int>(period: .weekly, day: 4, value: 2)
+        let point = cell.point(baseDate: base)
+
+        #expect(point.date == Date(year: 2026, month: 6, day: 5))
+        #expect(point.count == 2)
     }
 
     // MARK: - Combining

--- a/Tests/ScoutTests/UI/MiniChartSeriesTests.swift
+++ b/Tests/ScoutTests/UI/MiniChartSeriesTests.swift
@@ -1,0 +1,104 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct MiniChartSeriesTests {
+    /// Seven days, so each slice spans exactly one day.
+    let range = Date(year: 2026, month: 6, day: 1)..<Date(year: 2026, month: 6, day: 8)
+
+    private func makePoint(day: Int, hour: Int = 0, count: Int) -> ChartPoint<Int> {
+        ChartPoint(date: Date(year: 2026, month: 6, day: day, hour: hour), count: count)
+    }
+
+    // MARK: - Slicing
+
+    @Test("Empty points produce sliceCount zeros")
+    func emptyPoints() {
+        let series = MiniChartSeries(points: [], range: range, aggregation: .total)
+        #expect(series.values == Array(repeating: 0, count: MiniChartSeries.sliceCount))
+    }
+
+    @Test("Points land in their slice, oldest first")
+    func slicing() {
+        let points = [makePoint(day: 1, count: 1), makePoint(day: 4, count: 5)]
+        let series = MiniChartSeries(points: points, range: range, aggregation: .total)
+
+        #expect(series.values == [1, 0, 0, 5, 0, 0, 0])
+    }
+
+    @Test("A point on a slice boundary belongs to the later slice")
+    func sliceBoundary() {
+        let series = MiniChartSeries(points: [makePoint(day: 2, count: 7)], range: range, aggregation: .total)
+        #expect(series.values == [0, 7, 0, 0, 0, 0, 0])
+    }
+
+    @Test("Points outside the range are ignored")
+    func outsideRange() {
+        let points = [
+            ChartPoint(date: Date(year: 2026, month: 5, day: 31), count: 9),
+            ChartPoint(date: range.upperBound, count: 9),
+            makePoint(day: 1, count: 1),
+        ]
+        let series = MiniChartSeries(points: points, range: range, aggregation: .total)
+
+        #expect(series.values == [1, 0, 0, 0, 0, 0, 0])
+    }
+
+    @Test("A range not divisible by sliceCount still spans all slices")
+    func unevenRange() {
+        let range = Date(year: 2026, month: 5, day: 9)..<Date(year: 2026, month: 6, day: 8)
+        let points = [
+            ChartPoint(date: range.lowerBound, count: 1),
+            ChartPoint(date: range.upperBound.addingTimeInterval(-1), count: 2),
+        ]
+        let series = MiniChartSeries(points: points, range: range, aggregation: .total)
+
+        #expect(series.values == [1, 0, 0, 0, 0, 0, 2])
+    }
+
+    @Test("An empty range produces zeros instead of crashing")
+    func emptyRange() {
+        let date = Date(year: 2026, month: 6, day: 1)
+        let series = MiniChartSeries(points: [makePoint(day: 1, count: 5)], range: date..<date, aggregation: .total)
+
+        #expect(series.values == Array(repeating: 0, count: MiniChartSeries.sliceCount))
+    }
+
+    // MARK: - Aggregation
+
+    @Test("Total sums all points in a slice")
+    func totalAggregation() {
+        let points = [makePoint(day: 1, hour: 3, count: 1), makePoint(day: 1, hour: 12, count: 2)]
+        let series = MiniChartSeries(points: points, range: range, aggregation: .total)
+
+        #expect(series.values == [3, 0, 0, 0, 0, 0, 0])
+    }
+
+    @Test("Latest picks the newest point in a slice")
+    func latestAggregation() {
+        let points = [makePoint(day: 1, hour: 3, count: 10), makePoint(day: 1, hour: 20, count: 4)]
+        let series = MiniChartSeries(points: points, range: range, aggregation: .latest)
+
+        #expect(series.values == [4, 0, 0, 0, 0, 0, 0])
+    }
+
+    @Test("Latest aggregates each slice independently")
+    func latestPerSlice() {
+        let points = [
+            makePoint(day: 1, hour: 3, count: 10),
+            makePoint(day: 1, hour: 20, count: 4),
+            makePoint(day: 5, count: 9),
+        ]
+        let series = MiniChartSeries(points: points, range: range, aggregation: .latest)
+
+        #expect(series.values == [4, 0, 0, 0, 9, 0, 0])
+    }
+}


### PR DESCRIPTION
Home rows for Crashes, Users, and Sessions now show an inline area mini-chart between the title and the count. `MiniChartSeries` compresses a period into seven equal time slices — summing event counts, or taking the newest value for active users — and `MiniChart` draws them as a smooth gradient-filled line, falling back to a redacted placeholder of the same size while data loads. The shared `RowSummary` keeps the charts and counts stacked into aligned columns across rows. Along the way this fixes a one-day shift in `PeriodCell.secondsSinceBase` (the stored `day` is 0-based), adds sample activity records so the Home preview renders the Users section with data, and records the new code-organization guidelines in `CLAUDE.md`.