### PR TITLE
Read DAU/WAU/MAU from the native server endpoint

### DIFF
--- a/Sources/Scout/Core/Backend/ActiveUsersReading.swift
+++ b/Sources/Scout/Core/Backend/ActiveUsersReading.swift
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+/// A backend that answers DAU/WAU/MAU natively.
+///
+/// CloudKit cannot aggregate, so the client reconstructs active users from the
+/// hand-maintained `ActiveUser` `PeriodMatrix`. A Scout server aggregates over
+/// raw `Session` records and serves the finished series, sparing the client
+/// that bookkeeping.
+///
+protocol ActiveUsersReading {
+    func activeUsers(in range: Range<Date>) async throws -> [ActiveUserPoint]
+}
+
+/// The server's native active-user series — the response of
+/// `GET /api/v1/metrics/active-users`.
+///
+struct ActiveUsersResponse: Decodable {
+    let series: [ActiveUserPoint]
+}
+
+/// One day of the series: distinct active installs as of `date`, counted over
+/// the trailing day (`dau`), 7 days (`wau`), and calendar month (`mau`).
+///
+/// `date` is milliseconds since the Unix epoch at UTC midnight, matching the
+/// rest of the wire format.
+///
+struct ActiveUserPoint: Decodable, Equatable {
+    let date: Int64
+    let dau: Int
+    let wau: Int
+    let mau: Int
+}

--- a/Sources/Scout/Core/Backend/HTTPDatabase.swift
+++ b/Sources/Scout/Core/Backend/HTTPDatabase.swift
@@ -101,6 +101,29 @@ extension HTTPDatabase: RecordLookup {
     }
 }
 
+// MARK: - Metrics
+
+extension HTTPDatabase: ActiveUsersReading {
+    /// Fetches the server's native DAU/WAU/MAU series over `range`.
+    ///
+    /// The server aggregates from raw `Session` records, so the client reads a
+    /// finished series instead of rebuilding it from `PeriodMatrix` cells.
+    ///
+    func activeUsers(in range: Range<Date>) async throws -> [ActiveUserPoint] {
+        let from = Int64((range.lowerBound.timeIntervalSince1970 * 1000).rounded())
+        let to = Int64((range.upperBound.timeIntervalSince1970 * 1000).rounded())
+
+        guard let endpoint = URL(string: "api/v1/metrics/active-users?from=\(from)&to=\(to)", relativeTo: url) else {
+            throw HTTPDatabaseError(status: 0, reason: "Malformed metrics URL")
+        }
+
+        let (data, response) = try await session.data(for: request(for: endpoint, method: "GET"))
+        try check(response, data: data)
+
+        return try JSONDecoder().decode(ActiveUsersResponse.self, from: data).series
+    }
+}
+
 // MARK: - Transport
 
 /// A non-2xx response from a Scout server.

--- a/Sources/Scout/UI/Activity/ActivityMatrix+Series.swift
+++ b/Sources/Scout/UI/Activity/ActivityMatrix+Series.swift
@@ -1,0 +1,51 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension Matrix where T == PeriodCell<Int> {
+    /// Rebuilds the monthly activity matrices the chart consumes from a Scout
+    /// server's flat DAU/WAU/MAU series.
+    ///
+    /// Each day contributes one cell per period to its month's matrix, matching
+    /// the `PeriodMatrix` shape a CloudKit client would have produced — the
+    /// matrix base date is the month start and a cell's `day` is its 0-based
+    /// day-of-month offset. Zero-activity days are dropped, since they never
+    /// surface as cells.
+    ///
+    static func from(series: [ActiveUserPoint]) -> [ActivityMatrix] {
+        let calendar = Calendar.utc
+        var byMonth: [Date: [PeriodCell<Int>]] = [:]
+
+        for point in series {
+            let day = Date(timeIntervalSince1970: Double(point.date) / 1000)
+            let month = day.startOfMonth
+            let index = calendar.dateComponents([.day], from: month, to: day).day ?? 0
+
+            for (period, value) in [
+                (ActivityPeriod.daily, point.dau),
+                (ActivityPeriod.weekly, point.wau),
+                (ActivityPeriod.monthly, point.mau),
+            ] where value > 0 {
+                byMonth[month, default: []].append(
+                    PeriodCell(period: period, day: index, value: value)
+                )
+            }
+        }
+
+        return byMonth.map { month, cells in
+            ActivityMatrix(
+                recordType: PeriodCell<Int>.recordType,
+                date: month,
+                name: "ActiveUser",
+                category: nil,
+                record: nil,
+                cells: cells
+            )
+        }
+    }
+}

--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -24,4 +24,18 @@ class ActivityProvider: QueryProvider<ActivityMatrix> {
             )
         }
     }
+
+    /// A Scout server aggregates DAU/WAU/MAU natively, so read its flat series
+    /// and rebuild the chart's matrices from it.
+    ///
+    /// CloudKit backends still answer the `PeriodMatrix` query the initializer
+    /// builds.
+    ///
+    override func fetch(in database: AppDatabase) async throws -> [ActivityMatrix] {
+        guard let server = database as? ActiveUsersReading else {
+            return try await super.fetch(in: database)
+        }
+        let series = try await server.activeUsers(in: Calendar.utc.defaultRange)
+        return ActivityMatrix.from(series: series)
+    }
 }

--- a/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
+++ b/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
@@ -94,6 +94,24 @@ struct ServerContractTests {
         #expect(indices == [0, 1, 2, 3, 4])
     }
 
+    @Test("The active-user series counts a written Session")
+    func activeUserSeries() async throws {
+        let database = try makeDatabase()
+        let install = UUID().uuidString
+        let day = eventDate.startOfDay
+
+        try await database.write(record: makeSession(installID: install, startDate: day.addingTimeInterval(3600)))
+
+        let series = try await database.activeUsers(in: day..<day.addingDay())
+        let point = try #require(series.first { $0.date == Int64((day.timeIntervalSince1970 * 1000).rounded()) })
+
+        // The server forward-marks the install as active that day across all
+        // three windows; shared data may push the counts higher.
+        #expect(point.dau >= 1)
+        #expect(point.wau >= 1)
+        #expect(point.mau >= 1)
+    }
+
     private func makeDatabase() throws -> HTTPDatabase {
         let url = try #require(serverURL)
         return HTTPDatabase(url: url, apiKey: ProcessInfo.processInfo.environment["SCOUT_SERVER_API_KEY"])
@@ -111,6 +129,14 @@ struct ServerContractTests {
         record["param_count"] = Int64(index)
         record["date"] = eventDate
         record["params"] = eventParams
+        return record
+    }
+
+    private func makeSession(installID: String, startDate: Date) -> CKRecord {
+        let record = CKRecord(recordType: "Session", recordID: CKRecord.ID(recordName: "contract-\(UUID().uuidString)"))
+        record["session_id"] = UUID().uuidString
+        record["install_id"] = installID
+        record["start_date"] = startDate
         return record
     }
 

--- a/Tests/ScoutTests/UI/Activity/ActivityProviderTests.swift
+++ b/Tests/ScoutTests/UI/Activity/ActivityProviderTests.swift
@@ -1,0 +1,92 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+struct ActivityProviderTests {
+    @Test("Reads the native series from a Scout server and rebuilds matrices")
+    func fetchUsesServerSeries() async throws {
+        let database = ServerStub(series: [
+            ActiveUserPoint(date: ms(2026, 6, 10), dau: 2, wau: 2, mau: 2),
+            ActiveUserPoint(date: ms(2026, 6, 11), dau: 1, wau: 3, mau: 2),
+            ActiveUserPoint(date: ms(2026, 7, 1), dau: 0, wau: 0, mau: 5),
+        ])
+
+        let provider = ActivityProvider()
+        await provider.fetchIfNeeded(in: database)
+        let matrices = try #require(try provider.result?.get())
+
+        // One matrix per month: June (all periods) and July (only its MAU cell).
+        #expect(matrices.count == 2)
+
+        let daily = matrices.points(on: .daily).sorted()
+        let weekly = matrices.points(on: .weekly).sorted()
+        let monthly = matrices.points(on: .monthly).sorted()
+
+        // Zero-activity days never become cells.
+        #expect(daily.map(\.count) == [2, 1])
+        #expect(weekly.map(\.count) == [2, 3])
+        #expect(monthly.map(\.count) == [2, 2, 5])
+
+        // Day offsets resolve back to the original dates.
+        #expect(daily.first?.date == date(2026, 6, 10))
+        #expect(monthly.last?.date == date(2026, 7, 1))
+    }
+
+    @Test("Non-server backends still issue the PeriodMatrix query")
+    func fetchFallsBackToMatrixQuery() async throws {
+        let database = DatabaseStub()
+
+        let provider = ActivityProvider()
+        await provider.fetchIfNeeded(in: database)
+        _ = try #require(try provider.result?.get())
+
+        #expect(database.readCount(of: PeriodCell<Int>.recordType) == 1)
+    }
+
+    // MARK: - Helpers
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        DateComponents(calendar: .utc, year: year, month: month, day: day).date!
+    }
+
+    private func ms(_ year: Int, _ month: Int, _ day: Int) -> Int64 {
+        Int64((date(year, month, day).timeIntervalSince1970 * 1000).rounded())
+    }
+}
+
+/// An `AppDatabase` that also answers the native active-user series, standing
+/// in for a Scout server backend.
+///
+private final class ServerStub: AppDatabase, ActiveUsersReading, @unchecked Sendable {
+    let series: [ActiveUserPoint]
+
+    init(series: [ActiveUserPoint]) {
+        self.series = series
+    }
+
+    func activeUsers(in range: Range<Date>) async throws -> [ActiveUserPoint] {
+        series
+    }
+
+    func lookup(id: CKRecord.ID, fields: [CKRecord.FieldKey]?) async throws -> CKRecord {
+        throw CKError(.unknownItem)
+    }
+
+    func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+        RecordChunk(records: [], cursor: nil)
+    }
+
+    func readMore(from cursor: RecordCursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+        RecordChunk(records: [], cursor: nil)
+    }
+}


### PR DESCRIPTION
When the primary backend is a Scout server, `ActivityProvider` now reads the flat active-users series from `GET /api/v1/metrics/active-users` and rebuilds the chart's monthly matrices from it, rather than reconstructing them from the `ActiveUser` `PeriodMatrix`. The matrix shape only exists because CloudKit cannot aggregate, so against a server — which already aggregates from raw `Session` records — there is no reason to round-trip through it. CloudKit backends are unchanged and keep answering the existing matrix query.

`HTTPDatabase` gains an `ActiveUsersReading` conformance that calls the endpoint, and `ActivityProvider.fetch` branches on it; a non-server backend falls through to the original `CKQuery`. The flat `{date, dau, wau, mau}` series is folded back into `ActivityMatrix` values by `from(series:)` so the rest of the chart pipeline is untouched.

This depends on the server endpoint added in kasianov-mikhail/scout-server#10. The new contract test stays skipped unless `SCOUT_SERVER_URL` points at a live server, so ordinary CI is unaffected; it only runs in the cross-repo contract job, where the server already has the endpoint.
