### PR TITLE
Use the custom Header for the Home Log section

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -24,37 +24,35 @@ struct HomeContent: View {
         .listStyle(.plain)
     }
 
+    @ViewBuilder
     private var logSection: some View {
-        Section {
-            Row {
-                Image(systemName: "list.bullet")
-                    .foregroundColor(.blue)
-                    .frame(width: 24)
-                Text(verbatim: "Events")
-                Spacer()
-            } destination: {
-                AnalyticsView()
-            }
-            Row {
-                Image(systemName: "chart.bar")
-                    .foregroundColor(.blue)
-                    .frame(width: 24)
-                Text(verbatim: "Metrics")
-                Spacer()
-            } destination: {
-                MetricsList().navigationTitle(en: "Metrics")
-            }
-            Row {
-                Image(systemName: "exclamationmark.triangle")
-                    .foregroundColor(.red)
-                    .frame(width: 24)
-                Text(verbatim: "Crashes")
-                Spacer()
-            } destination: {
-                CrashListView()
-            }
-        } header: {
-            Header(title: "Log")
+        Header(title: "Log")
+        Row {
+            Image(systemName: "list.bullet")
+                .foregroundColor(.blue)
+                .frame(width: 24)
+            Text(verbatim: "Events")
+            Spacer()
+        } destination: {
+            AnalyticsView()
+        }
+        Row {
+            Image(systemName: "chart.bar")
+                .foregroundColor(.blue)
+                .frame(width: 24)
+            Text(verbatim: "Metrics")
+            Spacer()
+        } destination: {
+            MetricsList().navigationTitle(en: "Metrics")
+        }
+        Row {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundColor(.red)
+                .frame(width: 24)
+            Text(verbatim: "Crashes")
+            Spacer()
+        } destination: {
+            CrashListView()
         }
     }
 
@@ -118,6 +116,6 @@ struct HomeContent: View {
 
 #Preview {
     NavigationStack {
-        HomeContent()
+        HomeContent().navigationTitle("Home")
     }
 }


### PR DESCRIPTION
The Log section header on the Home screen was wrapped in a `Section` `header:` closure, so it picked up the system section header treatment — sticky pinning and a background overlay while scrolling. Now `Header(title: "Log")` is placed as a regular list row, matching how `EventView` renders its Params, Stats, and History headers, so the Home screen header scrolls and looks the same as everywhere else.