### PR TITLE
Disable Codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,8 @@
 ignore:
   - Tests
 
+comment: false
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Adds `comment: false` to `codecov.yml` so Codecov no longer posts an automatic comment on every pull request, which in turn stops the email notifications those comments generate. Coverage status checks are unaffected and continue to appear on PRs.