### PR TITLE
Use primary color for the Timeline row label

### DIFF
--- a/Sources/Scout/UI/Event/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/EventView.Sections.swift
@@ -100,12 +100,12 @@ extension EventView {
             Row {
                 Image(systemName: "calendar.day.timeline.left")
                     .frame(width: 24)
+                    .foregroundStyle(.blue)
                 Text(verbatim: "Timeline")
                 Spacer()
             } destination: {
                 Timeline(deviceID: deviceID, event: event)
             }
-            .foregroundStyle(.blue)
         }
     }
 }


### PR DESCRIPTION
The Timeline row on the event screen tinted both the icon and the label blue, which made the label look like a link. The `Timeline` text now uses the primary foreground color, while the calendar icon keeps its blue tint, matching how other rows on the screen are styled.