### PR TITLE
Fix README code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 
 Add the dependency to your `Package.swift`:
 ```swift
-.package(url: "https://github.com/kasianov-mikhail/scout.git", from: "3.0.0")
+.package(url: "https://github.com/kasianov-mikhail/scout.git", from: "3.3.0")
 ```
 
 For CloudKit setup and schema upload, see the full [Installation Guide](INSTALLATION.md).
@@ -48,11 +48,11 @@ import Logging
 
 let logger = Logger(label: "MyApp")
 
-logger.warning(
+logger.info(
     "Search_Performed",
     metadata: [
-        "description": .string(error.localizedDescription),
-        "ip": .string(ip),
+        "query": "coffee shops",
+        "result_count": "12",
     ]
 )
 ```


### PR DESCRIPTION
Updates the installation snippet to reference the latest release (`3.3.0`) and reworks the logging example so it is self-contained: the previous snippet used undeclared `error` and `ip` variables and logged a search event at the `warning` level. The example now shows a plain `info` log with simple string metadata that can be copied and run as is.