### PR TITLE
Apply the background-time guard to hosted-server requests

### DIFF
--- a/Sources/Scout/Core/Database/BackgroundExecutionTime.swift
+++ b/Sources/Scout/Core/Database/BackgroundExecutionTime.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#if os(iOS)
+    import UIKit
+#else
+    import Foundation
+#endif
+
+/// The minimum background execution time, in seconds, that must remain before
+/// Scout starts a new database request.
+private let minimumBackgroundTime: TimeInterval = 15
+
+/// Throws ``InsufficientBackgroundTimeError`` when too little background
+/// execution time remains to safely start a database request.
+///
+/// Every backend gates its requests on this so an upload or read isn't started
+/// only to be stranded when iOS suspends the app — CloudKit through its request
+/// runner and hosted servers through ``HTTPDatabase``. It is a no-op anywhere
+/// but iOS, where apps keep running in the background and the remaining time is
+/// effectively unbounded.
+///
+func requireBackgroundTime() async throws {
+    #if os(iOS)
+        guard await UIApplication.shared.backgroundTimeRemaining > minimumBackgroundTime else {
+            throw InsufficientBackgroundTimeError()
+        }
+    #endif
+}
+
+/// Raised when a database request is skipped because too little background
+/// execution time remains.
+///
+struct InsufficientBackgroundTimeError: LocalizedError {
+    let errorDescription: String? = "The operation was aborted because the remaining background time is insufficient."
+    let failureReason: String? = "Not enough background time remaining."
+    let helpAnchor: String? = "https://developer.apple.com/documentation/uikit/uiapplication/backgroundtimeremaining"
+    let recoverySuggestion: String? = "Try again later."
+}

--- a/Sources/Scout/Hosted/HTTPDatabase.swift
+++ b/Sources/Scout/Hosted/HTTPDatabase.swift
@@ -93,9 +93,7 @@ extension HTTPDatabase: RecordLookup {
             throw HTTPDatabaseError(status: 0, reason: "Malformed record URL")
         }
 
-        let (data, response) = try await session.data(for: request(for: endpoint, method: "GET"))
-        try check(response, data: data)
-
+        let data = try await perform(request(for: endpoint, method: "GET"))
         return try JSONDecoder().decode(HTTPRecord.self, from: data).toRecord
     }
 }
@@ -136,9 +134,7 @@ extension HTTPDatabase: ActiveUsersReading {
             throw HTTPDatabaseError(status: 0, reason: "Malformed metrics URL")
         }
 
-        let (data, response) = try await session.data(for: request(for: endpoint, method: "GET"))
-        try check(response, data: data)
-
+        let data = try await perform(request(for: endpoint, method: "GET"))
         return try JSONDecoder().decode(ActiveUsersResponse.self, from: data).series
     }
 }
@@ -160,9 +156,7 @@ extension HTTPDatabase: MetricSeriesReading {
             throw HTTPDatabaseError(status: 0, reason: "Malformed metrics URL")
         }
 
-        let (data, response) = try await session.data(for: request(for: endpoint, method: "GET"))
-        try check(response, data: data)
-
+        let data = try await perform(request(for: endpoint, method: "GET"))
         return try JSONDecoder().decode(MetricSeriesResponse.self, from: data).series
     }
 }
@@ -190,10 +184,20 @@ extension HTTPDatabase {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(body)
 
+        let data = try await perform(request)
+        return try JSONDecoder().decode(Reply.self, from: data)
+    }
+
+    /// Runs one request, gating on background time and validating the response.
+    ///
+    /// Every network call funnels through here so the background-time guard that
+    /// protects CloudKit requests applies equally to hosted servers.
+    ///
+    private func perform(_ request: URLRequest) async throws -> Data {
+        try await requireBackgroundTime()
         let (data, response) = try await session.data(for: request)
         try check(response, data: data)
-
-        return try JSONDecoder().decode(Reply.self, from: data)
+        return data
     }
 
     private func request(for endpoint: URL, method: String) -> URLRequest {

--- a/Sources/Scout/Native/Request/CKDatabase+Runner.swift
+++ b/Sources/Scout/Native/Request/CKDatabase+Runner.swift
@@ -7,28 +7,13 @@
 
 import CloudKit
 
-#if os(iOS)
-    import UIKit
-#endif
-
 extension CKDatabase {
     @discardableResult func runner<R>(body: @Sendable (CKDatabase) async throws -> R) async throws -> R {
-        #if os(iOS)
-            guard await UIApplication.shared.backgroundTimeRemaining > 15 else {
-                throw RunnerError()
-            }
-        #endif
+        try await requireBackgroundTime()
 
         return try await requestLimiter.withSlot {
             try await configuredWith(configuration: .scout, body: body)
         }
-    }
-
-    struct RunnerError: LocalizedError {
-        let errorDescription: String? = "The operation was aborted because the remaining background time is insufficient."
-        let failureReason: String? = "Not enough background time remaining."
-        let helpAnchor: String? = "https://developer.apple.com/documentation/uikit/uiapplication/backgroundtimeremaining"
-        let recoverySuggestion: String? = "Try again later."
     }
 }
 


### PR DESCRIPTION
Scout's minimum background-time check — which avoids starting a request that iOS would strand when it suspends the app — previously lived only in CloudKit's `CKDatabase.runner`, so requests to hosted Scout servers ran without it. This extracts the check into a shared `requireBackgroundTime()` helper (renaming the former `RunnerError` to `InsufficientBackgroundTimeError`) and runs it from both backends: CloudKit's runner and a new `HTTPDatabase.perform` chokepoint that every hosted request now funnels through, which also folds together the response handling that was duplicated across the HTTP read paths. The guard is a no-op in the foreground, where the remaining background time is effectively unbounded, so it only takes effect during background sync.