### PR TITLE
Align event screen row icons

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -68,6 +68,7 @@ extension EventView {
                 StatRow(
                     color: .blue,
                     period: period,
+                    systemImage: "calendar",
                     stat: stat
                 ) {
                     StatView(

--- a/Sources/Scout/UI/Event/Param/ParamBadge.swift
+++ b/Sources/Scout/UI/Event/Param/ParamBadge.swift
@@ -17,15 +17,15 @@ struct ParamIcon: View {
             switch value.icon {
             case .symbol(let name):
                 Image(systemName: name)
-                    .font(.footnote.weight(.medium))
+                    .font(.body)
             case .text(let text):
                 Text(text)
-                    .font(.footnote.weight(.semibold))
+                    .font(.body.weight(.semibold))
                     .fixedSize()
             }
         }
         .foregroundStyle(value.color)
-        .frame(width: 21)
+        .frame(width: 24)
     }
 }
 
@@ -47,7 +47,7 @@ extension ParamValue {
     /// The accent color of the value's kind.
     var color: Color {
         switch self {
-        case .string: .gray
+        case .string: .primary
         case .stringConvertible(let convertible): convertible.color
         case .dictionary: .indigo
         case .array: .brown

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -70,7 +70,7 @@ struct ParamRow: View {
             } else {
                 HStack(spacing: 13) {
                     Redacted(length: 2)
-                        .frame(width: 21)
+                        .frame(width: 24)
                         .opacity(0.5)
 
                     Redacted(length: 8).opacity(0.5)


### PR DESCRIPTION
Adds a calendar icon to the period rows in the event screen's Stats section, which also switches their titles from blue to the primary text color, matching the icon-and-title style of the home screen sections. Enlarges `ParamIcon` from a footnote-sized glyph in a 21-point frame to a body-sized one in a 24-point frame so parameter rows line up with the other rows, and recolors the string kind (`Aa`) from gray to primary. The loading placeholder in `ParamRow` is widened to match.