### PR TITLE
Harden the Server contract workflow and widen its coverage

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -6,10 +6,22 @@ name: Server
 # on top of PostgreSQL and runs ServerContractTests through HTTPDatabase.
 # It runs when the backend code changes here and when scout-server pushes to
 # main (repository_dispatch sent by its Notify workflow).
+# The backend code under contract reaches beyond Core/Backend: HTTPDatabase is
+# built on the RecordReader/RecordWriter/RecordChunk/RecordCursor types in
+# Core/Database/Record, whose pagination and cursor semantics travel over the
+# wire, so changes there must re-run the contract too.
 on:
+  push:
+    branches: [main]
+    paths:
+      - "Sources/Scout/Core/Backend/**"
+      - "Sources/Scout/Core/Database/Record/**"
+      - "Tests/ScoutTests/Core/Backend/**"
+      - ".github/workflows/server.yml"
   pull_request:
     paths:
       - "Sources/Scout/Core/Backend/**"
+      - "Sources/Scout/Core/Database/Record/**"
       - "Tests/ScoutTests/Core/Backend/**"
       - ".github/workflows/server.yml"
   repository_dispatch:
@@ -49,6 +61,10 @@ jobs:
             fi
             sleep 1
           done
+          if ! "$pgbin/pg_isready" -q -h 127.0.0.1; then
+            echo "PostgreSQL did not become ready on 127.0.0.1:5432"
+            exit 1
+          fi
           "$pgbin/psql" -h 127.0.0.1 -d postgres -c "CREATE ROLE scout LOGIN PASSWORD 'scout'"
           "$pgbin/createdb" -h 127.0.0.1 -O scout scout
 
@@ -67,7 +83,12 @@ jobs:
           exit 1
 
       # The contract is platform-independent, so the tests run on the macOS
-      # destination — no simulator needed.
+      # destination — no simulator needed. xcodebuild forwards only variables
+      # with the TEST_RUNNER_ prefix into the test process (which reads them
+      # without it), so an API key would have to be set as
+      # TEST_RUNNER_SCOUT_SERVER_API_KEY — a bare SCOUT_SERVER_API_KEY never
+      # arrives. The default server accepts unauthenticated requests, so none
+      # is set today.
       - name: Run contract tests
         env:
           TEST_RUNNER_SCOUT_SERVER_URL: http://127.0.0.1:8080
@@ -76,7 +97,31 @@ jobs:
             -scheme Scout \
             -destination 'platform=macOS' \
             -only-testing:ScoutTests/ServerContractTests \
+            -resultBundlePath TestResults.xcresult \
             test
+
+      # The suite is skipped unless SCOUT_SERVER_URL reaches the test process,
+      # so a broken env hand-off (or an -only-testing identifier that matches
+      # nothing) would skip every test while xcodebuild still exits 0. Fail
+      # loudly when nothing actually ran rather than report a green that tested
+      # nothing.
+      - name: Verify the contract suite ran
+        run: |
+          summary="$(xcrun xcresulttool get test-results summary \
+            --path TestResults.xcresult --compact)"
+          # `0 passed` is a real count (jq's // keeps it); only a missing field
+          # yields empty, in which case the schema changed — warn, don't block.
+          passed="$(echo "$summary" | jq '.passedTests // empty')"
+          if [ -z "$passed" ]; then
+            echo "::warning::Could not read passedTests from the result bundle; skipping the ran-something check."
+            echo "$summary" | head -c 2000
+            exit 0
+          fi
+          echo "Contract tests passed: $passed"
+          if [ "$passed" -lt 1 ]; then
+            echo "::error::No contract tests executed — the suite skipped (SCOUT_SERVER_URL likely never reached the test process) or matched nothing."
+            exit 1
+          fi
 
       - name: Dump server log
         if: failure()

--- a/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
+++ b/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
@@ -18,6 +18,10 @@ private let serverURL = ProcessInfo.processInfo.environment["SCOUT_SERVER_URL"].
 /// asserted against a known constant rather than a record round trip.
 private let eventDate = Date(timeIntervalSince1970: 1_750_000_000)
 
+/// Fixed `params` bytes every contract record carries, so the `bytes` wire
+/// coding (base64) is exercised end to end and not just in unit tests.
+private let eventParams = Data([0x00, 0x01, 0xFE, 0xFF])
+
 /// End-to-end checks against a live Scout server.
 ///
 /// The HTTP wire format (`HTTPQueryCoding`/`HTTPRecordCoding`) is a contract
@@ -41,6 +45,7 @@ struct ServerContractTests {
         #expect(restored["name"] == "login")
         #expect(restored["param_count"] == Int64(1))
         #expect(restored["date"] == eventDate)
+        #expect(restored["params"] == eventParams)
     }
 
     @Test("Lookup honors the requested field list")
@@ -63,7 +68,7 @@ struct ServerContractTests {
 
         let chunk = try await database.read(matching: makeQuery(marker: marker), fields: nil)
 
-        #expect(chunk.records.compactMap { $0["param_count"] as? Int64 } == [0, 1, 2])
+        #expect(paramCounts(in: chunk.records) == [0, 1, 2])
         #expect(chunk.cursor == nil)
     }
 
@@ -74,14 +79,18 @@ struct ServerContractTests {
         try await database.write(records: (0..<5).map { makeEvent(name: marker, index: $0) })
 
         var chunk = try await database.read(matching: makeQuery(marker: marker), fields: nil, limit: 2)
-        var indices = chunk.records.compactMap { $0["param_count"] as? Int64 }
+        var indices = paramCounts(in: chunk.records)
         #expect(indices.count == 2)
 
-        while let cursor = chunk.cursor {
+        // Bounded so a server that never stops handing back a cursor fails the
+        // assertion below rather than looping until the job's CI timeout.
+        for _ in 0..<10 {
+            guard let cursor = chunk.cursor else { break }
             chunk = try await database.readMore(from: cursor, fields: nil)
-            indices += chunk.records.compactMap { $0["param_count"] as? Int64 }
+            indices += paramCounts(in: chunk.records)
         }
 
+        #expect(chunk.cursor == nil)
         #expect(indices == [0, 1, 2, 3, 4])
     }
 
@@ -101,6 +110,11 @@ struct ServerContractTests {
         record["name"] = name
         record["param_count"] = Int64(index)
         record["date"] = eventDate
+        record["params"] = eventParams
         return record
+    }
+
+    private func paramCounts(in records: [CKRecord]) -> [Int64] {
+        records.compactMap { $0["param_count"] as? Int64 }
     }
 }


### PR DESCRIPTION
The `Server` workflow added in #571 could report a green run without testing anything: the contract suite is skipped unless `SCOUT_SERVER_URL` reaches the test process, so a broken environment hand-off — or an `-only-testing` identifier that matches nothing — would skip every test while `xcodebuild` still exits zero. The workflow now captures a result bundle and fails when no test actually ran, falling back to a warning only if the result-bundle schema turns out to be unreadable so it never blocks CI spuriously.

Alongside that it gains a `push` trigger on `main` so the merged state is contract-checked rather than only PR heads, widens its path filter to `Core/Database/Record` where the `RecordChunk` and `RecordCursor` pagination types that travel over the wire live, fails fast with a clear message when PostgreSQL never becomes ready instead of dying later on an opaque `psql` error, and documents that an API key must be passed as `TEST_RUNNER_SCOUT_SERVER_API_KEY` because `xcodebuild` forwards only prefixed variables into the test process.

`ServerContractTests` now writes a `params` bytes field and asserts it round trips, exercising the `bytes` wire coding that previously only unit tests covered even though real `Event` records carry `params` as bytes. The pagination loop is bounded so a server that never stops handing back a cursor fails an assertion rather than hanging until the job timeout, and the thrice-repeated `param_count` extraction is folded into a `paramCounts(in:)` helper.