### PR TITLE
Keep the timeline scope picker from flickering on load

### DIFF
--- a/Sources/Scout/UI/Timeline/View/Timeline.swift
+++ b/Sources/Scout/UI/Timeline/View/Timeline.swift
@@ -47,8 +47,8 @@ struct Timeline: View {
                 }
             }
 
-            if showsList {
-                ToolbarItem(placement: .topBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
+                if showsList {
                     Button {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                             showLegend.toggle()


### PR DESCRIPTION
The `All`/`Event` segmented picker sits in the navigation bar's `.principal` toolbar slot but shared the `.toolbar` block with the info button, which was added only when the list was on screen via `if showsList`. As `TimelineProvider.result` cycled through its loading and loaded states the info button's `ToolbarItem` appeared and disappeared, so SwiftUI rebuilt the navigation bar and re-created the principal picker each time, making it blink — most visibly when switching between `All` and `Event`. This keeps the info button's `ToolbarItem` always present with the `showsList` check moved inside its content, so the toolbar's item set no longer changes with load state and the picker stays put.