### PR TITLE
Skip the event fetch when a timeline lane has no sessions

### DIFF
--- a/Sources/Scout/UI/Timeline/Pagination/Event+Fetch.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/Event+Fetch.swift
@@ -9,6 +9,10 @@ import CloudKit
 
 extension Event {
     static func fetch(sessionIDs: [UUID], name: String?, in database: AppDatabase) async throws -> [Event] {
+        guard sessionIDs.count > 0 else {
+            return []
+        }
+
         let ids = sessionIDs.map(\.uuidString)
         let predicate = predicate(ids: ids, name: name)
         let query = CKQuery(recordType: EventObject.recordType, predicate: predicate)


### PR DESCRIPTION
Fixes an endless loading spinner on the timeline: when the anchor event left one pagination lane with installs but no sessions, `Event.fetch` issued a CloudKit query with an empty `IN` predicate that never resolves, so the seeding task group in `TimelineProvider.start` awaited it forever and no result was ever published. `Event.fetch` now returns early with no events when there are no session IDs to query.

Closes #529