### PR TITLE
Tighten MetricReader and ActivityReader conformance

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Metrics/MetricReader.swift
+++ b/Sources/Scout/Core/Diagnostics/Metrics/MetricReader.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol MetricReader: RecordReader {
+protocol MetricReader: Sendable {
     func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries]
 }
 

--- a/Sources/Scout/Native/Access/NativeActivityReader.swift
+++ b/Sources/Scout/Native/Access/NativeActivityReader.swift
@@ -9,7 +9,7 @@ import CloudKit
 
 extension CKDatabase: ActivityReader {}
 
-extension ActivityReader {
+extension ActivityReader where Self: RecordReader {
     func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
         let query = RecordQuery(
             recordType: PeriodMatrix.self,

--- a/Sources/Scout/Native/Access/NativeMetricReader.swift
+++ b/Sources/Scout/Native/Access/NativeMetricReader.swift
@@ -9,7 +9,7 @@ import CloudKit
 
 extension CKDatabase: MetricReader {}
 
-extension MetricReader {
+extension MetricReader where Self: RecordReader {
     func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
         let categoryFilter = RecordQuery.Filter(
             field: "category",

--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -15,7 +15,7 @@ class ActivityProvider: ObservableObject, Provider {
     }
 }
 
-protocol ActivityReader: RecordReader {
+protocol ActivityReader: Sendable {
     func activity(in range: Range<Date>) async throws -> [ActivityPoint]
 }
 


### PR DESCRIPTION
`MetricReader` and `ActivityReader` each declared a single reading method but inherited `RecordReader`, purely so their default implementations in `NativeMetricReader` and `NativeActivityReader` could call `readAll` on `Self`. This drops the inheritance to `Sendable` and instead constrains those default implementations with `where Self: RecordReader`, so they stay shared across `CKDatabase` and the in-memory test doubles while each protocol shrinks to exactly its own requirement, mirroring the earlier `MatrixAggregator` cleanup. Callers are unaffected because `DatabaseReader` now lists `RecordReader` directly.

Stacked on #623 (`Make RecordReader explicit in DatabaseReader`), which it depends on; review and merge that first.