### PR TITLE
Provide bundle-configured backends as a Backend factory

### DIFF
--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -24,6 +24,21 @@ public enum Backend: Sendable {
     case server(url: URL, apiKey: String? = nil)
 }
 
+extension Backend {
+    /// The self-hosted Scout server whose address is baked into the build (the
+    /// `SCOUT_IP` and `SCOUT_API_KEYS` build settings). Empty when the build
+    /// carries no address.
+    ///
+    public static func fromBundle() -> [Backend] {
+        guard let address = Bundle.main.infoDictionary?["SCOUT_IP"] as? String, !address.isEmpty, let url = URL(string: address) else {
+            return []
+        }
+
+        let apiKey = Bundle.main.infoDictionary?["SCOUT_API_KEYS"] as? String
+        return [.server(url: url, apiKey: apiKey?.isEmpty == false ? apiKey : nil)]
+    }
+}
+
 /// The full database surface a backend must provide.
 protocol BackendDatabase: RecordWriter, RecordReader, RecordLookup, Sendable {}
 

--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -26,8 +26,9 @@ public enum Backend: Sendable {
 
 extension Backend {
     /// The self-hosted Scout server whose address is baked into the build (the
-    /// `SCOUT_IP` and `SCOUT_API_KEYS` build settings). Empty when the build
-    /// carries no address.
+    /// `SCOUT_IP` and `SCOUT_API_KEYS` build settings).
+    ///
+    /// Empty when the build carries no address.
     ///
     public static func fromBundle() -> [Backend] {
         guard let address = Bundle.main.infoDictionary?["SCOUT_IP"] as? String, !address.isEmpty, let url = URL(string: address) else {


### PR DESCRIPTION
Moves the logic that reads the build-baked Scout server address into the `Backend` type as a `fromBundle()` static factory, so the package owns it rather than the host app. It reads the `SCOUT_IP` and `SCOUT_API_KEYS` build settings from the bundle's info dictionary and returns a single `server` backend, or an empty array when no address is baked in. Call sites become `Backend.fromBundle()`, e.g. `setup(backends: Backend.fromBundle())`. The multi-condition `guard` was also reformatted to the house style — all conditions on one line with only the `else` block expanded.