### PR TITLE
Reuse Row for the StatView events total row

### DIFF
--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -48,22 +48,14 @@ struct StatView: View {
     }
 
     func total(count: Int) -> some View {
-        ZStack {
-            HStack {
-                Text(verbatim: "Events")
-                Spacer()
-                Text(count == 0 ? "—" : "\(count)")
-            }
-            .foregroundColor(.blue)
-
-            NavigationLink {
-                EventStatList(eventName: stat.eventName, range: extent.domain)
-            } label: {
-                EmptyView()
-            }
-            .opacity(0)
+        Row {
+            Text(verbatim: "Events")
+            Spacer()
+            Text(count == 0 ? "—" : "\(count)")
+        } destination: {
+            EventStatList(eventName: stat.eventName, range: extent.domain)
         }
-        .trailingRowSeparator()
+        .foregroundColor(.blue)
     }
 }
 


### PR DESCRIPTION
The `total(count:)` row in `StatView` was a third inline copy of the hidden-`NavigationLink`-behind-a-styled-row idiom, duplicating the `ZStack`, hidden link, and `listRowSeparatorTrailing` alignment guide that the shared `Row` primitive already provides. This swaps the inline implementation for `Row`, leaving that layout logic in one place alongside the other call sites. The `.foregroundColor(.blue)` now applies to the whole `Row`, which is visually equivalent since the link label is hidden.