### PR TITLE
Track raw-record delivery per backend so a down backend doesn't block the others

### DIFF
--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -34,6 +34,14 @@ extension HTTPDatabase: BackendDatabase {}
 /// branches on.
 ///
 struct ResolvedBackend: Sendable {
+    /// Stable identity used to track per-record delivery across sync cycles.
+    ///
+    /// Derived from the destination itself — the CloudKit container
+    /// identifier or the server URL — so it survives reordering or
+    /// re-resolving the backend list.
+    ///
+    let id: String
+
     let database: any BackendDatabase
 
     /// Whether the client must maintain matrix records on this backend.
@@ -57,6 +65,7 @@ extension Backend {
         switch self {
         case .cloudKit(let container):
             ResolvedBackend(
+                id: container.containerIdentifier ?? "cloudKit",
                 database: container.publicCloudDatabase,
                 needsClientAggregation: true,
                 acceptsRawMetrics: false,
@@ -68,6 +77,7 @@ extension Backend {
             )
         case .server(let url, let apiKey):
             ResolvedBackend(
+                id: url.absoluteString,
                 database: HTTPDatabase(url: url, apiKey: apiKey),
                 needsClientAggregation: false,
                 acceptsRawMetrics: true,

--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -21,6 +21,7 @@ struct SyncEngine: @unchecked Sendable {
         self.init(
             backends: [
                 ResolvedBackend(
+                    id: "default",
                     database: database,
                     needsClientAggregation: true,
                     acceptsRawMetrics: false,
@@ -42,43 +43,79 @@ struct SyncEngine: @unchecked Sendable {
             // Persist attempt counters so cleanup can retire records that keep failing.
             try context.save()
 
-            // Raw uploads are idempotent upserts keyed by record name, so a
-            // batch that failed on one backend safely re-runs on all of them.
+            // Each backend is an independent destination: a failure on one
+            // must not abort uploads to the others. Collect the first error
+            // and surface it once the batch has done all it can this cycle.
+            var firstError: Error?
+
+            // Raw fan-out. Skip backends that already hold the record (their
+            // delivery was recorded on an earlier cycle), so a healthy backend
+            // is never re-written while a failing one is retried.
             for backend in backends {
-                if let records = records(of: batch, for: backend) {
-                    try await backend.database.write(records: records)
+                do {
+                    let undelivered = batch.filter { !$0.deliveredRaw.contains(backend.id) }
+                    if let records = records(of: undelivered, for: backend), records.count > 0 {
+                        try await backend.database.write(records: records)
+                        for object in undelivered {
+                            object.markRawDelivered(to: backend.id)
+                        }
+                        // Persist per backend so its delivery survives a later
+                        // backend failing in the same cycle.
+                        try context.save()
+                    }
+                } catch {
+                    firstError = firstError ?? error
                 }
             }
 
-            // Records already counted into the server matrix on a previous
-            // attempt must not contribute again, or the matrix double-counts.
-            let pending = batch.filter { $0.syncState == .pending }
+            // Matrix contribution (CloudKit only). Records already counted on a
+            // previous attempt carry `.aggregated`, so they don't contribute
+            // again and double-count the matrix.
             let aggregating = backends.filter(\.needsClientAggregation)
+            let notAggregated = batch.filter { $0.syncState == .pending }
 
-            if pending.count > 0 && !aggregating.isEmpty {
-                for backend in aggregating {
-                    try await SyncCoordinator(
-                        database: backend.database,
-                        maxRetry: 3,
-                        batch: pending
-                    )
-                    .upload()
+            if notAggregated.count > 0 && !aggregating.isEmpty {
+                do {
+                    for backend in aggregating {
+                        try await SyncCoordinator(
+                            database: backend.database,
+                            maxRetry: 3,
+                            batch: notAggregated
+                        )
+                        .upload()
+                    }
+
+                    for object in notAggregated {
+                        object.syncState = .aggregated
+                    }
+
+                    // Persist right away so a crash before the final save
+                    // doesn't replay the matrix contribution on the next cycle.
+                    try context.save()
+                } catch {
+                    firstError = firstError ?? error
                 }
-
-                for object in pending {
-                    object.syncState = .aggregated
-                }
-
-                // Persist right away so a crash before the final save
-                // doesn't replay the matrix contribution on the next cycle.
-                try context.save()
             }
 
+            // A record is fully synced once its matrix is contributed (or no
+            // backend aggregates) and its raw record has reached every backend
+            // that takes one.
+            let matrixDone = aggregating.isEmpty
+            let rawBackends = backends.filter { records(of: batch, for: $0) != nil }
             for object in batch {
-                object.syncState = .synced
+                let rawDelivered = rawBackends.allSatisfy { object.deliveredRaw.contains($0.id) }
+                if rawDelivered && (matrixDone || object.syncState != .pending) {
+                    object.syncState = .synced
+                }
             }
 
             try context.save()
+
+            // Re-fetching the same unsynced batch would spin forever, so stop
+            // the cycle here; the next sync run retries only what's left.
+            if let firstError {
+                throw firstError
+            }
         }
     }
 

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -17,12 +17,17 @@ protocol Syncable: SyncableObject {
     static func group(in context: NSManagedObjectContext) throws -> [Self]?
 }
 
-/// Progress of a record through the sync pipeline.
+/// Progress of a record's CloudKit matrix contribution.
 ///
 /// A record advances `pending → aggregated → synced`. The intermediate
 /// `aggregated` state marks records whose counts are already merged into
-/// the server matrix, so a retry after a partial sync failure doesn't
+/// the CloudKit matrix, so a retry after a partial sync failure doesn't
 /// re-contribute them and double-count the matrix.
+///
+/// Raw record fan-out across backends is tracked separately, per backend,
+/// in `deliveryData`: a record only reaches `synced` once its matrix is
+/// contributed *and* its raw record has been delivered to every backend
+/// that takes one.
 ///
 enum SyncState: Int16 {
     /// Not uploaded yet; the next sync cycle picks the record up.
@@ -41,6 +46,9 @@ class SyncableObject: IDObject {
     @NSManaged var syncStatePrimitive: Int16
     @NSManaged var syncAttempts: Int
 
+    /// JSON-encoded set of backend ids that have received the raw record.
+    @NSManaged var deliveryData: Data?
+
     var syncState: SyncState {
         get {
             SyncState(rawValue: syncStatePrimitive) ?? .pending
@@ -48,6 +56,29 @@ class SyncableObject: IDObject {
         set {
             syncStatePrimitive = newValue.rawValue
         }
+    }
+
+    /// The backends whose raw upload of this record has already succeeded.
+    ///
+    /// Tracked per backend so a healthy backend isn't re-written while a
+    /// failing one is retried, and so a record only counts as fully synced
+    /// once every backend that needs the raw record has it.
+    ///
+    var deliveredRaw: Set<String> {
+        get {
+            guard let deliveryData, let ids = try? JSONDecoder().decode([String].self, from: deliveryData) else {
+                return []
+            }
+            return Set(ids)
+        }
+        set {
+            deliveryData = try? JSONEncoder().encode(newValue.sorted())
+        }
+    }
+
+    /// Records that `backendID` has received this record's raw upload.
+    func markRawDelivered(to backendID: String) {
+        deliveredRaw.insert(backendID)
     }
 
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {

--- a/Sources/Scout/Scout.xcdatamodeld/.xccurrentversion
+++ b/Sources/Scout/Scout.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>Scout 2.xcdatamodel</string>
+</dict>
+</plist>

--- a/Sources/Scout/Scout.xcdatamodeld/Scout 2.xcdatamodel/contents
+++ b/Sources/Scout/Scout.xcdatamodeld/Scout 2.xcdatamodel/contents
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CrashObject" representedClassName="CrashObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="crashID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="stackTrace" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="DateObject" representedClassName="DateObject" isAbstract="YES" syncable="YES" codeGenerationType="none">
+        <attribute name="datePrimitive" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="day" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="hour" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="month" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="week" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="DoubleMetricsObject" representedClassName="DoubleMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="none">
+        <attribute name="value" attributeType="Double" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="EventObject" representedClassName="EventObject" parentEntity="NamedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="eventID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="level" attributeType="String"/>
+        <attribute name="paramCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="params" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="DeviceObject" representedClassName="DeviceObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none"/>
+    <entity name="IDObject" representedClassName="IDObject" isAbstract="YES" parentEntity="DateObject" syncable="YES" codeGenerationType="none">
+        <attribute name="deviceID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="installID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="InstallObject" representedClassName="InstallObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none"/>
+
+    <entity name="IntMetricsObject" representedClassName="IntMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="none">
+        <attribute name="value" attributeType="Integer 64" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="LaunchObject" representedClassName="LaunchObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="MetricsObject" representedClassName="MetricsObject" isAbstract="YES" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="telemetry" attributeType="String"/>
+    </entity>
+    <entity name="NamedObject" representedClassName="NamedObject" isAbstract="YES" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="name" attributeType="String"/>
+    </entity>
+    <entity name="SessionObject" representedClassName="SessionObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="IDObject" syncable="YES" codeGenerationType="none">
+        <attribute name="deliveryData" optional="YES" attributeType="Binary"/>
+        <attribute name="syncAttempts" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="syncStatePrimitive" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="sessionID" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="VersionObject" representedClassName="VersionObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="buildNumber" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="UserActivityObject" representedClassName="UserActivityObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="dayCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="monthCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="period" attributeType="String"/>
+        <attribute name="userActivityID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="weekCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+</model>

--- a/Tests/ScoutTests/Core/Backend/SyncEngineBackendTests.swift
+++ b/Tests/ScoutTests/Core/Backend/SyncEngineBackendTests.swift
@@ -18,21 +18,28 @@ struct SyncEngineBackendTests {
     let server = InMemoryDatabase()
     let context = NSManagedObjectContext.inMemoryContext()
 
+    var cloudBackend: ResolvedBackend {
+        ResolvedBackend(
+            id: "cloud",
+            database: cloud,
+            needsClientAggregation: true,
+            acceptsRawMetrics: false,
+            checkAvailability: {}
+        )
+    }
+
+    var serverBackend: ResolvedBackend {
+        ResolvedBackend(
+            id: "server",
+            database: server,
+            needsClientAggregation: false,
+            acceptsRawMetrics: true,
+            checkAvailability: {}
+        )
+    }
+
     var backends: [ResolvedBackend] {
-        [
-            ResolvedBackend(
-                database: cloud,
-                needsClientAggregation: true,
-                acceptsRawMetrics: false,
-                checkAvailability: {}
-            ),
-            ResolvedBackend(
-                database: server,
-                needsClientAggregation: false,
-                acceptsRawMetrics: true,
-                checkAvailability: {}
-            ),
-        ]
+        [cloudBackend, serverBackend]
     }
 
     @Test("Events go raw to every backend, matrices only to CloudKit")
@@ -68,17 +75,7 @@ struct SyncEngineBackendTests {
         let event = EventObject.stub(name: "login", in: context)
         try context.save()
 
-        let engine = SyncEngine(
-            backends: [
-                ResolvedBackend(
-                    database: server,
-                    needsClientAggregation: false,
-                    acceptsRawMetrics: true,
-                    checkAvailability: {}
-                )
-            ],
-            context: context
-        )
+        let engine = SyncEngine(backends: [serverBackend], context: context)
         try await engine.send(type: EventObject.self)
 
         #expect(event.syncState == .synced)
@@ -86,8 +83,8 @@ struct SyncEngineBackendTests {
         #expect(server.records.filter { $0.recordType == Int.recordType }.isEmpty)
     }
 
-    @Test("A failing backend keeps the batch pending for every backend")
-    func failureKeepsBatchPending() async throws {
+    @Test("A failing backend leaves the batch unsynced without blocking the others")
+    func failureIsolatedToBackend() async throws {
         let event = EventObject.stub(name: "login", in: context)
         try context.save()
 
@@ -99,6 +96,53 @@ struct SyncEngineBackendTests {
             try await engine.send(type: EventObject.self)
         }
 
-        #expect(event.syncState == .pending)
+        // CloudKit got its raw record and matrix; the server got nothing.
+        #expect(event.syncState != .synced)
+        #expect(event.deliveredRaw.contains("cloud"))
+        #expect(!event.deliveredRaw.contains("server"))
+        #expect(cloud.records.filter { $0.recordType == "Event" }.count == 1)
+        #expect(server.records.filter { $0.recordType == "Event" }.count == 0)
+    }
+
+    @Test("The recovered backend is retried alone; healthy ones aren't rewritten")
+    func resumesWithoutRewritingHealthyBackends() async throws {
+        let event = EventObject.stub(name: "login", in: context)
+        try context.save()
+
+        // First cycle: the server is down.
+        server.writeErrors.append(CKError(.networkFailure))
+        let engine = SyncEngine(backends: backends, context: context)
+        await #expect(throws: (any Error).self) {
+            try await engine.send(type: EventObject.self)
+        }
+
+        // Second cycle: the server has recovered.
+        try await engine.send(type: EventObject.self)
+
+        #expect(event.syncState == .synced)
+        #expect(server.records.filter { $0.recordType == "Event" }.count == 1)
+        // CloudKit's raw record and matrix were each written exactly once.
+        #expect(cloud.records.filter { $0.recordType == "Event" }.count == 1)
+        #expect(cloud.records.filter { $0.recordType == Int.recordType }.count == 1)
+    }
+
+    @Test("Dropping a never-reached backend lets the record sync")
+    func droppingBackendUnblocks() async throws {
+        let event = EventObject.stub(name: "login", in: context)
+        try context.save()
+
+        // The server never accepts the record.
+        server.writeErrors.append(CKError(.networkFailure))
+        let withServer = SyncEngine(backends: backends, context: context)
+        await #expect(throws: (any Error).self) {
+            try await withServer.send(type: EventObject.self)
+        }
+        #expect(event.syncState != .synced)
+
+        // Reconfigured to CloudKit only — which already has the record.
+        let cloudOnly = SyncEngine(backends: [cloudBackend], context: context)
+        try await cloudOnly.send(type: EventObject.self)
+
+        #expect(event.syncState == .synced)
     }
 }


### PR DESCRIPTION
When Scout syncs to more than one backend, a record's sync state advanced once for all backends, so a single unreachable backend left the whole batch unsynced and re-sent every record to the already-healthy backends on each cycle — and after enough failed attempts the record could even be retired by cleanup though some backends had already received it.

Delivery of the raw record is now recorded per backend on `SyncableObject` (a new optional `deliveryData` field, surfaced as `deliveredRaw`), keyed by a stable `ResolvedBackend.id` derived from the CloudKit container identifier or the server URL. `SyncEngine` now treats each backend as an independent destination: a failure on one no longer aborts uploads to the others, a backend that already holds a record is skipped on retry, and a record only reaches `synced` once its CloudKit matrix is contributed and its raw record has reached every backend that takes one. The CloudKit matrix lifecycle (`pending → aggregated`) is unchanged, so matrices still can't double-count.

The schema change ships as a new `Scout.xcdatamodeld` version adding the optional `deliveryData` attribute, which migrates with lightweight inference.