### PR TITLE
Document the scout↔scout-server contract in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,7 @@ Never reset, wipe, or destroy the persistent store to recover from a model misma
 # CloudKit schema
 
 Never remove or rename fields, record types, or index modifiers (`QUERYABLE`/`SEARCHABLE`/`SORTABLE`) in the CloudKit `Schema` file — Production schemas are append-only and `cktool import-schema` will reject removals with `cannot remove field … which exists in active production type …`. To deprecate a field, stop writing it in code but keep its declaration in `Schema`.
+
+# Server contract
+
+scout and scout-server (`kasianov-mikhail/scout-server`) share an HTTP wire-format contract, so changes to the two repos are often interrelated: a change to request/response shapes, field names, the queryable-field set, or endpoints on the scout side (the `Core/Database/Backend` layer — `HTTPQueryCoding`, `HTTPRecordCoding`, `HTTPDatabase`) usually needs a matching change in scout-server, and vice versa. They are separate repos, so a contract change normally ships as a PR in each — call out the companion PR in both descriptions. `ServerContractTests` (run by the `Server` workflow in `.github/workflows/server.yml`, which boots a real scout-server) guards the wire format, so extend and run it when you touch either side rather than assuming the contract still holds.


### PR DESCRIPTION
Adds a `Server contract` rule to `CLAUDE.md` noting that scout and scout-server share an HTTP wire-format contract, so changes to the two repos are often interrelated. The rule points at the scout-side touchpoints (`HTTPQueryCoding`, `HTTPRecordCoding`, and `HTTPDatabase` in the `Core/Database/Backend` layer) and at `ServerContractTests`, which the `Server` workflow runs against a real scout-server to guard the wire format, so anyone touching either side knows to keep both in sync and ship a companion PR. Companion change on the scout-server side: https://github.com/kasianov-mikhail/scout-server/pull/29.