### PR TITLE
Add quiet Telegram CI notifications

### DIFF
--- a/.github/actions/telegram-notify/action.yml
+++ b/.github/actions/telegram-notify/action.yml
@@ -1,0 +1,41 @@
+name: Telegram notify
+description: >
+  Send a single Telegram message through the Bot API. The caller passes a
+  ready-built HTML body and decides whether it arrives with sound; this action
+  only performs the sendMessage call. Shared across scout and scout-server so the
+  message-delivery details live in one place.
+
+inputs:
+  token:
+    description: Telegram bot token (from a secret, never inline).
+    required: true
+  chat-id:
+    description: Target chat id.
+    required: true
+  text:
+    description: Message body, HTML parse mode.
+    required: true
+  silent:
+    description: Deliver without sound ("true") or with sound ("false", for errors).
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: sendMessage
+      shell: bash
+      env:
+        TG_TOKEN: ${{ inputs.token }}
+        TG_CHAT: ${{ inputs.chat-id }}
+        TG_TEXT: ${{ inputs.text }}
+        TG_SILENT: ${{ inputs.silent }}
+      run: |
+        curl -fsS -X POST \
+          "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
+          --data-urlencode "chat_id=${TG_CHAT}" \
+          --data-urlencode "text=${TG_TEXT}" \
+          --data-urlencode "parse_mode=HTML" \
+          --data-urlencode "disable_web_page_preview=true" \
+          --data-urlencode "disable_notification=${TG_SILENT}" \
+          -o /dev/null

--- a/.github/workflows/telegram.yml
+++ b/.github/workflows/telegram.yml
@@ -1,0 +1,87 @@
+name: Telegram
+
+# Telegram alerts for this repository. Policy is "quiet": green CI is never
+# announced, and CI failures notify only on main (PR failures are visible on
+# GitHub already). Failures arrive with sound; the release milestone is silent.
+#
+# The notifier reacts to other workflows via workflow_run rather than living
+# inside each one, so a single place owns the message format. Only workflows
+# that actually run on main are watched — the PR-only required checks (API,
+# Schema, Core Data) never reach this with head_branch == main.
+on:
+  workflow_run:
+    workflows: [Swift, Server, CodeQL]
+    types: [completed]
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  ci-failure:
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build message
+        id: build
+        env:
+          WORKFLOW: ${{ github.event.workflow_run.name }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
+          URL: ${{ github.event.workflow_run.html_url }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          esc() { printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'; }
+          text="$(printf '<b>❌ CI failed — %s</b>\n<pre>Check:   %s\nBranch:  main (%s)\nBy:      @%s</pre>\n<a href="%s">Open run →</a>' \
+            "$(esc "$REPO")" "$(esc "$WORKFLOW")" "$(esc "${SHA:0:7}")" "$(esc "$ACTOR")" "$URL")"
+          {
+            echo 'text<<EOF'
+            echo "$text"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/telegram-notify
+        with:
+          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          text: ${{ steps.build.outputs.text }}
+          silent: "false"
+
+  release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build message
+        id: build
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          URL: ${{ github.event.release.html_url }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          esc() { printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'; }
+          text="$(printf '<b>🚀 Released — %s %s</b>\n<a href="%s">Release notes →</a>' \
+            "$(esc "$REPO")" "$(esc "$TAG")" "$URL")"
+          {
+            echo 'text<<EOF'
+            echo "$text"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/telegram-notify
+        with:
+          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          text: ${{ steps.build.outputs.text }}
+          silent: "true"


### PR DESCRIPTION
Adds Telegram alerts for this repository's CI. A reusable `telegram-notify` composite action under `.github/actions` performs the Bot API `sendMessage` call, and a new `telegram.yml` workflow reacts to the existing workflows through `workflow_run`: a failed `Swift`, `Server`, or `CodeQL` run on `main` is delivered with sound, while a published release is delivered silently via `disable_notification`. Green CI and pull-request failures are never announced, keeping the channel quiet. The action is split out from the workflow so that the `scout-server` repository can reuse the same delivery and formatting by referencing it. Both repositories need `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` secrets for it to send anything.