### PR TITLE
Fix Node.js 20 and Homebrew tap trust warnings in CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -82,6 +82,7 @@ jobs:
         env:
           HOMEBREW_REQUIRE_TAP_TRUST: 1
         run: |
+          brew update --quiet
           brew trust --formula a7ex/homebrew-formulae/xcresultparser
           brew install a7ex/homebrew-formulae/xcresultparser
           xcresultparser --output-format cobertura TestResults.xcresult > coverage.xml

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -79,12 +79,15 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Convert coverage to Cobertura
+        env:
+          HOMEBREW_REQUIRE_TAP_TRUST: 1
         run: |
+          brew trust --formula a7ex/homebrew-formulae/xcresultparser
           brew install a7ex/homebrew-formulae/xcresultparser
           xcresultparser --output-format cobertura TestResults.xcresult > coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: coverage.xml
           flags: ios-${{ matrix.ios }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -82,8 +82,10 @@ jobs:
         env:
           HOMEBREW_REQUIRE_TAP_TRUST: 1
         run: |
+          # Preinstalled third-party taps are untrusted and trigger tap-trust warnings
+          brew tap | grep -v '^homebrew/' | xargs -n1 brew untap || true
           brew update --quiet
-          brew trust --formula a7ex/homebrew-formulae/xcresultparser
+          brew trust --tap a7ex/homebrew-formulae
           brew install a7ex/homebrew-formulae/xcresultparser
           xcresultparser --output-format cobertura TestResults.xcresult > coverage.xml
 


### PR DESCRIPTION
Resolves the two warning annotations on the iOS test jobs. Bumps `codecov/codecov-action` from v5 to v7, which runs `actions/github-script` v8 on Node 24 instead of the deprecated Node 20 build; the inputs we use (`files`, `flags`, `disable_search`, `use_oidc`) are unchanged across the upgrade. Also opts the coverage conversion step into `HOMEBREW_REQUIRE_TAP_TRUST`, trusting the `a7ex/homebrew-formulae` tap that provides `xcresultparser` and untapping the unused third-party taps preinstalled on the runner images (`aws/tap`, `azure/bicep`, `hashicorp/tap`) that triggered the warnings. The step runs `brew update` first because the images ship a Homebrew version that predates the `brew trust` command.