### PR TITLE
Remove unneeded CodeQL workflow configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      actions: read
 
     steps:
       - uses: actions/checkout@v6
@@ -45,5 +44,3 @@ jobs:
             build
 
       - uses: github/codeql-action/analyze@v4
-        with:
-          category: "/language:swift"


### PR DESCRIPTION
Trims two pieces of configuration from the `CodeQL` workflow that have no effect. The `actions: read` permission is only required for CodeQL result uploads in private repositories, and this repository is public. The explicit `category` on the analyze step only matters when distinguishing multiple analyses of the same commit, while this workflow runs a single Swift analysis, so the default is equivalent.