### PR TITLE
Tint Home Log counters with their row color

### DIFF
--- a/Sources/Scout/UI/Home/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Log/HomeLogSection.swift
@@ -54,7 +54,7 @@ struct HomeLogSection: View {
             Text(verbatim: title)
             Spacer()
             RedactedText(count: count)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(color)
                 .frame(minWidth: RowSummary.countWidth, alignment: .trailing)
         } destination: {
             destination()


### PR DESCRIPTION
The entry counters in the Home screen's Log section were rendered in the secondary gray, which made them look detached from their rows. They now use the same color as the row icon — red for `Crashes`, blue for `Events` and `Metrics` — matching how `RowSummary` tints counts in the stat rows above.