### PR TITLE
Optimize matrix duplicate merging to linear time

### DIFF
--- a/Sources/Scout/Core/Matrix/Cell/GridCell.swift
+++ b/Sources/Scout/Core/Matrix/Cell/GridCell.swift
@@ -42,8 +42,8 @@ extension GridCell: CellProtocol {
 // MARK: - Combining
 
 extension GridCell: Combining {
-    func isDuplicate(of other: GridCell<T>) -> Bool {
-        row == other.row && column == other.column
+    var duplicateKey: String {
+        key
     }
 
     static func + (lhs: Self, rhs: Self) -> Self {

--- a/Sources/Scout/Core/Matrix/Cell/PeriodCell.swift
+++ b/Sources/Scout/Core/Matrix/Cell/PeriodCell.swift
@@ -42,8 +42,8 @@ extension PeriodCell: CellProtocol {
 // MARK: - Combining
 
 extension PeriodCell: Combining {
-    func isDuplicate(of other: Self) -> Bool {
-        period == other.period && day == other.day
+    var duplicateKey: String {
+        key
     }
 
     static func + (lhs: PeriodCell, rhs: PeriodCell) -> PeriodCell {

--- a/Sources/Scout/Core/Matrix/Model/Combining.swift
+++ b/Sources/Scout/Core/Matrix/Model/Combining.swift
@@ -9,16 +9,22 @@ import Foundation
 
 /// A value that can be merged pairwise with an "equivalent" instance.
 ///
-/// `isDuplicate(of:)` answers whether two values refer to the same bucket
+/// `duplicateKey` identifies whether two values refer to the same bucket
 /// (e.g. same matrix coordinate); `+` combines them. `Array.mergeDuplicates`
-/// uses both to collapse a sequence down to one entry per bucket.
+/// uses both to collapse a sequence down to one entry per bucket in O(n).
 ///
 protocol Combining {
+    associatedtype DuplicateKey: Hashable
+    var duplicateKey: DuplicateKey { get }
     func isDuplicate(of other: Self) -> Bool
     static func + (lhs: Self, rhs: Self) -> Self
 }
 
 extension Combining {
+    func isDuplicate(of other: Self) -> Bool {
+        duplicateKey == other.duplicateKey
+    }
+
     static func += (lhs: inout Self, rhs: Self) {
         assert(lhs.isDuplicate(of: rhs), "Cannot combine non-duplicate instances of \(Self.self)")
         lhs = lhs + rhs
@@ -27,12 +33,13 @@ extension Combining {
 
 extension Array where Element: Combining {
     func mergeDuplicates() -> Self {
-        reduce(into: []) { result, value in
-            if let index = result.firstIndex(where: {
-                $0.isDuplicate(of: value)
-            }) {
+        var indexByKey: [Element.DuplicateKey: Int] = [:]
+
+        return reduce(into: []) { result, value in
+            if let index = indexByKey[value.duplicateKey] {
                 result[index] += value
             } else {
+                indexByKey[value.duplicateKey] = result.endIndex
                 result.append(value)
             }
         }

--- a/Sources/Scout/Core/Matrix/Model/Matrix.swift
+++ b/Sources/Scout/Core/Matrix/Model/Matrix.swift
@@ -19,11 +19,15 @@ struct Matrix<T: CellProtocol> {
 // MARK: - Combining
 
 extension Matrix: Combining {
-    func isDuplicate(of other: Matrix<T>) -> Bool {
-        date == other.date
-            && name == other.name
-            && category == other.category
-            && recordType == other.recordType
+    struct DuplicateKey: Hashable {
+        let recordType: String
+        let date: Date
+        let name: String
+        let category: String?
+    }
+
+    var duplicateKey: DuplicateKey {
+        DuplicateKey(recordType: recordType, date: date, name: name, category: category)
     }
 
     static func + (lhs: Self, rhs: Self) -> Self {


### PR DESCRIPTION
## Why
Merging duplicate matrix values used a linear search for each element, which made aggregation quadratic as input grew. This change makes deduplication scale predictably for larger metric/event datasets.

## What changed
- Added a hashable `duplicateKey` contract to `Combining` and a default `isDuplicate(of:)` implementation based on that key.
- Reworked `Array.mergeDuplicates()` to maintain an index map by `duplicateKey`, reducing merge complexity from O(n^2) to O(n) while preserving first-seen order.
- Updated `GridCell`, `PeriodCell`, and `Matrix` to provide stable duplicate keys used by the new merge path.

## Notes for reviewers
- `Matrix` uses a nominal `DuplicateKey` type to avoid brittle string matching logic for compound identity.
- Behavior is unchanged: duplicates still coalesce in-place and output order follows first occurrence.

## Validation
- `xcrun swift-format lint --strict --recursive Sources Tests`
- `xcodebuild -scheme Scout -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -resultBundlePath /tmp/scout-results.xcresult test`
- Test summary: 367 passed, 0 failed, 6 skipped