### PR TITLE
Extract shared blue pill button into PillButtonStyle

### DIFF
--- a/Sources/Scout/UI/Home/Onboarding/ReadyPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/ReadyPage.swift
@@ -35,13 +35,8 @@ struct ReadyPage: View {
                 dismiss()
             } label: {
                 Text(verbatim: "Get Started")
-                    .bold()
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(.blue)
-                    .foregroundStyle(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 100, style: .continuous))
             }
+            .buttonStyle(.pill)
             .padding(.horizontal, 32)
 
             Spacer()

--- a/Sources/Scout/UI/Primitives/Controls/ErrorView.swift
+++ b/Sources/Scout/UI/Primitives/Controls/ErrorView.swift
@@ -30,13 +30,8 @@ struct ErrorView: View {
             if let retry {
                 Button(action: retry) {
                     Text(verbatim: "Retry")
-                        .bold()
-                        .padding()
-                        .frame(maxWidth: .infinity)
-                        .background(Color.blue)
-                        .foregroundColor(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 100, style: .continuous))
                 }
+                .buttonStyle(.pill)
                 .padding(8)
             }
 

--- a/Sources/Scout/UI/Primitives/Controls/PillButtonStyle.swift
+++ b/Sources/Scout/UI/Primitives/Controls/PillButtonStyle.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct PillButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .bold()
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(.blue)
+            .foregroundStyle(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 100, style: .continuous))
+            .opacity(configuration.isPressed ? 0.7 : 1)
+    }
+}
+
+extension ButtonStyle where Self == PillButtonStyle {
+    static var pill: PillButtonStyle { PillButtonStyle() }
+}


### PR DESCRIPTION
The Retry button in `ErrorView` and the Get Started button in `ReadyPage` were two copies of the same blue, full-width, pill-shaped button styling. This pulls that styling into a reusable `PillButtonStyle` (with a `.pill` convenience accessor) and applies it at both call sites, removing the duplicated modifiers.

The style also adds a subtle pressed-state opacity that the inline versions lacked; the resting appearance is unchanged.