### PR TITLE
Warn when a Scout server API key would be sent over cleartext HTTP

### DIFF
--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -53,6 +53,8 @@ public func setup(backends: [Backend]) async throws {
         throw NoBackendsError()
     }
 
+    warnAboutCleartextKeys(in: backends)
+
     installExceptionHandler()
     installSignalHandler()
 
@@ -84,5 +86,15 @@ public func setup(backends: [Backend]) async throws {
 
     for case .cloudKit(let container) in backends {
         verifyParallelismIfDue(container: container)
+    }
+}
+
+/// Warns when an API key would be sent to a Scout server over a connection
+/// that isn't HTTPS, where the key — and every uploaded analytics record —
+/// would travel in cleartext and be readable by any network observer.
+///
+private func warnAboutCleartextKeys(in backends: [Backend]) {
+    for case .server(let url, _?) in backends where url.scheme?.lowercased() != "https" {
+        print("[Scout] The API key for '\(url)' will be sent over a non-HTTPS connection in cleartext. Use an https:// URL.")
     }
 }


### PR DESCRIPTION
A security review of the branch flagged that `setup(backends:)` accepted a `Backend.server` configured with any URL scheme, so a developer who pointed Scout at an `http://` endpoint (or a schemeless URL) would have the `X-API-Key` secret and every uploaded analytics record travel over the network in cleartext, readable by any observer. The SDK gave no signal that this was happening.

This adds a one-time `warnAboutCleartextKeys` check at the single `setup(backends:)` entry point that prints a `[Scout]` warning when an API key would be sent to a non-HTTPS server. It follows the package's existing developer-warning convention used for CloudKit schema problems, logs only the URL (never the key itself), and does not change behavior: the upload still proceeds, but the misconfiguration is now surfaced.
