### PR TITLE
Allow short single-condition guards to stay inline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@
 
 ## `guard` statements
 
-- `guard` statements with multiple conditions or pattern matching (`case .x = y`) should keep the conditions on a single line but expand the `else` block to multiple lines (`else {` / body / `}`).
-- Single-condition simple guards (`guard let x = y else { return }`, `guard !x else { return }`) stay fully inline.
+- A short, single-condition `guard` stays fully inline — both simple bindings (`guard let x = y else { return }`, `guard !x else { return }`) and pattern matching (`guard case .x = y else { return nil }`).
+- Expand the `else` block onto multiple lines (`else {` / body / `}`) when the `guard` has multiple conditions, or when its condition or `else` body is long or complex. Multi-condition guards still keep their conditions on a single line.
 
 ## Function and method signatures
 


### PR DESCRIPTION
Refines the `guard` style rule in `CLAUDE.md` so that a short, single-condition `guard` may stay on one line, including pattern matching such as `guard case .x = y else { return nil }`. Guards with multiple conditions, or whose condition or `else` body is long or complex, still expand the `else` block onto its own lines. The previous wording forced every pattern-matching guard to expand its `else`, which was stricter than intended for short cases.