### PR TITLE
Deprecate the container-only setup and HomeView entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ For the full walkthrough — backends, logging, and metrics — see the [Usage G
 
 ## Dashboard
 
-Present `HomeView` to browse logs, metrics, crashes, and user activity:
+Present `HomeView` to browse logs, metrics, crashes, and user activity. Hand it the same backend list you passed to `setup`:
 ```swift
-HomeView(container: container)
+HomeView(backends: [.cloudKit(container)])
 ```
-When running against Scout servers, hand it the same backend list you passed to `setup`:
+Or point it at a Scout server:
 ```swift
 HomeView(backends: [.server(url: serverURL, apiKey: "YOUR_API_KEY")])
 ```

--- a/Sources/Scout/Core/Bootstrap/Setup.swift
+++ b/Sources/Scout/Core/Bootstrap/Setup.swift
@@ -22,17 +22,6 @@ struct NoBackendsError: LocalizedError {
 
 @MainActor private var isSetup = false
 
-/// Initializes Scout's global infrastructure against a CloudKit container.
-///
-/// - Parameter container: The CloudKit container for all operations.
-/// - Throws: An error if initialization fails or if called more than once.
-/// - Important: Call from the main actor during app startup.
-///
-@MainActor
-public func setup(container: CKContainer) async throws {
-    try await setup(backends: [.cloudKit(container)])
-}
-
 /// Initializes Scout's global infrastructure against one or more backends.
 ///
 /// Every raw record is synced to every backend. CloudKit backends also
@@ -97,4 +86,10 @@ private func warnAboutCleartextKeys(in backends: [Backend]) {
     for case .server(let url, _?) in backends where url.scheme?.lowercased() != "https" {
         print("[Scout] The API key for '\(url)' will be sent over a non-HTTPS connection in cleartext. Use an https:// URL.")
     }
+}
+
+@MainActor
+@available(*, deprecated, message: "Use setup(backends:) with [.cloudKit(container)] instead.")
+public func setup(container: CKContainer) async throws {
+    try await setup(backends: [.cloudKit(container)])
 }

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -12,10 +12,6 @@ public struct HomeView: View {
     @StateObject private var dataSource: DataSourceModel
     @StateObject private var tint = Tint()
 
-    public init(container: CKContainer) {
-        _dataSource = StateObject(wrappedValue: DataSourceModel(backends: [.cloudKit(container)]))
-    }
-
     /// Reads analytics from the active backend, defaulting to the first.
     ///
     /// When several backends are configured, a toolbar control lets the user
@@ -53,6 +49,18 @@ public struct HomeView: View {
                 DataSourceMenu(servers: dataSource.servers, activeID: $dataSource.activeID)
             }
         }
+    }
+}
+
+extension HomeView {
+    /// Reads analytics from a single CloudKit container.
+    ///
+    /// A convenience over ``init(backends:)`` for the CloudKit-only case;
+    /// prefer that initializer, passing `[.cloudKit(container)]`.
+    ///
+    @available(*, deprecated, message: "Use init(backends:) with [.cloudKit(container)] instead.")
+    public init(container: CKContainer) {
+        self.init(backends: [.cloudKit(container)])
     }
 }
 

--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -22,7 +22,7 @@ struct SetupPage: View {
                 Step(
                     number: 1,
                     label: "Initialize Scout in your app",
-                    code: "try await setup(container: .default())"
+                    code: "try await setup(backends: [.cloudKit(.default())])"
                 )
                 Step(
                     number: 2,

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7,10 +7,10 @@ import Scout
 
 let container = CKContainer(identifier: "YOUR_CONTAINER_ID")
 
-try await setup(container: container)
+try await setup(backends: [.cloudKit(container)])
 ```
 
-To sync somewhere other than CloudKit — or to several destinations at once — pass a list of backends instead. Every raw record is uploaded to every backend, and the dashboard reads from the first one:
+To sync somewhere other than CloudKit — or to several destinations at once — add more backends to the list. Every raw record is uploaded to every backend, and the dashboard reads from the first one:
 ```swift
 try await setup(backends: [
     .cloudKit(container),


### PR DESCRIPTION
Scout has two ways to point at a destination: the older `container:` convenience and the newer `backends:` list, which subsumes it via `.cloudKit(container)`. This keeps both available but marks the `container:` forms of `setup` and `HomeView.init` as `@available(*, deprecated, …)` so the `backends:` API becomes the single recommended entry point. The deprecated `HomeView` initializer now lives in its own extension and forwards to `init(backends:)`, and the deprecated `setup(container:)` moves to the bottom of `Setup.swift`, both delegating instead of duplicating setup logic.

Documentation and the in-app onboarding follow suit: the `README`, the `USAGE` guide, and the `SetupPage` quick-setup snippet now all show the `backends:` form so nothing steers integrators toward a deprecated call. No behaviour changes — the deprecated paths still resolve through the same `backends:` machinery.