### PR TITLE
Reorder Home sections and drop the Stats header

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -18,8 +18,8 @@ struct HomeContent: View {
 
     var body: some View {
         List {
-            logSection
             statSection
+            logSection
         }
         .listStyle(.plain)
     }
@@ -62,21 +62,18 @@ struct HomeContent: View {
         Section {
             sectionRows
         } header: {
-            VStack(alignment: .leading, spacing: 12) {
-                Header(title: "Stats")
-                HomeSectionPicker(selection: $section)
-                    .padding(.bottom, 4)
-            }
-            .task(id: section) {
-                switch section {
-                case .sessions:
-                    await sessionStat.fetchIfNeeded(in: database)
-                case .crashes:
-                    await crashStat.fetchIfNeeded(in: database)
-                case .users:
-                    await activity.fetchIfNeeded(in: database)
+            HomeSectionPicker(selection: $section)
+                .padding(.bottom, 4)
+                .task(id: section) {
+                    switch section {
+                    case .sessions:
+                        await sessionStat.fetchIfNeeded(in: database)
+                    case .crashes:
+                        await crashStat.fetchIfNeeded(in: database)
+                    case .users:
+                        await activity.fetchIfNeeded(in: database)
+                    }
                 }
-            }
         }
     }
 


### PR DESCRIPTION
On the Home screen, the stat section now appears above the Log section. The `Stats` header is removed, so the section header consists of just the `HomeSectionPicker` segmented control; the data-fetching `.task` previously attached to the header stack now lives on the picker itself.