### PR TITLE
Show an error on the timeline when it loads no data

### DIFF
--- a/Sources/Scout/UI/Timeline/View/Timeline.swift
+++ b/Sources/Scout/UI/Timeline/View/Timeline.swift
@@ -25,7 +25,9 @@ struct Timeline: View {
             case nil:
                 ProgressView().frame(maxHeight: .infinity)
             case .failure(let error):
-                errorView(for: error)
+                errorView(Text(verbatim: error.localizedDescription))
+            case .success where provider.items.count == 0:
+                errorView(Text(verbatim: "The timeline couldn't be loaded."))
             case .success:
                 list
             }
@@ -95,8 +97,8 @@ struct Timeline: View {
         }
     }
 
-    private func errorView(for error: Error) -> some View {
-        ErrorView(description: Text(verbatim: error.localizedDescription)) {
+    private func errorView(_ description: Text) -> some View {
+        ErrorView(description: description) {
             Task(operation: load)
         }
     }

--- a/Tests/ScoutTests/UI/Timeline/TimelineProviderTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/TimelineProviderTests.swift
@@ -76,4 +76,15 @@ struct TimelineProviderTests {
 
         #expect(provider.exportText?.contains("- 2023-11-14T22:13:50Z  e") == true)
     }
+
+    @Test("A backend with no records publishes an empty result")
+    func testEmptyBackendPublishesNoItems() async throws {
+        let provider = TimelineProvider()
+        let feed = TimelineFeed(deviceID: deviceID, database: DatabaseStub())
+
+        await provider.start(feed: feed, anchorEvent: nil, eventName: nil)
+
+        _ = try #require(provider.result).get()
+        #expect(provider.items.count == 0)
+    }
 }


### PR DESCRIPTION
The timeline screen rendered a blank screen whenever it loaded but had nothing to show, instead of telling the user anything was wrong. This happens most visibly against a custom Scout server, where the underlying reads resolve to an empty rail rather than throwing, so the screen's existing failure path was never reached.

The view now falls back to the shared `ErrorView` when a successful load produces no `items`, reusing the same error design every other screen uses. Since the timeline is always opened from an existing event, an empty result reliably means the data couldn't be loaded rather than a legitimately empty timeline. The underlying loading behaviour is left untouched.
