### PR TITLE
Hide the timeline info button when there's no list to annotate

### DIFF
--- a/Sources/Scout/UI/Timeline/View/Timeline.swift
+++ b/Sources/Scout/UI/Timeline/View/Timeline.swift
@@ -47,14 +47,16 @@ struct Timeline: View {
                 }
             }
 
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                        showLegend.toggle()
-                        if !showLegend { expandedKind = nil }
+            if showsList {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                            showLegend.toggle()
+                            if !showLegend { expandedKind = nil }
+                        }
+                    } label: {
+                        Image(systemName: showLegend ? "info.circle.fill" : "info.circle")
                     }
-                } label: {
-                    Image(systemName: showLegend ? "info.circle.fill" : "info.circle")
                 }
             }
 
@@ -70,6 +72,19 @@ struct Timeline: View {
         .onChange(of: scope) { _ in
             Task(operation: load)
         }
+    }
+
+    /// Whether the timeline list is on screen.
+    ///
+    /// The legend toggled by the info button floats over the list, so the
+    /// button is only shown in this state — it has nothing to reveal while
+    /// loading or on an error or empty result.
+    ///
+    private var showsList: Bool {
+        if case .success = provider.result, provider.items.count > 0 {
+            return true
+        }
+        return false
     }
 
     private var list: some View {


### PR DESCRIPTION
In the timeline's loading, error, and empty states the info button in the navigation bar was inert. It toggles the rail `Legend`, which floats as an overlay over the timeline list, so with no list on screen tapping it could never reveal anything.

This change gates the button on a new `showsList` property that is true only when a populated list is displayed, mirroring the existing `if event != nil` pattern used for the All/Event picker. The button now appears only when there is a timeline to annotate. The All/Event picker is left in place since switching scope triggers a reload and can recover from the error state, unlike the legend.
