### PR TITLE
Harden timeline rail pagination and trim its CloudKit queries

### DIFF
--- a/Sources/Scout/UI/Timeline/Export/TimelineExport.swift
+++ b/Sources/Scout/UI/Timeline/Export/TimelineExport.swift
@@ -27,15 +27,15 @@ struct TimelineExport {
 
         var lines = [title, summary]
 
-        for install in rail.installs.sorted(byDate: \.install.date) {
+        for install in rail.installs {
             lines.append("")
             lines.append(header(for: install.install))
 
-            for launch in install.launches.sorted(byDate: \.launch.startDate) {
+            for launch in install.launches {
                 lines.append("")
                 lines.append(header(for: launch.launch))
 
-                for session in launch.sessions.sorted(byDate: \.session.startDate) {
+                for session in launch.sessions {
                     lines.append("")
                     lines.append(header(for: session.session))
                     lines.append(contentsOf: rows(for: session))

--- a/Sources/Scout/UI/Timeline/Item/TimelineItem+Items.swift
+++ b/Sources/Scout/UI/Timeline/Item/TimelineItem+Items.swift
@@ -14,7 +14,7 @@ extension TimelineItem {
         for install in rail.installs {
             for launch in install.launches {
                 for session in launch.sessions {
-                    for event in session.events.sorted(byDate: \.date) {
+                    for event in session.events {
                         if let date = event.date {
                             result.append(
                                 TimelineItem(

--- a/Sources/Scout/UI/Timeline/Pagination/Event+Fetch.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/Event+Fetch.swift
@@ -19,7 +19,7 @@ extension Event {
 
         return
             try await database
-            .readAll(matching: query, fields: nil)
+            .readAll(matching: query, fields: Event.desiredKeys)
             .map(Event.init)
     }
 

--- a/Sources/Scout/UI/Timeline/Pagination/RailLane.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/RailLane.swift
@@ -41,14 +41,36 @@ final class RailLane: ObservableObject {
     /// cursor) into the fresh timeline.
     private var generation = 0
 
+    /// Whether a load currently holds the cursor; concurrent `loadMore` calls
+    /// wait for it instead of racing the cursor and dropping a chunk.
+    private var isFetching = false
+
+    /// Continuations of `loadMore` calls parked behind an in-flight load.
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
     func loadMore(in database: AppDatabase) async throws -> (sessions: [Session], events: [Event]) {
-        guard cursor != nil || pendingInstalls.count > 0 else {
+        // Snapshot before parking: a reset that lands while this call waits
+        // means the chunk now belongs to a newer timeline, not this caller.
+        let generation = generation
+
+        // A stale in-flight load (e.g. from a superseded `start`) may still
+        // advance the cursor; wait for it to land instead of racing it.
+        while isFetching {
+            await withCheckedContinuation { waiters.append($0) }
+        }
+
+        guard generation == self.generation, cursor != nil || pendingInstalls.count > 0 else {
             throw CancellationError()
         }
 
-        let generation = generation
+        isFetching = true
         isLoading = true
         defer {
+            isFetching = false
+            let parked = waiters
+            waiters = []
+            parked.forEach { $0.resume() }
+
             if generation == self.generation {
                 isLoading = false
             }
@@ -85,10 +107,15 @@ final class RailLane: ObservableObject {
         return (sessions, events)
     }
 
+    /// Sessions per chunk: a filtered timeline keeps only the matching events,
+    /// so it needs a bigger net per round to reach the seed target without a
+    /// long tail of follow-up requests.
+    private var chunkLimit: Int { eventName == nil ? 25 : 100 }
+
     private func chunk(in database: AppDatabase) async throws -> RecordChunk {
         guard let cursor else {
-            return try await Session.fetchChunk(installIDs: pendingInstalls, anchor: anchorDate, ascending: ascending, in: database)
+            return try await Session.fetchChunk(installIDs: pendingInstalls, anchor: anchorDate, ascending: ascending, limit: chunkLimit, in: database)
         }
-        return try await database.readMore(from: cursor, fields: nil)
+        return try await database.readMore(from: cursor, fields: Session.desiredKeys)
     }
 }

--- a/Sources/Scout/UI/Timeline/Pagination/RailPagination.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/RailPagination.swift
@@ -46,6 +46,13 @@ struct RailPagination: View {
     }
 
     private func loadMore() async {
+        // A reload may have replaced the result since this footer scheduled
+        // the load; bail out before consuming a chunk the new timeline needs.
+        guard case .success = result else {
+            lane.isLoading = false
+            return
+        }
+
         do {
             let (sessions, events) = try await lane.loadMore(in: database)
             guard case .success(let rail) = result else {
@@ -53,7 +60,9 @@ struct RailPagination: View {
             }
             result = .success(rail.merged(sessions: sessions, events: events))
         } catch is CancellationError {
-            // The lane was reset while this load was in flight; drop it.
+            // The lane was reset while this load was in flight; drop it, and
+            // release the spinner `loadIfVisible` raised for this load.
+            lane.isLoading = false
         } catch {
             result = .failure(error)
         }

--- a/Sources/Scout/UI/Timeline/Pagination/Session+FetchChunk.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/Session+FetchChunk.swift
@@ -8,14 +8,16 @@
 import CloudKit
 
 extension Session {
-    static func fetchChunk(installIDs: [UUID], anchor: Date?, ascending: Bool, in database: AppDatabase) async throws -> RecordChunk {
+    static func fetchChunk(installIDs: [UUID], anchor: Date?, ascending: Bool, limit: Int, in database: AppDatabase) async throws -> RecordChunk {
         var predicates = [
             NSPredicate(format: "install_id IN %@", installIDs.map(\.uuidString))
         ]
 
         // The anchor session itself starts at or before the anchor event, so
         // it belongs to the descending (older) lane; the ascending lane picks
-        // up strictly later sessions.
+        // up strictly later sessions. CloudKit comparisons skip records that
+        // lack the field, but `SessionObject.toRecord` always writes
+        // `start_date`, so the bound drops nothing.
         if let anchor {
             predicates.append(
                 NSPredicate(format: ascending ? "start_date > %@" : "start_date <= %@", anchor as NSDate)
@@ -30,6 +32,6 @@ extension Session {
             NSSortDescriptor(key: "start_date", ascending: ascending)
         ]
 
-        return try await database.read(matching: query, fields: nil, limit: 25)
+        return try await database.read(matching: query, fields: Session.desiredKeys, limit: limit)
     }
 }

--- a/Sources/Scout/UI/Timeline/Provider/Rail+Split.swift
+++ b/Sources/Scout/UI/Timeline/Provider/Rail+Split.swift
@@ -8,12 +8,16 @@
 import Foundation
 
 extension Rail {
+    /// Splits the installs into the two pagination lanes around the anchor
+    /// event, or `nil` when the anchor is unusable — no event, no install id,
+    /// or an install that is not part of this rail (e.g. not synced yet).
+    ///
     func split(at anchor: Event?) -> (older: [UUID], newer: [UUID])? {
-        guard let anchorInstallID = anchor?.installID else {
+        guard let anchor, let anchorInstallID = anchor.installID else {
             return nil
         }
 
-        let sorted = installs.map(\.install).sorted(byDate: \.date)
+        let sorted = installs.map(\.install)
 
         guard let anchorIndex = sorted.firstIndex(where: { $0.installID == anchorInstallID }) else {
             return nil
@@ -24,7 +28,7 @@ extension Rail {
         // With an anchor date the lanes split the anchor install between them
         // (`start_date` bound in `Session.fetchChunk` keeps them disjoint);
         // without one the whole anchor install stays in the older lane.
-        let newerStart = anchor?.date == nil ? anchorIndex + 1 : anchorIndex
+        let newerStart = anchor.date == nil ? anchorIndex + 1 : anchorIndex
         let newer = sorted[newerStart...].compactMap(\.installID)
 
         return (Array(older), Array(newer))

--- a/Sources/Scout/UI/Timeline/Provider/TimelineFeed.swift
+++ b/Sources/Scout/UI/Timeline/Provider/TimelineFeed.swift
@@ -16,7 +16,7 @@ struct TimelineFeed {
             recordType: DeviceObject.recordType,
             predicate: NSPredicate(format: "device_id == %@", deviceID.uuidString)
         )
-        if let record = try await database.readAll(matching: query, fields: nil).first {
+        if let record = try await database.read(matching: query, fields: Device.desiredKeys, limit: 1).records.first {
             return try Device(record: record)
         }
         return Device(
@@ -33,7 +33,7 @@ struct TimelineFeed {
         )
         return
             try await database
-            .readAll(matching: query, fields: nil)
+            .readAll(matching: query, fields: Install.desiredKeys)
             .map(Install.init)
     }
 
@@ -44,7 +44,7 @@ struct TimelineFeed {
         )
         return
             try await database
-            .readAll(matching: query, fields: nil)
+            .readAll(matching: query, fields: Launch.desiredKeys)
             .map(Launch.init)
     }
 }

--- a/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
+++ b/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
@@ -10,7 +10,21 @@ import SwiftUI
 
 @MainActor
 final class TimelineProvider: ObservableObject {
-    @Published var result: Result<Rail, Error>?
+    @Published var result: Result<Rail, Error>? {
+        didSet {
+            let rail = try? result?.get()
+            items = rail.map(TimelineItem.items(from:)) ?? []
+            exportText = rail.flatMap { TimelineExport(rail: $0).text }
+        }
+    }
+
+    /// Derived from `result` once per change, so view body re-evaluations
+    /// (legend toggles, scroll) don't rebuild the row list from the tree.
+    private(set) var items: [TimelineItem] = []
+
+    /// The Markdown export of `result`, rebuilt once per change rather than
+    /// on every toolbar render.
+    private(set) var exportText: String?
 
     let older = RailLane(ascending: false)
     let newer = RailLane(ascending: true)
@@ -33,8 +47,17 @@ final class TimelineProvider: ObservableObject {
         do {
             let rail = try await feed.rail()
 
-            guard let split = rail.split(at: anchorEvent) else {
-                return
+            let split: (older: [UUID], newer: [UUID])
+            if let anchored = rail.split(at: anchorEvent) {
+                split = anchored
+            } else {
+                // No usable anchor (no event, or its install isn't in the
+                // rail yet): load the whole timeline from its start through
+                // the ascending lane instead of spinning forever.
+                for lane in [older, newer] {
+                    lane.anchorDate = nil
+                }
+                split = (older: [], newer: rail.installs.compactMap(\.install.installID))
             }
 
             older.pendingInstalls = split.older
@@ -46,6 +69,12 @@ final class TimelineProvider: ObservableObject {
             // Count only events that will actually render: `TimelineItem.items`
             // drops events without a date, so raw counts overestimate the seed.
             while events.count(where: { $0.date != nil }) < 50 {
+                // A newer `start` owns the lanes now; bail out before touching
+                // them, or this loop would consume the chunks it seeds with.
+                guard token == startToken else {
+                    throw CancellationError()
+                }
+
                 let lanes = [older, newer].filter { $0.pendingInstalls.count > 0 }
 
                 guard lanes.count > 0 else {

--- a/Sources/Scout/UI/Timeline/Rail/Rail.swift
+++ b/Sources/Scout/UI/Timeline/Rail/Rail.swift
@@ -7,6 +7,13 @@
 
 import CloudKit
 
+/// A device's full lifecycle tree: installs, their launches, their sessions,
+/// and the events and crashes inside each session.
+///
+/// Invariant: every level is sorted ascending by date — `Rail.init` sorts the
+/// tree once at construction, so consumers (rows, split, export) can rely on
+/// the order instead of re-sorting.
+///
 struct Rail: Identifiable {
     let device: Device
     var installs: [InstallRoot]

--- a/Sources/Scout/UI/Timeline/View/Timeline.swift
+++ b/Sources/Scout/UI/Timeline/View/Timeline.swift
@@ -26,8 +26,8 @@ struct Timeline: View {
                 ProgressView().frame(maxHeight: .infinity)
             case .failure(let error):
                 errorView(for: error)
-            case .success(let rail):
-                list(for: rail)
+            case .success:
+                list
             }
         }
         .navigationTitle(en: "Multi-Rail")
@@ -57,7 +57,7 @@ struct Timeline: View {
             }
 
             ToolbarItemGroup(placement: .bottomBar) {
-                if let text = exportText {
+                if let text = provider.exportText {
                     ShareLink(item: text)
                     CopyButton(text: text)
                     Spacer()
@@ -70,15 +70,8 @@ struct Timeline: View {
         }
     }
 
-    private var exportText: String? {
-        guard case .success(let rail) = provider.result else {
-            return nil
-        }
-        return TimelineExport(rail: rail).text
-    }
-
-    private func list(for rail: Rail) -> some View {
-        let items = TimelineItem.items(from: rail)
+    private var list: some View {
+        let items = provider.items
         let anchorIndex = event.flatMap { event in items.firstIndex { $0.id == event.id } }
 
         // The legend floats over the top of the list instead of sitting above

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -10,11 +10,13 @@ import Foundation
 
 @testable import Scout
 
-/// In-memory `AppDatabase` that answers every query with the canned records
-/// of the query's record type that match its predicate, truncated to the
-/// requested limit (without a continuation cursor). Reads can be suspended
-/// behind a `Gate` to freeze a fetch mid-flight, and are counted per record
-/// type so tests can assert how many queries a flow issued.
+/// In-memory `AppDatabase` for timeline tests.
+///
+/// Answers every query with the canned records of the query's record type
+/// that match its predicate, truncated to the requested limit (without a
+/// continuation cursor). Reads can be suspended behind a `Gate` to freeze a
+/// fetch mid-flight, and are counted per record type so tests can assert how
+/// many queries a flow issued.
 ///
 final class DatabaseStub: AppDatabase, @unchecked Sendable {
     private let lock = NSLock()

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -1,0 +1,144 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Foundation
+
+@testable import Scout
+
+/// In-memory `AppDatabase` that answers every query with the canned records
+/// of the query's record type that match its predicate, truncated to the
+/// requested limit (without a continuation cursor). Reads can be suspended
+/// behind a `Gate` to freeze a fetch mid-flight, and are counted per record
+/// type so tests can assert how many queries a flow issued.
+///
+final class DatabaseStub: AppDatabase, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: [CKRecord]] = [:]
+    private var counts: [String: Int] = [:]
+
+    /// When set, every read suspends until the gate opens.
+    var gate: Gate?
+
+    func add(_ records: CKRecord...) {
+        lock.lock()
+        defer { lock.unlock() }
+        for record in records {
+            storage[record.recordType, default: []].append(record)
+        }
+    }
+
+    func readCount(of recordType: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return counts[recordType] ?? 0
+    }
+
+    func lookup(id: CKRecord.ID) async throws -> CKRecord {
+        throw CKError(.unknownItem)
+    }
+
+    func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+        try await read(matching: query, fields: fields, limit: Int.max)
+    }
+
+    func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?, limit: Int) async throws -> RecordChunk {
+        await gate?.wait()
+        return chunk(matching: query, limit: limit)
+    }
+
+    private func chunk(matching query: CKQuery, limit: Int) -> RecordChunk {
+        lock.lock()
+        defer { lock.unlock() }
+        counts[query.recordType, default: 0] += 1
+
+        let predicate = query.predicate
+        predicate.allowEvaluation()
+        let records = (storage[query.recordType] ?? []).filter(predicate.evaluate)
+        return RecordChunk(records: Array(records.prefix(limit)), cursor: nil)
+    }
+
+    func readMore(from cursor: CKQueryOperation.Cursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+        RecordChunk(records: [], cursor: nil)
+    }
+}
+
+/// A reusable async latch: `wait()` suspends until `open()` is called; once
+/// open, it never blocks again.
+///
+final class Gate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        lock.lock()
+        isOpen = true
+        let parked = waiters
+        waiters = []
+        lock.unlock()
+        parked.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if isOpen {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+}
+
+// MARK: - Record builders
+
+extension CKRecord {
+    static func deviceStub(deviceID: UUID, date: Date) -> CKRecord {
+        let record = CKRecord(recordType: "Device", recordID: .init(recordName: deviceID.uuidString))
+        record["device_id"] = deviceID.uuidString
+        record["date"] = date
+        return record
+    }
+
+    static func installStub(installID: UUID, deviceID: UUID, date: Date) -> CKRecord {
+        let record = CKRecord(recordType: "Install", recordID: .init(recordName: installID.uuidString))
+        record["install_id"] = installID.uuidString
+        record["device_id"] = deviceID.uuidString
+        record["date"] = date
+        return record
+    }
+
+    static func launchStub(launchID: UUID, installID: UUID, deviceID: UUID, startDate: Date) -> CKRecord {
+        let record = CKRecord(recordType: "Launch", recordID: .init(recordName: launchID.uuidString))
+        record["launch_id"] = launchID.uuidString
+        record["install_id"] = installID.uuidString
+        record["device_id"] = deviceID.uuidString
+        record["start_date"] = startDate
+        return record
+    }
+
+    static func sessionStub(sessionID: UUID, launchID: UUID, installID: UUID, startDate: Date) -> CKRecord {
+        let record = CKRecord(recordType: "Session", recordID: .init(recordName: sessionID.uuidString))
+        record["session_id"] = sessionID.uuidString
+        record["launch_id"] = launchID.uuidString
+        record["install_id"] = installID.uuidString
+        record["start_date"] = startDate
+        return record
+    }
+
+    static func eventStub(name: String, sessionID: UUID, date: Date) -> CKRecord {
+        let record = CKRecord(recordType: "Event", recordID: .init(recordName: UUID().uuidString))
+        record["name"] = name
+        record["session_id"] = sessionID.uuidString
+        record["date"] = date
+        return record
+    }
+}

--- a/Tests/ScoutTests/UI/Timeline/RailLaneTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/RailLaneTests.swift
@@ -1,0 +1,106 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+struct RailLaneTests {
+    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private let installID = UUID()
+    private let launchID = UUID()
+    private let sessionID = UUID()
+
+    private func makeDatabase() -> DatabaseStub {
+        let database = DatabaseStub()
+        database.add(
+            .sessionStub(sessionID: sessionID, launchID: launchID, installID: installID, startDate: baseDate),
+            .eventStub(name: "e", sessionID: sessionID, date: baseDate.addingTimeInterval(10))
+        )
+        return database
+    }
+
+    @Test("Throws CancellationError when nothing is pending")
+    func testNothingPending() async {
+        let lane = RailLane(ascending: true)
+
+        await #expect(throws: CancellationError.self) {
+            try await lane.loadMore(in: DatabaseStub())
+        }
+    }
+
+    @Test("Loads sessions and events for pending installs")
+    func testLoadsChunk() async throws {
+        let lane = RailLane(ascending: true)
+        lane.pendingInstalls = [installID]
+
+        let (sessions, events) = try await lane.loadMore(in: makeDatabase())
+
+        #expect(sessions.map(\.sessionID) == [sessionID])
+        #expect(events.map(\.name) == ["e"])
+        #expect(lane.pendingInstalls.count == 0)
+        #expect(!lane.isLoading)
+    }
+
+    @Test("A reset mid-flight discards the chunk")
+    func testResetMidFlight() async {
+        let database = makeDatabase()
+        let gate = Gate()
+        database.gate = gate
+
+        let lane = RailLane(ascending: true)
+        lane.pendingInstalls = [installID]
+
+        let load = Task {
+            try await lane.loadMore(in: database)
+        }
+
+        await Task.yield()
+        lane.eventName = "reset"
+        gate.open()
+
+        await #expect(throws: CancellationError.self) {
+            try await load.value
+        }
+        #expect(!lane.isLoading)
+    }
+
+    @Test("Concurrent loads are serialized instead of racing the cursor")
+    func testSerializedLoads() async {
+        let database = makeDatabase()
+        let gate = Gate()
+        database.gate = gate
+
+        let lane = RailLane(ascending: true)
+        lane.pendingInstalls = [installID]
+
+        let first = Task {
+            try await lane.loadMore(in: database)
+        }
+        let second = Task {
+            try await lane.loadMore(in: database)
+        }
+
+        await Task.yield()
+        gate.open()
+
+        let results = [await first.result, await second.result]
+        let loaded = results.compactMap { try? $0.get() }
+        let cancelled = results.count { (try? $0.get()) == nil }
+
+        // One call wins the chunk and exhausts the lane; the parked one wakes
+        // up to an empty lane and bails out. A single session query proves the
+        // cursor was never raced.
+        #expect(loaded.count == 1)
+        #expect(cancelled == 1)
+        #expect(loaded[0].sessions.map(\.sessionID) == [sessionID])
+        #expect(database.readCount(of: "Session") == 1)
+    }
+}

--- a/Tests/ScoutTests/UI/Timeline/RailSplitTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/RailSplitTests.swift
@@ -1,0 +1,83 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct RailSplitTests {
+    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+    private func at(_ offset: TimeInterval) -> Date { baseDate.addingTimeInterval(offset) }
+
+    private let deviceID = UUID()
+    private let installIDs = [UUID(), UUID(), UUID()]
+
+    /// A rail with three installs sorted oldest → newest.
+    private var rail: Rail {
+        Rail(
+            device: .stub(deviceID: deviceID),
+            installs: installIDs.enumerated().map { index, id in
+                .stub(installID: id, deviceID: deviceID, date: at(TimeInterval(index * 100)))
+            },
+            launches: []
+        )
+    }
+
+    @Test("No anchor event returns nil")
+    func testNoAnchor() {
+        #expect(rail.split(at: nil) == nil)
+    }
+
+    @Test("Anchor without an install id returns nil")
+    func testNoInstallID() {
+        let anchor = Event.stub(name: "a", installID: nil)
+        #expect(rail.split(at: anchor) == nil)
+    }
+
+    @Test("Anchor whose install is not in the rail returns nil")
+    func testMissingInstall() {
+        let anchor = Event.stub(name: "a", installID: UUID())
+        #expect(rail.split(at: anchor) == nil)
+    }
+
+    @Test("Dated anchor shares its install between both lanes")
+    func testDatedAnchor() {
+        let anchor = Event.stub(name: "a", installID: installIDs[1], date: at(150))
+        let split = rail.split(at: anchor)
+
+        #expect(split?.older == [installIDs[1], installIDs[0]])
+        #expect(split?.newer == [installIDs[1], installIDs[2]])
+    }
+
+    @Test("Undated anchor keeps its whole install in the older lane")
+    func testUndatedAnchor() {
+        let anchor = Event.stub(name: "a", installID: installIDs[1], date: nil)
+        let split = rail.split(at: anchor)
+
+        #expect(split?.older == [installIDs[1], installIDs[0]])
+        #expect(split?.newer == [installIDs[2]])
+    }
+
+    @Test("Anchor in the newest install leaves only it in the newer lane")
+    func testNewestAnchor() {
+        let anchor = Event.stub(name: "a", installID: installIDs[2], date: at(250))
+        let split = rail.split(at: anchor)
+
+        #expect(split?.older == [installIDs[2], installIDs[1], installIDs[0]])
+        #expect(split?.newer == [installIDs[2]])
+    }
+
+    @Test("Anchor in the oldest install leaves only it in the older lane")
+    func testOldestAnchor() {
+        let anchor = Event.stub(name: "a", installID: installIDs[0], date: at(50))
+        let split = rail.split(at: anchor)
+
+        #expect(split?.older == [installIDs[0]])
+        #expect(split?.newer == installIDs)
+    }
+}

--- a/Tests/ScoutTests/UI/Timeline/TimelineItemConnectedTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/TimelineItemConnectedTests.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct TimelineItemConnectedTests {
+    private func makeItem(sessionID: UUID?, active: Set<LegendKind> = [.install, .launch, .session]) -> TimelineItem {
+        TimelineItem(
+            id: CKRecord.ID(recordName: UUID().uuidString),
+            name: "e",
+            date: Date(timeIntervalSince1970: 1_700_000_000),
+            active: active,
+            installID: UUID(),
+            launchID: UUID(),
+            sessionID: sessionID
+        )
+    }
+
+    @Test("Rows in the same group are connected")
+    func testSameGroup() {
+        let sessionID = UUID()
+        let a = makeItem(sessionID: sessionID)
+        let b = makeItem(sessionID: sessionID)
+
+        #expect(connected(a, b, on: .session))
+    }
+
+    @Test("Rows in different groups are not connected")
+    func testDifferentGroups() {
+        #expect(!connected(makeItem(sessionID: UUID()), makeItem(sessionID: UUID()), on: .session))
+    }
+
+    @Test("A missing neighbor breaks the rail")
+    func testMissingNeighbor() {
+        let item = makeItem(sessionID: UUID())
+
+        #expect(!connected(nil, item, on: .session))
+        #expect(!connected(item, nil, on: .session))
+    }
+
+    @Test("A nil group id breaks the rail even when both rows are active")
+    func testNilGroupID() {
+        let a = makeItem(sessionID: nil)
+        let b = makeItem(sessionID: nil)
+
+        #expect(!connected(a, b, on: .session))
+    }
+
+    @Test("An inactive kind breaks the rail")
+    func testInactiveKind() {
+        let sessionID = UUID()
+        let a = makeItem(sessionID: sessionID, active: [.install])
+        let b = makeItem(sessionID: sessionID)
+
+        #expect(!connected(a, b, on: .session))
+    }
+}

--- a/Tests/ScoutTests/UI/Timeline/TimelineProviderTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/TimelineProviderTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+struct TimelineProviderTests {
+    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+    private func at(_ offset: TimeInterval) -> Date { baseDate.addingTimeInterval(offset) }
+
+    private let deviceID = UUID()
+    private let installID = UUID()
+    private let launchID = UUID()
+    private let sessionID = UUID()
+
+    private func makeDatabase() -> DatabaseStub {
+        let database = DatabaseStub()
+        database.add(
+            .deviceStub(deviceID: deviceID, date: baseDate),
+            .installStub(installID: installID, deviceID: deviceID, date: baseDate),
+            .launchStub(launchID: launchID, installID: installID, deviceID: deviceID, startDate: at(10)),
+            .sessionStub(sessionID: sessionID, launchID: launchID, installID: installID, startDate: at(20)),
+            .eventStub(name: "e", sessionID: sessionID, date: at(30))
+        )
+        return database
+    }
+
+    private func start(_ provider: TimelineProvider, database: DatabaseStub, anchorEvent: Event?) async {
+        let feed = TimelineFeed(deviceID: deviceID, database: database)
+        await provider.start(feed: feed, anchorEvent: anchorEvent, eventName: nil)
+    }
+
+    @Test("Publishes a result without an anchor event")
+    func testNoAnchorPublishes() async throws {
+        let provider = TimelineProvider()
+        await start(provider, database: makeDatabase(), anchorEvent: nil)
+
+        let rail = try #require(provider.result).get()
+        #expect(rail.installs.map(\.install.installID) == [installID])
+        #expect(provider.items.map(\.name) == ["e"])
+    }
+
+    @Test("Publishes a result when the anchor's install is not in the rail")
+    func testMissingAnchorInstallPublishes() async throws {
+        let provider = TimelineProvider()
+        let anchor = Event.stub(name: "a", installID: UUID(), date: at(30))
+        await start(provider, database: makeDatabase(), anchorEvent: anchor)
+
+        let rail = try #require(provider.result).get()
+        #expect(rail.installs.map(\.install.installID) == [installID])
+    }
+
+    @Test("Anchored start seeds the timeline around the anchor")
+    func testAnchoredStart() async throws {
+        let provider = TimelineProvider()
+        let anchor = Event.stub(name: "e", sessionID: sessionID, installID: installID, date: at(30))
+        await start(provider, database: makeDatabase(), anchorEvent: anchor)
+
+        let rail = try #require(provider.result).get()
+        let sessions = rail.installs.flatMap { $0.launches.flatMap(\.sessions) }
+        #expect(sessions.map(\.session.sessionID) == [sessionID])
+        #expect(provider.items.map(\.name) == ["e"])
+    }
+
+    @Test("Caches the export text alongside the published result")
+    func testExportTextCached() async throws {
+        let provider = TimelineProvider()
+        await start(provider, database: makeDatabase(), anchorEvent: nil)
+
+        #expect(provider.exportText?.contains("- 2023-11-14T22:13:50Z  e") == true)
+    }
+}

--- a/Tests/ScoutTests/UI/TimelineExportTests.swift
+++ b/Tests/ScoutTests/UI/TimelineExportTests.swift
@@ -164,11 +164,23 @@ struct TimelineExportTests {
         #expect(text?.contains("1 event") == true)
     }
 
-    @Test("Sessions are sorted by start date")
+    @Test("Sessions render in the tree's chronological order")
     func testSessionsSorted() {
-        let later = SessionRoot(session: .stub(startDate: at(2800)), events: [], crashes: [])
-        let earlier = SessionRoot(session: .stub(startDate: at(40)), events: [], crashes: [])
-        let rail = rail(sessions: [later, earlier])
+        let deviceID = UUID()
+        let installID = UUID()
+        let launchID = UUID()
+
+        // `Rail.init` sorts the tree; the export relies on that invariant
+        // instead of re-sorting, so feed it unsorted input.
+        let rail = Rail(
+            device: .stub(deviceID: deviceID),
+            installs: [.stub(installID: installID, deviceID: deviceID, date: baseDate)],
+            launches: [.stub(launchID: launchID, installID: installID, startDate: baseDate)],
+            sessions: [
+                .stub(launchID: launchID, startDate: at(2800)),
+                .stub(launchID: launchID, startDate: at(40)),
+            ]
+        )
 
         let text = TimelineExport(rail: rail).text!
         let first = text.range(of: "#### Session 2023-11-14 22:14")


### PR DESCRIPTION
This change fixes two ways the multi-rail timeline could silently misbehave. When the anchor event was missing or its install had not synced yet, `TimelineProvider` returned without publishing a result and the screen spun forever — it now falls back to loading the whole rail through the ascending lane. And when a reload superseded an in-flight load, the old call could race the new one on a shared `RailLane` cursor and silently drop a chunk of sessions; `loadMore` now serializes concurrent calls behind a waiter queue, snapshots its `generation` before parking, and `RailPagination` bails out of stale footer tasks before they touch the lane.

It also trims the feature's CloudKit traffic and rendering work: timeline queries pass each model's `desiredKeys` instead of fetching every field, the session chunk grows to 100 when filtering by event name so rare events need fewer round trips, the device lookup reads a single record, and `TimelineProvider` caches `items` and `exportText` once per result change instead of rebuilding them on every body evaluation. Redundant re-sorts in `Rail.split`, `TimelineItem.items`, and `TimelineExport` are removed in favor of the sortedness invariant that `Rail.init` establishes and now documents.

New tests cover `Rail.split` edge cases, `RailLane` cancellation and serialization, provider seeding, and `connected(_:_:on:)`, backed by a `DatabaseStub` that evaluates query predicates and honors limits.