### PR TITLE
Unify backend sync progress into one per-backend map

### DIFF
--- a/Sources/Scout/Core/Sync/SyncEngine.swift
+++ b/Sources/Scout/Core/Sync/SyncEngine.swift
@@ -43,70 +43,73 @@ struct SyncEngine: @unchecked Sendable {
             // Persist attempt counters so cleanup can retire records that keep failing.
             try context.save()
 
-            // Each backend is an independent destination: a failure on one
-            // must not abort uploads to the others. Collect the first error
-            // and surface it once the batch has done all it can this cycle.
+            // What each backend needs for this batch: a raw upload if it takes
+            // raw records for this type, plus a matrix contribution if it
+            // aggregates on the client. Computed once — `records(of:for:)` is
+            // uniform across a batch (it casts on the static type).
+            let requirements = backends.map { (backend: $0, need: required(for: $0, in: batch)) }
+
+            // Records left `.aggregated` by an older build already contributed
+            // their matrix and, by that build's ordering, raw-uploaded to every
+            // backend. Seed that progress so the new pipeline neither re-uploads
+            // nor double-counts, then drop the legacy state.
+            for object in batch where object.syncState == .aggregated {
+                for requirement in requirements {
+                    object.mark(requirement.need, for: requirement.backend.id)
+                }
+                object.syncState = .pending
+            }
+
+            // Each backend is an independent destination: a failure on one must
+            // not abort uploads to the others. Collect the first error and
+            // surface it once the batch has done all it can this cycle.
             var firstError: Error?
 
-            // Raw fan-out. Skip backends that already hold the record (their
-            // delivery was recorded on an earlier cycle), so a healthy backend
-            // is never re-written while a failing one is retried.
             for backend in backends {
                 do {
-                    let undelivered = batch.filter { !$0.deliveredRaw.contains(backend.id) }
-                    if let records = records(of: undelivered, for: backend), records.count > 0 {
+                    // Raw upload. Skip records this backend already holds, so a
+                    // healthy backend is never re-written while a failing one is
+                    // retried. Raw writes are idempotent upserts keyed by record
+                    // name, so a repeat after a partial failure is harmless.
+                    let needRaw = batch.filter { !$0.progress(for: backend.id).contains(.raw) }
+                    if let records = records(of: needRaw, for: backend), records.count > 0 {
                         try await backend.database.write(records: records)
-                        for object in undelivered {
-                            object.markRawDelivered(to: backend.id)
+                        for object in needRaw {
+                            object.mark(.raw, for: backend.id)
                         }
-                        // Persist per backend so its delivery survives a later
+                        // Persist per backend so its progress survives a later
                         // backend failing in the same cycle.
                         try context.save()
                     }
+
+                    // Matrix contribution. Tracked per backend because a matrix
+                    // is additive: a record already folded in must not contribute
+                    // again, even if another backend's matrix failed mid-cycle.
+                    if backend.needsClientAggregation {
+                        let needMatrix = batch.filter { !$0.progress(for: backend.id).contains(.matrix) }
+                        if needMatrix.count > 0 {
+                            try await SyncCoordinator(
+                                database: backend.database,
+                                maxRetry: 3,
+                                batch: needMatrix
+                            )
+                            .upload()
+                            for object in needMatrix {
+                                object.mark(.matrix, for: backend.id)
+                            }
+                            // Persist right away so a crash before the final save
+                            // doesn't replay the matrix contribution next cycle.
+                            try context.save()
+                        }
+                    }
                 } catch {
                     firstError = firstError ?? error
                 }
             }
 
-            // Matrix contribution (CloudKit only). Records already counted on a
-            // previous attempt carry `.aggregated`, so they don't contribute
-            // again and double-count the matrix.
-            let aggregating = backends.filter(\.needsClientAggregation)
-            let notAggregated = batch.filter { $0.syncState == .pending }
-
-            if notAggregated.count > 0 && !aggregating.isEmpty {
-                do {
-                    for backend in aggregating {
-                        try await SyncCoordinator(
-                            database: backend.database,
-                            maxRetry: 3,
-                            batch: notAggregated
-                        )
-                        .upload()
-                    }
-
-                    for object in notAggregated {
-                        object.syncState = .aggregated
-                    }
-
-                    // Persist right away so a crash before the final save
-                    // doesn't replay the matrix contribution on the next cycle.
-                    try context.save()
-                } catch {
-                    firstError = firstError ?? error
-                }
-            }
-
-            // A record is fully synced once its matrix is contributed (or no
-            // backend aggregates) and its raw record has reached every backend
-            // that takes one.
-            let matrixDone = aggregating.isEmpty
-            let rawBackends = backends.filter { records(of: batch, for: $0) != nil }
-            for object in batch {
-                let rawDelivered = rawBackends.allSatisfy { object.deliveredRaw.contains($0.id) }
-                if rawDelivered && (matrixDone || object.syncState != .pending) {
-                    object.syncState = .synced
-                }
+            // A record is synced once every backend has everything it needs.
+            for object in batch where requirements.allSatisfy({ object.progress(for: $0.backend.id).isSuperset(of: $0.need) }) {
+                object.syncState = .synced
             }
 
             try context.save()
@@ -117,6 +120,21 @@ struct SyncEngine: @unchecked Sendable {
                 throw firstError
             }
         }
+    }
+
+    /// The progress a backend must reach before it's done with this batch: a
+    /// raw upload when it takes raw records for this type, and a matrix
+    /// contribution when it aggregates on the client.
+    ///
+    private func required(for backend: ResolvedBackend, in batch: [some Syncable]) -> BackendProgress {
+        var need: BackendProgress = []
+        if records(of: batch, for: backend) != nil {
+            need.insert(.raw)
+        }
+        if backend.needsClientAggregation {
+            need.insert(.matrix)
+        }
+        return need
     }
 
     /// The raw records a batch contributes to a backend, if any.

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -17,28 +17,35 @@ protocol Syncable: SyncableObject {
     static func group(in context: NSManagedObjectContext) throws -> [Self]?
 }
 
-/// Progress of a record's CloudKit matrix contribution.
+/// Whether a record still needs syncing.
 ///
-/// A record advances `pending → aggregated → synced`. The intermediate
-/// `aggregated` state marks records whose counts are already merged into
-/// the CloudKit matrix, so a retry after a partial sync failure doesn't
-/// re-contribute them and double-count the matrix.
-///
-/// Raw record fan-out across backends is tracked separately, per backend,
-/// in `deliveryData`: a record only reaches `synced` once its matrix is
-/// contributed *and* its raw record has been delivered to every backend
-/// that takes one.
+/// `pending` until every backend has everything it needs — which steps each
+/// backend has completed lives per backend in `delivery` — then `synced`.
 ///
 enum SyncState: Int16 {
-    /// Not uploaded yet; the next sync cycle picks the record up.
+    /// Not yet fully delivered; the next sync cycle picks the record up.
     case pending = 0
 
-    /// Counts are merged into the server matrix, but the cycle hasn't
-    /// finished — the record is still re-sent as a raw upload (idempotent).
+    /// Legacy. Written by builds before per-backend `delivery` tracking,
+    /// where it meant the CloudKit matrix had been contributed. New code
+    /// never writes it; `SyncEngine` migrates such records on the next cycle.
     case aggregated = 1
 
-    /// Fully uploaded; eligible for cleanup once old enough.
+    /// Delivered to every backend; eligible for cleanup once old enough.
     case synced = 2
+}
+
+/// Which steps of the sync pipeline a record has completed on one backend.
+///
+/// Raw uploads are idempotent upserts, so `.raw` only spares a healthy
+/// backend a redundant re-write. Matrix contributions are additive, so
+/// `.matrix` is what keeps a CloudKit matrix from double-counting on retry.
+///
+struct BackendProgress: OptionSet, Sendable {
+    let rawValue: Int
+
+    static let raw = BackendProgress(rawValue: 1 << 0)
+    static let matrix = BackendProgress(rawValue: 1 << 1)
 }
 
 @objc(SyncableObject)
@@ -46,7 +53,7 @@ class SyncableObject: IDObject {
     @NSManaged var syncStatePrimitive: Int16
     @NSManaged var syncAttempts: Int
 
-    /// JSON-encoded set of backend ids that have received the raw record.
+    /// JSON-encoded per-backend sync progress (`[backendID: rawValue]`).
     @NSManaged var deliveryData: Data?
 
     var syncState: SyncState {
@@ -58,27 +65,35 @@ class SyncableObject: IDObject {
         }
     }
 
-    /// The backends whose raw upload of this record has already succeeded.
+    /// How far this record has progressed on each backend, keyed by
+    /// `ResolvedBackend.id`.
     ///
-    /// Tracked per backend so a healthy backend isn't re-written while a
-    /// failing one is retried, and so a record only counts as fully synced
-    /// once every backend that needs the raw record has it.
+    /// Tracked per backend so a healthy backend isn't re-written or re-counted
+    /// while a failing one is retried, and so a record only reaches `synced`
+    /// once every backend has everything it needs.
     ///
-    var deliveredRaw: Set<String> {
+    var delivery: [String: BackendProgress] {
         get {
-            guard let deliveryData, let ids = try? JSONDecoder().decode([String].self, from: deliveryData) else {
-                return []
+            guard let deliveryData, let stored = try? JSONDecoder().decode([String: Int].self, from: deliveryData) else {
+                return [:]
             }
-            return Set(ids)
+            return stored.mapValues(BackendProgress.init(rawValue:))
         }
         set {
-            deliveryData = try? JSONEncoder().encode(newValue.sorted())
+            deliveryData = try? JSONEncoder().encode(newValue.mapValues(\.rawValue))
         }
     }
 
-    /// Records that `backendID` has received this record's raw upload.
-    func markRawDelivered(to backendID: String) {
-        deliveredRaw.insert(backendID)
+    /// The steps `backendID` has completed for this record.
+    func progress(for backendID: String) -> BackendProgress {
+        delivery[backendID] ?? []
+    }
+
+    /// Records that `steps` have completed for `backendID`.
+    func mark(_ steps: BackendProgress, for backendID: String) {
+        var map = delivery
+        map[backendID, default: []].formUnion(steps)
+        delivery = map
     }
 
     static func batch<T: SyncableObject>(in context: NSManagedObjectContext, matching keyPaths: [PartialKeyPath<T>]) throws -> [T]? {

--- a/Tests/ScoutTests/Core/Backend/SyncEngineBackendTests.swift
+++ b/Tests/ScoutTests/Core/Backend/SyncEngineBackendTests.swift
@@ -15,6 +15,7 @@ import Testing
 @Suite("SyncEngine with multiple backends")
 struct SyncEngineBackendTests {
     let cloud = InMemoryDatabase()
+    let cloud2 = InMemoryDatabase()
     let server = InMemoryDatabase()
     let context = NSManagedObjectContext.inMemoryContext()
 
@@ -22,6 +23,16 @@ struct SyncEngineBackendTests {
         ResolvedBackend(
             id: "cloud",
             database: cloud,
+            needsClientAggregation: true,
+            acceptsRawMetrics: false,
+            checkAvailability: {}
+        )
+    }
+
+    var cloud2Backend: ResolvedBackend {
+        ResolvedBackend(
+            id: "cloud2",
+            database: cloud2,
             needsClientAggregation: true,
             acceptsRawMetrics: false,
             checkAvailability: {}
@@ -98,10 +109,29 @@ struct SyncEngineBackendTests {
 
         // CloudKit got its raw record and matrix; the server got nothing.
         #expect(event.syncState != .synced)
-        #expect(event.deliveredRaw.contains("cloud"))
-        #expect(!event.deliveredRaw.contains("server"))
+        #expect(event.progress(for: "cloud") == [.raw, .matrix])
+        #expect(event.progress(for: "server").isEmpty)
         #expect(cloud.records.filter { $0.recordType == "Event" }.count == 1)
         #expect(server.records.filter { $0.recordType == "Event" }.count == 0)
+    }
+
+    @Test("A matrix is contributed per CloudKit backend, never twice")
+    func matrixPerCloudKitBackend() async throws {
+        let event = EventObject.stub(name: "login", in: context)
+        // Simulate a prior cycle where the first CloudKit backend was fully
+        // delivered but the second only received the raw record.
+        event.mark([.raw, .matrix], for: "cloud")
+        event.mark(.raw, for: "cloud2")
+        try context.save()
+
+        let engine = SyncEngine(backends: [cloudBackend, cloud2Backend], context: context)
+        try await engine.send(type: EventObject.self)
+
+        #expect(event.syncState == .synced)
+        // The first backend's matrix isn't contributed a second time...
+        #expect(cloud.records.filter { $0.recordType == Int.recordType }.isEmpty)
+        // ...while the second backend's matrix is contributed exactly once.
+        #expect(cloud2.records.filter { $0.recordType == Int.recordType }.count == 1)
     }
 
     @Test("The recovered backend is retried alone; healthy ones aren't rewritten")

--- a/Tests/ScoutTests/Core/Sync/SyncEngineTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncEngineTests.swift
@@ -35,8 +35,8 @@ struct SyncEngineTests {
         #expect(!context.hasChanges)
     }
 
-    @Test("Uploads the matrix once and marks the batch aggregated")
-    func marksBatchAggregated() async throws {
+    @Test("Uploads the matrix once and marks the batch synced")
+    func marksBatchSynced() async throws {
         let event = EventObject.stub(name: "x", in: context)
         try context.save()
 
@@ -47,10 +47,27 @@ struct SyncEngineTests {
         #expect(database.records.filter { $0.recordType == Int.recordType }.count == 1)
     }
 
-    @Test("Does not re-contribute an aggregated batch to the matrix on retry")
-    func skipsMatrixUploadOnRetry() async throws {
-        // Simulate a crash after the matrix upload was persisted but before
-        // the final save: the record is aggregated yet still unsynced.
+    @Test("Does not re-upload or re-contribute progress already recorded for a backend")
+    func skipsDeliveredStepsOnRetry() async throws {
+        // Simulate a crash after the raw upload and matrix contribution were
+        // persisted but before the final save: progress is recorded yet the
+        // record is still unsynced.
+        let event = EventObject.stub(name: "x", in: context)
+        event.mark([.raw, .matrix], for: "default")
+        try context.save()
+
+        let engine = SyncEngine(database: database, context: context)
+        try await engine.send(type: EventObject.self)
+
+        #expect(event.syncState == .synced)
+        #expect(database.events.isEmpty)
+        #expect(database.records.filter { $0.recordType == Int.recordType }.isEmpty)
+    }
+
+    @Test("Migrates a legacy aggregated record without re-uploading or re-counting")
+    func migratesLegacyAggregated() async throws {
+        // A record left `.aggregated` by an older build already reached every
+        // backend; the new pipeline must neither re-upload nor double-count it.
         let event = EventObject.stub(name: "x", in: context)
         event.syncState = .aggregated
         try context.save()
@@ -59,7 +76,6 @@ struct SyncEngineTests {
         try await engine.send(type: EventObject.self)
 
         #expect(event.syncState == .synced)
-        #expect(database.events.count == 1)
-        #expect(database.records.filter { $0.recordType == Int.recordType }.count == 0)
+        #expect(database.records.isEmpty)
     }
 }


### PR DESCRIPTION
Stacked on #578.

Building on the per-backend raw-delivery tracking from #578, this folds the CloudKit matrix state into the same `delivery` map so a record's whole sync progress is expressed one way: `[backendID: BackendProgress]`, where `BackendProgress` records whether the raw upload and the matrix contribution have completed for that backend. `syncStatePrimitive` is no longer a three-step matrix lifecycle — it's just `pending` until every backend has what it needs, then `synced` — and the `.aggregated` case is retired, kept only so `SyncEngine` can migrate records an older build left in that state.

Because the matrix is now tracked per backend rather than once globally, a record folded into one CloudKit backend's matrix is never folded into it again even if another backend's matrix upload fails mid-cycle — closing a latent double-count when more than one CloudKit backend is configured. There is no schema change: the `deliveryData` attribute already exists and only its encoding evolves from a set of ids to a per-backend progress map.