### PR TITLE
Drop the leading article from the CloudKit requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 
 - iOS 16.0+
 - Swift 6.0+
-- An [Apple Developer](https://developer.apple.com) account with [CloudKit](https://developer.apple.com/icloud/cloudkit/) enabled
+- [Apple Developer](https://developer.apple.com) account with [CloudKit](https://developer.apple.com/icloud/cloudkit/) enabled
 
 ## Installation
 


### PR DESCRIPTION
Removes the leading `An` from the CloudKit requirement bullet in the README so it reads as a bare noun phrase, matching the `iOS 16.0+` and `Swift 6.0+` items above it. This makes the three requirements parallel in structure and reads a touch cleaner.