### PR TITLE
Load the events list only on first entry, not on every return

### DIFF
--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -67,7 +67,7 @@ struct AnalyticsView: View {
                 }
             }
             .task {
-                await fetch()
+                await provider.fetchIfNeeded(for: filter, in: database)
             }
             .refreshable {
                 await fetch()

--- a/Sources/Scout/UI/Event/Provider/EventProvider.swift
+++ b/Sources/Scout/UI/Event/Provider/EventProvider.swift
@@ -15,6 +15,12 @@ class EventProvider: ObservableObject {
     @Published var cursor: RecordCursor?
     @Published var message: Message?
 
+    /// Fetches only when no events have been loaded yet, so returning to the list does not reload.
+    func fetchIfNeeded(for filter: Event.Query, in database: AppDatabase) async {
+        guard events == nil else { return }
+        await fetch(for: filter, in: database)
+    }
+
     func fetch(for filter: Event.Query, in database: AppDatabase) async {
         do {
             let query = CKQuery(recordType: EventObject.recordType, predicate: filter.buildPredicate())

--- a/Tests/ScoutTests/UI/Event/EventProviderTests.swift
+++ b/Tests/ScoutTests/UI/Event/EventProviderTests.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+struct EventProviderTests {
+    @Test("fetchIfNeeded loads events on the first call")
+    func fetchIfNeededLoadsOnFirstCall() async throws {
+        let database = DatabaseStub()
+        database.add(
+            CKRecord.eventStub(name: "login", sessionID: UUID(), date: Date()),
+            CKRecord.eventStub(name: "logout", sessionID: UUID(), date: Date())
+        )
+
+        let provider = EventProvider()
+        await provider.fetchIfNeeded(for: Event.Query(), in: database)
+
+        #expect(provider.events?.count == 2)
+        #expect(database.readCount(of: EventObject.recordType) == 1)
+    }
+
+    @Test("fetchIfNeeded does not reload once events are present")
+    func fetchIfNeededSkipsWhenLoaded() async throws {
+        let database = DatabaseStub()
+        database.add(CKRecord.eventStub(name: "login", sessionID: UUID(), date: Date()))
+
+        let provider = EventProvider()
+        await provider.fetchIfNeeded(for: Event.Query(), in: database)
+        await provider.fetchIfNeeded(for: Event.Query(), in: database)
+
+        #expect(database.readCount(of: EventObject.recordType) == 1)
+    }
+}


### PR DESCRIPTION
The Events list re-ran its fetch in the view's `.task` every time the view reappeared, so navigating back from an event's detail reloaded the whole list. This adds `EventProvider.fetchIfNeeded`, which fetches only when no events have been loaded yet, and calls it from the list's `.task` in `AnalyticsView` so data loads on the first entry but not on return. Pull-to-refresh and level-filter changes still force a reload, since they call `fetch` directly. A new `EventProviderTests` suite covers both branches — loading on the first call and skipping the read on the second.