### PR TITLE
Add a Server workflow with contract tests against scout-server

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -3,10 +3,9 @@ name: Server
 # Contract tests against a live scout-server. The HTTP wire format
 # (HTTPQueryCoding/HTTPRecordCoding) is shared with that repository, and unit
 # tests can only verify Scout's side of it, so this workflow boots the server
-# and runs ServerContractTests through HTTPDatabase. It runs when the backend
-# code changes here and when scout-server pushes to main (repository_dispatch
-# sent by its Notify workflow). While scout-server has no implementation yet
-# (no Package.swift), the contract run is skipped.
+# on top of PostgreSQL and runs ServerContractTests through HTTPDatabase.
+# It runs when the backend code changes here and when scout-server pushes to
+# main (repository_dispatch sent by its Notify workflow).
 on:
   pull_request:
     paths:
@@ -37,26 +36,29 @@ jobs:
           repository: kasianov-mikhail/scout-server
           path: scout-server
 
-      - name: Probe server implementation
-        id: probe
+      # The server's default Fluent config: user scout, password scout,
+      # database scout on localhost:5432.
+      - name: Start PostgreSQL
         run: |
-          if [ -f scout-server/Package.swift ]; then
-            echo "runnable=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "scout-server has no Package.swift yet, skipping the contract run."
-            echo "runnable=false" >> "$GITHUB_OUTPUT"
-          fi
+          brew install postgresql@17
+          pgbin="$(brew --prefix postgresql@17)/bin"
+          brew services start postgresql@17
+          for _ in $(seq 1 30); do
+            if "$pgbin/pg_isready" -q -h 127.0.0.1; then
+              break
+            fi
+            sleep 1
+          done
+          "$pgbin/psql" -h 127.0.0.1 -d postgres -c "CREATE ROLE scout LOGIN PASSWORD 'scout'"
+          "$pgbin/createdb" -h 127.0.0.1 -O scout scout
 
-      # The contract this step encodes: `swift run` in a scout-server checkout
-      # must boot a server listening on 127.0.0.1:8080 with default config.
       - name: Start scout-server
-        if: steps.probe.outputs.runnable == 'true'
         working-directory: scout-server
         run: |
           swift build
           nohup swift run --skip-build > server.log 2>&1 &
           for _ in $(seq 1 60); do
-            if curl -s -o /dev/null http://127.0.0.1:8080; then
+            if curl -fs -o /dev/null http://127.0.0.1:8080/healthz; then
               exit 0
             fi
             sleep 1
@@ -64,24 +66,18 @@ jobs:
           echo "scout-server did not come up on port 8080"
           exit 1
 
-      - name: Prepare simulator
-        if: steps.probe.outputs.runnable == 'true'
-        run: |
-          if ! xcrun simctl list devices available | grep -q "iPhone"; then
-            xcodebuild -downloadPlatform iOS
-          fi
-
+      # The contract is platform-independent, so the tests run on the macOS
+      # destination — no simulator needed.
       - name: Run contract tests
-        if: steps.probe.outputs.runnable == 'true'
         env:
           TEST_RUNNER_SCOUT_SERVER_URL: http://127.0.0.1:8080
         run: |
           xcodebuild \
             -scheme Scout \
-            -destination 'platform=iOS Simulator,name=iPhone 17' \
+            -destination 'platform=macOS' \
             -only-testing:ScoutTests/ServerContractTests \
             test
 
       - name: Dump server log
-        if: failure() && steps.probe.outputs.runnable == 'true'
+        if: failure()
         run: cat scout-server/server.log

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,0 +1,87 @@
+name: Server
+
+# Contract tests against a live scout-server. The HTTP wire format
+# (HTTPQueryCoding/HTTPRecordCoding) is shared with that repository, and unit
+# tests can only verify Scout's side of it, so this workflow boots the server
+# and runs ServerContractTests through HTTPDatabase. It runs when the backend
+# code changes here and when scout-server pushes to main (repository_dispatch
+# sent by its Notify workflow). While scout-server has no implementation yet
+# (no Package.swift), the contract run is skipped.
+on:
+  pull_request:
+    paths:
+      - "Sources/Scout/Core/Backend/**"
+      - "Tests/ScoutTests/Core/Backend/**"
+      - ".github/workflows/server.yml"
+  repository_dispatch:
+    types: [scout-server-updated]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: server-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  contract:
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v6
+        with:
+          repository: kasianov-mikhail/scout-server
+          path: scout-server
+
+      - name: Probe server implementation
+        id: probe
+        run: |
+          if [ -f scout-server/Package.swift ]; then
+            echo "runnable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "scout-server has no Package.swift yet, skipping the contract run."
+            echo "runnable=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The contract this step encodes: `swift run` in a scout-server checkout
+      # must boot a server listening on 127.0.0.1:8080 with default config.
+      - name: Start scout-server
+        if: steps.probe.outputs.runnable == 'true'
+        working-directory: scout-server
+        run: |
+          swift build
+          nohup swift run --skip-build > server.log 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -s -o /dev/null http://127.0.0.1:8080; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "scout-server did not come up on port 8080"
+          exit 1
+
+      - name: Prepare simulator
+        if: steps.probe.outputs.runnable == 'true'
+        run: |
+          if ! xcrun simctl list devices available | grep -q "iPhone"; then
+            xcodebuild -downloadPlatform iOS
+          fi
+
+      - name: Run contract tests
+        if: steps.probe.outputs.runnable == 'true'
+        env:
+          TEST_RUNNER_SCOUT_SERVER_URL: http://127.0.0.1:8080
+        run: |
+          xcodebuild \
+            -scheme Scout \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
+            -only-testing:ScoutTests/ServerContractTests \
+            test
+
+      - name: Dump server log
+        if: failure() && steps.probe.outputs.runnable == 'true'
+        run: cat scout-server/server.log

--- a/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
+++ b/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
@@ -1,0 +1,106 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Scout
+
+/// The live server under test, supplied by the Server workflow.
+private let serverURL = ProcessInfo.processInfo.environment["SCOUT_SERVER_URL"].flatMap(URL.init(string:))
+
+/// A fixed timestamp all contract records carry, so date equality is
+/// asserted against a known constant rather than a record round trip.
+private let eventDate = Date(timeIntervalSince1970: 1_750_000_000)
+
+/// End-to-end checks against a live Scout server.
+///
+/// The HTTP wire format (`HTTPQueryCoding`/`HTTPRecordCoding`) is a contract
+/// shared with the `scout-server` repository, and unit tests can only verify
+/// Scout's side of it. These tests exercise `HTTPDatabase` against a running
+/// server instead: they are skipped unless `SCOUT_SERVER_URL` points at one,
+/// which the Server workflow arranges in CI.
+///
+@Suite("Scout server contract", .enabled(if: serverURL != nil))
+struct ServerContractTests {
+    @Test("A written record can be looked up by name")
+    func writeAndLookup() async throws {
+        let database = try makeDatabase()
+        let record = makeEvent(name: "login", index: 1)
+
+        try await database.write(record: record)
+        let restored = try await database.lookup(id: record.recordID, fields: nil)
+
+        #expect(restored.recordType == "Event")
+        #expect(restored.recordID.recordName == record.recordID.recordName)
+        #expect(restored["name"] == "login")
+        #expect(restored["index"] == Int64(1))
+        #expect(restored["date"] == eventDate)
+    }
+
+    @Test("Lookup honors the requested field list")
+    func lookupProjection() async throws {
+        let database = try makeDatabase()
+        let record = makeEvent(name: "login", index: 1)
+
+        try await database.write(record: record)
+        let restored = try await database.lookup(id: record.recordID, fields: ["name"])
+
+        #expect(restored["name"] == "login")
+        #expect(restored["index"] == nil)
+    }
+
+    @Test("Queries filter and sort on the server")
+    func queryFilterAndSort() async throws {
+        let database = try makeDatabase()
+        let marker = UUID().uuidString
+        try await database.write(records: (0..<3).reversed().map { makeEvent(name: marker, index: $0) })
+
+        let chunk = try await database.read(matching: makeQuery(marker: marker), fields: nil)
+
+        #expect(chunk.records.compactMap { $0["index"] as? Int64 } == [0, 1, 2])
+        #expect(chunk.cursor == nil)
+    }
+
+    @Test("Cursors page through a result set larger than the limit")
+    func pagination() async throws {
+        let database = try makeDatabase()
+        let marker = UUID().uuidString
+        try await database.write(records: (0..<5).map { makeEvent(name: marker, index: $0) })
+
+        var chunk = try await database.read(matching: makeQuery(marker: marker), fields: nil, limit: 2)
+        var indices = chunk.records.compactMap { $0["index"] as? Int64 }
+        #expect(indices.count == 2)
+
+        while let cursor = chunk.cursor {
+            chunk = try await database.readMore(from: cursor, fields: nil)
+            indices += chunk.records.compactMap { $0["index"] as? Int64 }
+        }
+
+        #expect(indices == [0, 1, 2, 3, 4])
+    }
+
+    private func makeDatabase() throws -> HTTPDatabase {
+        let url = try #require(serverURL)
+        return HTTPDatabase(url: url, apiKey: ProcessInfo.processInfo.environment["SCOUT_SERVER_API_KEY"])
+    }
+
+    private func makeQuery(marker: String) -> CKQuery {
+        let query = CKQuery(recordType: "Event", predicate: NSPredicate(format: "name == %@", marker))
+        query.sortDescriptors = [NSSortDescriptor(key: "index", ascending: true)]
+        return query
+    }
+
+    private func makeEvent(name: String, index: Int) -> CKRecord {
+        let record = CKRecord(recordType: "Event", recordID: CKRecord.ID(recordName: "contract-\(UUID().uuidString)"))
+        record["name"] = name
+        record["index"] = Int64(index)
+        record["date"] = eventDate
+        return record
+    }
+}

--- a/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
+++ b/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
@@ -39,7 +39,7 @@ struct ServerContractTests {
         #expect(restored.recordType == "Event")
         #expect(restored.recordID.recordName == record.recordID.recordName)
         #expect(restored["name"] == "login")
-        #expect(restored["index"] == Int64(1))
+        #expect(restored["param_count"] == Int64(1))
         #expect(restored["date"] == eventDate)
     }
 
@@ -52,7 +52,7 @@ struct ServerContractTests {
         let restored = try await database.lookup(id: record.recordID, fields: ["name"])
 
         #expect(restored["name"] == "login")
-        #expect(restored["index"] == nil)
+        #expect(restored["param_count"] == nil)
     }
 
     @Test("Queries filter and sort on the server")
@@ -63,7 +63,7 @@ struct ServerContractTests {
 
         let chunk = try await database.read(matching: makeQuery(marker: marker), fields: nil)
 
-        #expect(chunk.records.compactMap { $0["index"] as? Int64 } == [0, 1, 2])
+        #expect(chunk.records.compactMap { $0["param_count"] as? Int64 } == [0, 1, 2])
         #expect(chunk.cursor == nil)
     }
 
@@ -74,12 +74,12 @@ struct ServerContractTests {
         try await database.write(records: (0..<5).map { makeEvent(name: marker, index: $0) })
 
         var chunk = try await database.read(matching: makeQuery(marker: marker), fields: nil, limit: 2)
-        var indices = chunk.records.compactMap { $0["index"] as? Int64 }
+        var indices = chunk.records.compactMap { $0["param_count"] as? Int64 }
         #expect(indices.count == 2)
 
         while let cursor = chunk.cursor {
             chunk = try await database.readMore(from: cursor, fields: nil)
-            indices += chunk.records.compactMap { $0["index"] as? Int64 }
+            indices += chunk.records.compactMap { $0["param_count"] as? Int64 }
         }
 
         #expect(indices == [0, 1, 2, 3, 4])
@@ -92,14 +92,14 @@ struct ServerContractTests {
 
     private func makeQuery(marker: String) -> CKQuery {
         let query = CKQuery(recordType: "Event", predicate: NSPredicate(format: "name == %@", marker))
-        query.sortDescriptors = [NSSortDescriptor(key: "index", ascending: true)]
+        query.sortDescriptors = [NSSortDescriptor(key: "param_count", ascending: true)]
         return query
     }
 
     private func makeEvent(name: String, index: Int) -> CKRecord {
         let record = CKRecord(recordType: "Event", recordID: CKRecord.ID(recordName: "contract-\(UUID().uuidString)"))
         record["name"] = name
-        record["index"] = Int64(index)
+        record["param_count"] = Int64(index)
         record["date"] = eventDate
         return record
     }


### PR DESCRIPTION
The HTTP wire format introduced in #569 is a contract shared with the [scout-server](https://github.com/kasianov-mikhail/scout-server) repository, and the existing unit tests can only verify Scout's side of it. This adds `ServerContractTests`, an end-to-end suite that exercises `HTTPDatabase` (writes, lookups with field projection, filtered and sorted queries, cursor pagination) against a live server, skipped unless `SCOUT_SERVER_URL` is set. A new Server workflow checks out scout-server, boots it on top of PostgreSQL, and runs the suite whenever the backend code changes here, and also on a `scout-server-updated` repository dispatch so server-side changes re-validate the contract.