### PR TITLE
Reorder Home screen segments to Users, Sessions, Crashes

### DIFF
--- a/Sources/Scout/UI/Home/HomeSectionPicker.swift
+++ b/Sources/Scout/UI/Home/HomeSectionPicker.swift
@@ -10,33 +10,33 @@ import SwiftUI
 
 /// A Home screen stat section selectable in ``HomeSectionPicker``.
 enum HomeSection: CaseIterable, Identifiable {
+    case users
     case sessions
     case crashes
-    case users
 
     var id: Self { self }
 
     var title: String {
         switch self {
+        case .users: "Users"
         case .sessions: "Sessions"
         case .crashes: "Crashes"
-        case .users: "Users"
         }
     }
 
     var color: Color {
         switch self {
+        case .users: .green
         case .sessions: .purple
         case .crashes: .red
-        case .users: .green
         }
     }
 
     var systemImage: String {
         switch self {
+        case .users: "person.2"
         case .sessions: "clock"
         case .crashes: "exclamationmark.triangle"
-        case .users: "person.2"
         }
     }
 }


### PR DESCRIPTION
Reorders the segments in the Home screen section picker so they appear as Users, Sessions, Crashes. The order is driven by the case declaration order of the `HomeSection` enum, so the cases were rearranged accordingly, and the `switch` statements in `title`, `color`, and `systemImage` were updated to match the new order for consistency.