### PR TITLE
Tint the toolbar Filter button with the primary color

### DIFF
--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -78,7 +78,7 @@ struct FilterButton: View {
         .sheet(isPresented: $isFilterPresented) {
             FilterView(selected: $levels).presentationDetents([.height(440)])
         }
-        .tint(.blue)
+        .tint(.primary)
     }
 }
 


### PR DESCRIPTION
The `FilterButton` shown in the analytics toolbar was tinted blue, which made it stand out from the rest of the toolbar controls. It now uses the primary color via `.tint(.primary)` so it matches the surrounding UI in both light and dark appearances.