### PR TITLE
Trim CloudKit fetches with desiredKeys in schema checks and param lookups

### DIFF
--- a/Sources/Scout/Core/Database/Schema/CKContainer+Verify.swift
+++ b/Sources/Scout/Core/Database/Schema/CKContainer+Verify.swift
@@ -50,7 +50,7 @@ extension CKContainer {
 
             do {
                 try await publicCloudDatabase.runner { database in
-                    _ = try await database.records(matching: query, resultsLimit: 1)
+                    _ = try await database.records(matching: query, desiredKeys: [], resultsLimit: 1)
                 }
             } catch let error as CKError where error.isSchemaError {
                 print("[Scout] Schema error for '\(recordType)': \(error.localizedDescription)")

--- a/Sources/Scout/UI/Database/Record/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/Record/DefaultDatabase.swift
@@ -29,7 +29,7 @@ struct DefaultDatabase: AppDatabase {
         RecordChunk(records: [], cursor: nil)
     }
 
-    func lookup(id: CKRecord.ID) async throws -> CKRecord {
+    func lookup(id: CKRecord.ID, fields: [CKRecord.FieldKey]?) async throws -> CKRecord {
         Event.sampleRecords.randomElement()!
     }
 }

--- a/Sources/Scout/UI/Database/Record/RecordLookup.swift
+++ b/Sources/Scout/UI/Database/Record/RecordLookup.swift
@@ -8,13 +8,16 @@
 import CloudKit
 
 protocol RecordLookup {
-    func lookup(id: CKRecord.ID) async throws -> CKRecord
+    func lookup(id: CKRecord.ID, fields: [CKRecord.FieldKey]?) async throws -> CKRecord
 }
 
 extension CKDatabase: RecordLookup {
-    func lookup(id: CKRecord.ID) async throws -> CKRecord {
+    func lookup(id: CKRecord.ID, fields: [CKRecord.FieldKey]?) async throws -> CKRecord {
         try await runner { database in
-            try await database.record(for: id)
+            guard let result = try await database.records(for: [id], desiredKeys: fields)[id] else {
+                throw CKError(.unknownItem)
+            }
+            return try result.get()
         }
     }
 }

--- a/Sources/Scout/UI/Event/Param/ParamProvider.swift
+++ b/Sources/Scout/UI/Event/Param/ParamProvider.swift
@@ -18,7 +18,7 @@ class ParamProvider: ObservableObject, Provider {
 
     func fetch(in database: AppDatabase) async throws -> Output {
         try await database
-            .lookup(id: recordID)["params"]
+            .lookup(id: recordID, fields: ["params"])["params"]
             .map(Item.fromData)?
             .sorted() ?? []
     }

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -40,7 +40,7 @@ final class DatabaseStub: AppDatabase, @unchecked Sendable {
         return counts[recordType] ?? 0
     }
 
-    func lookup(id: CKRecord.ID) async throws -> CKRecord {
+    func lookup(id: CKRecord.ID, fields: [CKRecord.FieldKey]?) async throws -> CKRecord {
         throw CKError(.unknownItem)
     }
 


### PR DESCRIPTION
The startup schema verification queries each record type only to confirm it exists, yet downloaded a full record per type — including matrices with ~170 cells and events carrying a `params` blob. The probe now passes empty `desiredKeys` so no field data is transferred. Similarly, the event detail screen fetched the entire `Event` record just to read its `params` field; `RecordLookup.lookup` now accepts a `fields` list backed by `records(for:desiredKeys:)`, and `ParamProvider` requests only `params`.