### PR TITLE
Animate the recenter button's scroll

### DIFF
--- a/Sources/Scout/UI/Timeline/View/Anchor/AnchoredScroll.swift
+++ b/Sources/Scout/UI/Timeline/View/Anchor/AnchoredScroll.swift
@@ -31,7 +31,9 @@ struct AnchoredScroll<ID: Hashable>: ViewModifier {
                     ToolbarItemGroup(placement: .bottomBar) {
                         if let direction = recenterDirection(in: viewport) {
                             Button {
-                                center(with: proxy)
+                                withAnimation {
+                                    center(with: proxy)
+                                }
                             } label: {
                                 Image(systemName: direction.symbol)
                             }


### PR DESCRIPTION
Tapping the timeline's recenter button previously jumped to the anchor row instantly. The button's `center(with:)` call in `AnchoredScroll` is now wrapped in `withAnimation`, so the list scrolls back to the anchor smoothly. The initial centering and the pagination re-centering stay non-animated, since they compensate for layout shifts and must apply instantly.