### PR TITLE
Extract trailingRowSeparator() modifier

### DIFF
--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -67,9 +67,7 @@ struct CrashListView: View {
             }
             .opacity(0)
         }
-        .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-            dimension[.trailing]
-        }
+        .trailingRowSeparator()
     }
 }
 

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.Suggestion.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.Suggestion.swift
@@ -20,9 +20,7 @@ extension AnalyticsView {
                     .foregroundStyle(.blue)
                 Spacer()
             }
-            .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-                dimension[.trailing]
-            }
+            .trailingRowSeparator()
         }
     }
 }

--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -28,9 +28,7 @@ struct FilterView: View {
                     Spacer()
                 }
                 .contentShape(Rectangle())
-                .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-                    dimension[.trailing]
-                }
+                .trailingRowSeparator()
                 .onTapGesture {
                     criteria.toggle(level)
                 }

--- a/Sources/Scout/UI/Event/List/EventList.swift
+++ b/Sources/Scout/UI/Event/List/EventList.swift
@@ -67,9 +67,7 @@ struct EventList: View {
             .opacity(0)
         }
         .listRowBackground(event.level?.color?.opacity(0.12) ?? .clear)
-        .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-            dimension[.trailing]
-        }
+        .trailingRowSeparator()
     }
 }
 

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -81,9 +81,7 @@ struct ParamRow: View {
             }
         }
         .lineLimit(1)
-        .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-            dimension[.trailing]
-        }
+        .trailingRowSeparator()
     }
 }
 

--- a/Sources/Scout/UI/Primitives/Controls/Row.swift
+++ b/Sources/Scout/UI/Primitives/Controls/Row.swift
@@ -24,9 +24,7 @@ struct Row<Content: View, Destination: View>: View {
             }
             .opacity(0)
         }
-        .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-            dimension[.trailing]
-        }
+        .trailingRowSeparator()
     }
 }
 

--- a/Sources/Scout/UI/Primitives/Modifiers/View+TrailingRowSeparator.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/View+TrailingRowSeparator.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    func trailingRowSeparator() -> some View {
+        alignmentGuide(.listRowSeparatorTrailing) { dimension in
+            dimension[.trailing]
+        }
+    }
+}

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -63,9 +63,7 @@ struct StatView: View {
             }
             .opacity(0)
         }
-        .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-            dimension[.trailing]
-        }
+        .trailingRowSeparator()
     }
 }
 


### PR DESCRIPTION
The `.alignmentGuide(.listRowSeparatorTrailing)` block that pins a list row separator's trailing end to the row content was copy-pasted across seven views. This pulls it into a single `trailingRowSeparator()` `View` extension in `Primitives/Modifiers` and updates every call site to use it, removing the duplication.