### PR TITLE
Collapse HomeLogSection result unwrapping into one property

### DIFF
--- a/Sources/Scout/UI/Home/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Log/HomeLogSection.swift
@@ -24,41 +24,35 @@ struct HomeLogSection: View {
             title: "Events",
             image: "list.bullet",
             color: .blue,
-            count: intSpan?.total { $0 != CrashObject.recordType },
+            count: spans?.int.total { $0 != CrashObject.recordType },
             destination: { AnalyticsView() }
         )
         HomeLogRow(
             title: "Metrics",
             image: "chart.bar",
             color: .blue,
-            count: metricsCount,
+            count: spans.map { $0.int.series + $0.double.series },
             destination: { MetricsList() }
         )
         HomeLogRow(
             title: "Crashes",
             image: "exclamationmark.triangle",
             color: .red,
-            count: intSpan?.total { $0 == CrashObject.recordType },
+            count: spans?.int.total { $0 == CrashObject.recordType },
             destination: { CrashListView() }
         )
     }
 
-    private var intSpan: MatrixSpan<Int>? {
-        guard let result = try? provider.result?.get() else {
-            return nil
-        }
-        return MatrixSpan(matrices: result.0, range: period.initialRange)
-    }
-
-    private var metricsCount: Int? {
+    private var spans: (int: MatrixSpan<Int>, double: MatrixSpan<Double>)? {
         guard let result = try? provider.result?.get() else {
             return nil
         }
 
-        let int = MatrixSpan(matrices: result.0, range: period.initialRange)
-        let double = MatrixSpan(matrices: result.1, range: period.initialRange)
-
-        return int.series + double.series
+        let range = period.initialRange
+        return (
+            MatrixSpan(matrices: result.0, range: range),
+            MatrixSpan(matrices: result.1, range: range)
+        )
     }
 }
 


### PR DESCRIPTION
`HomeLogSection` previously unwrapped `provider.result` in two separate computed properties, `intSpan` and `metricsCount`, with `metricsCount` rebuilding the same int span from scratch. This replaces both with a single `spans` property that unwraps the result once and returns both the int and double `MatrixSpan` values as a tuple. The row count call sites now read from `spans` directly, and `period.initialRange` is computed once. No behavior change.