### PR TITLE
Tighten MatrixAggregator conformance

### DIFF
--- a/Sources/Scout/Native/Matrix/Syncable/MatrixAggregator.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/MatrixAggregator.swift
@@ -7,13 +7,11 @@
 
 import CloudKit
 
-protocol MatrixAggregator: RecordWriter, RecordReader {
+protocol MatrixAggregator: Sendable {
     func aggregate<C: CellProtocol>(matrix: Matrix<C>) async throws
 }
 
-extension CKDatabase: MatrixAggregator {}
-
-extension MatrixAggregator {
+extension CKDatabase: MatrixAggregator {
     func aggregate(matrix: Matrix<some CellProtocol>) async throws {
         try await MatrixUploader(database: self, maxRetry: 3, matrix: matrix).upload()
     }

--- a/Tests/ScoutTests/Transient/InMemoryDatabase.swift
+++ b/Tests/ScoutTests/Transient/InMemoryDatabase.swift
@@ -58,7 +58,11 @@ final class InMemoryDatabase: DatabaseReader, RecordWriter, @unchecked Sendable 
     }
 }
 
-extension InMemoryDatabase: MatrixAggregator {}
+extension InMemoryDatabase: MatrixAggregator {
+    func aggregate(matrix: Matrix<some CellProtocol>) async throws {
+        try await MatrixUploader(database: self, maxRetry: 3, matrix: matrix).upload()
+    }
+}
 
 extension InMemoryDatabase {
     var events: [Record] {


### PR DESCRIPTION
Make `MatrixAggregator` `Sendable` and move the `aggregate(matrix:)` implementation onto the `CKDatabase` conformance. This keeps the protocol surface smaller while preserving the existing upload behavior. The test-only `InMemoryDatabase` now carries its own matching `aggregate(matrix:)` implementation, since it no longer inherits one from a protocol extension.