### PR TITLE
Add a rule to propose capturing new conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
+# Maintaining these instructions
+
+When you notice recurring feedback or a new project convention that isn't captured here yet, proactively propose adding it as a rule to this file — surface it as a suggested edit for the user to approve rather than editing on your own initiative.
+
 # Git & pull requests
 
 When pushing new commits to an existing PR, update its title and description to reflect the full scope of changes.


### PR DESCRIPTION
Adds a `Maintaining these instructions` section to `CLAUDE.md` so that when recurring feedback or a new project convention surfaces, Claude proposes capturing it as a rule in this file instead of letting it stay tacit. The rule makes clear that such changes are offered as suggested edits for approval, not applied on Claude's own initiative.
