### PR TITLE
Add comment conventions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@
 - Document only public API: write doc comments (`///`) for `public`/`open` declarations only, and leave `internal`, `private`, and `fileprivate` declarations undocumented (an inline `//` note for genuinely non-obvious logic is still fine).
 - Multi-line doc comments (`///`) must end with a trailing empty `///` line, except when they document a single-line property declaration (a stored `let`/`var` written on one line), where the trailing empty `///` is omitted. Single-line doc comments never need it.
 
+## `MARK` comments
+
+- Don't use `// MARK:` comments to divide code into sections.
+
 ## `guard` statements
 
 - `guard` statements with multiple conditions or pattern matching (`case .x = y`) should keep the conditions on a single line but expand the `else` block to multiple lines (`else {` / body / `}`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@
 
 ## Doc comments
 
+- Document only public API: write doc comments (`///`) for `public`/`open` declarations only, and leave `internal`, `private`, and `fileprivate` declarations undocumented (an inline `//` note for genuinely non-obvious logic is still fine).
 - Multi-line doc comments (`///`) must end with a trailing empty `///` line, except when they document a single-line property declaration (a stored `let`/`var` written on one line), where the trailing empty `///` is omitted. Single-line doc comments never need it.
 
 ## `guard` statements


### PR DESCRIPTION
Adds two comment conventions to `CLAUDE.md`. Doc comments (`///`) go only on `public`/`open` declarations, leaving `internal`, `private`, and `fileprivate` code undocumented (an inline `//` for genuinely non-obvious logic is still fine). And `// MARK:` comments aren't used to divide code into sections. The same rules are added to the sibling \`scout-ip\` and \`scout-server\` repos.