### PR TITLE
Support syncing to multiple backends, including self-hosted Scout servers

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -25,3 +25,16 @@ let container = CKContainer(identifier: "YOUR_CONTAINER_ID")
 
 try await setup(container: container)
 ```
+
+## Using a Scout Server
+
+Instead of CloudKit — or in addition to it — Scout can sync to one or more self-hosted [Scout servers](https://github.com/kasianov-mikhail/scout-server). A server needs no schema upload: it aggregates analytics natively.
+
+```swift
+try await setup(backends: [
+    .cloudKit(container),
+    .server(url: URL(string: "https://scout.example.com")!, apiKey: "YOUR_API_KEY"),
+])
+```
+
+See the [server repository](https://github.com/kasianov-mikhail/scout-server) for deployment instructions and Docker images.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 | 📊 | **Metrics** | Integrates with [swift-metrics](https://github.com/apple/swift-metrics). Counters, timers, and floating-point counters are recorded alongside logs. |
 | 💥 | **Crash Reporting** | Captures uncaught exceptions and signals (SIGABRT, SIGSEGV, etc.) with stack traces. Reports are flushed on the next launch. |
 | ☁️ | **CloudKit Sync** | All data is stored locally with Core Data and synced to a public [CloudKit](https://developer.apple.com/icloud/cloudkit/) database. No custom backend required. |
+| 🌐 | **Multiple Backends** | Sync to CloudKit, to one or more self-hosted [Scout servers](https://github.com/kasianov-mikhail/scout-server), or to any combination of them at once. |
 | 📱 | **SwiftUI Dashboard** | A built-in `HomeView` with charts, event lists, crash details, and activity tracking for debugging in development builds. |
 
 ## Requirements
@@ -56,6 +57,15 @@ let container = CKContainer(identifier: "YOUR_CONTAINER_ID")
 try await setup(container: container)
 ```
 
+To sync somewhere other than CloudKit — or to several destinations at once — pass a list of backends instead. Every raw record is uploaded to every backend, and the dashboard reads from the first one:
+```swift
+try await setup(backends: [
+    .cloudKit(container),
+    .server(url: URL(string: "https://scout.example.com")!, apiKey: "YOUR_API_KEY"),
+])
+```
+A [Scout server](https://github.com/kasianov-mikhail/scout-server) aggregates analytics natively, so it needs no schema upload and receives raw metric values instead of client-maintained matrices.
+
 After setup, use the standard [swift-log](https://github.com/apple/swift-log) API to write logs:
 ```swift
 import Logging
@@ -84,6 +94,10 @@ Timer(label: "response_time").recordSeconds(duration)
 Present `HomeView` to browse logs, metrics, crashes, and user activity:
 ```swift
 HomeView(container: container)
+```
+When running against Scout servers, hand it the same backend list you passed to `setup`:
+```swift
+HomeView(backends: [.server(url: serverURL, apiKey: "YOUR_API_KEY")])
 ```
 > Use this only in debug builds to avoid exposing log data in production.
 

--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -1,0 +1,85 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+/// A destination Scout syncs analytics to and reads them back from.
+///
+/// Scout can run against CloudKit, against one or more Scout servers, or
+/// against any mix of them at once: every raw record is uploaded to every
+/// backend, while reads go to the first backend in the list (the primary).
+///
+public enum Backend: Sendable {
+    /// The CloudKit container Scout traditionally syncs to. CloudKit cannot
+    /// aggregate server-side, so the client also maintains matrix records.
+    case cloudKit(CKContainer)
+
+    /// A Scout server (`scout-server`). Aggregation happens in SQL on the
+    /// server, so only raw records are uploaded — including raw metric
+    /// values, which on CloudKit exist solely as matrices.
+    case server(url: URL, apiKey: String? = nil)
+}
+
+/// The full database surface a backend must provide.
+protocol BackendDatabase: RecordWriter, RecordReader, RecordLookup, Sendable {}
+
+extension CKDatabase: BackendDatabase {}
+extension HTTPDatabase: BackendDatabase {}
+
+/// A backend resolved into its database plus the traits the sync pipeline
+/// branches on.
+///
+struct ResolvedBackend: Sendable {
+    let database: any BackendDatabase
+
+    /// Whether the client must maintain matrix records on this backend.
+    ///
+    /// True for CloudKit; Scout servers aggregate natively.
+    ///
+    let needsClientAggregation: Bool
+
+    /// Whether raw metric values can be uploaded.
+    ///
+    /// Scout servers accept them; on CloudKit metrics exist only as matrices.
+    ///
+    let acceptsRawMetrics: Bool
+
+    /// Throws when the backend cannot accept uploads right now.
+    let checkAvailability: @Sendable () async throws -> Void
+}
+
+extension Backend {
+    var resolved: ResolvedBackend {
+        switch self {
+        case .cloudKit(let container):
+            ResolvedBackend(
+                database: container.publicCloudDatabase,
+                needsClientAggregation: true,
+                acceptsRawMetrics: false,
+                checkAvailability: {
+                    guard try await container.accountStatus() == .available else {
+                        throw SyncController.NotLoggedInError()
+                    }
+                }
+            )
+        case .server(let url, let apiKey):
+            ResolvedBackend(
+                database: HTTPDatabase(url: url, apiKey: apiKey),
+                needsClientAggregation: false,
+                acceptsRawMetrics: true,
+                checkAvailability: {}
+            )
+        }
+    }
+}
+
+extension [Backend] {
+    /// The database UI reads go to — the first backend's.
+    var primaryDatabase: (any BackendDatabase)? {
+        first?.resolved.database
+    }
+}

--- a/Sources/Scout/Core/Backend/HTTPDatabase.swift
+++ b/Sources/Scout/Core/Backend/HTTPDatabase.swift
@@ -1,0 +1,156 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Foundation
+
+/// Maximum number of records per write request, matching the server's cap
+/// on its side and CloudKit's modify limit on ours.
+private let maxBatchSize = 400
+
+/// A Scout server reachable over HTTP, exposed through the same record
+/// surface as CloudKit so the rest of the package cannot tell them apart.
+///
+struct HTTPDatabase: Sendable {
+    let url: URL
+    let apiKey: String?
+    let session: URLSession
+
+    init(url: URL, apiKey: String?, session: URLSession = .shared) {
+        // Relative endpoint resolution drops the last path component of a
+        // base URL without a trailing slash, so normalize it here.
+        self.url = url.absoluteString.hasSuffix("/") ? url : URL(string: url.absoluteString + "/") ?? url
+        self.apiKey = apiKey
+        self.session = session
+    }
+}
+
+// MARK: - Writing
+
+extension HTTPDatabase: RecordWriter {
+    func write(record: CKRecord) async throws {
+        try await write(records: [record])
+    }
+
+    func write(records: [CKRecord]) async throws {
+        for chunk in records.chunked(into: maxBatchSize) {
+            let request = HTTPWriteRequest(records: chunk.map(HTTPRecord.init))
+            try await send(request, to: "api/v1/records", into: HTTPWriteAck.self)
+        }
+    }
+
+    private struct HTTPWriteAck: Decodable {
+        let saved: Int
+    }
+}
+
+// MARK: - Reading
+
+extension HTTPDatabase: RecordReader {
+    func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+        try await read(matching: query, fields: fields, limit: CKQueryOperation.maximumResults)
+    }
+
+    func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?, limit: Int) async throws -> RecordChunk {
+        try await run(query: HTTPQuery(query: query, fields: fields, limit: limit))
+    }
+
+    func readMore(from cursor: RecordCursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+        guard case .server(let token) = cursor else {
+            throw CursorMismatchError()
+        }
+        var query = HTTPQuery()
+        query.cursor = token
+        return try await run(query: query)
+    }
+
+    private func run(query: HTTPQuery) async throws -> RecordChunk {
+        let response = try await send(query, to: "api/v1/records/query", into: HTTPQueryResponse.self)
+        return RecordChunk(
+            records: response.records.map(\.toRecord),
+            cursor: response.cursor.map(RecordCursor.server)
+        )
+    }
+}
+
+// MARK: - Lookup
+
+extension HTTPDatabase: RecordLookup {
+    func lookup(id: CKRecord.ID, fields: [CKRecord.FieldKey]?) async throws -> CKRecord {
+        let allowed = CharacterSet.urlPathAllowed.subtracting(CharacterSet(charactersIn: "/"))
+        let name = id.recordName.addingPercentEncoding(withAllowedCharacters: allowed) ?? id.recordName
+
+        var path = "api/v1/records/\(name)"
+        if let fields {
+            let list = fields.joined(separator: ",")
+            path += "?fields=\(list.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? list)"
+        }
+
+        guard let endpoint = URL(string: path, relativeTo: url) else {
+            throw HTTPDatabaseError(status: 0, reason: "Malformed record URL")
+        }
+
+        let (data, response) = try await session.data(for: request(for: endpoint, method: "GET"))
+        try check(response, data: data)
+
+        return try JSONDecoder().decode(HTTPRecord.self, from: data).toRecord
+    }
+}
+
+// MARK: - Transport
+
+/// A non-2xx response from a Scout server.
+struct HTTPDatabaseError: LocalizedError {
+    let status: Int
+    let reason: String?
+
+    var errorDescription: String? {
+        "Scout server returned \(status)\(reason.map { ": \($0)" } ?? "")"
+    }
+}
+
+extension HTTPDatabase {
+    @discardableResult
+    private func send<Body: Encodable, Reply: Decodable>(_ body: Body, to path: String, into reply: Reply.Type) async throws -> Reply {
+        guard let endpoint = URL(string: path, relativeTo: url) else {
+            throw HTTPDatabaseError(status: 0, reason: "Malformed endpoint URL")
+        }
+
+        var request = request(for: endpoint, method: "POST")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await session.data(for: request)
+        try check(response, data: data)
+
+        return try JSONDecoder().decode(Reply.self, from: data)
+    }
+
+    private func request(for endpoint: URL, method: String) -> URLRequest {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = method
+        request.timeoutInterval = 10
+        if let apiKey {
+            request.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        }
+        return request
+    }
+
+    private func check(_ response: URLResponse, data: Data) throws {
+        guard let http = response as? HTTPURLResponse else {
+            return
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let reason = try? JSONDecoder().decode(HTTPErrorBody.self, from: data).reason
+            throw HTTPDatabaseError(status: http.statusCode, reason: reason)
+        }
+    }
+
+    private struct HTTPErrorBody: Decodable {
+        let reason: String?
+    }
+}

--- a/Sources/Scout/Core/Backend/HTTPQueryCoding.swift
+++ b/Sources/Scout/Core/Backend/HTTPQueryCoding.swift
@@ -1,0 +1,144 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+/// A record query in the server's wire format, the counterpart of `CKQuery`.
+struct HTTPQuery: Codable, Equatable, Sendable {
+    var recordType: String?
+    var filters: [HTTPFilter]?
+    var sort: [HTTPSort]?
+    var limit: Int?
+    var fields: [String]?
+    var cursor: String?
+}
+
+struct HTTPFilter: Codable, Equatable, Sendable {
+    enum Operator: String, Codable, Sendable {
+        case equals
+        case notEquals
+        case greaterThan
+        case greaterThanOrEquals
+        case lessThan
+        case lessThanOrEquals
+        case `in`
+        case beginsWith
+    }
+
+    let field: String
+    let op: Operator
+    let value: HTTPFieldValue
+}
+
+struct HTTPSort: Codable, Equatable, Sendable {
+    let field: String
+    let ascending: Bool
+}
+
+// MARK: - CKQuery Translation
+
+/// The query uses an `NSPredicate` shape Scout never produces, so the
+/// server has no equivalent for it.
+///
+struct UnsupportedQueryError: LocalizedError {
+    let predicate: NSPredicate
+
+    var errorDescription: String? {
+        "The predicate '\(predicate.predicateFormat)' cannot be sent to a Scout server"
+    }
+}
+
+extension HTTPQuery {
+    /// Translates the `CKQuery` shapes Scout builds — compound ANDs over
+    /// comparisons (`==`, `!=`, `<`, `<=`, `>`, `>=`, `IN`, `BEGINSWITH`)
+    /// plus `TRUEPREDICATE` — into the server's filter language.
+    ///
+    init(query: CKQuery, fields: [CKRecord.FieldKey]?, limit: Int?) throws {
+        self.recordType = query.recordType
+        self.filters = try Self.filters(of: query.predicate)
+        self.fields = fields
+
+        if let limit, limit != CKQueryOperation.maximumResults {
+            self.limit = limit
+        }
+
+        let sort = (query.sortDescriptors ?? []).compactMap { descriptor in
+            descriptor.key.map { HTTPSort(field: $0, ascending: descriptor.ascending) }
+        }
+        if !sort.isEmpty {
+            self.sort = sort
+        }
+    }
+
+    private static func filters(of predicate: NSPredicate) throws -> [HTTPFilter] {
+        if predicate.predicateFormat == "TRUEPREDICATE" {
+            return []
+        }
+
+        if let compound = predicate as? NSCompoundPredicate {
+            guard compound.compoundPredicateType == .and else {
+                throw UnsupportedQueryError(predicate: predicate)
+            }
+            return try (compound.subpredicates as? [NSPredicate] ?? []).flatMap(filters)
+        }
+
+        if let comparison = predicate as? NSComparisonPredicate {
+            return try [filter(of: comparison)]
+        }
+
+        throw UnsupportedQueryError(predicate: predicate)
+    }
+
+    private static func filter(of comparison: NSComparisonPredicate) throws -> HTTPFilter {
+        guard comparison.leftExpression.expressionType == .keyPath, comparison.rightExpression.expressionType == .constantValue else {
+            throw UnsupportedQueryError(predicate: comparison)
+        }
+
+        let field = comparison.leftExpression.keyPath
+
+        let op: HTTPFilter.Operator =
+            switch comparison.predicateOperatorType {
+            case .equalTo: .equals
+            case .notEqualTo: .notEquals
+            case .greaterThan: .greaterThan
+            case .greaterThanOrEqualTo: .greaterThanOrEquals
+            case .lessThan: .lessThan
+            case .lessThanOrEqualTo: .lessThanOrEquals
+            case .in: .in
+            case .beginsWith: .beginsWith
+            default: throw UnsupportedQueryError(predicate: comparison)
+            }
+
+        guard let constant = comparison.rightExpression.constantValue, let value = Self.value(of: constant) else {
+            throw UnsupportedQueryError(predicate: comparison)
+        }
+
+        return HTTPFilter(field: field, op: op, value: value)
+    }
+
+    private static func value(of constant: Any) -> HTTPFieldValue? {
+        switch constant {
+        case let values as [String]:
+            .strings(values)
+        case let value as UUID:
+            .string(value.uuidString)
+        default:
+            HTTPFieldValue(recordValue: constant)
+        }
+    }
+}
+
+// MARK: - Envelopes
+
+struct HTTPWriteRequest: Codable {
+    let records: [HTTPRecord]
+}
+
+struct HTTPQueryResponse: Codable {
+    let records: [HTTPRecord]
+    let cursor: String?
+}

--- a/Sources/Scout/Core/Backend/HTTPQueryCoding.swift
+++ b/Sources/Scout/Core/Backend/HTTPQueryCoding.swift
@@ -45,10 +45,14 @@ struct HTTPSort: Codable, Equatable, Sendable {
 /// server has no equivalent for it.
 ///
 struct UnsupportedQueryError: LocalizedError {
-    let predicate: NSPredicate
+    let format: String
+
+    init(predicate: NSPredicate) {
+        format = predicate.predicateFormat
+    }
 
     var errorDescription: String? {
-        "The predicate '\(predicate.predicateFormat)' cannot be sent to a Scout server"
+        "The predicate '\(format)' cannot be sent to a Scout server"
     }
 }
 

--- a/Sources/Scout/Core/Backend/HTTPRecordCoding.swift
+++ b/Sources/Scout/Core/Backend/HTTPRecordCoding.swift
@@ -1,0 +1,146 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+/// A typed record field value, the wire format shared with Scout servers.
+///
+/// Encoded as a single-key JSON object, e.g. `{"string": "login"}`. Dates
+/// travel as integer milliseconds since the Unix epoch so equality survives
+/// the round trip; bytes travel as base64.
+///
+enum HTTPFieldValue: Equatable, Sendable {
+    case string(String)
+    case int(Int64)
+    case double(Double)
+    case date(Date)
+    case bytes(Data)
+    case strings([String])
+}
+
+extension HTTPFieldValue: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case string, int, double, date, bytes, strings
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let value = try container.decodeIfPresent(String.self, forKey: .string) {
+            self = .string(value)
+        } else if let value = try container.decodeIfPresent(Int64.self, forKey: .int) {
+            self = .int(value)
+        } else if let value = try container.decodeIfPresent(Double.self, forKey: .double) {
+            self = .double(value)
+        } else if let value = try container.decodeIfPresent(Int64.self, forKey: .date) {
+            self = .date(Date(timeIntervalSince1970: Double(value) / 1000))
+        } else if let value = try container.decodeIfPresent(Data.self, forKey: .bytes) {
+            self = .bytes(value)
+        } else if let value = try container.decodeIfPresent([String].self, forKey: .strings) {
+            self = .strings(value)
+        } else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unknown field value type"
+                )
+            )
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .string(let value):
+            try container.encode(value, forKey: .string)
+        case .int(let value):
+            try container.encode(value, forKey: .int)
+        case .double(let value):
+            try container.encode(value, forKey: .double)
+        case .date(let value):
+            try container.encode(Int64((value.timeIntervalSince1970 * 1000).rounded()), forKey: .date)
+        case .bytes(let value):
+            try container.encode(value, forKey: .bytes)
+        case .strings(let value):
+            try container.encode(value, forKey: .strings)
+        }
+    }
+}
+
+// MARK: - CloudKit Bridging
+
+extension HTTPFieldValue {
+    /// Maps a `CKRecord` value to its wire form.
+    ///
+    /// Numbers are split by their Core Foundation storage: floating-point
+    /// numbers become `double`, everything else `int`.
+    ///
+    init?(recordValue: Any) {
+        switch recordValue {
+        case let value as String:
+            self = .string(value)
+        case let value as Date:
+            self = .date(value)
+        case let value as Data:
+            self = .bytes(value)
+        case let value as [String]:
+            self = .strings(value)
+        case let value as NSNumber:
+            if CFNumberIsFloatType(value) {
+                self = .double(value.doubleValue)
+            } else {
+                self = .int(value.int64Value)
+            }
+        default:
+            return nil
+        }
+    }
+
+    var recordValue: any CKRecordValueProtocol {
+        switch self {
+        case .string(let value): value
+        case .int(let value): value
+        case .double(let value): value
+        case .date(let value): value
+        case .bytes(let value): value
+        case .strings(let value): value
+        }
+    }
+}
+
+// MARK: - Records
+
+/// Wire representation of a single record.
+struct HTTPRecord: Codable, Equatable, Sendable {
+    let recordType: String
+    let recordName: String
+    var fields: [String: HTTPFieldValue]
+}
+
+extension HTTPRecord {
+    init(record: CKRecord) {
+        recordType = record.recordType
+        recordName = record.recordID.recordName
+        fields = Dictionary(
+            uniqueKeysWithValues: record.allKeys().compactMap { key in
+                record[key].flatMap(HTTPFieldValue.init).map { (key, $0) }
+            }
+        )
+    }
+
+    var toRecord: CKRecord {
+        let record = CKRecord(
+            recordType: recordType,
+            recordID: CKRecord.ID(recordName: recordName)
+        )
+        for (key, value) in fields {
+            record[key] = value.recordValue
+        }
+        return record
+    }
+}

--- a/Sources/Scout/Core/Backend/ServerRepresentable.swift
+++ b/Sources/Scout/Core/Backend/ServerRepresentable.swift
@@ -1,0 +1,79 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+/// Can be serialized into a record for upload to a Scout server.
+///
+/// Most types reuse their CloudKit record as-is. Metrics are the
+/// exception: on CloudKit they exist only as client-maintained matrices,
+/// but Scout servers aggregate natively and take the raw values instead,
+/// as `IntMetric`/`DoubleMetric` records.
+///
+/// `UserActivityObject` is deliberately absent: servers derive DAU/WAU/MAU
+/// from `Session` records, so activity flags never leave the device.
+///
+protocol ServerRepresentable {
+    var toServerRecord: CKRecord { get }
+}
+
+extension ServerRepresentable where Self: CKRepresentable {
+    var toServerRecord: CKRecord { toRecord }
+}
+
+extension EventObject: ServerRepresentable {}
+extension SessionObject: ServerRepresentable {}
+extension LaunchObject: ServerRepresentable {}
+extension InstallObject: ServerRepresentable {}
+extension DeviceObject: ServerRepresentable {}
+extension VersionObject: ServerRepresentable {}
+extension CrashObject: ServerRepresentable {}
+
+// MARK: - Metrics
+
+extension MetricsObject {
+    /// Builds the raw metric record.
+    ///
+    /// The matrix pipeline stores the telemetry type in the matrix
+    /// `category` field, and the server keeps that name so aggregated
+    /// metrics come back shaped identically.
+    ///
+    /// Metrics carry no UUID attribute, so the stable Core Data object URI
+    /// names the record — re-uploading the same object after a partial
+    /// sync upserts instead of double-counting.
+    ///
+    fileprivate func serverRecord(type: String, value: any CKRecordValueProtocol) -> CKRecord {
+        let recordID = CKRecord.ID(recordName: objectID.uriRepresentation().absoluteString)
+        let record = CKRecord(recordType: type, recordID: recordID)
+
+        record["name"] = name
+        record["category"] = telemetry
+        record["value"] = value
+        record["date"] = date
+        record["session_id"] = sessionID.uuidString
+
+        record.setValuesForKeys(metadata)
+
+        return record
+    }
+}
+
+extension IntMetricsObject: ServerRepresentable {
+    static let serverRecordType = "IntMetric"
+
+    var toServerRecord: CKRecord {
+        serverRecord(type: Self.serverRecordType, value: value)
+    }
+}
+
+extension DoubleMetricsObject: ServerRepresentable {
+    static let serverRecordType = "DoubleMetric"
+
+    var toServerRecord: CKRecord {
+        serverRecord(type: Self.serverRecordType, value: value)
+    }
+}

--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -15,9 +15,14 @@ struct SetupError: LocalizedError {
     let recoverySuggestion: String? = "Review the code to ensure setup is called only once"
 }
 
+struct NoBackendsError: LocalizedError {
+    let errorDescription: String? = "Scout requires at least one backend"
+    let recoverySuggestion: String? = "Pass a CloudKit container or a Scout server to setup"
+}
+
 @MainActor private var isSetup = false
 
-/// Initializes Scout's global infrastructure.
+/// Initializes Scout's global infrastructure against a CloudKit container.
 ///
 /// - Parameter container: The CloudKit container for all operations.
 /// - Throws: An error if initialization fails or if called more than once.
@@ -25,8 +30,27 @@ struct SetupError: LocalizedError {
 ///
 @MainActor
 public func setup(container: CKContainer) async throws {
+    try await setup(backends: [.cloudKit(container)])
+}
+
+/// Initializes Scout's global infrastructure against one or more backends.
+///
+/// Every raw record is synced to every backend. CloudKit backends also
+/// receive client-maintained matrix records; Scout servers aggregate
+/// natively and receive raw metric values instead.
+///
+/// - Parameter backends: The backends to sync to, in any combination of
+///   CloudKit containers and Scout servers.
+/// - Throws: An error if initialization fails or if called more than once.
+/// - Important: Call from the main actor during app startup.
+///
+@MainActor
+public func setup(backends: [Backend]) async throws {
     guard !isSetup else {
         throw SetupError()
+    }
+    guard !backends.isEmpty else {
+        throw NoBackendsError()
     }
 
     installExceptionHandler()
@@ -38,7 +62,7 @@ public func setup(container: CKContainer) async throws {
         LaunchObject.completeStale,
     )
 
-    let sync = SyncController(container: container).synchronize
+    let sync = SyncController(backends: backends.map(\.resolved)).synchronize
 
     ActionTable.appState.startListening(completion: sync)
 
@@ -58,5 +82,7 @@ public func setup(container: CKContainer) async throws {
 
     isSetup = true
 
-    verifyParallelismIfDue(container: container)
+    for case .cloudKit(let container) in backends {
+        verifyParallelismIfDue(container: container)
+    }
 }

--- a/Sources/Scout/Core/Database/Record/RecordChunk.swift
+++ b/Sources/Scout/Core/Database/Record/RecordChunk.swift
@@ -9,7 +9,7 @@ import CloudKit
 
 struct RecordChunk {
     let records: [CKRecord]
-    let cursor: CKQueryOperation.Cursor?
+    let cursor: RecordCursor?
 }
 
 // MARK: - CloudKit Mapping
@@ -17,7 +17,7 @@ struct RecordChunk {
 extension RecordChunk {
     init(results: ([(CKRecord.ID, Result<CKRecord, Error>)], CKQueryOperation.Cursor?)) throws {
         records = try results.0.records()
-        cursor = results.1
+        cursor = results.1.map(RecordCursor.cloudKit)
     }
 }
 

--- a/Sources/Scout/Core/Database/Record/RecordCursor.swift
+++ b/Sources/Scout/Core/Database/Record/RecordCursor.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+
+/// A backend-agnostic continuation point for paginated reads.
+///
+/// CloudKit hands back an opaque `CKQueryOperation.Cursor`; Scout servers
+/// return an opaque token string. Each `RecordReader` only ever receives
+/// cursors it produced itself, since paginated reads always continue on
+/// the database that started them.
+///
+enum RecordCursor: @unchecked Sendable {
+    case cloudKit(CKQueryOperation.Cursor)
+    case server(String)
+}
+
+/// The continuation was produced by a different backend than the one
+/// asked to resume from it.
+///
+struct CursorMismatchError: LocalizedError {
+    let errorDescription: String? = "The pagination cursor belongs to a different backend"
+}

--- a/Sources/Scout/Core/Database/Record/RecordReader.swift
+++ b/Sources/Scout/Core/Database/Record/RecordReader.swift
@@ -10,7 +10,7 @@ import CloudKit
 protocol RecordReader: Sendable {
     func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk
     func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?, limit: Int) async throws -> RecordChunk
-    func readMore(from cursor: CKQueryOperation.Cursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk
+    func readMore(from cursor: RecordCursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk
 }
 
 extension RecordReader {
@@ -44,8 +44,11 @@ extension CKDatabase: RecordReader {
         }
     }
 
-    func readMore(from cursor: CKQueryOperation.Cursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
-        try await runner { database in
+    func readMore(from cursor: RecordCursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+        guard case .cloudKit(let cursor) = cursor else {
+            throw CursorMismatchError()
+        }
+        return try await runner { database in
             try await RecordChunk(
                 results: database.records(
                     continuingMatchFrom: cursor,

--- a/Sources/Scout/Core/Sync/SyncController.swift
+++ b/Sources/Scout/Core/Sync/SyncController.swift
@@ -10,23 +10,30 @@ import CloudKit
 typealias SyncAction = @MainActor () async throws -> Void
 
 @MainActor class SyncController {
-    let container: CKContainer
+    let backends: [ResolvedBackend]
 
     private let dispatcher: Dispatcher
 
-    init(container: CKContainer, dispatcher: Dispatcher = QueueDispatcher()) {
-        self.container = container
+    init(backends: [ResolvedBackend], dispatcher: Dispatcher = QueueDispatcher()) {
+        self.backends = backends
         self.dispatcher = dispatcher
+    }
+
+    convenience init(container: CKContainer, dispatcher: Dispatcher = QueueDispatcher()) {
+        self.init(backends: [Backend.cloudKit(container).resolved], dispatcher: dispatcher)
     }
 
     func synchronize() async throws {
         try SyncableObject.cleanup(in: persistentContainer.viewContext)
 
-        guard try await container.accountStatus() == .available else {
-            throw NotLoggedInError()
+        // Sync advances a record's state once for all backends, so every
+        // backend must be reachable before any upload starts — otherwise a
+        // record could be marked synced without reaching the missing one.
+        for backend in backends {
+            try await backend.checkAvailability()
         }
 
-        let engine = SyncEngine(database: container.publicCloudDatabase, context: persistentContainer.viewContext)
+        let engine = SyncEngine(backends: backends, context: persistentContainer.viewContext)
         let jobPlan = SyncJobPlan(engine: engine)
 
         try await dispatcher.performEnsuringBackground {

--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -9,8 +9,27 @@ import CloudKit
 import CoreData
 
 struct SyncEngine: @unchecked Sendable {
-    let database: Database
+    let backends: [ResolvedBackend]
     let context: NSManagedObjectContext
+
+    init(backends: [ResolvedBackend], context: NSManagedObjectContext) {
+        self.backends = backends
+        self.context = context
+    }
+
+    init(database: any BackendDatabase, context: NSManagedObjectContext) {
+        self.init(
+            backends: [
+                ResolvedBackend(
+                    database: database,
+                    needsClientAggregation: true,
+                    acceptsRawMetrics: false,
+                    checkAvailability: {}
+                )
+            ],
+            context: context
+        )
+    }
 
     @MainActor func send<T: Syncable & MatrixBatch>(type syncable: T.Type) async throws {
         while let batch = try syncable.group(in: context) {
@@ -23,23 +42,28 @@ struct SyncEngine: @unchecked Sendable {
             // Persist attempt counters so cleanup can retire records that keep failing.
             try context.save()
 
-            if let objects = batch as? [CKRepresentable] {
-                try await database.write(
-                    records: objects.map(\.toRecord)
-                )
+            // Raw uploads are idempotent upserts keyed by record name, so a
+            // batch that failed on one backend safely re-runs on all of them.
+            for backend in backends {
+                if let records = records(of: batch, for: backend) {
+                    try await backend.database.write(records: records)
+                }
             }
 
             // Records already counted into the server matrix on a previous
             // attempt must not contribute again, or the matrix double-counts.
             let pending = batch.filter { $0.syncState == .pending }
+            let aggregating = backends.filter(\.needsClientAggregation)
 
-            if pending.count > 0 {
-                try await SyncCoordinator(
-                    database: database,
-                    maxRetry: 3,
-                    batch: pending
-                )
-                .upload()
+            if pending.count > 0 && !aggregating.isEmpty {
+                for backend in aggregating {
+                    try await SyncCoordinator(
+                        database: backend.database,
+                        maxRetry: 3,
+                        batch: pending
+                    )
+                    .upload()
+                }
 
                 for object in pending {
                     object.syncState = .aggregated
@@ -56,5 +80,21 @@ struct SyncEngine: @unchecked Sendable {
 
             try context.save()
         }
+    }
+
+    /// The raw records a batch contributes to a backend, if any.
+    ///
+    /// Backends with native aggregation take the server representation,
+    /// which exists for more types (raw metrics have no CloudKit record).
+    /// Types with neither representation sync as matrices only.
+    ///
+    private func records(of batch: [some Syncable], for backend: ResolvedBackend) -> [CKRecord]? {
+        if backend.acceptsRawMetrics, let objects = batch as? [ServerRepresentable] {
+            return objects.map(\.toServerRecord)
+        }
+        if let objects = batch as? [CKRepresentable] {
+            return objects.map(\.toRecord)
+        }
+        return nil
     }
 }

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -11,7 +11,7 @@ import SwiftUI
 @MainActor
 class CrashProvider: ObservableObject {
     @Published var crashes: [Crash]?
-    @Published var cursor: CKQueryOperation.Cursor?
+    @Published var cursor: RecordCursor?
 
     func fetch(in database: AppDatabase) async {
         do {
@@ -33,7 +33,7 @@ class CrashProvider: ObservableObject {
         }
     }
 
-    func fetchMore(cursor: CKQueryOperation.Cursor, in database: AppDatabase) async {
+    func fetchMore(cursor: RecordCursor, in database: AppDatabase) async {
         do {
             let results = try await database.readMore(
                 from: cursor,

--- a/Sources/Scout/UI/Database/Record/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/Record/DefaultDatabase.swift
@@ -25,7 +25,7 @@ struct DefaultDatabase: AppDatabase {
         return RecordChunk(records: records, cursor: nil)
     }
 
-    func readMore(from cursor: CKQueryOperation.Cursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+    func readMore(from cursor: RecordCursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
         RecordChunk(records: [], cursor: nil)
     }
 

--- a/Sources/Scout/UI/Event/Provider/EventProvider.swift
+++ b/Sources/Scout/UI/Event/Provider/EventProvider.swift
@@ -12,7 +12,7 @@ import SwiftUI
 @MainActor
 class EventProvider: ObservableObject {
     @Published var events: [Event]?
-    @Published var cursor: CKQueryOperation.Cursor?
+    @Published var cursor: RecordCursor?
     @Published var message: Message?
 
     func fetch(for filter: Event.Query, in database: AppDatabase) async {
@@ -32,7 +32,7 @@ class EventProvider: ObservableObject {
         }
     }
 
-    func fetchMore(cursor: CKQueryOperation.Cursor, in database: AppDatabase) async {
+    func fetchMore(cursor: RecordCursor, in database: AppDatabase) async {
         do {
             let results = try await database.readMore(
                 from: cursor,

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -9,25 +9,55 @@ import CloudKit
 import SwiftUI
 
 public struct HomeView: View {
-    let container: CKContainer
+    let database: any AppDatabase
+    let container: CKContainer?
 
     @StateObject private var tint = Tint()
 
     public init(container: CKContainer) {
+        self.database = container.publicCloudDatabase
         self.container = container
+    }
+
+    /// Reads analytics from the first backend in the list.
+    ///
+    /// CloudKit account and schema warnings only apply when that backend
+    /// is a CloudKit container.
+    ///
+    public init(backends: [Backend]) {
+        if let primary = backends.primaryDatabase {
+            self.database = primary
+        } else {
+            self.database = DefaultDatabase()
+        }
+
+        if case .cloudKit(let container) = backends.first {
+            self.container = container
+        } else {
+            self.container = nil
+        }
     }
 
     public var body: some View {
         NavigationStack {
             HomeContent()
                 .navigationTitle(en: "Home")
-                .iCloudWarning(container: container)
-                .schemaWarning(container: container)
+                .cloudKitWarnings(container: container)
                 .dismissable()
         }
         .onboardingSheet()
         .tint(tint.value)
         .environmentObject(tint)
-        .environment(\.database, container.publicCloudDatabase)
+        .environment(\.database, database)
+    }
+}
+
+extension View {
+    @ViewBuilder fileprivate func cloudKitWarnings(container: CKContainer?) -> some View {
+        if let container {
+            iCloudWarning(container: container).schemaWarning(container: container)
+        } else {
+            self
+        }
     }
 }

--- a/Sources/Scout/UI/Timeline/Pagination/RailLane.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/RailLane.swift
@@ -34,7 +34,7 @@ final class RailLane: ObservableObject {
     @Published var pendingInstalls: [UUID] = []
     @Published var isLoading = false
 
-    private var cursor: CKQueryOperation.Cursor?
+    private var cursor: RecordCursor?
 
     /// Bumped by every reset; an in-flight load compares against it after each
     /// suspension and bails out instead of mixing a stale chunk (or a wiped

--- a/Tests/ScoutTests/Core/Backend/HTTPQueryCodingTests.swift
+++ b/Tests/ScoutTests/Core/Backend/HTTPQueryCodingTests.swift
@@ -1,0 +1,115 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Testing
+
+@testable import Scout
+
+@Suite("HTTPQuery translation")
+struct HTTPQueryCodingTests {
+    @Test("Compound AND predicate becomes a flat filter list")
+    func compoundPredicate() throws {
+        let from = Date(timeIntervalSince1970: 1_700_000_000)
+        let to = Date(timeIntervalSince1970: 1_800_000_000)
+
+        let query = CKQuery(
+            recordType: "DateIntMatrix",
+            predicate: NSCompoundPredicate(
+                type: .and,
+                subpredicates: [
+                    NSPredicate(format: "date >= %@ AND date < %@", from as NSDate, to as NSDate),
+                    NSPredicate(format: "name == %@", "login"),
+                ]
+            )
+        )
+
+        let http = try HTTPQuery(query: query, fields: nil, limit: nil)
+
+        #expect(http.recordType == "DateIntMatrix")
+        #expect(
+            http.filters == [
+                HTTPFilter(field: "date", op: .greaterThanOrEquals, value: .date(from)),
+                HTTPFilter(field: "date", op: .lessThan, value: .date(to)),
+                HTTPFilter(field: "name", op: .equals, value: .string("login")),
+            ]
+        )
+    }
+
+    @Test("IN, BEGINSWITH, and inequality operators")
+    func operators() throws {
+        let query = CKQuery(
+            recordType: "Session",
+            predicate: NSCompoundPredicate(
+                type: .and,
+                subpredicates: [
+                    NSPredicate(format: "install_id IN %@", ["a", "b"]),
+                    NSPredicate(format: "name BEGINSWITH %@", "cart_"),
+                    NSPredicate(format: "param_count != %d", 3),
+                ]
+            )
+        )
+
+        let http = try HTTPQuery(query: query, fields: nil, limit: nil)
+
+        #expect(
+            http.filters == [
+                HTTPFilter(field: "install_id", op: .in, value: .strings(["a", "b"])),
+                HTTPFilter(field: "name", op: .beginsWith, value: .string("cart_")),
+                HTTPFilter(field: "param_count", op: .notEquals, value: .int(3)),
+            ]
+        )
+    }
+
+    @Test("TRUEPREDICATE maps to no filters")
+    func truePredicate() throws {
+        let query = CKQuery(recordType: "Event", predicate: NSPredicate(value: true))
+
+        let http = try HTTPQuery(query: query, fields: nil, limit: nil)
+
+        #expect(http.filters?.isEmpty == true)
+    }
+
+    @Test("Sort descriptors, fields, and limit carry over")
+    func sortAndLimit() throws {
+        let query = CKQuery(recordType: "Event", predicate: NSPredicate(value: true))
+        query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+
+        let http = try HTTPQuery(query: query, fields: ["name", "date"], limit: 25)
+
+        #expect(http.sort == [HTTPSort(field: "date", ascending: false)])
+        #expect(http.fields == ["name", "date"])
+        #expect(http.limit == 25)
+    }
+
+    @Test("The CloudKit maximum is the server default and travels as no limit")
+    func defaultLimit() throws {
+        let query = CKQuery(recordType: "Event", predicate: NSPredicate(value: true))
+
+        let http = try HTTPQuery(query: query, fields: nil, limit: CKQueryOperation.maximumResults)
+
+        #expect(http.limit == nil)
+    }
+
+    @Test("OR predicates are rejected")
+    func unsupportedPredicate() {
+        let query = CKQuery(
+            recordType: "Event",
+            predicate: NSCompoundPredicate(
+                type: .or,
+                subpredicates: [
+                    NSPredicate(format: "name == %@", "a"),
+                    NSPredicate(format: "name == %@", "b"),
+                ]
+            )
+        )
+
+        #expect(throws: UnsupportedQueryError.self) {
+            try HTTPQuery(query: query, fields: nil, limit: nil)
+        }
+    }
+}

--- a/Tests/ScoutTests/Core/Backend/HTTPRecordCodingTests.swift
+++ b/Tests/ScoutTests/Core/Backend/HTTPRecordCodingTests.swift
@@ -1,0 +1,68 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("HTTPRecord coding")
+struct HTTPRecordCodingTests {
+    @Test("CKRecord round-trips through the wire format")
+    func recordRoundTrip() throws {
+        let date = Date(timeIntervalSince1970: 1_750_000_000)
+
+        let record = CKRecord(
+            recordType: "Event",
+            recordID: CKRecord.ID(recordName: "record-1")
+        )
+        record["name"] = "login"
+        record["param_count"] = Int64(2)
+        record["value"] = 1.5
+        record["date"] = date
+        record["params"] = Data([1, 2, 3])
+
+        let wire = HTTPRecord(record: record)
+        let data = try JSONEncoder().encode(wire)
+        let restored = try JSONDecoder().decode(HTTPRecord.self, from: data).toRecord
+
+        #expect(restored.recordType == "Event")
+        #expect(restored.recordID.recordName == "record-1")
+        #expect(restored["name"] == "login")
+        #expect(restored["param_count"] == Int64(2))
+        #expect(restored["value"] == 1.5)
+        #expect(restored["date"] == date)
+        #expect(restored["params"] == Data([1, 2, 3]))
+    }
+
+    @Test("Integer and floating-point numbers keep their type")
+    func numberTypes() throws {
+        #expect(HTTPFieldValue(recordValue: Int64(7)) == .int(7))
+        #expect(HTTPFieldValue(recordValue: 7 as Int) == .int(7))
+        #expect(HTTPFieldValue(recordValue: 7.5) == .double(7.5))
+        #expect(HTTPFieldValue(recordValue: 7.0) == .double(7))
+    }
+
+    @Test("Dates survive encoding with millisecond precision")
+    func datePrecision() throws {
+        let value = HTTPFieldValue.date(Date(timeIntervalSince1970: 1_750_000_000.123))
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(HTTPFieldValue.self, from: data)
+
+        let original = try #require(value.dateValue?.timeIntervalSince1970)
+        let restored = try #require(decoded.dateValue?.timeIntervalSince1970)
+        #expect(abs(original - restored) < 0.001)
+    }
+}
+
+extension HTTPFieldValue {
+    fileprivate var dateValue: Date? {
+        if case .date(let date) = self { return date }
+        return nil
+    }
+}

--- a/Tests/ScoutTests/Core/Backend/ServerRepresentableTests.swift
+++ b/Tests/ScoutTests/Core/Backend/ServerRepresentableTests.swift
@@ -1,0 +1,87 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("ServerRepresentable")
+struct ServerRepresentableTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("CloudKit-representable types reuse their CloudKit record")
+    func reusesCloudKitRecord() throws {
+        let event = EventObject.stub(name: "login", in: context)
+        try context.save()
+
+        let record = event.toServerRecord
+
+        #expect(record.recordType == "Event")
+        #expect(record["name"] == "login")
+        #expect(record.recordID == event.toRecord.recordID)
+    }
+
+    @Test("Int metrics serialize as raw IntMetric records")
+    func intMetricRecord() throws {
+        let metric = IntMetricsObject.stub(name: "requests", telemetry: "counter", value: 5, in: context)
+        try context.save()
+
+        let record = metric.toServerRecord
+
+        #expect(record.recordType == "IntMetric")
+        #expect(record["name"] == "requests")
+        #expect(record["category"] == "counter")
+        #expect(record["value"] == 5)
+        #expect(record["week"] != nil)
+        #expect(record["install_id"] != nil)
+    }
+
+    @Test("Metric record names are stable across repeated serialization")
+    func stableMetricRecordName() throws {
+        let metric = DoubleMetricsObject.stub(name: "duration", telemetry: "timer", value: 1.5, in: context)
+        try context.save()
+
+        let record = metric.toServerRecord
+
+        #expect(record.recordType == "DoubleMetric")
+        #expect(record["value"] == 1.5)
+        #expect(record.recordID == metric.toServerRecord.recordID)
+    }
+}
+
+// MARK: - Stubs
+
+extension IntMetricsObject {
+    @discardableResult static func stub(name: String, telemetry: String, value: Int, in context: NSManagedObjectContext) -> IntMetricsObject {
+        let entity = NSEntityDescription.entity(forEntityName: "IntMetricsObject", in: context)!
+        let metric = IntMetricsObject(entity: entity, insertInto: context)
+
+        metric.name = name
+        metric.telemetry = telemetry
+        metric.value = value
+        metric.date = Date()
+
+        return metric
+    }
+}
+
+extension DoubleMetricsObject {
+    @discardableResult static func stub(name: String, telemetry: String, value: Double, in context: NSManagedObjectContext) -> DoubleMetricsObject {
+        let entity = NSEntityDescription.entity(forEntityName: "DoubleMetricsObject", in: context)!
+        let metric = DoubleMetricsObject(entity: entity, insertInto: context)
+
+        metric.name = name
+        metric.telemetry = telemetry
+        metric.value = value
+        metric.date = Date()
+
+        return metric
+    }
+}

--- a/Tests/ScoutTests/Core/Backend/SyncEngineBackendTests.swift
+++ b/Tests/ScoutTests/Core/Backend/SyncEngineBackendTests.swift
@@ -1,0 +1,104 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("SyncEngine with multiple backends")
+struct SyncEngineBackendTests {
+    let cloud = InMemoryDatabase()
+    let server = InMemoryDatabase()
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    var backends: [ResolvedBackend] {
+        [
+            ResolvedBackend(
+                database: cloud,
+                needsClientAggregation: true,
+                acceptsRawMetrics: false,
+                checkAvailability: {}
+            ),
+            ResolvedBackend(
+                database: server,
+                needsClientAggregation: false,
+                acceptsRawMetrics: true,
+                checkAvailability: {}
+            ),
+        ]
+    }
+
+    @Test("Events go raw to every backend, matrices only to CloudKit")
+    func eventsFanOut() async throws {
+        EventObject.stub(name: "login", in: context)
+        try context.save()
+
+        let engine = SyncEngine(backends: backends, context: context)
+        try await engine.send(type: EventObject.self)
+
+        #expect(cloud.records.filter { $0.recordType == "Event" }.count == 1)
+        #expect(server.records.filter { $0.recordType == "Event" }.count == 1)
+        #expect(cloud.records.filter { $0.recordType == Int.recordType }.count == 1)
+        #expect(server.records.filter { $0.recordType == Int.recordType }.count == 0)
+    }
+
+    @Test("Metrics go raw to servers and as matrices to CloudKit")
+    func metricsSplit() async throws {
+        IntMetricsObject.stub(name: "requests", telemetry: "counter", value: 5, in: context)
+        try context.save()
+
+        let engine = SyncEngine(backends: backends, context: context)
+        try await engine.send(type: IntMetricsObject.self)
+
+        #expect(server.records.filter { $0.recordType == "IntMetric" }.count == 1)
+        #expect(cloud.records.filter { $0.recordType == "IntMetric" }.count == 0)
+        #expect(cloud.records.filter { $0.recordType == Int.recordType }.count == 1)
+        #expect(server.records.filter { $0.recordType == Int.recordType }.count == 0)
+    }
+
+    @Test("A server-only setup skips the matrix stage entirely")
+    func serverOnly() async throws {
+        let event = EventObject.stub(name: "login", in: context)
+        try context.save()
+
+        let engine = SyncEngine(
+            backends: [
+                ResolvedBackend(
+                    database: server,
+                    needsClientAggregation: false,
+                    acceptsRawMetrics: true,
+                    checkAvailability: {}
+                )
+            ],
+            context: context
+        )
+        try await engine.send(type: EventObject.self)
+
+        #expect(event.syncState == .synced)
+        #expect(server.records.filter { $0.recordType == "Event" }.count == 1)
+        #expect(server.records.filter { $0.recordType == Int.recordType }.isEmpty)
+    }
+
+    @Test("A failing backend keeps the batch pending for every backend")
+    func failureKeepsBatchPending() async throws {
+        let event = EventObject.stub(name: "login", in: context)
+        try context.save()
+
+        server.writeErrors.append(CKError(.networkFailure))
+
+        let engine = SyncEngine(backends: backends, context: context)
+
+        await #expect(throws: (any Error).self) {
+            try await engine.send(type: EventObject.self)
+        }
+
+        #expect(event.syncState == .pending)
+    }
+}

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -64,7 +64,7 @@ final class DatabaseStub: AppDatabase, @unchecked Sendable {
         return RecordChunk(records: Array(records.prefix(limit)), cursor: nil)
     }
 
-    func readMore(from cursor: CKQueryOperation.Cursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+    func readMore(from cursor: RecordCursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
         RecordChunk(records: [], cursor: nil)
     }
 }

--- a/Tests/ScoutTests/Transient/InMemoryDatabase.swift
+++ b/Tests/ScoutTests/Transient/InMemoryDatabase.swift
@@ -9,10 +9,17 @@ import CloudKit
 
 @testable import Scout
 
-final class InMemoryDatabase: Database, @unchecked Sendable {
+final class InMemoryDatabase: BackendDatabase, @unchecked Sendable {
     var records: [CKRecord] = []
     var errors: [Error] = []
     var writeErrors: [Error] = []
+
+    func lookup(id: CKRecord.ID, fields: [CKRecord.FieldKey]?) async throws -> CKRecord {
+        guard let record = records.first(where: { $0.recordID == id }) else {
+            throw CKError(.unknownItem)
+        }
+        return record
+    }
 
     func write(record: CKRecord) async throws {
         if let error = writeErrors.popLast() ?? errors.popLast() {
@@ -42,7 +49,7 @@ final class InMemoryDatabase: Database, @unchecked Sendable {
         )
     }
 
-    func readMore(from cursor: CKQueryOperation.Cursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+    func readMore(from cursor: RecordCursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
         if let error = errors.popLast() {
             throw error
         }


### PR DESCRIPTION
Scout can now sync analytics to CloudKit, to one or more self-hosted [Scout servers](https://github.com/kasianov-mikhail/scout-server), or to any combination of them at once. A new public `Backend` enum describes a destination, `setup(backends:)` bootstraps the pipeline against the whole list, and `HomeView(backends:)` points the dashboard at the first backend; the existing `setup(container:)` and `HomeView(container:)` entry points are unchanged.

Under the hood, `SyncEngine` fans raw record uploads out to every backend, while the client-side matrix aggregation step now runs only for backends that need it — Scout servers aggregate natively, so they instead receive raw metric values through a new `ServerRepresentable` representation (`IntMetric`/`DoubleMetric` records, which CloudKit never sees). `HTTPDatabase` implements the existing `RecordWriter`/`RecordReader`/`RecordLookup` surface over the server's JSON API, translating `CKQuery` predicates into the server's filter language, and pagination cursors are wrapped in a backend-agnostic `RecordCursor` so reads work identically against either backend.

New unit tests cover the query and record wire coding, the server representations, and the multi-backend sync flows.