### PR TITLE
Read metric charts from a Scout server's flat series

### DIFF
--- a/Sources/Scout/Core/Backend/HTTPDatabase.swift
+++ b/Sources/Scout/Core/Backend/HTTPDatabase.swift
@@ -141,6 +141,30 @@ extension HTTPDatabase: ActiveUsersReading {
     }
 }
 
+extension HTTPDatabase: MetricSeriesReading {
+    /// Fetches the server's flat per-name series for a telemetry `category`.
+    ///
+    /// Requests sparse hourly buckets so a year-long range stays as compact as
+    /// the matrix it replaces; the metrics UI rebuilds the weekly grid the
+    /// chart consumes from the result.
+    ///
+    func metricSeries(category: String, values: String, in range: Range<Date>) async throws -> [MetricSeries] {
+        let from = Int64((range.lowerBound.timeIntervalSince1970 * 1000).rounded())
+        let to = Int64((range.upperBound.timeIntervalSince1970 * 1000).rounded())
+        let category = category.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? category
+
+        let path = "api/v1/metrics/series?category=\(category)&values=\(values)&bucket=hour&dense=false&from=\(from)&to=\(to)"
+        guard let endpoint = URL(string: path, relativeTo: url) else {
+            throw HTTPDatabaseError(status: 0, reason: "Malformed metrics URL")
+        }
+
+        let (data, response) = try await session.data(for: request(for: endpoint, method: "GET"))
+        try check(response, data: data)
+
+        return try JSONDecoder().decode(MetricSeriesResponse.self, from: data).series
+    }
+}
+
 // MARK: - Transport
 
 /// A non-2xx response from a Scout server.

--- a/Sources/Scout/Core/Backend/MetricSeriesReading.swift
+++ b/Sources/Scout/Core/Backend/MetricSeriesReading.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+/// A backend that answers flat per-name metric series natively.
+///
+/// CloudKit cannot aggregate, so the client reads the `DateIntMatrix` /
+/// `DateDoubleMatrix` grids and flattens them. A Scout server aggregates over
+/// raw records and serves a finished series, so the client fetches a whole
+/// telemetry category in one request instead.
+///
+protocol MetricSeriesReading {
+    /// The series for every name in `category` of the given value flavor
+    /// (`"int"` or `"double"`) over `range`.
+    ///
+    func metricSeries(category: String, values: String, in range: Range<Date>) async throws -> [MetricSeries]
+}
+
+/// The server's grouped metric series — the response of
+/// `GET /api/v1/metrics/series`.
+///
+struct MetricSeriesResponse: Decodable {
+    let series: [MetricSeries]
+}
+
+/// One name's series over the requested range.
+///
+struct MetricSeries: Decodable {
+    let name: String
+    let category: String?
+    let points: [MetricSeriesPoint]
+}
+
+/// One bucket of a series: the aggregate `value` at `date`, milliseconds since
+/// the Unix epoch at the UTC bucket start.
+///
+struct MetricSeriesPoint: Decodable {
+    let date: Int64
+    let value: MetricValue
+}
+
+/// A typed series value: `int` for record counts and `IntMetric` sums,
+/// `double` for `DoubleMetric` sums. Encoded as a single-key object, e.g.
+/// `{"int": 42}`, matching the rest of the wire format.
+///
+enum MetricValue: Decodable, Equatable {
+    case int(Int)
+    case double(Double)
+
+    private enum CodingKeys: String, CodingKey {
+        case int, double
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let value = try container.decodeIfPresent(Int.self, forKey: .int) {
+            self = .int(value)
+        } else if let value = try container.decodeIfPresent(Double.self, forKey: .double) {
+            self = .double(value)
+        } else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unknown metric value type"
+                )
+            )
+        }
+    }
+}

--- a/Sources/Scout/Core/Backend/MetricSeriesReading.swift
+++ b/Sources/Scout/Core/Backend/MetricSeriesReading.swift
@@ -44,9 +44,11 @@ struct MetricSeriesPoint: Decodable {
     let value: MetricValue
 }
 
-/// A typed series value: `int` for record counts and `IntMetric` sums,
-/// `double` for `DoubleMetric` sums. Encoded as a single-key object, e.g.
-/// `{"int": 42}`, matching the rest of the wire format.
+/// A typed series value.
+///
+/// `int` carries record counts and `IntMetric` sums, `double` carries
+/// `DoubleMetric` sums. Encoded as a single-key object, e.g. `{"int": 42}`,
+/// matching the rest of the wire format.
 ///
 enum MetricValue: Decodable, Equatable {
     case int(Int)

--- a/Sources/Scout/UI/Chart/Model/ChartNumeric.swift
+++ b/Sources/Scout/UI/Chart/Model/ChartNumeric.swift
@@ -20,4 +20,35 @@ import Foundation
 /// matrix-to-chart transformations to guarantee that values are both
 /// persistable (domain layer) and plottable (UI layer).
 ///
-typealias ChartNumeric = MatrixValue & Plottable
+typealias ChartNumeric = MatrixValue & Plottable & MetricSeriesScalar
+
+/// Bridges a server `MetricValue` to a chart scalar so a flat `MetricSeries`
+/// can rebuild typed `GridMatrix` cells. `seriesValues` is the value flavor the
+/// `/metrics/series` endpoint expects for this scalar.
+///
+protocol MetricSeriesScalar {
+    static var seriesValues: String { get }
+    static func chartValue(_ value: MetricValue) -> Self
+}
+
+extension Int: MetricSeriesScalar {
+    static var seriesValues: String { "int" }
+
+    static func chartValue(_ value: MetricValue) -> Int {
+        switch value {
+        case .int(let value): value
+        case .double(let value): Int(value)
+        }
+    }
+}
+
+extension Double: MetricSeriesScalar {
+    static var seriesValues: String { "double" }
+
+    static func chartValue(_ value: MetricValue) -> Double {
+        switch value {
+        case .int(let value): Double(value)
+        case .double(let value): value
+        }
+    }
+}

--- a/Sources/Scout/UI/Metrics/MetricsProvider.swift
+++ b/Sources/Scout/UI/Metrics/MetricsProvider.swift
@@ -8,7 +8,10 @@
 import CloudKit
 
 class MetricsProvider<T: ChartNumeric>: QueryProvider<GridMatrix<T>> {
+    private let telemetry: Telemetry.Export
+
     init(telemetry: Telemetry.Export) {
+        self.telemetry = telemetry
         super.init {
             let predicate = NSCompoundPredicate(
                 type: .and,
@@ -23,5 +26,23 @@ class MetricsProvider<T: ChartNumeric>: QueryProvider<GridMatrix<T>> {
                 predicate: predicate
             )
         }
+    }
+
+    /// A Scout server aggregates these series natively, so fetch the flat
+    /// per-name series for the category and rebuild the grid the chart consumes.
+    ///
+    /// CloudKit backends still answer the `DateIntMatrix` / `DateDoubleMatrix`
+    /// query the initializer builds.
+    ///
+    override func fetch(in database: AppDatabase) async throws -> [GridMatrix<T>] {
+        guard let server = database as? MetricSeriesReading else {
+            return try await super.fetch(in: database)
+        }
+        let series = try await server.metricSeries(
+            category: telemetry.rawValue,
+            values: T.seriesValues,
+            in: Calendar.utc.defaultRange
+        )
+        return series.gridMatrices()
     }
 }

--- a/Sources/Scout/UI/Metrics/Series/MetricSeries+Grid.swift
+++ b/Sources/Scout/UI/Metrics/Series/MetricSeries+Grid.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension Sequence where Element == MetricSeries {
+    /// Rebuilds the weekly `GridMatrix` objects the chart consumes from a Scout
+    /// server's flat per-name series.
+    ///
+    /// Each point lands in its week's matrix at the `cell_<weekday>_<hour>`
+    /// position a CloudKit client would have written, so the rest of the
+    /// metrics pipeline (`pointGroups`, the chart) is unchanged. The server
+    /// sends sparse hourly buckets, so every point is a real cell — there are
+    /// no zero-fills to drop.
+    ///
+    func gridMatrices<T: ChartNumeric>() -> [GridMatrix<T>] {
+        let calendar = Calendar.utc
+        var byWeek: [WeekKey: [GridCell<T>]] = [:]
+
+        for series in self {
+            for point in series.points {
+                let date = Date(timeIntervalSince1970: Double(point.date) / 1000)
+                let key = WeekKey(name: series.name, category: series.category, week: date.startOfWeek)
+                byWeek[key, default: []].append(
+                    GridCell(
+                        row: calendar.component(.weekday, from: date),
+                        column: calendar.component(.hour, from: date),
+                        value: T.chartValue(point.value)
+                    )
+                )
+            }
+        }
+
+        return byWeek.map { key, cells in
+            GridMatrix(
+                recordType: T.recordType,
+                date: key.week,
+                name: key.name,
+                category: key.category,
+                record: nil,
+                cells: cells
+            )
+        }
+    }
+}
+
+private struct WeekKey: Hashable {
+    let name: String
+    let category: String?
+    let week: Date
+}

--- a/Tests/ScoutTests/UI/Metrics/MetricsProviderTests.swift
+++ b/Tests/ScoutTests/UI/Metrics/MetricsProviderTests.swift
@@ -1,0 +1,102 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+struct MetricsProviderTests {
+    @Test("Reads the flat series from a Scout server and rebuilds grid matrices")
+    func fetchUsesServerSeries() async throws {
+        let database = MetricsServerStub(series: [
+            MetricSeries(
+                name: "api_calls",
+                category: "counter",
+                points: [
+                    MetricSeriesPoint(date: ms(2026, 6, 10, 9), value: .int(2)),
+                    MetricSeriesPoint(date: ms(2026, 6, 10, 10), value: .int(3)),
+                    MetricSeriesPoint(date: ms(2026, 6, 17, 9), value: .int(1)),
+                ]
+            ),
+            MetricSeries(
+                name: "errors",
+                category: "counter",
+                points: [
+                    MetricSeriesPoint(date: ms(2026, 6, 10, 9), value: .int(4))
+                ]
+            ),
+        ])
+
+        let provider = MetricsProvider<Int>(telemetry: .counter)
+        await provider.fetchIfNeeded(in: database)
+        let matrices = try #require(try provider.result?.get())
+
+        let groups = matrices.pointGroups()
+        #expect(Set(groups.map(\.name)) == ["api_calls", "errors"])
+
+        let calls = try #require(groups.first { $0.name == "api_calls" })
+        // Points span two weeks but flatten under the one name.
+        #expect(calls.points.map(\.count).sorted() == [1, 2, 3])
+        // The cell position round-trips back to the original hour.
+        #expect(calls.points.contains { $0.date == date(2026, 6, 10, 9) })
+        #expect(calls.points.contains { $0.date == date(2026, 6, 17, 9) })
+
+        let errors = try #require(groups.first { $0.name == "errors" })
+        #expect(errors.points.map(\.count) == [4])
+    }
+
+    @Test("Non-server backends still issue the matrix query")
+    func fetchFallsBackToMatrixQuery() async throws {
+        let database = DatabaseStub()
+
+        let provider = MetricsProvider<Int>(telemetry: .counter)
+        await provider.fetchIfNeeded(in: database)
+        _ = try #require(try provider.result?.get())
+
+        #expect(database.readCount(of: Int.recordType) == 1)
+    }
+
+    // MARK: - Helpers
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int) -> Date {
+        DateComponents(calendar: .utc, year: year, month: month, day: day, hour: hour).date!
+    }
+
+    private func ms(_ year: Int, _ month: Int, _ day: Int, _ hour: Int) -> Int64 {
+        Int64((date(year, month, day, hour).timeIntervalSince1970 * 1000).rounded())
+    }
+}
+
+/// An `AppDatabase` that also answers the native metric series, standing in for
+/// a Scout server backend.
+///
+private final class MetricsServerStub: AppDatabase, MetricSeriesReading, @unchecked Sendable {
+    let series: [MetricSeries]
+
+    init(series: [MetricSeries]) {
+        self.series = series
+    }
+
+    func metricSeries(category: String, values: String, in range: Range<Date>) async throws -> [MetricSeries] {
+        series
+    }
+
+    func lookup(id: CKRecord.ID, fields: [CKRecord.FieldKey]?) async throws -> CKRecord {
+        throw CKError(.unknownItem)
+    }
+
+    func read(matching query: CKQuery, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+        RecordChunk(records: [], cursor: nil)
+    }
+
+    func readMore(from cursor: RecordCursor, fields: [CKRecord.FieldKey]?) async throws -> RecordChunk {
+        RecordChunk(records: [], cursor: nil)
+    }
+}


### PR DESCRIPTION
When the dashboard talks to a Scout server, the metrics charts now fetch the flat `/metrics/series` endpoint instead of querying `DateIntMatrix` / `DateDoubleMatrix` grids and flattening them. `MetricsProvider` asks the server for every name in a telemetry category as a sparse hourly series and rebuilds the weekly `GridMatrix` objects the chart already consumes, so `pointGroups` and the rest of the pipeline are untouched. CloudKit backends keep issuing the matrix query, mirroring how `ActivityProvider` already handles the active-user series.

The plumbing follows the existing `ActiveUsersReading` shape: a `MetricSeriesReading` protocol with its DTOs and an `HTTPDatabase` conformance, plus a small `MetricSeriesScalar` bridge so the generic chart scalar can decode the server's typed values and report the `int`/`double` flavor the endpoint expects.

This depends on the server-side endpoint in kasianov-mikhail/scout-server#27, which must be deployed for the server path to resolve; without it, CloudKit backends are unaffected.