### PR TITLE
Extract a shared date-range predicate helper and simplify Event.Query

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -10,13 +10,12 @@ import CloudKit
 class ActivityProvider: QueryProvider<ActivityMatrix> {
     init() {
         super.init {
-            let dateRange = Calendar.utc.defaultRange
-
-            let predicate = NSPredicate(
-                format: "date >= %@ AND date < %@ AND name == %@",
-                dateRange.lowerBound as NSDate,
-                dateRange.upperBound as NSDate,
-                "ActiveUser"
+            let predicate = NSCompoundPredicate(
+                type: .and,
+                subpredicates: [
+                    Calendar.utc.defaultRange.datePredicate,
+                    NSPredicate(format: "name == %@", "ActiveUser"),
+                ]
             )
 
             return CKQuery(

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -15,7 +15,10 @@ class CrashProvider: ObservableObject {
 
     func fetch(in database: AppDatabase) async {
         do {
-            let query = CKQuery(recordType: CrashObject.recordType, predicate: Self.predicate)
+            let query = CKQuery(
+                recordType: CrashObject.recordType,
+                predicate: Calendar.utc.defaultRange.datePredicate
+            )
             query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
 
             let results = try await database.read(
@@ -42,15 +45,5 @@ class CrashProvider: ObservableObject {
         } catch {
             // Keep existing data on pagination failure
         }
-    }
-
-    private static var predicate: NSPredicate {
-        let dateRange = Calendar.utc.defaultRange
-
-        return NSPredicate(
-            format: "date >= %@ AND date < %@",
-            dateRange.lowerBound as NSDate,
-            dateRange.upperBound as NSDate
-        )
     }
 }

--- a/Sources/Scout/UI/Event/Event.Query.swift
+++ b/Sources/Scout/UI/Event/Event.Query.swift
@@ -9,17 +9,17 @@ import Foundation
 
 extension Event {
     struct Query {
-        var levels = Set(Level.allCases)
+        private static let allLevels = Set(Level.allCases)
+
+        var levels = Query.allLevels
         var text = ""
         var name = ""
-        var installID: UUID?
-        var sessionID: UUID?
         var dates: Range<Date>?
 
         func buildPredicate() -> NSPredicate {
             var predicates: [NSPredicate] = []
 
-            if levels != Set(Level.allCases) {
+            if levels != Query.allLevels {
                 predicates.append(.init(format: "level IN %@", levels.map(\.rawValue)))
             }
             if !text.isEmpty {
@@ -28,50 +28,11 @@ extension Event {
             if !name.isEmpty {
                 predicates.append(.init(format: "name == %@", name))
             }
-            if let installID = installID?.uuidString {
-                predicates.append(.init(format: "install_id == %@", installID))
-            }
-            if let sessionID = sessionID?.uuidString {
-                predicates.append(.init(format: "session_id == %@", sessionID))
-            }
             if let dates {
-                predicates.append(
-                    .init(
-                        format: "date >= %@ AND date < %@",
-                        dates.lowerBound as NSDate,
-                        dates.upperBound as NSDate
-                    )
-                )
+                predicates.append(dates.datePredicate)
             }
 
             return NSCompoundPredicate(type: .and, subpredicates: predicates)
         }
-    }
-}
-
-extension Event.Query: CustomStringConvertible {
-    var description: String {
-        var components: [String] = []
-
-        if levels != Set(Event.Level.allCases) {
-            components.append("levels: \(levels.map(\.description).joined(separator: ", "))")
-        }
-        if !text.isEmpty {
-            components.append("text: \(text)")
-        }
-        if !name.isEmpty {
-            components.append("name: \(name)")
-        }
-        if let installID {
-            components.append("installID: \(installID)")
-        }
-        if let sessionID {
-            components.append("sessionID: \(sessionID)")
-        }
-        if let dates {
-            components.append("dates: \(dates.lowerBound) - \(dates.upperBound)")
-        }
-
-        return components.joined(separator: ", \n")
     }
 }

--- a/Sources/Scout/UI/Metrics/MetricsProvider.swift
+++ b/Sources/Scout/UI/Metrics/MetricsProvider.swift
@@ -10,13 +10,12 @@ import CloudKit
 class MetricsProvider<T: ChartNumeric>: QueryProvider<GridMatrix<T>> {
     init(telemetry: Telemetry.Export) {
         super.init {
-            let dateRange = Calendar.utc.defaultRange
-
-            let predicate = NSPredicate(
-                format: "date >= %@ AND date < %@ AND category == %@",
-                dateRange.lowerBound as NSDate,
-                dateRange.upperBound as NSDate,
-                telemetry.rawValue
+            let predicate = NSCompoundPredicate(
+                type: .and,
+                subpredicates: [
+                    Calendar.utc.defaultRange.datePredicate,
+                    NSPredicate(format: "category == %@", telemetry.rawValue),
+                ]
             )
 
             return CKQuery(

--- a/Sources/Scout/UI/Stats/StatProvider.swift
+++ b/Sources/Scout/UI/Stats/StatProvider.swift
@@ -16,13 +16,12 @@ class StatProvider: QueryProvider<GridMatrix<Int>> {
         self.periods = periods
 
         super.init {
-            let dateRange = Calendar.utc.defaultRange
-
-            let predicate = NSPredicate(
-                format: "date >= %@ AND date < %@ AND name == %@",
-                dateRange.lowerBound as NSDate,
-                dateRange.upperBound as NSDate,
-                eventName
+            let predicate = NSCompoundPredicate(
+                type: .and,
+                subpredicates: [
+                    Calendar.utc.defaultRange.datePredicate,
+                    NSPredicate(format: "name == %@", eventName),
+                ]
             )
 
             return CKQuery(

--- a/Sources/Scout/UI/Utilities/Calendar+Range.swift
+++ b/Sources/Scout/UI/Utilities/Calendar+Range.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 extension Calendar {
-    var defaultRange: ClosedRange<Date> {
+    var defaultRange: Range<Date> {
         let today = Date().startOfDay
         let yearAgo = today.addingYear(-1).addingWeek(-1)
         let tomorrow = today.addingDay()
-        return yearAgo...tomorrow
+        return yearAgo..<tomorrow
     }
 }

--- a/Sources/Scout/UI/Utilities/Range+Predicate.swift
+++ b/Sources/Scout/UI/Utilities/Range+Predicate.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension Range<Date> {
+    /// A predicate matching records whose `date` falls within this range.
+    var datePredicate: NSPredicate {
+        NSPredicate(
+            format: "date >= %@ AND date < %@",
+            lowerBound as NSDate,
+            upperBound as NSDate
+        )
+    }
+}

--- a/Tests/ScoutTests/UI/Event/EventQueryTests.swift
+++ b/Tests/ScoutTests/UI/Event/EventQueryTests.swift
@@ -49,26 +49,6 @@ struct EventQueryTests {
         #expect(predicate.predicateFormat.contains("name == \"Login\""))
     }
 
-    @Test("Filter by installID") func installID() {
-        let id = UUID()
-        var query = Event.Query()
-        query.installID = id
-        let predicate = query.buildPredicate()
-
-        #expect(predicate.predicateFormat.contains("install_id"))
-        #expect(predicate.predicateFormat.contains(id.uuidString))
-    }
-
-    @Test("Filter by sessionID") func sessionID() {
-        let id = UUID()
-        var query = Event.Query()
-        query.sessionID = id
-        let predicate = query.buildPredicate()
-
-        #expect(predicate.predicateFormat.contains("session_id"))
-        #expect(predicate.predicateFormat.contains(id.uuidString))
-    }
-
     @Test("Filter by date range") func dates() {
         let start = Date(timeIntervalSinceReferenceDate: 0)
         let end = Date(timeIntervalSinceReferenceDate: 86400)

--- a/Tests/ScoutTests/UI/Utilities/RangePredicateTests.swift
+++ b/Tests/ScoutTests/UI/Utilities/RangePredicateTests.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct RangePredicateTests {
+    @Test("Date range predicate matches dates in the half-open range") func datePredicate() {
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let end = Date(timeIntervalSinceReferenceDate: 86400)
+        let predicate = (start..<end).datePredicate
+
+        #expect(predicate.evaluate(with: ["date": start]))
+        #expect(predicate.evaluate(with: ["date": start.addingTimeInterval(3600)]))
+        #expect(!predicate.evaluate(with: ["date": end]))
+        #expect(!predicate.evaluate(with: ["date": start.addingTimeInterval(-1)]))
+    }
+}


### PR DESCRIPTION
Extracts the date-range `NSPredicate` that was duplicated across `MetricsProvider`, `ActivityProvider`, `CrashProvider`, `StatProvider`, and `Event.Query` into a single `Range<Date>.datePredicate` helper, with the extra `category`/`name` conditions now composed via `NSCompoundPredicate`. `Calendar.defaultRange` becomes a half-open `Range<Date>`, matching the exclusive upper bound every consumer already relied on, so all five sites share one type and one helper.

Also cleans up `Event.Query` itself: the `installID` and `sessionID` fields have been dead since the History views were removed, and the `CustomStringConvertible` conformance had no callers while structurally mirroring `buildPredicate`. Both are gone, and the all-levels sentinel set is now a cached static constant. The produced predicates are unchanged, covered by a new `RangePredicateTests` plus the existing `EventQueryTests`.