### PR TITLE
Use opaque some parameters instead of single-use generics

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Metrics/MetricsObject+RecordEncodable.swift
+++ b/Sources/Scout/Core/Diagnostics/Metrics/MetricsObject+RecordEncodable.swift
@@ -24,7 +24,7 @@ extension DoubleMetricsObject: RecordEncodable {
 }
 
 extension MetricsObject {
-    fileprivate func metricRecord<V: RecordValueConvertible>(type: String, value: V) -> Record {
+    fileprivate func metricRecord(type: String, value: some RecordValueConvertible) -> Record {
         var record = Record(recordType: type, recordID: objectID.uriRepresentation().absoluteString)
 
         record["name"] = name

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -8,7 +8,7 @@
 import CoreData
 
 extension CKTelemetryHandler {
-    func logMetrics<T: MetricScalar>(telemetry: Telemetry.Export, value: T) {
+    func logMetrics(telemetry: Telemetry.Export, value: some MetricScalar) {
         let label = self.label
         let sync = self.sync
         Task {

--- a/Sources/Scout/Hosted/HTTPDatabase.swift
+++ b/Sources/Scout/Hosted/HTTPDatabase.swift
@@ -42,7 +42,7 @@ struct HTTPDatabaseError: LocalizedError {
 
 extension HTTPDatabase {
     @discardableResult
-    func send<Body: Encodable, Reply: Decodable>(_ body: Body, to path: String, into reply: Reply.Type) async throws -> Reply {
+    func send<Reply: Decodable>(_ body: some Encodable, to path: String, into reply: Reply.Type) async throws -> Reply {
         guard let endpoint = URL(string: path, relativeTo: url) else {
             throw HTTPDatabaseError(status: 0, reason: "Malformed endpoint URL")
         }

--- a/Sources/Scout/Native/Matrix/Syncable/MatrixAggregator.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/MatrixAggregator.swift
@@ -14,7 +14,7 @@ protocol MatrixAggregator: RecordWriter, RecordReader {
 extension CKDatabase: MatrixAggregator {}
 
 extension MatrixAggregator {
-    func aggregate<C: CellProtocol>(matrix: Matrix<C>) async throws {
+    func aggregate(matrix: Matrix<some CellProtocol>) async throws {
         try await MatrixUploader(database: self, maxRetry: 3, matrix: matrix).upload()
     }
 }

--- a/Sources/Scout/UI/Chart/Scale/ChartTiming.swift
+++ b/Sources/Scout/UI/Chart/Scale/ChartTiming.swift
@@ -28,7 +28,7 @@ extension ChartTiming {
     /// when defined, otherwise bucket bin starts thinned to at most four —
     /// the dates the automatic axis picks for binned bar charts.
     ///
-    func tickDates<T: ChartNumeric>(for segment: [ChartPoint<T>]) -> [Date] {
+    func tickDates(for segment: [ChartPoint<some ChartNumeric>]) -> [Date] {
         if let values = tickValues {
             return values
         }

--- a/Sources/Scout/UI/Timeline/View/Anchor/AnchoredScroll.swift
+++ b/Sources/Scout/UI/Timeline/View/Anchor/AnchoredScroll.swift
@@ -89,7 +89,7 @@ struct AnchoredScroll<ID: Hashable>: ViewModifier {
 }
 
 extension View {
-    func anchoredScroll<ID: Hashable>(id: ID?, revision: Int = 0) -> some View {
+    func anchoredScroll(id: (some Hashable)?, revision: Int = 0) -> some View {
         modifier(AnchoredScroll(id: id, revision: revision))
     }
 }


### PR DESCRIPTION
Replaces explicit generic type parameters with Swift's lightweight `some` opaque-parameter syntax wherever the type is used only once, as a single value-position parameter, and is not referenced in the return type or the function body. This trims the boilerplate `<T: …>` clauses on `tickDates`, `anchoredScroll`, `metricRecord`, `logMetrics`, the `aggregate` default implementation, and the body parameter of `HTTPDatabase.send`.

Declarations where the type parameter appears in the return type, spans multiple parameters, is named in the body, sits in a metatype (`.Type`) position, or is a protocol requirement are left as explicit generics, since `some` either cannot express them or would change their meaning. `HTTPDatabase.send` keeps its `Reply` generic for that reason and converts only the request body. No public API changes, and the full test suite passes.
