### PR TITLE
Run CodeQL on a nightly schedule instead of every push and PR

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,19 +1,15 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
-    - cron: "33 7 * * 1"
+    - cron: "33 2 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
   group: codeql-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   analyze:


### PR DESCRIPTION
CodeQL analysis took 20+ minutes of macOS runner time on every PR push and merge, even though it is not a required status check, so it mostly competed with the test matrix and API check for the limited concurrent macOS slots — most PR runs were cancelled by the next push before finishing. The workflow now runs on a nightly schedule (02:33 UTC) with a `workflow_dispatch` trigger for on-demand scans, which keeps `main` scanned daily while freeing runner capacity for merge-blocking checks. The `cancel-in-progress` setting in the `concurrency` block is gone too, since there are no longer stale PR runs to cancel.