### PR TITLE
Extract a shared ParamValueRow for parameter rows

### DIFF
--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -46,19 +46,12 @@ struct ParamRow: View {
             if let item {
                 let value = ParamValue(parsing: item.value)
 
-                HStack(spacing: 13) {
-                    ParamIcon(value: value)
-
-                    Text(item.key)
-                        .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    Text(value.summary)
-                        .monospaced()
-                        .font(.system(size: 16))
-                        .foregroundStyle(value.isContainer ? .secondary : .primary)
-                }
+                ParamValueRow(
+                    value: value,
+                    label: item.key,
+                    labelStyle: .secondary,
+                    summaryStyle: value.isContainer ? .secondary : .primary
+                )
 
                 NavigationLink {
                     ParamView(item: item)

--- a/Sources/Scout/UI/Event/Param/ParamValueRow.swift
+++ b/Sources/Scout/UI/Event/Param/ParamValueRow.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct ParamValueRow: View {
+    let value: ParamValue
+    let label: String
+    let labelStyle: HierarchicalShapeStyle
+    let summaryStyle: HierarchicalShapeStyle
+
+    var body: some View {
+        HStack(spacing: 13) {
+            ParamIcon(value: value)
+
+            Text(label)
+                .foregroundStyle(labelStyle)
+
+            Spacer()
+
+            Text(value.summary)
+                .monospaced()
+                .font(.system(size: 16))
+                .foregroundStyle(summaryStyle)
+                .lineLimit(1)
+        }
+    }
+}
+
+extension ParamValueRow {
+    init(node: ParamValue.Node) {
+        self.init(
+            value: node.value,
+            label: node.label,
+            labelStyle: node.value.isContainer ? .primary : .secondary,
+            summaryStyle: node.value.isContainer ? .tertiary : .primary
+        )
+    }
+}

--- a/Sources/Scout/UI/Event/Param/ParamView.swift
+++ b/Sources/Scout/UI/Event/Param/ParamView.swift
@@ -33,7 +33,7 @@ struct ParamView: View {
             if value.isContainer {
                 List(value.nodes) { node in
                     ZStack {
-                        ParamNodeRow(node: node)
+                        ParamValueRow(node: node)
 
                         NavigationLink {
                             ParamView(node: node)
@@ -82,30 +82,6 @@ private struct ParamScalarView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal)
-        }
-    }
-}
-
-/// A row of the expandable value tree: a colored kind icon, the key or index,
-/// and the scalar value or a child count for containers.
-///
-struct ParamNodeRow: View {
-    let node: ParamValue.Node
-
-    var body: some View {
-        HStack(spacing: 13) {
-            ParamIcon(value: node.value)
-
-            Text(node.label)
-                .foregroundStyle(node.value.isContainer ? .primary : .secondary)
-
-            Spacer()
-
-            Text(node.value.summary)
-                .monospaced()
-                .font(.system(size: 16))
-                .foregroundStyle(node.value.isContainer ? .tertiary : .primary)
-                .lineLimit(1)
         }
     }
 }


### PR DESCRIPTION
The list of parameters and the expandable value tree each rendered their own row, and the two layouts had started to drift apart even though they share the same icon, label, and summary structure. This factors the common layout into a single `ParamValueRow` that takes the label and summary `foregroundStyle`s as parameters, so the styling differences between the two contexts become explicit arguments rather than duplicated view code.

`ParamRow` now builds its content from `ParamValueRow`, and the standalone `ParamNodeRow` was replaced by a convenience `init(node:)` added to `ParamValueRow` in an extension, so the tree calls `ParamValueRow(node:)` directly. This is a structure-only refactor with no behavior change — the existing styles are carried over verbatim into the new initializers.
