### PR TITLE
Add typed display and drill-down navigation for event parameters

### DIFF
--- a/Sources/Scout/UI/Event/Param/ParamBadge.swift
+++ b/Sources/Scout/UI/Event/Param/ParamBadge.swift
@@ -1,0 +1,70 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+/// The colored kind icon of a value.
+struct ParamIcon: View {
+    let value: ParamValue
+
+    var body: some View {
+        Group {
+            switch value.icon {
+            case .symbol(let name):
+                Image(systemName: name)
+                    .font(.footnote.weight(.medium))
+            case .text(let text):
+                Text(text)
+                    .font(.footnote.weight(.semibold))
+                    .fixedSize()
+            }
+        }
+        .foregroundStyle(value.color)
+        .frame(width: 21)
+    }
+}
+
+/// A capsule naming the recognized scalar kind.
+struct ParamBadge: View {
+    let convertible: ParamValue.Convertible
+
+    var body: some View {
+        Label(convertible.label, systemImage: convertible.iconName)
+            .font(.caption.weight(.medium))
+            .foregroundStyle(convertible.color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(convertible.color.opacity(0.13), in: Capsule())
+    }
+}
+
+extension ParamValue {
+    /// The accent color of the value's kind.
+    var color: Color {
+        switch self {
+        case .string: .gray
+        case .stringConvertible(let convertible): convertible.color
+        case .dictionary: .indigo
+        case .array: .brown
+        }
+    }
+}
+
+extension ParamValue.Convertible {
+    /// The accent color of the scalar kind.
+    var color: Color {
+        switch self {
+        case .number: .blue
+        case .boolean(true): .green
+        case .boolean(false): .red
+        case .uuid: .purple
+        case .url: .teal
+        case .date: .orange
+        }
+    }
+}

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -13,6 +13,11 @@ struct ParamList: View {
 
     @EnvironmentObject var tint: Tint
 
+    /// All parameters as `key: value` lines, used for sharing and copying.
+    private var text: String {
+        items.map(\.description).joined(separator: "\n")
+    }
+
     var body: some View {
         List {
             ForEach(items) { item in
@@ -21,6 +26,13 @@ struct ParamList: View {
         }
         .listStyle(.plain)
         .navigationTitle(en: "Params")
+        .toolbar {
+            ToolbarItemGroup(placement: .bottomBar) {
+                ShareLink(item: text)
+                CopyButton(text: text)
+                Spacer()
+            }
+        }
         .onAppear {
             tint.value = nil
         }
@@ -32,29 +44,41 @@ struct ParamRow: View {
 
     var body: some View {
         ZStack {
-            HStack {
-                if let key = item?.key {
-                    Text(key).foregroundStyle(.secondary)
-                } else {
-                    Redacted(length: 8).opacity(0.5)
-                }
-
-                Spacer()
-
-                if let value = item?.value {
-                    Text(value).monospaced().font(.system(size: 16))
-                } else {
-                    Redacted(length: 8).opacity(0.5)
-                }
-            }
-
             if let item {
+                let value = ParamValue(parsing: item.value)
+
+                HStack(spacing: 13) {
+                    ParamIcon(value: value)
+
+                    Text(item.key)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Text(value.summary)
+                        .monospaced()
+                        .font(.system(size: 16))
+                        .foregroundStyle(value.isContainer ? .secondary : .primary)
+                }
+
                 NavigationLink {
                     ParamView(item: item)
                 } label: {
                     EmptyView()
                 }
                 .opacity(0)
+            } else {
+                HStack(spacing: 13) {
+                    Redacted(length: 2)
+                        .frame(width: 21)
+                        .opacity(0.5)
+
+                    Redacted(length: 8).opacity(0.5)
+
+                    Spacer()
+
+                    Redacted(length: 8).opacity(0.5)
+                }
             }
         }
         .lineLimit(1)
@@ -68,12 +92,7 @@ struct ParamRow: View {
 
 #Preview {
     NavigationStack {
-        let items = [
-            ParamProvider.Item(key: "key1", value: "value1"),
-            ParamProvider.Item(key: "key2", value: "value2"),
-            ParamProvider.Item(key: "key3", value: "value3"),
-        ]
-        ParamList(items: items)
+        ParamList(items: ParamProvider.Item.sampleMetrics)
     }
     .environmentObject(Tint())
 }

--- a/Sources/Scout/UI/Event/Param/ParamProvider.Item.swift
+++ b/Sources/Scout/UI/Event/Param/ParamProvider.Item.swift
@@ -26,3 +26,109 @@ extension ParamProvider {
         }
     }
 }
+
+// MARK: - Sample Data
+
+extension ParamProvider.Item {
+    /// An in-app purchase where every value is a typed scalar.
+    static var samplePurchase: [ParamProvider.Item] {
+        [
+            ParamProvider.Item(key: "product_id", value: "com.scout.pro.yearly"),
+            ParamProvider.Item(key: "price", value: "49.99"),
+            ParamProvider.Item(key: "currency", value: "USD"),
+            ParamProvider.Item(key: "introductory", value: "true"),
+            ParamProvider.Item(key: "transaction_id", value: "1B2F4A89-0C3D-4E5F-A6B7-C8D9E0F1A2B3"),
+            ParamProvider.Item(key: "receipt_url", value: "https://buy.itunes.apple.com/verifyReceipt"),
+            ParamProvider.Item(key: "purchased_at", value: "2026-06-11T09:41:00Z"),
+        ]
+    }
+
+    /// An experiment assignment with plain and structured array values.
+    static var sampleExperiments: [ParamProvider.Item] {
+        [
+            ParamProvider.Item(key: "cohort", value: "B"),
+            ParamProvider.Item(key: "enrolled", value: "true"),
+            ParamProvider.Item(key: "updated_at", value: "2026-06-09T18:25:43.511Z"),
+            ParamProvider.Item(key: "variants", value: #"["chart_v2", "onboarding_short", "paywall_soft"]"#),
+            ParamProvider.Item(key: "weights", value: "[0.5, 0.3, 0.2]"),
+            ParamProvider.Item(
+                key: "assignments",
+                value: """
+                    [
+                      {"name": "chart_v2", "active": true, "since": "2026-05-02T10:00:00Z"},
+                      {"name": "onboarding_short", "active": true, "since": "2026-05-20T08:30:00Z"},
+                      {"name": "paywall_soft", "active": false, "since": "2026-04-11T12:00:00Z"}
+                    ]
+                    """
+            ),
+        ]
+    }
+
+    /// A user profile with deeply nested preferences.
+    static var sampleProfile: [ParamProvider.Item] {
+        [
+            ParamProvider.Item(key: "user_id", value: "C0FFEE00-1234-4ABC-9DEF-567890ABCDEF"),
+            ParamProvider.Item(key: "plan", value: "premium"),
+            ParamProvider.Item(key: "age", value: "34"),
+            ParamProvider.Item(key: "verified", value: "true"),
+            ParamProvider.Item(key: "signup_date", value: "2024-11-03T14:00:00Z"),
+            ParamProvider.Item(
+                key: "preferences",
+                value: """
+                    {
+                      "appearance": {
+                        "theme": "dark",
+                        "text_size": 1.15,
+                        "reduce_motion": false
+                      },
+                      "notifications": {
+                        "push": true,
+                        "email": false,
+                        "quiet_hours": ["22:00", "08:00"]
+                      }
+                    }
+                    """
+            ),
+        ]
+    }
+
+    /// A crash report with a long multi-line stack trace string.
+    static var sampleCrash: [ParamProvider.Item] {
+        [
+            ParamProvider.Item(key: "signal", value: "SIGSEGV"),
+            ParamProvider.Item(key: "thread", value: "12"),
+            ParamProvider.Item(key: "uptime_s", value: "3724.6"),
+            ParamProvider.Item(
+                key: "memory",
+                value: #"{"footprint_mb": 412.7, "peak_mb": 523.1, "pressure": "warning"}"#
+            ),
+            ParamProvider.Item(
+                key: "stack_trace",
+                value: """
+                    0  Scout      0x0000000102e4f8a4 ChartModel.rebuild() + 132
+                    1  Scout      0x0000000102e4d210 ChartView.body.getter + 88
+                    2  SwiftUI    0x00000001c2a91e40 ViewGraph.update() + 1056
+                    3  SwiftUI    0x00000001c2a8f6b0 ViewRendererHost.render() + 384
+                    4  UIKitCore  0x00000001b8e2d4c8 _UIUpdateSequenceRun + 84
+                    5  UIKitCore  0x00000001b8e2cf08 schedulerStepScheduledMainSection + 144
+                    6  CoreFoundation 0x00000001a6b3e9ac __CFRunLoopRun + 1996
+                    7  Scout      0x0000000102e21034 main + 64
+                    """
+            ),
+        ]
+    }
+
+    /// A performance metric with numeric samples and a histogram.
+    static var sampleMetrics: [ParamProvider.Item] {
+        [
+            ParamProvider.Item(key: "name", value: "chart_render"),
+            ParamProvider.Item(key: "unit", value: "ms"),
+            ParamProvider.Item(key: "count", value: "240"),
+            ParamProvider.Item(key: "p50", value: "16.7"),
+            ParamProvider.Item(key: "p95", value: "182.4"),
+            ParamProvider.Item(key: "collected_at", value: "2026-06-11T07:00:00Z"),
+            ParamProvider.Item(key: "samples", value: "[12.1, 14.9, 16.7, 21.3, 48.2, 182.4]"),
+            ParamProvider.Item(key: "histogram", value: #"{"0_50": 218, "50_100": 14, "100_250": 8}"#),
+        ]
+    }
+}

--- a/Sources/Scout/UI/Event/Param/ParamView.swift
+++ b/Sources/Scout/UI/Event/Param/ParamView.swift
@@ -8,24 +8,51 @@
 import SwiftUI
 
 struct ParamView: View {
-    let item: ParamProvider.Item
+    private let key: String
+    private let value: ParamValue
+    private let raw: String
 
     @EnvironmentObject var tint: Tint
 
+    /// Shows a fetched parameter, keeping its raw text for sharing.
+    init(item: ParamProvider.Item) {
+        key = item.key
+        value = ParamValue(parsing: item.value)
+        raw = item.value
+    }
+
+    /// Shows a nested value reached by drilling into a container.
+    init(node: ParamValue.Node) {
+        key = node.label
+        value = node.value
+        raw = node.value.text
+    }
+
     var body: some View {
-        ScrollView {
-            Text(item.value)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal)
-                .monospaced()
-                .textSelection(.enabled)
-                .navigationTitle(item.key)
-            Spacer()
+        Group {
+            if value.isContainer {
+                List(value.nodes) { node in
+                    ZStack {
+                        ParamNodeRow(node: node)
+
+                        NavigationLink {
+                            ParamView(node: node)
+                        } label: {
+                            EmptyView()
+                        }
+                        .opacity(0)
+                    }
+                }
+                .listStyle(.plain)
+            } else {
+                ParamScalarView(raw: raw, value: value)
+            }
         }
+        .navigationTitle(key)
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
-                ShareLink(item: item.value)
-                CopyButton(text: item.value)
+                ShareLink(item: raw)
+                CopyButton(text: raw)
                 Spacer()
             }
         }
@@ -35,22 +62,80 @@ struct ParamView: View {
     }
 }
 
+/// The scalar layout of a parameter value: a kind badge for recognized scalars
+/// above the verbatim text.
+///
+private struct ParamScalarView: View {
+    let raw: String
+    let value: ParamValue
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 13) {
+                if case .stringConvertible(let convertible) = value {
+                    ParamBadge(convertible: convertible)
+                }
+
+                Text(raw)
+                    .monospaced()
+                    .textSelection(.enabled)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal)
+        }
+    }
+}
+
+/// A row of the expandable value tree: a colored kind icon, the key or index,
+/// and the scalar value or a child count for containers.
+///
+struct ParamNodeRow: View {
+    let node: ParamValue.Node
+
+    var body: some View {
+        HStack(spacing: 13) {
+            ParamIcon(value: node.value)
+
+            Text(node.label)
+                .foregroundStyle(node.value.isContainer ? .primary : .secondary)
+
+            Spacer()
+
+            Text(node.value.summary)
+                .monospaced()
+                .font(.system(size: 16))
+                .foregroundStyle(node.value.isContainer ? .tertiary : .primary)
+                .lineLimit(1)
+        }
+    }
+}
+
 // MARK: - Preview
 
-#Preview {
+#Preview("Dictionary") {
     NavigationStack {
-        ParamView(
-            item: ParamProvider.Item(
-                key: "payload",
-                value: """
-                    {
-                      "query": "8.8.8.8",
-                      "country": "United States",
-                      "isp": "Google LLC"
-                    }
-                    """
-            )
-        )
+        ParamView(item: ParamProvider.Item.sampleProfile.first { $0.key == "preferences" }!)
+    }
+    .environmentObject(Tint())
+}
+
+#Preview("Array") {
+    NavigationStack {
+        ParamView(item: ParamProvider.Item.sampleExperiments.first { $0.key == "assignments" }!)
+    }
+    .environmentObject(Tint())
+}
+
+#Preview("Scalar") {
+    NavigationStack {
+        ParamView(item: ParamProvider.Item.samplePurchase.first { $0.key == "purchased_at" }!)
+    }
+    .environmentObject(Tint())
+}
+
+#Preview("Text") {
+    NavigationStack {
+        ParamView(item: ParamProvider.Item.sampleCrash.first { $0.key == "stack_trace" }!)
     }
     .environmentObject(Tint())
 }

--- a/Sources/Scout/UI/Event/Param/Value/ParamValue+Display.swift
+++ b/Sources/Scout/UI/Event/Param/Value/ParamValue+Display.swift
@@ -1,0 +1,84 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+extension ParamValue {
+    /// Whether the value is a dictionary or an array.
+    var isContainer: Bool {
+        switch self {
+        case .dictionary, .array: true
+        case .string, .stringConvertible: false
+        }
+    }
+
+    /// A one-line digest of the value, used where space is limited.
+    var summary: String {
+        switch self {
+        case .string(let string):
+            string
+        case .stringConvertible(let convertible):
+            convertible.text
+        case .dictionary(let entries):
+            entries.count == 1 ? "1 pair" : "\(entries.count) pairs"
+        case .array(let values):
+            values.count == 1 ? "1 item" : "\(values.count) items"
+        }
+    }
+
+    /// The glyph of the value's kind: an SF Symbol where one fits, literal
+    /// text for arrays, which SF Symbols has no bracket glyph for.
+    ///
+    var icon: Icon {
+        switch self {
+        case .string: .symbol("textformat")
+        case .stringConvertible(let convertible): .symbol(convertible.iconName)
+        case .dictionary: .symbol("curlybraces")
+        case .array: .text("[ ]")
+        }
+    }
+
+    /// A kind glyph: either an SF Symbol name or text drawn verbatim.
+    enum Icon: Hashable {
+        case symbol(String)
+        case text(String)
+    }
+}
+
+extension ParamValue.Convertible {
+    /// The verbatim text of the scalar.
+    var text: String {
+        switch self {
+        case .number(let text), .uuid(let text), .url(let text), .date(let text):
+            text
+        case .boolean(let value):
+            value ? "true" : "false"
+        }
+    }
+
+    /// A short name of the scalar kind, shown in the value badge.
+    var label: String {
+        switch self {
+        case .number: "Number"
+        case .boolean: "Boolean"
+        case .uuid: "UUID"
+        case .url: "URL"
+        case .date: "Date"
+        }
+    }
+
+    /// An SF Symbol of the scalar kind.
+    var iconName: String {
+        switch self {
+        case .number: "number"
+        case .boolean(true): "checkmark.circle"
+        case .boolean(false): "xmark.circle"
+        case .uuid: "tag"
+        case .url: "link"
+        case .date: "calendar"
+        }
+    }
+}

--- a/Sources/Scout/UI/Event/Param/Value/ParamValue+Nodes.swift
+++ b/Sources/Scout/UI/Event/Param/Value/ParamValue+Nodes.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+extension ParamValue {
+    /// A direct child of a container value, used to render drill-down lists.
+    struct Node: Identifiable {
+        /// The dictionary key or array index leading to the node.
+        let label: String
+
+        /// The value at this node.
+        let value: ParamValue
+
+        var id: String { label }
+    }
+
+    /// The direct children of a container: dictionary entries keyed by name,
+    /// array elements keyed by index. Scalars have none.
+    ///
+    var nodes: [Node] {
+        switch self {
+        case .dictionary(let entries):
+            entries.map { Node(label: $0.key, value: $0.value) }
+        case .array(let values):
+            values.enumerated().map { Node(label: "\($0.offset)", value: $0.element) }
+        case .string, .stringConvertible:
+            []
+        }
+    }
+}

--- a/Sources/Scout/UI/Event/Param/Value/ParamValue+Nodes.swift
+++ b/Sources/Scout/UI/Event/Param/Value/ParamValue+Nodes.swift
@@ -18,8 +18,10 @@ extension ParamValue {
         var id: String { label }
     }
 
-    /// The direct children of a container: dictionary entries keyed by name,
-    /// array elements keyed by index. Scalars have none.
+    /// The direct children of a container.
+    ///
+    /// Dictionary entries are keyed by name, array elements by index.
+    /// Scalars have none.
     ///
     var nodes: [Node] {
         switch self {

--- a/Sources/Scout/UI/Event/Param/Value/ParamValue+Parsing.swift
+++ b/Sources/Scout/UI/Event/Param/Value/ParamValue+Parsing.swift
@@ -1,0 +1,108 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+extension ParamValue {
+    /// Parses a raw parameter string into its display classification.
+    init(parsing raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let structure = Self.structure(from: trimmed) {
+            self = structure
+        } else if let convertible = Convertible(parsing: trimmed) {
+            self = .stringConvertible(convertible)
+        } else {
+            self = .string(raw)
+        }
+    }
+
+    private static func structure(from text: String) -> ParamValue? {
+        guard text.hasPrefix("{") || text.hasPrefix("[") else {
+            return nil
+        }
+        guard let data = text.data(using: .utf8), let object = try? JSONSerialization.jsonObject(with: data) else {
+            return nil
+        }
+        return value(of: object)
+    }
+
+    private static func value(of object: Any) -> ParamValue? {
+        switch object {
+        case let dictionary as [String: Any]:
+            let entries = dictionary.sorted { $0.key < $1.key }.compactMap { pair in
+                value(of: pair.value).map { Entry(key: pair.key, value: $0) }
+            }
+            return .dictionary(entries)
+        case let array as [Any]:
+            return .array(array.compactMap(value(of:)))
+        case let number as NSNumber:
+            return number.isBoolean
+                ? .stringConvertible(.boolean(number.boolValue))
+                : .stringConvertible(.number("\(number)"))
+        case let string as String:
+            if let convertible = Convertible(parsing: string) {
+                return .stringConvertible(convertible)
+            }
+            return .string(string)
+        case is NSNull:
+            return .string("null")
+        default:
+            return nil
+        }
+    }
+}
+
+extension ParamValue.Convertible {
+    /// Recognizes a typed scalar from its textual shape, or fails for plain text.
+    init?(parsing text: String) {
+        if text == "true" || text == "false" {
+            self = .boolean(text == "true")
+        } else if Self.isNumber(text) {
+            self = .number(text)
+        } else if UUID(uuidString: text) != nil {
+            self = .uuid(text)
+        } else if Self.isURL(text) {
+            self = .url(text)
+        } else if Self.isDate(text) {
+            self = .date(text)
+        } else {
+            return nil
+        }
+    }
+
+    /// Characters of a decimal or scientific-notation number; excludes look-alikes
+    /// that `Double.init` would also accept, such as hex literals or "inf".
+    private static let numberScalars = CharacterSet(charactersIn: "0123456789+-.eE")
+
+    private static func isNumber(_ text: String) -> Bool {
+        guard text.count > 0, Double(text) != nil else {
+            return false
+        }
+        return text.unicodeScalars.allSatisfy(numberScalars.contains)
+    }
+
+    private static func isURL(_ text: String) -> Bool {
+        guard let components = URLComponents(string: text) else {
+            return false
+        }
+        return components.scheme != nil && (components.host?.count ?? 0) > 0
+    }
+
+    private static func isDate(_ text: String) -> Bool {
+        (try? Date(text, strategy: .iso8601)) != nil
+            || (try? Date(text, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true))) != nil
+    }
+}
+
+extension NSNumber {
+    /// Whether the number wraps a JSON boolean rather than a numeric value.
+    fileprivate var isBoolean: Bool {
+        CFGetTypeID(self) == CFBooleanGetTypeID()
+    }
+}

--- a/Sources/Scout/UI/Event/Param/Value/ParamValue+Text.swift
+++ b/Sources/Scout/UI/Event/Param/Value/ParamValue+Text.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+extension ParamValue {
+    /// A shareable text form of the value: scalars verbatim, containers as
+    /// pretty-printed JSON with sorted keys.
+    ///
+    var text: String {
+        switch self {
+        case .string(let string):
+            return string
+        case .stringConvertible(let convertible):
+            return convertible.text
+        case .dictionary, .array:
+            let options: JSONSerialization.WritingOptions = [.prettyPrinted, .sortedKeys]
+            guard let data = try? JSONSerialization.data(withJSONObject: jsonObject, options: options), let text = String(data: data, encoding: .utf8) else {
+                return summary
+            }
+            return text
+        }
+    }
+
+    private var jsonObject: Any {
+        switch self {
+        case .string(let string):
+            string
+        case .stringConvertible(let convertible):
+            convertible.jsonObject
+        case .dictionary(let entries):
+            Dictionary(uniqueKeysWithValues: entries.map { ($0.key, $0.value.jsonObject) })
+        case .array(let values):
+            values.map(\.jsonObject)
+        }
+    }
+}
+
+extension ParamValue.Convertible {
+    /// The Foundation representation used to rebuild JSON from parsed values.
+    fileprivate var jsonObject: Any {
+        switch self {
+        case .boolean(let value):
+            value
+        case .number(let text):
+            Decimal(string: text).map { NSDecimalNumber(decimal: $0) } ?? text
+        case .uuid(let text), .url(let text), .date(let text):
+            text
+        }
+    }
+}

--- a/Sources/Scout/UI/Event/Param/Value/ParamValue.swift
+++ b/Sources/Scout/UI/Event/Param/Value/ParamValue.swift
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+/// A display-oriented classification of a raw parameter value, mirroring the
+/// `Logger.MetadataValue` cases the value originated from.
+///
+/// Parameters arrive as plain strings, so the original case is recovered from the
+/// textual shape: JSON objects and arrays become `.dictionary` and `.array`,
+/// recognizable scalars become `.stringConvertible`, and everything else stays `.string`.
+///
+enum ParamValue: Hashable {
+    /// A plain string value.
+    case string(String)
+
+    /// A scalar that reads as a typed value, such as a number or a URL.
+    case stringConvertible(Convertible)
+
+    /// A dictionary value with entries ordered by key.
+    case dictionary([Entry])
+
+    /// An array of values.
+    case array([ParamValue])
+}
+
+extension ParamValue {
+    /// A typed scalar recognized from its textual shape.
+    enum Convertible: Hashable {
+        case number(String)
+        case boolean(Bool)
+        case uuid(String)
+        case url(String)
+        case date(String)
+    }
+
+    /// A key–value pair of a dictionary value.
+    struct Entry: Hashable, Identifiable {
+        let key: String
+        let value: ParamValue
+
+        var id: String { key }
+    }
+}

--- a/Tests/ScoutTests/UI/Event/ParamValueTests.swift
+++ b/Tests/ScoutTests/UI/Event/ParamValueTests.swift
@@ -1,0 +1,176 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct ParamValueTests {
+    @Test("Plain text stays a string")
+    func plainString() {
+        #expect(ParamValue(parsing: "hello world") == .string("hello world"))
+    }
+
+    @Test("Empty value stays a string")
+    func emptyString() {
+        #expect(ParamValue(parsing: "") == .string(""))
+    }
+
+    @Test("Integers, decimals, and exponents read as numbers")
+    func numbers() {
+        #expect(ParamValue(parsing: "200") == .stringConvertible(.number("200")))
+        #expect(ParamValue(parsing: "-182.4") == .stringConvertible(.number("-182.4")))
+        #expect(ParamValue(parsing: "1e5") == .stringConvertible(.number("1e5")))
+    }
+
+    @Test("Number look-alikes stay strings")
+    func numberLookalikes() {
+        #expect(ParamValue(parsing: "1.2.3") == .string("1.2.3"))
+        #expect(ParamValue(parsing: "0x1F") == .string("0x1F"))
+        #expect(ParamValue(parsing: "inf") == .string("inf"))
+    }
+
+    @Test("Booleans read as booleans")
+    func booleans() {
+        #expect(ParamValue(parsing: "true") == .stringConvertible(.boolean(true)))
+        #expect(ParamValue(parsing: "false") == .stringConvertible(.boolean(false)))
+    }
+
+    @Test("UUIDs read as UUIDs")
+    func uuid() {
+        let text = "7F9C24E5-86B4-4B7A-91D2-3C5A0E8F6D1B"
+        #expect(ParamValue(parsing: text) == .stringConvertible(.uuid(text)))
+    }
+
+    @Test("URLs with a scheme and host read as URLs")
+    func urls() {
+        #expect(ParamValue(parsing: "https://example.com/path") == .stringConvertible(.url("https://example.com/path")))
+        #expect(ParamValue(parsing: "scout://events/recent") == .stringConvertible(.url("scout://events/recent")))
+        #expect(ParamValue(parsing: "com.scout.pro.yearly") == .string("com.scout.pro.yearly"))
+    }
+
+    @Test("ISO 8601 dates read as dates")
+    func dates() {
+        #expect(ParamValue(parsing: "2026-06-11T09:41:00Z") == .stringConvertible(.date("2026-06-11T09:41:00Z")))
+        #expect(ParamValue(parsing: "2026-06-09T18:25:43.511Z") == .stringConvertible(.date("2026-06-09T18:25:43.511Z")))
+    }
+
+    @Test("JSON objects become dictionaries with sorted keys")
+    func jsonObject() {
+        let value = ParamValue(parsing: #"{"b": "text", "a": 7, "c": true}"#)
+        let expected = ParamValue.dictionary([
+            ParamValue.Entry(key: "a", value: .stringConvertible(.number("7"))),
+            ParamValue.Entry(key: "b", value: .string("text")),
+            ParamValue.Entry(key: "c", value: .stringConvertible(.boolean(true))),
+        ])
+        #expect(value == expected)
+    }
+
+    @Test("JSON arrays become arrays")
+    func jsonArray() {
+        let value = ParamValue(parsing: #"["a", 1, false]"#)
+        #expect(value == .array([.string("a"), .stringConvertible(.number("1")), .stringConvertible(.boolean(false))]))
+    }
+
+    @Test("Nested containers parse recursively")
+    func nested() {
+        let value = ParamValue(parsing: #"{"outer": {"inner": [1]}}"#)
+        let expected = ParamValue.dictionary([
+            ParamValue.Entry(
+                key: "outer",
+                value: .dictionary([
+                    ParamValue.Entry(key: "inner", value: .array([.stringConvertible(.number("1"))]))
+                ])
+            )
+        ])
+        #expect(value == expected)
+    }
+
+    @Test("Scalar strings inside JSON are classified")
+    func nestedScalars() {
+        let value = ParamValue(parsing: #"{"link": "https://example.com", "when": "2026-06-11T09:41:00Z"}"#)
+        let expected = ParamValue.dictionary([
+            ParamValue.Entry(key: "link", value: .stringConvertible(.url("https://example.com"))),
+            ParamValue.Entry(key: "when", value: .stringConvertible(.date("2026-06-11T09:41:00Z"))),
+        ])
+        #expect(value == expected)
+    }
+
+    @Test("Malformed JSON stays a string")
+    func malformedJSON() {
+        #expect(ParamValue(parsing: "{not json}") == .string("{not json}"))
+        #expect(ParamValue(parsing: "[1, 2") == .string("[1, 2"))
+    }
+
+    @Test("Containers expose their direct children as nodes")
+    func nodes() {
+        let nodes = ParamValue(parsing: #"{"a": {"b": [5]}}"#).nodes
+
+        #expect(nodes.count == 1)
+        #expect(nodes[0].label == "a" && nodes[0].value.isContainer)
+
+        let inner = nodes[0].value.nodes
+        #expect(inner.count == 1)
+        #expect(inner[0].label == "b" && inner[0].value.isContainer)
+
+        let leaves = inner[0].value.nodes
+        #expect(leaves.count == 1)
+        #expect(leaves[0].label == "0")
+        #expect(leaves[0].value == .stringConvertible(.number("5")))
+        #expect(leaves[0].value.nodes.count == 0)
+    }
+
+    @Test("Array elements become indexed nodes")
+    func arrayNodes() {
+        let nodes = ParamValue(parsing: #"["a", "b"]"#).nodes
+
+        #expect(nodes.count == 2)
+        #expect(nodes[0].label == "0" && nodes[0].value == .string("a"))
+        #expect(nodes[1].label == "1" && nodes[1].value == .string("b"))
+    }
+
+    @Test("Scalars produce no nodes")
+    func scalarNodes() {
+        #expect(ParamValue(parsing: "plain").nodes.count == 0)
+    }
+
+    @Test("Text renders scalars verbatim")
+    func scalarText() {
+        #expect(ParamValue(parsing: "plain").text == "plain")
+        #expect(ParamValue(parsing: "182.4").text == "182.4")
+        #expect(ParamValue(parsing: "true").text == "true")
+        #expect(ParamValue(parsing: "2026-06-11T09:41:00Z").text == "2026-06-11T09:41:00Z")
+    }
+
+    @Test("Text renders containers as JSON with sorted keys")
+    func containerText() {
+        let text = ParamValue(parsing: #"{"b": 2, "a": "x", "c": [true]}"#).text
+
+        #expect(text.hasPrefix("{") && text.hasSuffix("}"))
+        #expect(text.contains(#""a" : "x""#))
+        #expect(text.contains(#""b" : 2"#))
+        #expect(text.contains("true"))
+    }
+
+    @Test("Icons cover every kind")
+    func icons() {
+        #expect(ParamValue(parsing: "plain").icon == .symbol("textformat"))
+        #expect(ParamValue(parsing: "42").icon == .symbol("number"))
+        #expect(ParamValue(parsing: #"{"a": 1}"#).icon == .symbol("curlybraces"))
+        #expect(ParamValue(parsing: "[1]").icon == .text("[ ]"))
+    }
+
+    @Test("Summaries digest each case")
+    func summaries() {
+        #expect(ParamValue(parsing: "plain").summary == "plain")
+        #expect(ParamValue(parsing: "42").summary == "42")
+        #expect(ParamValue(parsing: #"{"a": 1, "b": 2}"#).summary == "2 pairs")
+        #expect(ParamValue(parsing: "[1]").summary == "1 item")
+    }
+}


### PR DESCRIPTION
Event parameter values were shown as raw strings in both `ParamList` and `ParamView`. This change introduces `ParamValue`, a model that classifies each raw string into the `Logger.MetadataValue`-style cases: plain strings, typed scalars (numbers, booleans, UUIDs, URLs, ISO 8601 dates), dictionaries, and arrays. List rows now lead with a colored kind icon (arrays drawn as literal `[ ]`, since SF Symbols has no bracket glyph) and show a compact summary for containers, while `ParamView` lets you drill into dictionaries and arrays level by level and shows a kind badge for scalars. Both screens gained bottom-bar share/copy; nested values are re-serialized as pretty-printed JSON with sorted keys. Parsing, display, and serialization live in the new `Param/Value` files and are covered by unit tests.