### PR TITLE
Extract shared DebouncedReset for delayed state resets

### DIFF
--- a/Sources/Scout/UI/Message/MessageView.Presenter.swift
+++ b/Sources/Scout/UI/Message/MessageView.Presenter.swift
@@ -10,7 +10,7 @@ import SwiftUI
 extension MessageView {
     struct Presenter: ViewModifier {
         @Binding var message: Message?
-        @State private var hideTask: Task<Void, Never>?
+        @State private var hide = DebouncedReset()
 
         func body(content: Content) -> some View {
             content.overlay(alignment: .top) {
@@ -28,20 +28,15 @@ extension MessageView {
                 }
             }
             .onChange(of: message) { message in
-                hideTask?.cancel()
-
                 if message != nil {
-                    hideTask = Task {
-                        try? await hideMessage(delay: 5)
+                    hide.schedule(after: .seconds(5)) {
+                        self.message = nil
                     }
+                } else {
+                    hide.cancel()
                 }
             }
             .animation(.easeInOut, value: message)
-        }
-
-        func hideMessage(delay: Int) async throws {
-            try await Task.sleep(for: .seconds(delay))
-            message = nil
         }
     }
 }

--- a/Sources/Scout/UI/Share/CopyButton.swift
+++ b/Sources/Scout/UI/Share/CopyButton.swift
@@ -14,7 +14,7 @@ struct CopyButton: View {
     let text: String
 
     @State private var isCopied = false
-    @State private var revertTask: Task<Void, Never>?
+    @State private var revert = DebouncedReset()
 
     var body: some View {
         Button {
@@ -26,10 +26,7 @@ struct CopyButton: View {
             #endif
             isCopied = true
 
-            revertTask?.cancel()
-            revertTask = Task {
-                try? await Task.sleep(for: .seconds(2))
-                guard !Task.isCancelled else { return }
+            revert.schedule(after: .seconds(2)) {
                 isCopied = false
             }
         } label: {

--- a/Sources/Scout/UI/Utilities/DebouncedReset.swift
+++ b/Sources/Scout/UI/Utilities/DebouncedReset.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+// Schedules a delayed action, cancelling any previously scheduled one so that
+// only the most recent call takes effect once the delay elapses.
+struct DebouncedReset {
+    private var task: Task<Void, Never>?
+
+    mutating func schedule(after delay: Duration, _ action: @MainActor @escaping () -> Void) {
+        task?.cancel()
+        task = Task { @MainActor in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            action()
+        }
+    }
+
+    mutating func cancel() {
+        task?.cancel()
+        task = nil
+    }
+}


### PR DESCRIPTION
Both `CopyButton` and `MessageView.Presenter` carried the same pattern: cancel a pending `Task` and schedule a delayed reset of view state. This unifies that into a small `DebouncedReset` helper in `UI/Utilities`, which cancels any previously scheduled work before starting the next, so call sites no longer repeat the cancel-then-reschedule dance.

`CopyButton` and the message presenter now hold a `DebouncedReset` instead of a raw `Task` handle, and the presenter's standalone `hideMessage(delay:)` method is gone since its body now lives inline in the scheduled closure. Behavior is unchanged — the 2s checkmark revert and 5s message auto-hide keep their timings, the cancellation guard moves into the helper, and the scheduled closures are `@MainActor` since both mutate view state.
