### PR TITLE
Display metric series rows in italic

### DIFF
--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -61,6 +61,7 @@ struct MetricsContent<T: ChartNumeric>: View {
             Text(group.points.total[keyPath: formatter])
         }
         .monospaced()
+        .italic()
         .font(.system(size: 17))
         .lineLimit(1)
     }


### PR DESCRIPTION
Metric series rows in the metrics list now render in italic. The `.italic()` modifier is applied to the row layout in `MetricsContent` alongside the existing monospaced styling, so both the series name and its total value are affected.