### PR TITLE
Extract timeline export formatting into ExportFormat

### DIFF
--- a/Sources/Scout/UI/Timeline/Export/ExportFormat.swift
+++ b/Sources/Scout/UI/Timeline/Export/ExportFormat.swift
@@ -36,7 +36,9 @@ enum ExportFormat {
     }
 
     /// Formats a date range, repeating the date in the end bound only when
-    /// the range spans more than one day. An open range renders as its start.
+    /// the range spans more than one day.
+    ///
+    /// An open range renders as its start.
     ///
     static func range(from start: Date, to end: Date?) -> String {
         guard let end else {

--- a/Sources/Scout/UI/Timeline/Export/ExportFormat.swift
+++ b/Sources/Scout/UI/Timeline/Export/ExportFormat.swift
@@ -1,0 +1,71 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+/// Formats the dates, identifiers, and counts that appear in exported
+/// timeline documents.
+///
+/// All dates are rendered in UTC — headers in a human-readable form, rows as
+/// ISO 8601 timestamps — so the text reads well and stays machine-parseable.
+///
+enum ExportFormat {
+    /// An ISO 8601 timestamp, e.g. `2023-11-14T22:14:00Z`.
+    static func timestamp(_ date: Date) -> String {
+        Self.iso8601.format(date)
+    }
+
+    /// A calendar day, e.g. `2023-11-14`.
+    static func day(_ date: Date) -> String {
+        Self.dayStyle.format(date)
+    }
+
+    /// A time of day with minute precision, e.g. `22:14`.
+    static func time(_ date: Date) -> String {
+        Self.timeStyle.format(date)
+    }
+
+    /// A day and time with minute precision, e.g. `2023-11-14 22:14`.
+    static func minute(_ date: Date) -> String {
+        "\(day(date)) \(time(date))"
+    }
+
+    /// Formats a date range, repeating the date in the end bound only when
+    /// the range spans more than one day. An open range renders as its start.
+    ///
+    static func range(from start: Date, to end: Date?) -> String {
+        guard let end else {
+            return minute(start)
+        }
+        let sameDay = day(start) == day(end)
+        let suffix = sameDay ? time(end) : minute(end)
+        return "\(minute(start))–\(suffix)"
+    }
+
+    /// The first eight characters of the identifier, lowercased.
+    static func shortID(_ id: UUID) -> String {
+        String(id.uuidString.lowercased().prefix(8))
+    }
+
+    /// A count with its pluralized noun, e.g. `1 install` or `3 installs`.
+    static func counted(_ count: Int, _ singular: String, _ plural: String) -> String {
+        "\(count) \(count == 1 ? singular : plural)"
+    }
+}
+
+// MARK: - Styles
+
+extension ExportFormat {
+    private static let iso8601 = Date.ISO8601FormatStyle()
+    private static let dayStyle = utcStyle("\(year: .padded(4))-\(month: .twoDigits)-\(day: .twoDigits)")
+    private static let timeStyle = utcStyle("\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits)")
+
+    private static func utcStyle(_ format: Date.FormatString) -> Date.VerbatimFormatStyle {
+        Date.VerbatimFormatStyle(format: format, timeZone: .gmt, calendar: Calendar(identifier: .gregorian))
+    }
+}

--- a/Sources/Scout/UI/Timeline/Export/TimelineExport.swift
+++ b/Sources/Scout/UI/Timeline/Export/TimelineExport.swift
@@ -13,8 +13,7 @@ import Foundation
 /// The document mirrors the rail hierarchy: a title with the device ID and a
 /// summary of counts, then a section per install, launch, and session, with
 /// events and crashes as chronological list rows under their session. Dates
-/// are rendered in UTC — headers in a human-readable form, rows as ISO 8601
-/// timestamps — so the text reads well and stays machine-parseable.
+/// and identifiers are rendered through ``ExportFormat``.
 ///
 struct TimelineExport {
     let rail: Rail
@@ -52,7 +51,7 @@ struct TimelineExport {
 extension TimelineExport {
     private var title: String {
         if let deviceID = rail.device.deviceID {
-            return "# Scout Timeline — Device \(shortID(deviceID))"
+            return "# Scout Timeline — Device \(ExportFormat.shortID(deviceID))"
         }
         return "# Scout Timeline"
     }
@@ -64,13 +63,13 @@ extension TimelineExport {
         let crashes = sessions.flatMap(\.crashes).filter { $0.date != nil }
 
         var parts = [
-            counted(rail.installs.count, "install", "installs"),
-            counted(launches.count, "launch", "launches"),
-            counted(sessions.count, "session", "sessions"),
-            counted(events.count, "event", "events"),
+            ExportFormat.counted(rail.installs.count, "install", "installs"),
+            ExportFormat.counted(launches.count, "launch", "launches"),
+            ExportFormat.counted(sessions.count, "session", "sessions"),
+            ExportFormat.counted(events.count, "event", "events"),
         ]
         if crashes.count > 0 {
-            parts.append(counted(crashes.count, "crash", "crashes"))
+            parts.append(ExportFormat.counted(crashes.count, "crash", "crashes"))
         }
         return parts.joined(separator: " · ")
     }
@@ -78,10 +77,10 @@ extension TimelineExport {
     private func header(for install: Install) -> String {
         var parts = ["## Install"]
         if let date = install.date {
-            parts.append(Self.day.format(date))
+            parts.append(ExportFormat.day(date))
         }
         if let id = install.installID {
-            parts.append("(\(shortID(id)))")
+            parts.append("(\(ExportFormat.shortID(id)))")
         }
         return parts.joined(separator: " ")
     }
@@ -89,10 +88,10 @@ extension TimelineExport {
     private func header(for launch: Launch) -> String {
         var parts = ["### Launch"]
         if let date = launch.startDate {
-            parts.append(Self.minute(date))
+            parts.append(ExportFormat.minute(date))
         }
         if let id = launch.launchID {
-            parts.append("(\(shortID(id)))")
+            parts.append("(\(ExportFormat.shortID(id)))")
         }
         return parts.joined(separator: " ")
     }
@@ -100,24 +99,12 @@ extension TimelineExport {
     private func header(for session: Session) -> String {
         var parts = ["#### Session"]
         if let start = session.startDate {
-            parts.append(range(from: start, to: session.endDate))
+            parts.append(ExportFormat.range(from: start, to: session.endDate))
         }
         if let id = session.sessionID {
-            parts.append("(\(shortID(id)))")
+            parts.append("(\(ExportFormat.shortID(id)))")
         }
         return parts.joined(separator: " ")
-    }
-
-    /// Formats a session range, repeating the date in the end bound only when
-    /// the session spans more than one day.
-    ///
-    private func range(from start: Date, to end: Date?) -> String {
-        guard let end else {
-            return Self.minute(start)
-        }
-        let sameDay = Self.day.format(start) == Self.day.format(end)
-        let suffix = sameDay ? Self.time.format(end) : Self.minute(end)
-        return "\(Self.minute(start))–\(suffix)"
     }
 }
 
@@ -133,7 +120,7 @@ extension TimelineExport {
         }
         return (events + crashes)
             .sorted { $0.date < $1.date }
-            .map { "- \(Self.timestamp.format($0.date))  \($0.label)" }
+            .map { "- \(ExportFormat.timestamp($0.date))  \($0.label)" }
     }
 
     private func label(for crash: Crash) -> String {
@@ -141,29 +128,5 @@ extension TimelineExport {
             return "⚠️ crash: \(crash.name) (\(reason))"
         }
         return "⚠️ crash: \(crash.name)"
-    }
-}
-
-// MARK: - Formatting
-
-extension TimelineExport {
-    private func shortID(_ id: UUID) -> String {
-        String(id.uuidString.lowercased().prefix(8))
-    }
-
-    private func counted(_ count: Int, _ singular: String, _ plural: String) -> String {
-        "\(count) \(count == 1 ? singular : plural)"
-    }
-
-    private static let timestamp = Date.ISO8601FormatStyle()
-    private static let day = utcStyle("\(year: .padded(4))-\(month: .twoDigits)-\(day: .twoDigits)")
-    private static let time = utcStyle("\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits)")
-
-    private static func minute(_ date: Date) -> String {
-        "\(day.format(date)) \(time.format(date))"
-    }
-
-    private static func utcStyle(_ format: Date.FormatString) -> Date.VerbatimFormatStyle {
-        Date.VerbatimFormatStyle(format: format, timeZone: .gmt, calendar: Calendar(identifier: .gregorian))
     }
 }

--- a/Tests/ScoutTests/UI/ExportFormatTests.swift
+++ b/Tests/ScoutTests/UI/ExportFormatTests.swift
@@ -1,0 +1,67 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct ExportFormatTests {
+    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)  // 2023-11-14 22:13:20 UTC
+    private func at(_ offset: TimeInterval) -> Date { baseDate.addingTimeInterval(offset) }
+
+    @Test("Timestamps render as ISO 8601 in UTC")
+    func testTimestamp() {
+        #expect(ExportFormat.timestamp(baseDate) == "2023-11-14T22:13:20Z")
+    }
+
+    @Test("Days render as zero-padded year-month-day in UTC")
+    func testDay() {
+        #expect(ExportFormat.day(baseDate) == "2023-11-14")
+        #expect(ExportFormat.day(Date(timeIntervalSince1970: 0)) == "1970-01-01")
+    }
+
+    @Test("Times render as 24-hour hour and minute in UTC")
+    func testTime() {
+        #expect(ExportFormat.time(baseDate) == "22:13")
+        #expect(ExportFormat.time(Date(timeIntervalSince1970: 0)) == "00:00")
+    }
+
+    @Test("Minutes combine the day and time")
+    func testMinute() {
+        #expect(ExportFormat.minute(baseDate) == "2023-11-14 22:13")
+    }
+
+    @Test("Same-day ranges render the end bound as a bare time")
+    func testSameDayRange() {
+        #expect(ExportFormat.range(from: baseDate, to: at(360)) == "2023-11-14 22:13–22:19")
+    }
+
+    @Test("Multi-day ranges repeat the date in the end bound")
+    func testMultiDayRange() {
+        #expect(ExportFormat.range(from: baseDate, to: at(86_400)) == "2023-11-14 22:13–2023-11-15 22:13")
+    }
+
+    @Test("Open ranges render as their start")
+    func testOpenRange() {
+        #expect(ExportFormat.range(from: baseDate, to: nil) == "2023-11-14 22:13")
+    }
+
+    @Test("Short IDs are the first eight characters, lowercased")
+    func testShortID() {
+        let id = UUID(uuidString: "ABCDEF12-3456-7890-ABCD-EF1234567890")!
+        #expect(ExportFormat.shortID(id) == "abcdef12")
+    }
+
+    @Test("Counts pluralize their noun")
+    func testCounted() {
+        #expect(ExportFormat.counted(1, "crash", "crashes") == "1 crash")
+        #expect(ExportFormat.counted(0, "crash", "crashes") == "0 crashes")
+        #expect(ExportFormat.counted(3, "event", "events") == "3 events")
+    }
+}


### PR DESCRIPTION
Splits `TimelineExport` into two entities: the date, identifier, and count formatting moves into a new stateless `ExportFormat` enum, while `TimelineExport` keeps only the rail traversal and document composition. The formatting rules — UTC date styles, session range rendering, ID shortening, and pluralized counts — are now covered directly by `ExportFormatTests` rather than only indirectly through full-document assertions, and the existing `TimelineExportTests` confirm the exported document is unchanged.