### PR TITLE
Make RecordReader explicit in DatabaseReader

### DIFF
--- a/Sources/Scout/Core/Database/Access/Database.swift
+++ b/Sources/Scout/Core/Database/Access/Database.swift
@@ -9,5 +9,5 @@ import Foundation
 
 typealias Database = DatabaseReader & DatabaseWriter
 
-typealias DatabaseReader = RecordLocator & MetricReader & ActivityReader & Sendable
+typealias DatabaseReader = RecordLocator & RecordReader & MetricReader & ActivityReader & Sendable
 typealias DatabaseWriter = RecordWriter & Sendable


### PR DESCRIPTION
`DatabaseReader` is consumed as a record reader throughout the UI providers — they call `read`, `readAll`, and `readMore` on it — yet the composition only picked up `RecordReader` indirectly, because `MetricReader` and `ActivityReader` happen to inherit it. List `RecordReader` directly in the typealias so the requirement matches how the type is used and stops depending on those two protocols to re-export it. This is behavior-preserving and sets up tightening `MetricReader` and `ActivityReader` to drop that inheritance.