### PR TITLE
Extract RangeControl's date formatter into a testable factory

### DIFF
--- a/Sources/Scout/UI/Chart/Range/RangeControl.swift
+++ b/Sources/Scout/UI/Chart/Range/RangeControl.swift
@@ -10,13 +10,6 @@ import SwiftUI
 struct RangeControl<T: ChartTimeScale>: View {
     @Binding var extent: ChartExtent<T>
 
-    let formatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.dateStyle = .medium
-        return formatter
-    }()
-
     var body: some View {
         HStack {
             MoveButton(image: "chevron.left") {
@@ -24,7 +17,7 @@ struct RangeControl<T: ChartTimeScale>: View {
             }
             .disabled(!extent.isLeftEnabled)
 
-            Text(extent.domain.label(using: formatter))
+            Text(extent.domain.label(using: rangeDateFormatter))
                 .font(.system(size: 16))
                 .monospaced()
                 .frame(height: 44)

--- a/Sources/Scout/UI/Chart/Range/RangeDateFormatter.swift
+++ b/Sources/Scout/UI/Chart/Range/RangeDateFormatter.swift
@@ -1,0 +1,15 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+let rangeDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US")
+    formatter.dateStyle = .medium
+    return formatter
+}()

--- a/Tests/ScoutTests/UI/Chart/RangeDateFormatterTests.swift
+++ b/Tests/ScoutTests/UI/Chart/RangeDateFormatterTests.swift
@@ -1,0 +1,26 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct RangeDateFormatterTests {
+    @Test("Uses the en_US locale and medium date style") func testConfiguration() {
+        #expect(rangeDateFormatter.locale == Locale(identifier: "en_US"))
+        #expect(rangeDateFormatter.dateStyle == .medium)
+    }
+
+    @Test("Formats a date in the expected style") func testFormatting() throws {
+        let parser = DateFormatter()
+        parser.dateFormat = "yyyy-MM-dd"
+        let date = try #require(parser.date(from: "2024-01-01"))
+
+        #expect(rangeDateFormatter.string(from: date) == "Jan 1, 2024")
+    }
+}


### PR DESCRIPTION
`RangeControl` built its `DateFormatter` inline in the view body, which kept the formatting configuration untested. This moves it out into a top-level `rangeDateFormatter` constant in its own `RangeDateFormatter.swift`, placed next to its use site in the `Range` folder and following the existing `utcDateFormatter` pattern. The view now references the shared formatter instead of constructing its own. The `en_US` locale and `.medium` date style are unchanged.

A new `RangeDateFormatterTests` covers the formatter's locale and date style as well as a sample formatted string.
