### PR TITLE
Remove the Flutter section from the installation guide

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -25,11 +25,3 @@ let container = CKContainer(identifier: "YOUR_CONTAINER_ID")
 
 try await setup(container: container)
 ```
-
-## Flutter
-
-For Flutter projects, use [scout_sdk](https://pub.dev/packages/scout_sdk):
-```yaml
-dependencies:
-  scout_sdk: ^0.1.0
-```


### PR DESCRIPTION
Removes the `Flutter` section with the `scout_sdk` reference from `INSTALLATION.md`, leaving the guide focused on the native Swift integration.