### PR TITLE
Add stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-message: >
+            This issue has been inactive for 60 days, so it has been marked as
+            stale. It will be closed in 14 days unless there is new activity.
+          stale-pr-message: >
+            This pull request has been inactive for 60 days, so it has been
+            marked as stale. It will be closed in 14 days unless there is new
+            activity.
+          exempt-issue-labels: pinned,security
+          exempt-pr-labels: pinned,security


### PR DESCRIPTION
Adds a `Stale` workflow that runs daily and marks issues and pull requests with no activity for 60 days as stale, closing them after another 14 days of silence. Items labeled `pinned` or `security` are exempt, and the workflow can also be triggered manually.