### PR TITLE
Persist Home screen section and log period across launches

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct HomeContent: View {
     @Environment(\.database) var database
 
-    @State private var section = HomeSection.sessions
+    @AppStorage("scout_home_section") private var section = HomeSection.sessions
 
     @StateObject var activity = ActivityProvider()
     @StateObject var sessionStat = StatProvider(eventName: "Session", periods: Period.summary)

--- a/Sources/Scout/UI/Home/HomeSectionPicker.swift
+++ b/Sources/Scout/UI/Home/HomeSectionPicker.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 /// A Home screen stat section selectable in ``HomeSectionPicker``.
-enum HomeSection: CaseIterable, Identifiable {
+enum HomeSection: String, CaseIterable, Identifiable {
     case users
     case sessions
     case crashes

--- a/Sources/Scout/UI/Home/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Log/HomeLogSection.swift
@@ -14,7 +14,7 @@ import SwiftUI
 struct HomeLogSection: View {
     @Environment(\.database) var database
 
-    @State private var period = Period.today
+    @AppStorage("scout_home_log_period") private var period = Period.today
 
     @StateObject private var provider = HomeLogProvider()
 


### PR DESCRIPTION
The Home screen now remembers its UI state between app launches. The stat section chosen in the segmented control and the period selected in the Log header are stored via `AppStorage` (the `scout_home_section` and `scout_home_log_period` defaults), following the existing convention used by onboarding. `HomeSection` gains a `String` raw value so it can be stored directly.