### PR TITLE
Add macOS support to the Scout package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "Scout",
     platforms: [
-        .iOS(.v16)
+        .iOS(.v16),
+        .macOS(.v13),
     ],
     products: [
         .library(

--- a/Sources/Scout/Core/Bootstrap/ActionTable.AppState.swift
+++ b/Sources/Scout/Core/Bootstrap/ActionTable.AppState.swift
@@ -5,17 +5,17 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import UIKit
+import Foundation
 
 extension ActionTable {
     static let appState = ActionTable(actions: [
-        UIApplication.willEnterForegroundNotification: {
+        AppLifecycle.willEnterForeground: {
             try await persistentContainer.performBackgroundTasks(
                 SessionObject.trigger,
                 UserActivityObject.trigger
             )
         },
-        UIApplication.didEnterBackgroundNotification: {
+        AppLifecycle.didEnterBackground: {
             try await persistentContainer.performBackgroundTasks(
                 SessionObject.complete,
                 UserActivityObject.trigger

--- a/Sources/Scout/Core/Bootstrap/ActionTable.swift
+++ b/Sources/Scout/Core/Bootstrap/ActionTable.swift
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import UIKit
+import Foundation
 
 struct ActionTable {
     typealias Action = @Sendable () async throws -> Void

--- a/Sources/Scout/Core/Bootstrap/AppLifecycle.swift
+++ b/Sources/Scout/Core/Bootstrap/AppLifecycle.swift
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#if canImport(UIKit)
+    import UIKit
+#else
+    import AppKit
+#endif
+
+/// Cross-platform application lifecycle notification names.
+enum AppLifecycle {
+    /// `willEnterForeground` on iOS, `willBecomeActive` on macOS.
+    static var willEnterForeground: Notification.Name {
+        #if canImport(UIKit)
+            UIApplication.willEnterForegroundNotification
+        #else
+            NSApplication.willBecomeActiveNotification
+        #endif
+    }
+
+    /// `didEnterBackground` on iOS, `didResignActive` on macOS.
+    static var didEnterBackground: Notification.Name {
+        #if canImport(UIKit)
+            UIApplication.didEnterBackgroundNotification
+        #else
+            NSApplication.didResignActiveNotification
+        #endif
+    }
+}

--- a/Sources/Scout/Core/Database/CKDatabase+Runner.swift
+++ b/Sources/Scout/Core/Database/CKDatabase+Runner.swift
@@ -6,13 +6,18 @@
 // https://opensource.org/licenses/MIT.
 
 import CloudKit
-import UIKit
+
+#if os(iOS)
+    import UIKit
+#endif
 
 extension CKDatabase {
     @discardableResult func runner<R>(body: @Sendable (CKDatabase) async throws -> R) async throws -> R {
-        guard await UIApplication.shared.backgroundTimeRemaining > 15 else {
-            throw RunnerError()
-        }
+        #if os(iOS)
+            guard await UIApplication.shared.backgroundTimeRemaining > 15 else {
+                throw RunnerError()
+            }
+        #endif
 
         return try await requestLimiter.withSlot {
             try await configuredWith(configuration: .scout, body: body)

--- a/Sources/Scout/Core/Utilities/Dispatcher/Dispatcher.swift
+++ b/Sources/Scout/Core/Utilities/Dispatcher/Dispatcher.swift
@@ -5,7 +5,11 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import UIKit
+#if os(iOS)
+    import UIKit
+#else
+    import Foundation
+#endif
 
 protocol Dispatcher: Sendable {
     func perform(_ work: @escaping Work) async throws
@@ -17,14 +21,21 @@ extension Dispatcher {
 
 extension Dispatcher {
     /// Cancels `work` on expiration rather than letting iOS silently revoke background time.
+    ///
+    /// On macOS, where apps keep running in the background, it simply performs `work`.
+    ///
     func performEnsuringBackground(_ work: @escaping Work) async throws {
-        try await perform { @MainActor in
-            let work = Task(operation: work)
-            let task = UIApplication.shared.beginBackgroundTask(withName: "scout.sync", expirationHandler: work.cancel)
+        #if os(iOS)
+            try await perform { @MainActor in
+                let work = Task(operation: work)
+                let task = UIApplication.shared.beginBackgroundTask(withName: "scout.sync", expirationHandler: work.cancel)
 
-            defer { UIApplication.shared.endBackgroundTask(task) }
+                defer { UIApplication.shared.endBackgroundTask(task) }
 
-            try await work.value
-        }
+                try await work.value
+            }
+        #else
+            try await perform(work)
+        #endif
     }
 }

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -24,9 +24,9 @@ struct AnalyticsView: View {
                 eventList
             }
         }
-        .searchable(text: $filter.text, placement: .navigationBarDrawer(displayMode: .always), prompt: Text(verbatim: "Search"))
+        .searchable(text: $filter.text, placement: .pinned, prompt: Text(verbatim: "Search"))
         .autocorrectionDisabled(true)  // stop keyboard suggestions
-        .keyboardType(.alphabet)  // stop keyboard suggestions
+        .alphabetKeyboard()  // stop keyboard suggestions
         .searchSuggestions {
             if let events = provider.events, filter.text.isEmpty {
                 ForEach(events.unique(by: \.name, max: 7), id: \.self) {
@@ -35,12 +35,14 @@ struct AnalyticsView: View {
             }
         }
         .onSubmit(of: .search) {
-            UIApplication.shared.sendAction(
-                #selector(UIResponder.resignFirstResponder),
-                to: nil,
-                from: nil,
-                for: nil
-            )  // hide keyboard on suggestion selected
+            #if os(iOS)
+                UIApplication.shared.sendAction(
+                    #selector(UIResponder.resignFirstResponder),
+                    to: nil,
+                    from: nil,
+                    for: nil
+                )  // hide keyboard on suggestion selected
+            #endif
 
             Task {
                 search.events = nil

--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -59,7 +59,7 @@ struct FilterView: View {
             .listStyle(.plain)
             .scrollDisabled(true)
             .navigationTitle(en: "Filter")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
         }
     }
 }
@@ -76,7 +76,7 @@ struct FilterButton: View {
             Text(verbatim: "Filter")
         }
         .sheet(isPresented: $isFilterPresented) {
-            FilterView(selected: $levels).presentationDetents([.height(440)])
+            FilterView(selected: $levels).presentationHeight(440)
         }
         .tint(.primary)
     }

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -7,7 +7,6 @@
 
 import CloudKit
 import SwiftUI
-import UIKit
 
 public struct HomeView: View {
     let container: CKContainer
@@ -21,7 +20,7 @@ public struct HomeView: View {
     public var body: some View {
         NavigationStack {
             HomeContent()
-                .navigationBarTitle("Home")
+                .navigationTitle(en: "Home")
                 .iCloudWarning(container: container)
                 .schemaWarning(container: container)
                 .dismissable()

--- a/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
+++ b/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
@@ -7,7 +7,6 @@
 
 import CloudKit
 import SwiftUI
-import UIKit
 
 extension View {
     func iCloudWarning(container: CKContainer) -> some View {
@@ -44,7 +43,7 @@ private struct ICloudWarningModifier: ViewModifier {
             .task {
                 await verify()
             }
-            .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            .onReceive(NotificationCenter.default.publisher(for: AppLifecycle.willEnterForeground)) { _ in
                 Task {
                     await verify()
                 }

--- a/Sources/Scout/UI/Home/Onboarding/OnboardingView.swift
+++ b/Sources/Scout/UI/Home/Onboarding/OnboardingView.swift
@@ -21,8 +21,7 @@ struct OnboardingView: View {
                 SetupPage().tag(1)
                 ReadyPage().tag(2)
             }
-            .tabViewStyle(.page(indexDisplayMode: .always))
-            .indexViewStyle(.page(backgroundDisplayMode: .always))
+            .pagedTabs()
         }
     }
 }

--- a/Sources/Scout/UI/Message/MessageView.Presenter.swift
+++ b/Sources/Scout/UI/Message/MessageView.Presenter.swift
@@ -48,7 +48,7 @@ extension MessageView {
 
 // MARK: - Preview
 
-@available(iOS 17.0, *)
+@available(iOS 17.0, macOS 14.0, *)
 #Preview("Above the navigation bar") {
     @Previewable @State var message: Message?
 
@@ -80,7 +80,7 @@ extension MessageView {
             .disabled(message == nil)
         }
         .navigationTitle(en: "Message Presenter")
-        .navigationBarTitleDisplayMode(.inline)
+        .inlineNavigationTitle()
     }
     .message($message)
 }

--- a/Sources/Scout/UI/Primitives/Modifiers/NSColor+macOS.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/NSColor+macOS.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#if os(macOS)
+    import AppKit
+
+    /// Stand-in for the iOS-only tiered system gray, matching its light and dark values.
+    extension NSColor {
+        static var systemGray3: NSColor {
+            NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                    ? NSColor(red: 72 / 255, green: 72 / 255, blue: 74 / 255, alpha: 1)
+                    : NSColor(red: 199 / 255, green: 199 / 255, blue: 204 / 255, alpha: 1)
+            }
+        }
+    }
+#endif

--- a/Sources/Scout/UI/Primitives/Modifiers/SearchFieldPlacement+Pinned.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/SearchFieldPlacement+Pinned.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension SearchFieldPlacement {
+    /// An always-visible search field: pinned under the navigation bar on iOS, automatic on macOS.
+    static var pinned: SearchFieldPlacement {
+        #if os(iOS)
+            .navigationBarDrawer(displayMode: .always)
+        #else
+            .automatic
+        #endif
+    }
+}

--- a/Sources/Scout/UI/Primitives/Modifiers/ToolbarItemPlacement+macOS.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/ToolbarItemPlacement+macOS.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#if os(macOS)
+    import SwiftUI
+
+    /// Stand-ins for the iOS-only placements, mapped to their closest macOS equivalents
+    /// so call sites stay platform-agnostic.
+    ///
+    extension ToolbarItemPlacement {
+        static var topBarLeading: ToolbarItemPlacement { .navigation }
+        static var topBarTrailing: ToolbarItemPlacement { .primaryAction }
+        static var bottomBar: ToolbarItemPlacement { .secondaryAction }
+    }
+#endif

--- a/Sources/Scout/UI/Primitives/Modifiers/ToolbarPlacement+macOS.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/ToolbarPlacement+macOS.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#if os(macOS)
+    import SwiftUI
+
+    /// Stand-in for the iOS-only placement: the window toolbar is the macOS
+    /// counterpart of the navigation bar.
+    ///
+    extension ToolbarPlacement {
+        static var navigationBar: ToolbarPlacement { .windowToolbar }
+    }
+#endif

--- a/Sources/Scout/UI/Primitives/Modifiers/View+AlphabetKeyboard.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/View+AlphabetKeyboard.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    /// Plain alphabet keyboard on iOS to stop keyboard suggestions; no-op on macOS.
+    func alphabetKeyboard() -> some View {
+        #if os(iOS)
+            keyboardType(.alphabet)
+        #else
+            self
+        #endif
+    }
+}

--- a/Sources/Scout/UI/Primitives/Modifiers/View+InlineNavigationTitle.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/View+InlineNavigationTitle.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    /// Inline navigation title on iOS; no-op on macOS, where titles have no display mode.
+    func inlineNavigationTitle() -> some View {
+        #if os(iOS)
+            navigationBarTitleDisplayMode(.inline)
+        #else
+            self
+        #endif
+    }
+}

--- a/Sources/Scout/UI/Primitives/Modifiers/View+PagedTabs.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/View+PagedTabs.swift
@@ -1,0 +1,22 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    /// Paged tabs with always-visible page dots on iOS; the default tab style
+    /// on macOS, which has no page style.
+    ///
+    func pagedTabs() -> some View {
+        #if os(iOS)
+            tabViewStyle(.page(indexDisplayMode: .always))
+                .indexViewStyle(.page(backgroundDisplayMode: .always))
+        #else
+            self
+        #endif
+    }
+}

--- a/Sources/Scout/UI/Primitives/Modifiers/View+PresentationHeight.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/View+PresentationHeight.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    /// Gives a sheet a fixed height: a detent on iOS, an explicit golden-ratio
+    /// frame on macOS, where sheets have no detents.
+    ///
+    func presentationHeight(_ height: CGFloat) -> some View {
+        #if os(iOS)
+            presentationDetents([.height(height)])
+        #else
+            frame(width: height / 1.618, height: height)
+        #endif
+    }
+}

--- a/Sources/Scout/UI/Share/CopyButton.swift
+++ b/Sources/Scout/UI/Share/CopyButton.swift
@@ -18,7 +18,12 @@ struct CopyButton: View {
 
     var body: some View {
         Button {
-            UIPasteboard.general.string = text
+            #if os(iOS)
+                UIPasteboard.general.string = text
+            #else
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(text, forType: .string)
+            #endif
             isCopied = true
 
             revertTask?.cancel()
@@ -40,7 +45,7 @@ struct CopyButton: View {
     NavigationStack {
         Text(verbatim: "Content")
             .navigationTitle(en: "Copy Button")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     CopyButton(text: "Copied text")

--- a/Sources/Scout/UI/Timeline/View/Timeline.swift
+++ b/Sources/Scout/UI/Timeline/View/Timeline.swift
@@ -31,7 +31,7 @@ struct Timeline: View {
             }
         }
         .navigationTitle(en: "Multi-Rail")
-        .navigationBarTitleDisplayMode(.inline)
+        .inlineNavigationTitle()
         .toolbar {
             if event != nil {
                 ToolbarItem(placement: .principal) {

--- a/Tests/ScoutTests/UI/Chart/ComparisonChartViewTests.swift
+++ b/Tests/ScoutTests/UI/Chart/ComparisonChartViewTests.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import Testing
-import UIKit
 
 @testable import Scout
 
@@ -31,7 +30,7 @@ struct ComparisonChartViewTests {
             .frame(width: 400, height: 300)
         )
 
-        #expect(renderer.uiImage?.size == CGSize(width: 400, height: 300))
+        #expect(renderedSize(of: renderer) == CGSize(width: 400, height: 300))
     }
 
     @Test("Renders the placeholder when both periods are empty") @MainActor func testEmptyRender() {
@@ -42,7 +41,16 @@ struct ComparisonChartViewTests {
                 .frame(width: 400, height: 300)
         )
 
-        #expect(renderer.uiImage?.size == CGSize(width: 400, height: 300))
+        #expect(renderedSize(of: renderer) == CGSize(width: 400, height: 300))
+    }
+
+    /// The rendered image size in points: `uiImage` on iOS, `nsImage` on macOS.
+    @MainActor func renderedSize(of renderer: ImageRenderer<some View>) -> CGSize? {
+        #if os(iOS)
+            renderer.uiImage?.size
+        #else
+            renderer.nsImage?.size
+        #endif
     }
 
     func makePoints(in range: Range<Date>, count: Int) -> [ChartPoint<Int>] {


### PR DESCRIPTION
Scout now builds and passes its test suite on macOS in addition to iOS, so a native macOS client can consume the package and read the same CloudKit container. The package declares `.macOS(.v13)`, and the iOS-only background-task and lifecycle code in `CKDatabase.runner`, `Dispatcher`, and `ActionTable` is conditionally compiled, with a new `AppLifecycle` type abstracting over `UIApplication`/`NSApplication` notifications.

iOS-only SwiftUI APIs are bridged through small shims in `UI/Primitives/Modifiers`: macOS stand-ins for the toolbar placements, `ToolbarPlacement.navigationBar`, and `NSColor.systemGray3`, plus cross-platform modifiers like `inlineNavigationTitle()`, `presentationHeight(_:)`, `pagedTabs()`, and a `pinned` search field placement. `CopyButton` writes to `NSPasteboard` on macOS, and the chart render test reads `nsImage` instead of `uiImage` there.