### PR TITLE
Make the filter sheet opaque and use symbols for its toolbar buttons

### DIFF
--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -40,7 +40,7 @@ struct FilterView: View {
                     Button {
                         criteria.reset()
                     } label: {
-                        Text(verbatim: "Reset")
+                        Image(systemName: "arrow.counterclockwise")
                     }
                     .disabled(!criteria.isResetEnabled)
                 }
@@ -49,7 +49,7 @@ struct FilterView: View {
                         criteria.apply()
                         dismiss()
                     } label: {
-                        Text(verbatim: "Apply")
+                        Image(systemName: "checkmark")
                     }
                     .disabled(!criteria.isApplyEnabled)
                     .fontWeight(.semibold)
@@ -76,7 +76,9 @@ struct FilterButton: View {
             Text(verbatim: "Filter")
         }
         .sheet(isPresented: $isFilterPresented) {
-            FilterView(selected: $levels).presentationHeight(440)
+            FilterView(selected: $levels)
+                .presentationHeight(440)
+                .opaquePresentationBackground()
         }
         .tint(.primary)
     }

--- a/Sources/Scout/UI/Primitives/Modifiers/View+OpaquePresentationBackground.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/View+OpaquePresentationBackground.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+extension View {
+    /// Gives a sheet an opaque system background, overriding the translucent
+    /// material newer OS versions apply by default.
+    ///
+    @ViewBuilder
+    func opaquePresentationBackground() -> some View {
+        if #available(iOS 16.4, macOS 13.3, *) {
+            presentationBackground(.background)
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
The events filter sheet rendered with the translucent glass background that newer OS versions apply to sheets by default, letting the list behind it show through. A new `opaquePresentationBackground()` modifier now gives the sheet an opaque system background, guarded by an availability check since `presentationBackground` arrived after the package's platform minimums. The sheet's toolbar buttons also swap their `Reset` and `Apply` texts for the `arrow.counterclockwise` and `checkmark` symbols.