### PR TITLE
Split the README Usage section into a dedicated USAGE.md

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -15,26 +15,4 @@ Upload the [schema file](https://github.com/kasianov-mikhail/scout/blob/main/Sch
 3. Go to the "Schema" section and use "Import Schema" to upload the schema file.
 4. Click "Deploy to Production" to apply the schema.
 
-## Configure Scout
-
-```swift
-import CloudKit
-import Scout
-
-let container = CKContainer(identifier: "YOUR_CONTAINER_ID")
-
-try await setup(container: container)
-```
-
-## Using a Scout Server
-
-Instead of CloudKit — or in addition to it — Scout can sync to one or more self-hosted [Scout servers](https://github.com/kasianov-mikhail/scout-server). A server needs no schema upload: it aggregates analytics natively.
-
-```swift
-try await setup(backends: [
-    .cloudKit(container),
-    .server(url: URL(string: "https://scout.example.com")!, apiKey: "YOUR_API_KEY"),
-])
-```
-
-See the [server repository](https://github.com/kasianov-mikhail/scout-server) for deployment instructions and Docker images.
+Once CloudKit is enabled and the schema is uploaded, see the [Usage Guide](USAGE.md) for configuring `setup`, adding [Scout server](https://github.com/kasianov-mikhail/scout-server) backends, and writing logs and metrics.

--- a/README.md
+++ b/README.md
@@ -47,47 +47,9 @@ For CloudKit setup and schema upload, see the full [Installation Guide](INSTALLA
 
 ## Usage
 
-Call `setup` once during app launch. This bootstraps logging, metrics, and crash reporting:
-```swift
-import CloudKit
-import Scout
+Call `setup` once during app launch to bootstrap logging, metrics, and crash reporting, then write logs and metrics through the standard [swift-log](https://github.com/apple/swift-log) and [swift-metrics](https://github.com/apple/swift-metrics) APIs.
 
-let container = CKContainer(identifier: "YOUR_CONTAINER_ID")
-
-try await setup(container: container)
-```
-
-To sync somewhere other than CloudKit — or to several destinations at once — pass a list of backends instead. Every raw record is uploaded to every backend, and the dashboard reads from the first one:
-```swift
-try await setup(backends: [
-    .cloudKit(container),
-    .server(url: URL(string: "https://scout.example.com")!, apiKey: "YOUR_API_KEY"),
-])
-```
-A [Scout server](https://github.com/kasianov-mikhail/scout-server) aggregates analytics natively, so it needs no schema upload and receives raw metric values instead of client-maintained matrices.
-
-After setup, use the standard [swift-log](https://github.com/apple/swift-log) API to write logs:
-```swift
-import Logging
-
-let logger = Logger(label: "MyApp")
-
-logger.info(
-    "Search_Performed",
-    metadata: [
-        "query": "coffee shops",
-        "result_count": "12",
-    ]
-)
-```
-
-Metrics work the same way via [swift-metrics](https://github.com/apple/swift-metrics):
-```swift
-import Metrics
-
-Counter(label: "api_requests").increment()
-Timer(label: "response_time").recordSeconds(duration)
-```
+For the full walkthrough — backends, logging, and metrics — see the [Usage Guide](USAGE.md).
 
 ## Dashboard
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,43 @@
+# Usage
+
+Call `setup` once during app launch. This bootstraps logging, metrics, and crash reporting:
+```swift
+import CloudKit
+import Scout
+
+let container = CKContainer(identifier: "YOUR_CONTAINER_ID")
+
+try await setup(container: container)
+```
+
+To sync somewhere other than CloudKit — or to several destinations at once — pass a list of backends instead. Every raw record is uploaded to every backend, and the dashboard reads from the first one:
+```swift
+try await setup(backends: [
+    .cloudKit(container),
+    .server(url: URL(string: "https://scout.example.com")!, apiKey: "YOUR_API_KEY"),
+])
+```
+A [Scout server](https://github.com/kasianov-mikhail/scout-server) aggregates analytics natively, so it needs no schema upload and receives raw metric values instead of client-maintained matrices.
+
+After setup, use the standard [swift-log](https://github.com/apple/swift-log) API to write logs:
+```swift
+import Logging
+
+let logger = Logger(label: "MyApp")
+
+logger.info(
+    "Search_Performed",
+    metadata: [
+        "query": "coffee shops",
+        "result_count": "12",
+    ]
+)
+```
+
+Metrics work the same way via [swift-metrics](https://github.com/apple/swift-metrics):
+```swift
+import Metrics
+
+Counter(label: "api_requests").increment()
+Timer(label: "response_time").recordSeconds(duration)
+```


### PR DESCRIPTION
The `Usage` section of the README had grown large enough to crowd the overview, so this moves the full walkthrough — `setup`, multiple backends, logging, and metrics — into a dedicated `USAGE.md` and leaves a short summary with a link in its place.

Moving the `setup` snippets exposed an overlap with `INSTALLATION.md`, which carried its own copies of the same configuration. `INSTALLATION.md` is now trimmed to its unique install-time content (enabling CloudKit and uploading the schema) and points at the new Usage Guide, so the two files no longer duplicate each other and can't drift apart. The docs now split cleanly: `INSTALLATION.md` covers one-time infrastructure, `USAGE.md` covers how you call the API, and `README.md` stays an overview that links to both.
