### PR TITLE
Unify Home stat sections under a section picker

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct HomeContent: View {
     @Environment(\.database) var database
 
+    @State private var section = HomeSection.sessions
+
     @StateObject var activity = ActivityProvider()
     @StateObject var sessionStat = StatProvider(eventName: "Session", periods: Period.summary)
     @StateObject var crashStat = StatProvider(eventName: "Crash", periods: Period.summary)
@@ -17,9 +19,7 @@ struct HomeContent: View {
     var body: some View {
         List {
             logSection
-            crashSection
-            activitySection
-            sessionSection
+            statSection
         }
         .listStyle(.plain)
     }
@@ -44,84 +44,76 @@ struct HomeContent: View {
             } destination: {
                 MetricsList().navigationTitle(en: "Metrics")
             }
-        } header: {
-            Header(title: "Log")
-        }
-    }
-
-    private var crashSection: some View {
-        Section {
-            ForEach(Period.summary) { period in
-                StatRow(
-                    color: .red,
-                    period: period,
-                    systemImage: "exclamationmark.triangle",
-                    stat: crashStat
-                ) {
-                    StatView(
-                        showList: false,
-                        extent: ChartExtent(period: period),
-                        stat: crashStat
-                    )
-                    .environment(\.chartColor, .red)
-                    .navigationTitle(en: "Crashes")
-                }
-            }
-
             Row {
-                Image(systemName: "tray.full")
+                Image(systemName: "exclamationmark.triangle")
                     .foregroundColor(.red)
                     .frame(width: 24)
-                Text(verbatim: "All")
+                Text(verbatim: "Crashes")
                 Spacer()
             } destination: {
                 CrashListView()
             }
         } header: {
-            Header(title: "Crashes").task {
-                await crashStat.fetchIfNeeded(in: database)
-            }
+            Header(title: "Log")
         }
     }
 
-    private var activitySection: some View {
+    private var statSection: some View {
         Section {
+            sectionRows
+        } header: {
+            VStack(alignment: .leading, spacing: 12) {
+                Header(title: "Stats")
+                HomeSectionPicker(selection: $section)
+                    .padding(.bottom, 4)
+            }
+            .task(id: section) {
+                    switch section {
+                    case .sessions:
+                        await sessionStat.fetchIfNeeded(in: database)
+                    case .crashes:
+                        await crashStat.fetchIfNeeded(in: database)
+                    case .users:
+                        await activity.fetchIfNeeded(in: database)
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var sectionRows: some View {
+        switch section {
+        case .sessions:
+            statRows(for: sessionStat, section: .sessions)
+        case .crashes:
+            statRows(for: crashStat, section: .crashes)
+        case .users:
             ForEach(ActivityPeriod.allCases) { period in
                 ActivityRow(
                     period: period,
-                    color: .green,
-                    systemImage: "person.2",
+                    color: HomeSection.users.color,
+                    systemImage: HomeSection.users.systemImage,
                     activity: activity
                 )
-            }
-        } header: {
-            Header(title: "Users").task {
-                await activity.fetchIfNeeded(in: database)
             }
         }
     }
 
-    private var sessionSection: some View {
-        Section {
-            ForEach(Period.summary) { period in
-                StatRow(
-                    color: .purple,
-                    period: period,
-                    systemImage: "clock",
-                    stat: sessionStat
-                ) {
-                    StatView(
-                        showList: false,
-                        extent: ChartExtent(period: period),
-                        stat: sessionStat
-                    )
-                    .environment(\.chartColor, .purple)
-                    .navigationTitle(en: "Sessions")
-                }
-            }
-        } header: {
-            Header(title: "Sessions").task {
-                await sessionStat.fetchIfNeeded(in: database)
+    private func statRows(for stat: StatProvider, section: HomeSection) -> some View {
+        ForEach(Period.summary) { period in
+            StatRow(
+                color: section.color,
+                period: period,
+                systemImage: section.systemImage,
+                stat: stat
+            ) {
+                StatView(
+                    showList: false,
+                    extent: ChartExtent(period: period),
+                    stat: stat
+                )
+                .environment(\.chartColor, section.color)
+                .navigationTitle(en: section.title)
             }
         }
     }

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -68,15 +68,15 @@ struct HomeContent: View {
                     .padding(.bottom, 4)
             }
             .task(id: section) {
-                    switch section {
-                    case .sessions:
-                        await sessionStat.fetchIfNeeded(in: database)
-                    case .crashes:
-                        await crashStat.fetchIfNeeded(in: database)
-                    case .users:
-                        await activity.fetchIfNeeded(in: database)
-                    }
+                switch section {
+                case .sessions:
+                    await sessionStat.fetchIfNeeded(in: database)
+                case .crashes:
+                    await crashStat.fetchIfNeeded(in: database)
+                case .users:
+                    await activity.fetchIfNeeded(in: database)
                 }
+            }
         }
     }
 

--- a/Sources/Scout/UI/Home/HomeSectionPicker.swift
+++ b/Sources/Scout/UI/Home/HomeSectionPicker.swift
@@ -50,7 +50,20 @@ struct HomeSectionPicker: View {
     @Binding var selection: HomeSection
 
     var body: some View {
-        if #available(iOS 26.0, *) {
+        #if compiler(>=6.2)
+            if #available(iOS 26.0, *) {
+                glassPicker
+            } else {
+                solidPicker
+            }
+        #else
+            solidPicker
+        #endif
+    }
+
+    #if compiler(>=6.2)
+        @available(iOS 26.0, *)
+        private var glassPicker: some View {
             GlassEffectContainer(spacing: 16) {
                 HStack(spacing: 16) {
                     ForEach(HomeSection.allCases) { section in
@@ -59,12 +72,14 @@ struct HomeSectionPicker: View {
                     }
                 }
             }
-        } else {
-            HStack(spacing: 16) {
-                ForEach(HomeSection.allCases) { section in
-                    segment(for: section)
-                        .background(Capsule().fill(selection == section ? section.color : Color(.systemGray6)))
-                }
+        }
+    #endif
+
+    private var solidPicker: some View {
+        HStack(spacing: 16) {
+            ForEach(HomeSection.allCases) { section in
+                segment(for: section)
+                    .background(Capsule().fill(selection == section ? section.color : Color(.systemGray6)))
             }
         }
     }

--- a/Sources/Scout/UI/Home/HomeSectionPicker.swift
+++ b/Sources/Scout/UI/Home/HomeSectionPicker.swift
@@ -41,9 +41,10 @@ enum HomeSection: CaseIterable, Identifiable {
     }
 }
 
-/// A capsule-per-section switcher that tints the selected capsule with the
-/// section color. Capsules are made of Liquid Glass where available and fall
-/// back to solid fills on older systems.
+/// A capsule-per-section switcher tinted with the selected section's color.
+///
+/// Capsules are made of Liquid Glass where available and fall back to solid
+/// fills on older systems.
 ///
 struct HomeSectionPicker: View {
     @Binding var selection: HomeSection

--- a/Sources/Scout/UI/Home/HomeSectionPicker.swift
+++ b/Sources/Scout/UI/Home/HomeSectionPicker.swift
@@ -1,0 +1,98 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+/// A Home screen stat section selectable in ``HomeSectionPicker``.
+enum HomeSection: CaseIterable, Identifiable {
+    case sessions
+    case crashes
+    case users
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .sessions: "Sessions"
+        case .crashes: "Crashes"
+        case .users: "Users"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .sessions: .purple
+        case .crashes: .red
+        case .users: .green
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .sessions: "clock"
+        case .crashes: "exclamationmark.triangle"
+        case .users: "person.2"
+        }
+    }
+}
+
+/// A capsule-per-section switcher that tints the selected capsule with the
+/// section color. Capsules are made of Liquid Glass where available and fall
+/// back to solid fills on older systems.
+///
+struct HomeSectionPicker: View {
+    @Binding var selection: HomeSection
+
+    var body: some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer(spacing: 16) {
+                HStack(spacing: 16) {
+                    ForEach(HomeSection.allCases) { section in
+                        segment(for: section)
+                            .glassEffect(selection == section ? .regular.tint(section.color).interactive() : .regular.interactive())
+                    }
+                }
+            }
+        } else {
+            HStack(spacing: 16) {
+                ForEach(HomeSection.allCases) { section in
+                    segment(for: section)
+                        .background(Capsule().fill(selection == section ? section.color : Color(.systemGray6)))
+                }
+            }
+        }
+    }
+
+    private func segment(for section: HomeSection) -> some View {
+        Text(verbatim: section.title)
+            .font(.subheadline.weight(selection == section ? .medium : .regular))
+            .foregroundColor(selection == section ? .white : .primary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .contentShape(Capsule())
+            .onTapGesture {
+                withAnimation(.easeOut(duration: 0.15)) {
+                    selection = section
+                }
+            }
+    }
+}
+
+// MARK: - Previews
+
+private struct PickerPreview: View {
+    @State private var selection = HomeSection.sessions
+
+    var body: some View {
+        HomeSectionPicker(selection: $selection).padding()
+    }
+}
+
+#Preview {
+    PickerPreview()
+}


### PR DESCRIPTION
The Home screen previously stacked three similar sections — Sessions, Crashes, and Users — each with its own header and rows. They are now merged into a single `Stats` section switched by the new `HomeSectionPicker`: three equal-width capsules tinted with the section color, rendered with Liquid Glass (`glassEffect`) on iOS 26 and falling back to solid capsule fills on older systems. The picker sits in the sticky section header, and the corresponding provider is fetched lazily via `task(id:)` when a section is selected.

The `All` row of the former Crashes section moves into the `Log` section as `Crashes`, keeping `CrashListView` reachable. Shared row configuration (title, color, icon) lives in the new `HomeSection` enum, which also removes the duplication between the session and crash row builders.