### PR TITLE
Use Row component in CrashListView

### DIFF
--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -44,31 +44,21 @@ struct CrashListView: View {
     }
 
     private func row(for crash: Crash) -> some View {
-        ZStack {
-            HStack(spacing: 12) {
-                Text(crash.name)
-                    .font(.system(size: 17))
-                    .lineLimit(1)
-                    .monospaced()
+        Row {
+            Text(crash.name)
+                .font(.system(size: 17))
+                .lineLimit(1)
+                .monospaced()
 
-                Spacer()
+            Spacer()
 
-                if let date = crash.date {
-                    Text(verbatim: date.relativeString)
-                        .font(.system(size: 15))
-                        .foregroundStyle(Color.gray)
-                }
+            if let date = crash.date {
+                Text(verbatim: date.relativeString)
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.gray)
             }
-
-            NavigationLink {
-                CrashDetailView(crash: crash)
-            } label: {
-                EmptyView()
-            }
-            .opacity(0)
-        }
-        .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-            dimension[.trailing]
+        } destination: {
+            CrashDetailView(crash: crash)
         }
     }
 }


### PR DESCRIPTION
The row builder in `CrashListView` hand-rolled a `ZStack` with a hidden zero-opacity `NavigationLink` and the `listRowSeparatorTrailing` alignment guide, duplicating the exact pattern already provided by the reusable `Row` component. This swaps that manual implementation for `Row`, bringing `CrashListView` in line with the other rows that already use it (`ActivityRow`, `StatRow`, `HomeLogRow`) and removing the duplicated navigation plumbing.

Note that `Row` lays out its content with the default `HStack` spacing rather than the previous explicit `spacing: 12`. Because the content is separated by a `Spacer`, this is visually indistinguishable and matches the spacing of the sibling rows.