### PR TITLE
Remove MARK and restating comments across Sources and Tests

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityRow.swift
+++ b/Sources/Scout/UI/Activity/ActivityRow.swift
@@ -47,8 +47,6 @@ struct ActivityRow: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -49,8 +49,6 @@ struct ActivityView: View {
     }
 }
 
-// MARK: - Preview
-
 #Preview("ActivityView") {
     let activity = ActivityProvider()
     activity.result = .success([])

--- a/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
@@ -82,8 +82,6 @@ struct ComparisonChartView<T: ChartNumeric>: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview("ComparisonChartView – Week") {
     let extent = ChartExtent(period: Period.week)
     let today = Date().startOfDay

--- a/Sources/Scout/UI/Chart/Comparison/ComparisonPair.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonPair.swift
@@ -29,8 +29,6 @@ struct ComparisonPair<T: ChartNumeric>: Identifiable {
     var id: Date { date }
 }
 
-// MARK: - Bar Geometry
-
 extension ComparisonPair {
     /// Date of the bar's leading edge within the bucket slot.
     var barStart: Date { slotDate(at: barSlot.lowerBound) }
@@ -47,8 +45,6 @@ extension ComparisonPair {
         return bin.lowerBound.addingTimeInterval(length * fraction)
     }
 }
-
-// MARK: - Pairing
 
 extension Collection {
     /// Pairs each bucket of the current segment with the reference value

--- a/Sources/Scout/UI/Chart/Comparison/ReferenceLevel.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ReferenceLevel.swift
@@ -21,8 +21,6 @@ struct ReferenceLevel {
     var isDrop: Bool { reference < count }
 }
 
-// MARK: - Projection
-
 extension ReferenceLevel {
     /// Geometry for one bucket; nil for buckets without comparison data,
     /// empty in both periods, or falling outside the plot.
@@ -51,8 +49,6 @@ extension ReferenceLevel {
         )
     }
 }
-
-// MARK: - Paths
 
 extension [ReferenceLevel] {
     /// Levels where the value grew or held its ground.

--- a/Sources/Scout/UI/Chart/Model/MiniChartSeries.swift
+++ b/Sources/Scout/UI/Chart/Model/MiniChartSeries.swift
@@ -61,8 +61,6 @@ extension MiniChartSeries {
     }
 }
 
-// MARK: - Placeholder
-
 extension MiniChartSeries {
     /// A gentle wave drawn under redaction while the real series loads.
     static let placeholder = MiniChartSeries(values: [3, 5, 4, 6, 5, 7, 6])

--- a/Sources/Scout/UI/Chart/Picker/CompactPeriodPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/CompactPeriodPicker.swift
@@ -37,8 +37,6 @@ struct CompactPeriodPicker: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     struct Preview: View {
         @State private var selection = Period.today

--- a/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
@@ -33,8 +33,6 @@ extension ChartExtent {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     PeriodPicker(
         extent: .constant(ChartExtent(period: Period.today)),

--- a/Sources/Scout/UI/Chart/Range/RangeControl.swift
+++ b/Sources/Scout/UI/Chart/Range/RangeControl.swift
@@ -58,8 +58,6 @@ struct RangeControl<T: ChartTimeScale>: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     RangeControl(
         extent: .constant(ChartExtent(period: Period.today))

--- a/Sources/Scout/UI/Chart/Scale/ChartTimeScale.swift
+++ b/Sources/Scout/UI/Chart/Scale/ChartTimeScale.swift
@@ -42,8 +42,6 @@ protocol ChartTimeScale: Identifiable, Hashable {
     var horizonDate: Date { get }
 }
 
-// MARK: - Helpers
-
 extension ChartTimeScale {
     var today: Date {
         Date().startOfDay

--- a/Sources/Scout/UI/Chart/View/MiniChart.swift
+++ b/Sources/Scout/UI/Chart/View/MiniChart.swift
@@ -57,8 +57,6 @@ struct MiniChart: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -61,8 +61,6 @@ struct CrashDetailView: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     NavigationStack {
         CrashDetailView(crash: .sample)

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -73,8 +73,6 @@ struct CrashListView: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     NavigationStack {
         CrashListView()

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -25,8 +25,8 @@ struct AnalyticsView: View {
             }
         }
         .searchable(text: $filter.text, placement: .pinned, prompt: Text(verbatim: "Search"))
-        .autocorrectionDisabled(true)  // stop keyboard suggestions
-        .alphabetKeyboard()  // stop keyboard suggestions
+        .autocorrectionDisabled(true)
+        .alphabetKeyboard()
         .searchSuggestions {
             if let events = provider.events, filter.text.isEmpty {
                 ForEach(events.unique(by: \.name, max: 7), id: \.self) {
@@ -84,8 +84,6 @@ struct AnalyticsView: View {
         await provider.fetch(for: filter, in: database)
     }
 }
-
-// MARK: - Previews
 
 #Preview {
     NavigationStack {

--- a/Sources/Scout/UI/Event/Detail/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.Sections.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-// MARK: - Param Section
-
 extension EventView {
     struct ParamSection: View {
         let count: Int
@@ -48,8 +46,6 @@ extension EventView {
     }
 }
 
-// MARK: - Stat Section
-
 extension EventView {
     struct StatSection: View {
         @StateObject var stat: StatProvider
@@ -87,8 +83,6 @@ extension EventView {
         }
     }
 }
-
-// MARK: - History Section
 
 extension EventView {
     struct HistorySection: View {

--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -84,8 +84,6 @@ struct FilterButton: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     FilterButton(levels: .constant([]))
 }

--- a/Sources/Scout/UI/Event/List/EventList.swift
+++ b/Sources/Scout/UI/Event/List/EventList.swift
@@ -73,8 +73,6 @@ struct EventList: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview("Empty State") {
     let provider = EventProvider()
     provider.events = []

--- a/Sources/Scout/UI/Event/List/EventStatList.swift
+++ b/Sources/Scout/UI/Event/List/EventStatList.swift
@@ -43,8 +43,6 @@ struct EventStatList: View {
     }
 }
 
-// MARK: - Preview
-
 #Preview {
     NavigationStack {
         EventStatList(eventName: "Event", range: Period.week.initialRange)

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -87,8 +87,6 @@ struct ParamRow: View {
     }
 }
 
-// MARK: - Preview
-
 #Preview {
     NavigationStack {
         ParamList(items: ParamProvider.Item.sampleMetrics)

--- a/Sources/Scout/UI/Event/Param/ParamProvider.Item.swift
+++ b/Sources/Scout/UI/Event/Param/ParamProvider.Item.swift
@@ -27,8 +27,6 @@ extension ParamProvider {
     }
 }
 
-// MARK: - Sample Data
-
 extension ParamProvider.Item {
     /// An in-app purchase where every value is a typed scalar.
     static var samplePurchase: [ParamProvider.Item] {

--- a/Sources/Scout/UI/Event/Param/ParamView.swift
+++ b/Sources/Scout/UI/Event/Param/ParamView.swift
@@ -110,8 +110,6 @@ struct ParamNodeRow: View {
     }
 }
 
-// MARK: - Preview
-
 #Preview("Dictionary") {
     NavigationStack {
         ParamView(item: ParamProvider.Item.sampleProfile.first { $0.key == "preferences" }!)

--- a/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
@@ -60,8 +60,6 @@ extension View {
     }
 }
 
-// MARK: - Previews
-
 @available(iOS 17.0, macOS 14.0, *)
 #Preview {
     @Previewable @State var activeID = Connection.samples[0].id

--- a/Sources/Scout/UI/Home/HomeSectionPicker.swift
+++ b/Sources/Scout/UI/Home/HomeSectionPicker.swift
@@ -57,8 +57,6 @@ struct HomeSectionPicker: View {
     }
 }
 
-// MARK: - Previews
-
 private struct PickerPreview: View {
     @State private var selection = HomeSection.sessions
 

--- a/Sources/Scout/UI/Home/Log/HomeLogRow.swift
+++ b/Sources/Scout/UI/Home/Log/HomeLogRow.swift
@@ -31,8 +31,6 @@ struct HomeLogRow<Destination: View>: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Home/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Log/HomeLogSection.swift
@@ -62,8 +62,6 @@ struct HomeLogSection: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Home/Onboarding/OnboardingView.swift
+++ b/Sources/Scout/UI/Home/Onboarding/OnboardingView.swift
@@ -26,8 +26,6 @@ struct OnboardingView: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview("Page 1 – Welcome") {
     OnboardingView()
 }

--- a/Sources/Scout/UI/Message/Message.Level.swift
+++ b/Sources/Scout/UI/Message/Message.Level.swift
@@ -29,8 +29,6 @@ extension Message {
     }
 }
 
-// MARK: - Debug
-
 extension Message.Level {
     var text: String {
         "This is \(article) \(rawValue) message"

--- a/Sources/Scout/UI/Message/MessageView.Presenter.swift
+++ b/Sources/Scout/UI/Message/MessageView.Presenter.swift
@@ -46,8 +46,6 @@ extension MessageView {
     }
 }
 
-// MARK: - Preview
-
 @available(iOS 17.0, macOS 14.0, *)
 #Preview("Above the navigation bar") {
     @Previewable @State var message: Message?

--- a/Sources/Scout/UI/Metrics/Series/PointSeries.swift
+++ b/Sources/Scout/UI/Metrics/Series/PointSeries.swift
@@ -25,15 +25,11 @@ extension PointSeries {
     }
 }
 
-// MARK: - By Name
-
 extension Collection where Element: PointSeries {
     func named(_ name: String) -> Element? {
         first { $0.name == name }
     }
 }
-
-// MARK: - By Period
 
 extension Collection where Element: PointSeries & Comparable {
     func ranked(on period: Period) -> [Element] {

--- a/Sources/Scout/UI/Primitives/Controls/Header.swift
+++ b/Sources/Scout/UI/Primitives/Controls/Header.swift
@@ -42,8 +42,6 @@ struct SeeAllButton: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     List {
         Header(title: "Section Title")

--- a/Sources/Scout/UI/Primitives/Controls/Row.swift
+++ b/Sources/Scout/UI/Primitives/Controls/Row.swift
@@ -30,8 +30,6 @@ struct Row<Content: View, Destination: View>: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Primitives/Controls/RowSummary.swift
+++ b/Sources/Scout/UI/Primitives/Controls/RowSummary.swift
@@ -33,8 +33,6 @@ struct RowSummary: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Share/CopyButton.swift
+++ b/Sources/Scout/UI/Share/CopyButton.swift
@@ -39,8 +39,6 @@ struct CopyButton: View {
     }
 }
 
-// MARK: - Preview
-
 #Preview {
     NavigationStack {
         Text(verbatim: "Content")

--- a/Sources/Scout/UI/Stats/StatRow.swift
+++ b/Sources/Scout/UI/Stats/StatRow.swift
@@ -46,8 +46,6 @@ struct StatRow<Destination: View>: View {
     }
 }
 
-// MARK: - Previews
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Timeline/Export/ExportFormat.swift
+++ b/Sources/Scout/UI/Timeline/Export/ExportFormat.swift
@@ -60,8 +60,6 @@ enum ExportFormat {
     }
 }
 
-// MARK: - Styles
-
 extension ExportFormat {
     private static let iso8601 = Date.ISO8601FormatStyle()
     private static let dayStyle = utcStyle("\(year: .padded(4))-\(month: .twoDigits)-\(day: .twoDigits)")

--- a/Sources/Scout/UI/Timeline/Export/TimelineExport.swift
+++ b/Sources/Scout/UI/Timeline/Export/TimelineExport.swift
@@ -46,8 +46,6 @@ struct TimelineExport {
     }
 }
 
-// MARK: - Sections
-
 extension TimelineExport {
     private var title: String {
         if let deviceID = rail.device.deviceID {
@@ -107,8 +105,6 @@ extension TimelineExport {
         return parts.joined(separator: " ")
     }
 }
-
-// MARK: - Rows
 
 extension TimelineExport {
     private func rows(for session: SessionRoot) -> [String] {

--- a/Tests/ScoutTests/Architecture/CloudKitContainmentTests.swift
+++ b/Tests/ScoutTests/Architecture/CloudKitContainmentTests.swift
@@ -31,8 +31,6 @@ struct CloudKitContainmentTests {
         #expect(offenders.isEmpty, "import CloudKit found outside the CloudKit adapter: \(offenders)")
     }
 
-    // MARK: - Helpers
-
     /// Walks up from this test file to the package root and returns its
     /// `Sources/Scout` directory.
     ///

--- a/Tests/ScoutTests/Core/Activity/ActivityPeriodTests.swift
+++ b/Tests/ScoutTests/Core/Activity/ActivityPeriodTests.swift
@@ -11,8 +11,6 @@ import Testing
 @testable import Scout
 
 struct ActivityPeriodTests {
-    // MARK: - Raw Values
-
     @Test("Raw values encode correctly")
     func rawValues() {
         #expect(ActivityPeriod.daily.rawValue == "d")
@@ -28,16 +26,12 @@ struct ActivityPeriodTests {
         #expect(ActivityPeriod(rawValue: "x") == nil)
     }
 
-    // MARK: - Titles
-
     @Test("Titles are human-readable")
     func titles() {
         #expect(ActivityPeriod.daily.title == "Daily")
         #expect(ActivityPeriod.weekly.title == "Weekly")
         #expect(ActivityPeriod.monthly.title == "Monthly")
     }
-
-    // MARK: - Spread Components
 
     @Test("Daily spread component is day")
     func dailySpread() {
@@ -53,8 +47,6 @@ struct ActivityPeriodTests {
     func monthlySpread() {
         #expect(ActivityPeriod.monthly.spreadComponent == .month)
     }
-
-    // MARK: - CaseIterable
 
     @Test("All cases are present")
     func allCases() {

--- a/Tests/ScoutTests/Core/Activity/ActivityReaderTests.swift
+++ b/Tests/ScoutTests/Core/Activity/ActivityReaderTests.swift
@@ -58,8 +58,6 @@ struct ActivityReaderTests {
         #expect(series.count == 0)
     }
 
-    // MARK: - Helpers
-
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
         DateComponents(calendar: .utc, year: year, month: month, day: day).date!
     }

--- a/Tests/ScoutTests/Core/Backend/RecordEncodingTests.swift
+++ b/Tests/ScoutTests/Core/Backend/RecordEncodingTests.swift
@@ -55,8 +55,6 @@ struct RecordEncodingTests {
     }
 }
 
-// MARK: - Stubs
-
 extension IntMetricsObject {
     @discardableResult static func stub(name: String, telemetry: String, value: Int, in context: NSManagedObjectContext) -> IntMetricsObject {
         let entity = NSEntityDescription.entity(forEntityName: "IntMetricsObject", in: context)!

--- a/Tests/ScoutTests/Core/Backend/SchemaErrorTests.swift
+++ b/Tests/ScoutTests/Core/Backend/SchemaErrorTests.swift
@@ -12,8 +12,6 @@ import Testing
 
 @Suite("CKError.isSchemaError")
 struct SchemaErrorTests {
-    // MARK: - Matching codes with schema messages
-
     @Test("invalidArguments with 'record type' message")
     func invalidArgumentsRecordType() {
         let error = makeCKError(code: .invalidArguments, message: "Invalid record type 'Foo'")
@@ -32,8 +30,6 @@ struct SchemaErrorTests {
         #expect(error.isSchemaError)
     }
 
-    // MARK: - Matching codes without schema messages
-
     @Test("invalidArguments with unrelated message")
     func invalidArgumentsUnrelated() {
         let error = makeCKError(code: .invalidArguments, message: "Bad predicate format")
@@ -45,8 +41,6 @@ struct SchemaErrorTests {
         let error = makeCKError(code: .serverRejectedRequest, message: "Rate limit exceeded")
         #expect(!error.isSchemaError)
     }
-
-    // MARK: - Non-matching codes
 
     @Test("networkFailure is not a schema error")
     func networkFailure() {
@@ -60,15 +54,11 @@ struct SchemaErrorTests {
         #expect(!error.isSchemaError)
     }
 
-    // MARK: - Case insensitivity
-
     @Test("message matching is case-insensitive")
     func caseInsensitive() {
         let error = makeCKError(code: .invalidArguments, message: "Unknown RECORD TYPE 'Foo'")
         #expect(error.isSchemaError)
     }
-
-    // MARK: - Helper
 
     private func makeCKError(code: CKError.Code, message: String) -> CKError {
         let nsError = NSError(

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/CrashArchiveTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/CrashArchiveTests.swift
@@ -34,7 +34,6 @@ struct CrashArchiveTests {
         #expect(files.count == 1)
         #expect(files.first?.pathExtension == "crash")
 
-        // Cleanup
         try? FileManager.default.removeItem(at: tempDir)
     }
 
@@ -67,7 +66,6 @@ struct CrashArchiveTests {
         #expect(decoded.reason == "Unrecognized selector")
         #expect(decoded.stackTrace == ["0x1234", "0x5678", "0x9ABC"])
 
-        // Cleanup
         try? FileManager.default.removeItem(at: tempDir)
     }
 
@@ -100,7 +98,6 @@ struct CrashArchiveTests {
         #expect(decoded.reason == nil)
         #expect(decoded.stackTrace.isEmpty)
 
-        // Cleanup
         try? FileManager.default.removeItem(at: tempDir)
     }
 
@@ -126,7 +123,6 @@ struct CrashArchiveTests {
         #expect(files.count == 3)
         #expect(files.allSatisfy { $0.pathExtension == "crash" })
 
-        // Cleanup
         try? FileManager.default.removeItem(at: tempDir)
     }
 }

--- a/Tests/ScoutTests/Core/Diagnostics/Metrics/MetricReaderTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Metrics/MetricReaderTests.swift
@@ -67,8 +67,6 @@ struct MetricReaderTests {
         #expect(latency.points.first?.value == .double(1.5))
     }
 
-    // MARK: - Helpers
-
     private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0) -> Date {
         DateComponents(calendar: .utc, year: year, month: month, day: day, hour: hour).date!
     }

--- a/Tests/ScoutTests/Core/Diagnostics/Metrics/TelemetryExportTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Metrics/TelemetryExportTests.swift
@@ -11,8 +11,6 @@ import Testing
 @testable import Scout
 
 struct TelemetryExportTests {
-    // MARK: - Init from name and value
-
     @Test("Init with counter name creates counter")
     func initCounter() throws {
         let telemetry = try Telemetry(name: "counter", value: 5.0)
@@ -62,8 +60,6 @@ struct TelemetryExportTests {
         }
     }
 
-    // MARK: - Export property
-
     @Test("Export raw values match expected strings")
     func exportRawValues() {
         #expect(Telemetry.Export.counter.rawValue == "counter")
@@ -79,8 +75,6 @@ struct TelemetryExportTests {
     func exportAllCases() {
         #expect(Telemetry.Export.allCases.count == 7)
     }
-
-    // MARK: - ExportError
 
     @Test("ExportError description lists all valid names")
     func exportErrorDescription() {

--- a/Tests/ScoutTests/Core/Lifecycle/Base/MonitorErrorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Base/MonitorErrorTests.swift
@@ -11,8 +11,6 @@ import Testing
 @testable import Scout
 
 struct MonitorErrorTests {
-    // MARK: - Equality
-
     @Test("notFound equals notFound")
     func notFoundEquality() {
         #expect(MonitorError.notFound == MonitorError.notFound)
@@ -30,8 +28,6 @@ struct MonitorErrorTests {
         let date = Date()
         #expect(MonitorError.notFound != MonitorError.alreadyCompleted(date))
     }
-
-    // MARK: - Error description
 
     @Test("notFound description contains 'not found'")
     func notFoundDescription() {

--- a/Tests/ScoutTests/Core/Lifecycle/Device/DeviceObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Device/DeviceObjectTests.swift
@@ -27,7 +27,6 @@ struct DeviceObjectTests {
         let i2 = InstallObject.stub(date: week.addingHour(), in: context)
         i2.deviceID = deviceID
 
-        // Install with different deviceID
         InstallObject.stub(date: week, in: context).deviceID = UUID()
 
         try context.save()

--- a/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
@@ -27,7 +27,6 @@ struct InstallObjectTests {
         let v2 = VersionObject.stub(date: week.addingHour(), appVersion: "2.0", in: context)
         v2.installID = installID
 
-        // Version with different installID
         VersionObject.stub(date: week, appVersion: "3.0", in: context).installID = UUID()
 
         try context.save()

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
@@ -44,7 +44,6 @@ struct LaunchObjectTests {
         let session2 = SessionObject.stub(date: week.addingHour(), in: context)
         session2.launchID = launchID
 
-        // Session with different launchID
         SessionObject.stub(date: week, in: context).launchID = UUID()
 
         try context.save()
@@ -63,7 +62,6 @@ struct LaunchObjectTests {
         let version = VersionObject.stub(date: week, appVersion: "2.0", in: context)
         version.launchID = launchID
 
-        // Version with different launchID
         VersionObject.stub(date: week, appVersion: "1.0", in: context).launchID = UUID()
 
         try context.save()

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
@@ -41,7 +41,6 @@ struct SessionObjectTests {
         let launch = LaunchObject.stub(date: week, in: context)
         launch.launchID = launchID
 
-        // Launch with different launchID
         LaunchObject.stub(date: week, in: context).launchID = UUID()
 
         try context.save()

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
@@ -45,7 +45,6 @@ struct VersionObjectTests {
         let v2 = VersionObject.stub(date: week.addingHour(), appVersion: "2.0", in: context)
         v2.launchID = launchID2
 
-        // Different version
         let v3 = VersionObject.stub(date: week, appVersion: "1.0", in: context)
         v3.launchID = launchID3
 
@@ -73,7 +72,6 @@ struct VersionObjectTests {
         let install = InstallObject.stub(date: week, in: context)
         install.installID = installID
 
-        // Install with different installID
         InstallObject.stub(date: week, in: context).installID = UUID()
 
         try context.save()

--- a/Tests/ScoutTests/Core/Persistence/PersistenceLoadTests.swift
+++ b/Tests/ScoutTests/Core/Persistence/PersistenceLoadTests.swift
@@ -22,7 +22,6 @@ struct PersistenceLoadTests {
         description.type = NSInMemoryStoreType
         container.persistentStoreDescriptions = [description]
 
-        // This should not throw
         try container.loadStore()
     }
 

--- a/Tests/ScoutTests/Core/Utilities/Date/DateAddComponentTests.swift
+++ b/Tests/ScoutTests/Core/Utilities/Date/DateAddComponentTests.swift
@@ -13,8 +13,6 @@ import Testing
 struct DateAddComponentTests {
     let base = Date(timeIntervalSinceReferenceDate: 0)  // 2001-01-01 00:00:00 UTC
 
-    // MARK: - Adding (non-mutating)
-
     @Test("addingDay adds one day by default")
     func addingDayDefault() {
         let result = base.addingDay()
@@ -76,8 +74,6 @@ struct DateAddComponentTests {
         let result = base.adding(.minute, value: 30)
         #expect(result.timeIntervalSince(base) == 1800)
     }
-
-    // MARK: - Mutating
 
     @Test("addDay mutates in place")
     func addDayMutating() {

--- a/Tests/ScoutTests/Native/Matrix/Batch/NamedObjectTests.swift
+++ b/Tests/ScoutTests/Native/Matrix/Batch/NamedObjectTests.swift
@@ -68,8 +68,6 @@ struct NamedObjectTests {
     }
 }
 
-// MARK: - Stub
-
 extension NamedObject {
     @discardableResult fileprivate static func stub(
         name: String?,

--- a/Tests/ScoutTests/Native/Matrix/Cell/CellProtocolTests.swift
+++ b/Tests/ScoutTests/Native/Matrix/Cell/CellProtocolTests.swift
@@ -10,8 +10,6 @@ import Testing
 @testable import Scout
 
 struct CellProtocolTests {
-    // MARK: - leadingZero
-
     @Test("Single digit gets leading zero")
     func singleDigitLeadingZero() {
         #expect(0.leadingZero == "00")

--- a/Tests/ScoutTests/Native/Matrix/Cell/PeriodCellTests.swift
+++ b/Tests/ScoutTests/Native/Matrix/Cell/PeriodCellTests.swift
@@ -11,8 +11,6 @@ import Testing
 @testable import Scout
 
 struct PeriodCellTests {
-    // MARK: - Key Generation
-
     @Test("Key encodes period and day")
     func keyGeneration() {
         let cell = PeriodCell<Int>(period: .daily, day: 0, value: 5)
@@ -30,8 +28,6 @@ struct PeriodCellTests {
         let cell = PeriodCell<Int>(period: .monthly, day: 11, value: 1)
         #expect(cell.key == "cell_m_12")
     }
-
-    // MARK: - Key Parsing
 
     @Test("Init from key parses correctly")
     func initFromKey() throws {
@@ -62,8 +58,6 @@ struct PeriodCellTests {
         }
     }
 
-    // MARK: - Round-trip
-
     @Test("Key round-trips through init")
     func keyRoundTrip() throws {
         let original = PeriodCell<Int>(period: .monthly, day: 6, value: 42)
@@ -73,8 +67,6 @@ struct PeriodCellTests {
         #expect(restored.day == original.day)
         #expect(restored.value == original.value)
     }
-
-    // MARK: - Combining
 
     @Test("Addition combines values")
     func addition() {

--- a/Tests/ScoutTests/Native/Matrix/Model/CombiningTests.swift
+++ b/Tests/ScoutTests/Native/Matrix/Model/CombiningTests.swift
@@ -10,8 +10,6 @@ import Testing
 @testable import Scout
 
 struct CombiningTests {
-    // MARK: - mergeDuplicates
-
     @Test("Merge duplicates combines matching cells")
     func mergeDuplicates() {
         let cells = [

--- a/Tests/ScoutTests/Stubs/Objects/UserActivityObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/UserActivityObject+Stub.swift
@@ -27,7 +27,6 @@ extension UserActivityObject {
         activity.period = period.rawValue
         activity.setSynced(isSynced, in: context)
 
-        // Set all count fields to 0, then set the relevant one
         activity.dayCount = 0
         activity.weekCount = 0
         activity.monthCount = 0

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -97,8 +97,6 @@ final class Gate: @unchecked Sendable {
     }
 }
 
-// MARK: - Record builders
-
 extension Record {
     static func deviceStub(deviceID: UUID, date: Date) -> Record {
         var record = Record(recordType: "Device", recordID: deviceID.uuidString)

--- a/Tests/ScoutTests/UI/Activity/ActivityProviderTests.swift
+++ b/Tests/ScoutTests/UI/Activity/ActivityProviderTests.swift
@@ -49,8 +49,6 @@ struct ActivityProviderTests {
         #expect(database.readCount(of: PeriodCell<Int>.recordType) == 1)
     }
 
-    // MARK: - Helpers
-
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
         DateComponents(calendar: .utc, year: year, month: month, day: day).date!
     }

--- a/Tests/ScoutTests/UI/Chart/MiniChartSeriesTests.swift
+++ b/Tests/ScoutTests/UI/Chart/MiniChartSeriesTests.swift
@@ -18,8 +18,6 @@ struct MiniChartSeriesTests {
         ChartPoint(date: Date(year: 2026, month: 6, day: day, hour: hour), count: count)
     }
 
-    // MARK: - Slicing
-
     @Test("Empty points produce sliceCount zeros")
     func emptyPoints() {
         let series = MiniChartSeries(points: [], range: range, aggregation: .total)
@@ -71,8 +69,6 @@ struct MiniChartSeriesTests {
 
         #expect(series.values == Array(repeating: 0, count: MiniChartSeries.sliceCount))
     }
-
-    // MARK: - Aggregation
 
     @Test("Total sums all points in a slice")
     func totalAggregation() {

--- a/Tests/ScoutTests/UI/Home/HomeLogProviderTests.swift
+++ b/Tests/ScoutTests/UI/Home/HomeLogProviderTests.swift
@@ -72,8 +72,6 @@ struct HomeLogProviderTests {
         #expect(MatrixSpan(matrices: result.0, range: allTime).total { $0 != CrashObject.recordType } == 7)
     }
 
-    // MARK: - Factories
-
     private func makeRecord(type: String, name: String, category: String? = nil, date: Date = Date(), value: any RecordValueConvertible) -> Record {
         var record = Record(recordType: type, recordID: UUID().uuidString)
         record["name"] = name

--- a/Tests/ScoutTests/UI/Home/MatrixSpanTests.swift
+++ b/Tests/ScoutTests/UI/Home/MatrixSpanTests.swift
@@ -13,8 +13,6 @@ import Testing
 struct MatrixSpanTests {
     let range = Date(year: 2026, month: 6, day: 1)..<Date(year: 2026, month: 6, day: 8)
 
-    // MARK: - Events
-
     @Test("Count excludes crashes and metrics")
     func countExcludesCrashesAndMetrics() {
         let span = makeSpan([
@@ -38,8 +36,6 @@ struct MatrixSpanTests {
         #expect(span.total { $0 != CrashObject.recordType } == 3)
     }
 
-    // MARK: - Crashes
-
     @Test("Count sums the Crash matrices")
     func crashCount() {
         let span = makeSpan([
@@ -50,8 +46,6 @@ struct MatrixSpanTests {
 
         #expect(span.total { $0 == CrashObject.recordType } == 2)
     }
-
-    // MARK: - Metrics
 
     @Test("Metric count tallies distinct metrics across both matrix kinds")
     func metricCountIsDistinct() {
@@ -85,8 +79,6 @@ struct MatrixSpanTests {
 
         #expect(span.series == 0)
     }
-
-    // MARK: - Factories
 
     /// A span already narrowed to `range`, matching how the log section consumes it.
     private func makeSpan<T: ChartNumeric>(_ matrices: [GridMatrix<T>]) -> MatrixSpan<T> {

--- a/Tests/ScoutTests/UI/Metrics/MetricsProviderTests.swift
+++ b/Tests/ScoutTests/UI/Metrics/MetricsProviderTests.swift
@@ -62,8 +62,6 @@ struct MetricsProviderTests {
         #expect(database.readCount(of: Int.recordType) == 1)
     }
 
-    // MARK: - Helpers
-
     private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int) -> Date {
         DateComponents(calendar: .utc, year: year, month: month, day: day, hour: hour).date!
     }


### PR DESCRIPTION
This sweeps `Sources/Scout` and `Tests/ScoutTests` to drop comment noise. Every `// MARK:` section marker is removed, along with a small set of comments that just restate the line they sit on — the `// X with different Y` fixture labels in the lifecycle tests, a couple of duplicated `// stop keyboard suggestions` notes in `AnalyticsView`, the `// Cleanup` labels in `CrashArchiveTests`, and a few similar ones.

License headers, all `///` API doc comments, the substantive why-comments (timeline/rail concurrency and layout rationale, the `SIGABRT` reset in `ExceptionHandler`, server-contract notes), and the magic-value annotations that decode dates and grid coordinates are all kept.

The change is comment-only: the diff removes nothing but blank lines and whole `//` comments, except in `AnalyticsView` where two trailing comments were stripped while their code lines stayed byte-for-byte identical.