### PR TITLE
Upload test coverage to Codecov

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,6 +29,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 
+    permissions:
+      contents: read
+      id-token: write
+
     strategy:
       matrix:
         include:
@@ -73,3 +77,16 @@ jobs:
             xcrun xccov view --report --only-targets TestResults.xcresult
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Convert coverage to Cobertura
+        run: |
+          brew install a7ex/homebrew-formulae/xcresultparser
+          xcresultparser --output-format cobertura TestResults.xcresult > coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          flags: ios-${{ matrix.ios }}
+          disable_search: true
+          use_oidc: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+ignore:
+  - Tests
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Wires the test workflow up to Codecov. After tests run, each matrix leg converts `TestResults.xcresult` into Cobertura XML with `xcresultparser` and uploads it via `codecov-action`, authenticated through OIDC so no upload token secret is needed. A new `codecov.yml` ignores the `Tests` folder and keeps the Codecov status checks informational so they don't block PRs while coverage settles.