### PR TITLE
Extract shared PeriodPicker for metrics views

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -20,7 +20,7 @@ struct ActivityView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            PeriodPicker(extent: $extent, periods: ActivityPeriod.allCases)
+            PeriodExtentPicker(extent: $extent, periods: ActivityPeriod.allCases)
 
             ProviderView(provider: activity) { data in
                 RangeControl(extent: $extent)

--- a/Sources/Scout/UI/Chart/Picker/PeriodExtentPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/PeriodExtentPicker.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2024 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct PeriodExtentPicker<T: PickerCompatible & ChartTimeScale>: View {
+    @Binding var extent: ChartExtent<T>
+
+    let periods: [T]
+
+    var body: some View {
+        Picker("", selection: $extent.period) {
+            ForEach(periods) { period in
+                if period == extent.period, extent.isAccented {
+                    Text(period.shortTitle + "*")
+                } else {
+                    Text(period.shortTitle)
+                }
+            }
+        }
+        .padding(.horizontal)
+        .pickerStyle(.segmented)
+    }
+}
+
+extension ChartExtent {
+    fileprivate var isAccented: Bool {
+        isRightEnabled
+    }
+}
+
+#Preview {
+    PeriodExtentPicker(
+        extent: .constant(ChartExtent(period: Period.today)),
+        periods: Period.allCases
+    )
+}

--- a/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Mikhail Kasianov
+// Copyright 2026 Mikhail Kasianov
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
@@ -7,35 +7,29 @@
 
 import SwiftUI
 
-struct PeriodPicker<T: PickerCompatible & ChartTimeScale>: View {
-    @Binding var extent: ChartExtent<T>
-
-    let periods: [T]
+struct PeriodPicker: View {
+    @Binding var selection: Period
 
     var body: some View {
-        Picker("", selection: $extent.period) {
-            ForEach(periods) { period in
-                if period == extent.period, extent.isAccented {
-                    Text(period.shortTitle + "*")
-                } else {
-                    Text(period.shortTitle)
-                }
+        Picker(selection: $selection) {
+            ForEach(Period.allCases) { period in
+                Text(period.shortTitle.uppercased())
             }
+        } label: {
+            Text(verbatim: "Period")
         }
         .padding(.horizontal)
         .pickerStyle(.segmented)
     }
 }
 
-extension ChartExtent {
-    fileprivate var isAccented: Bool {
-        isRightEnabled
-    }
-}
-
 #Preview {
-    PeriodPicker(
-        extent: .constant(ChartExtent(period: Period.today)),
-        periods: Period.allCases
-    )
+    struct Preview: View {
+        @State private var selection = Period.today
+
+        var body: some View {
+            PeriodPicker(selection: $selection)
+        }
+    }
+    return Preview()
 }

--- a/Sources/Scout/UI/Metrics/MetricsList.swift
+++ b/Sources/Scout/UI/Metrics/MetricsList.swift
@@ -29,16 +29,8 @@ struct MetricsList: View {
     @State private var scope: Scope = .int
 
     var body: some View {
-        Picker(selection: $period) {
-            ForEach(Period.allCases) { period in
-                Text(period.shortTitle.uppercased())
-            }
-        } label: {
-            Text(verbatim: "Period")
-        }
-        .padding(.horizontal)
-        .padding(.bottom)
-        .pickerStyle(.segmented)
+        PeriodPicker(selection: $period)
+            .padding(.bottom)
 
         Picker(selection: $scope) {
             ForEach(Scope.allCases) { scope in

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -22,15 +22,7 @@ struct MetricsView<T: ChartNumeric>: View {
     }
 
     var body: some View {
-        Picker(selection: $extent.period) {
-            ForEach(Period.allCases) { period in
-                Text(period.shortTitle.uppercased())
-            }
-        } label: {
-            Text(verbatim: "Period")
-        }
-        .padding(.horizontal)
-        .pickerStyle(.segmented)
+        PeriodPicker(selection: $extent.period)
 
         RangeControl(extent: $extent)
 

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -19,7 +19,7 @@ struct StatView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            PeriodPicker(extent: $extent, periods: stat.periods)
+            PeriodExtentPicker(extent: $extent, periods: stat.periods)
 
             ProviderView(provider: stat) { data in
                 RangeControl(extent: $extent)


### PR DESCRIPTION
`MetricsView` and `MetricsList` each inlined the same segmented period `Picker` over `Period.allCases`, so this pulls that markup into a single reusable `PeriodPicker(selection:)` view that both now use. To free up the name, the existing extent-driven picker (the one with the `*` accent marker used by `ActivityView` and `StatView`) is renamed to `PeriodExtentPicker`, and its call sites are updated accordingly.

This is a structure/refactor-only change with no behavioral difference — for `Period` the short titles are already uppercase, so the rendered labels are unchanged.
