### PR TITLE
Add an icon to the event screen's Timeline row

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -97,21 +97,14 @@ extension EventView {
         }
 
         func timelineRow(deviceID: UUID) -> some View {
-            ZStack {
-                HStack {
-                    Text(verbatim: "Timeline").foregroundStyle(.blue)
-                    Spacer()
-                }
-
-                NavigationLink {
-                    Timeline(deviceID: deviceID, event: event)
-                } label: {
-                    EmptyView()
-                }
-                .opacity(0)
-            }
-            .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-                dimension[.trailing]
+            Row {
+                Image(systemName: "calendar.day.timeline.left")
+                    .foregroundColor(.blue)
+                    .frame(width: 24)
+                Text(verbatim: "Timeline")
+                Spacer()
+            } destination: {
+                Timeline(deviceID: deviceID, event: event)
             }
         }
     }

--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -99,13 +99,13 @@ extension EventView {
         func timelineRow(deviceID: UUID) -> some View {
             Row {
                 Image(systemName: "calendar.day.timeline.left")
-                    .foregroundColor(.blue)
                     .frame(width: 24)
-                Text(verbatim: "Timeline").foregroundStyle(.blue)
+                Text(verbatim: "Timeline")
                 Spacer()
             } destination: {
                 Timeline(deviceID: deviceID, event: event)
             }
+            .foregroundStyle(.blue)
         }
     }
 }

--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -101,7 +101,7 @@ extension EventView {
                 Image(systemName: "calendar.day.timeline.left")
                     .foregroundColor(.blue)
                     .frame(width: 24)
-                Text(verbatim: "Timeline")
+                Text(verbatim: "Timeline").foregroundStyle(.blue)
                 Spacer()
             } destination: {
                 Timeline(deviceID: deviceID, event: event)


### PR DESCRIPTION
Adds a `calendar.day.timeline.left` icon to the Timeline row in the event screen's History section, matching the icon-and-title row style of the Stats and Params rows; the title keeps its blue color. The row is also rewritten on top of the shared `Row` component instead of hand-rolling the same hidden `NavigationLink` layout in `HistorySection`.