### PR TITLE
Drop redundant CI workflow config

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          fetch-tags: true
 
       # The package does not build with plain SwiftPM (Scout.xcdatamodeld is
       # only processed by the Xcode build system), so instead of

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: codeql-${{ github.ref }}
-
 jobs:
   analyze:
     runs-on: macos-26


### PR DESCRIPTION
Removes two pieces of dead workflow configuration that have no effect today. The API workflow's checkout passed `fetch-tags: true` alongside `fetch-depth: 0`, but a full-depth fetch already retrieves every tag, so the flag did nothing. The CodeQL workflow carried a `concurrency` group that only ran on `schedule` and `workflow_dispatch` and had no `cancel-in-progress`, so it never actually serialized or cancelled anything. Both are pure cleanups with no behavior change.