### PR TITLE
Drop the "Last" prefix from time range titles

### DIFF
--- a/Sources/Scout/UI/Chart/Picker/Period.swift
+++ b/Sources/Scout/UI/Chart/Picker/Period.swift
@@ -27,11 +27,11 @@ extension Period {
         case .yesterday:
             "Yesterday"
         case .week:
-            "Last 7 days"
+            "7 days"
         case .month:
-            "Last 30 days"
+            "30 days"
         case .year:
-            "Last 365 days"
+            "365 days"
         }
     }
 }


### PR DESCRIPTION
Simplifies the period picker labels by dropping the "Last " prefix, so the relative time ranges now read as `7 days`, `30 days`, and `365 days` instead of `Last 7 days` and so on. This keeps the titles shorter and more consistent with the `Today` and `Yesterday` entries alongside them.