### PR TITLE
Co-locate the reading protocols with their consumers

### DIFF
--- a/Sources/Scout/Hosted/HTTPDatabase.swift
+++ b/Sources/Scout/Hosted/HTTPDatabase.swift
@@ -137,6 +137,13 @@ extension HTTPDatabase: ActiveUsersReading {
         let data = try await perform(request(for: endpoint, method: "GET"))
         return try JSONDecoder().decode(ActiveUsersResponse.self, from: data).series
     }
+
+    /// The server's native active-user series — the response of
+    /// `GET /api/v1/metrics/active-users`.
+    ///
+    private struct ActiveUsersResponse: Decodable {
+        let series: [ActiveUserPoint]
+    }
 }
 
 extension HTTPDatabase: MetricSeriesReading {
@@ -158,6 +165,13 @@ extension HTTPDatabase: MetricSeriesReading {
 
         let data = try await perform(request(for: endpoint, method: "GET"))
         return try JSONDecoder().decode(MetricSeriesResponse.self, from: data).series
+    }
+
+    /// The server's grouped metric series — the response of
+    /// `GET /api/v1/metrics/series`.
+    ///
+    private struct MetricSeriesResponse: Decodable {
+        let series: [MetricSeries]
     }
 }
 

--- a/Sources/Scout/UI/Activity/ActiveUsersReading.swift
+++ b/Sources/Scout/UI/Activity/ActiveUsersReading.swift
@@ -18,13 +18,6 @@ protocol ActiveUsersReading {
     func activeUsers(in range: Range<Date>) async throws -> [ActiveUserPoint]
 }
 
-/// The server's native active-user series — the response of
-/// `GET /api/v1/metrics/active-users`.
-///
-struct ActiveUsersResponse: Decodable {
-    let series: [ActiveUserPoint]
-}
-
 /// One day of the series: distinct active installs as of `date`, counted over
 /// the trailing day (`dau`), 7 days (`wau`), and calendar month (`mau`).
 ///

--- a/Sources/Scout/UI/Metrics/MetricSeriesReading.swift
+++ b/Sources/Scout/UI/Metrics/MetricSeriesReading.swift
@@ -21,13 +21,6 @@ protocol MetricSeriesReading {
     func metricSeries(category: String, values: String, in range: Range<Date>) async throws -> [MetricSeries]
 }
 
-/// The server's grouped metric series — the response of
-/// `GET /api/v1/metrics/series`.
-///
-struct MetricSeriesResponse: Decodable {
-    let series: [MetricSeries]
-}
-
 /// One name's series over the requested range.
 ///
 struct MetricSeries: Decodable {


### PR DESCRIPTION
`ActiveUsersReading` and `MetricSeriesReading` lived in `Core/Backend`, but each is an abstraction protocol that a UI provider probes for via `as?`, so per the dependency-inversion convention they belong next to their consumer rather than their conformer. This moves `ActiveUsersReading` and its `ActiveUserPoint` return type beside `ActivityProvider` in `UI/Activity`, and `MetricSeriesReading` together with `MetricSeries`, `MetricSeriesPoint`, and `MetricValue` beside `MetricsProvider` in `UI/Metrics`. The HTTP response envelopes `ActiveUsersResponse` and `MetricSeriesResponse` are only ever decoded by `HTTPDatabase`, so they fold into it as `private` nested structs alongside the existing `HTTPWriteAck` and `HTTPErrorBody`. This is a structure-only change and leaves the wire format untouched.