### PR TITLE
Extract shared OnboardingPage scaffold

### DIFF
--- a/Sources/Scout/UI/Home/Onboarding/OnboardingPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/OnboardingPage.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct OnboardingPage<Accessory: View, Content: View>: View {
+    let title: String
+    let spacing: CGFloat
+    @ViewBuilder let accessory: Accessory
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(spacing: spacing) {
+            ForEach(0..<3) { _ in Spacer() }
+
+            accessory
+
+            Text(verbatim: title)
+                .font(.title)
+                .bold()
+
+            content
+
+            ForEach(0..<5) { _ in Spacer() }
+        }
+    }
+}

--- a/Sources/Scout/UI/Home/Onboarding/ReadyPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/ReadyPage.swift
@@ -11,19 +11,11 @@ struct ReadyPage: View {
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
-        VStack(spacing: 24) {
-            Spacer()
-            Spacer()
-            Spacer()
-
+        OnboardingPage(title: "You're all set", spacing: 24) {
             Image(systemName: "checkmark.circle")
                 .font(.system(size: 64))
                 .foregroundStyle(.green)
-
-            Text(verbatim: "You're all set")
-                .font(.title)
-                .bold()
-
+        } content: {
             Text(verbatim: "Run your app and come back here to see your data.")
                 .font(.body)
                 .kerning(0.3)
@@ -43,12 +35,6 @@ struct ReadyPage: View {
                     .clipShape(RoundedRectangle(cornerRadius: 100, style: .continuous))
             }
             .padding(.horizontal, 32)
-
-            Spacer()
-            Spacer()
-            Spacer()
-            Spacer()
-            Spacer()
         }
     }
 }

--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -9,15 +9,9 @@ import SwiftUI
 
 struct SetupPage: View {
     var body: some View {
-        VStack(spacing: 32) {
-            Spacer()
-            Spacer()
-            Spacer()
-
-            Text(verbatim: "Quick Setup")
-                .font(.title)
-                .bold()
-
+        OnboardingPage(title: "Quick Setup", spacing: 32) {
+            EmptyView()
+        } content: {
             VStack(alignment: .leading, spacing: 20) {
                 Step(
                     number: 1,
@@ -36,12 +30,6 @@ struct SetupPage: View {
                 )
             }
             .padding(.horizontal, 24)
-
-            Spacer()
-            Spacer()
-            Spacer()
-            Spacer()
-            Spacer()
         }
     }
 

--- a/Sources/Scout/UI/Home/Onboarding/WelcomePage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/WelcomePage.swift
@@ -9,15 +9,9 @@ import SwiftUI
 
 struct WelcomePage: View {
     var body: some View {
-        VStack(spacing: 32) {
-            Spacer()
-            Spacer()
-            Spacer()
-
-            Text(verbatim: "Welcome to Scout")
-                .font(.title)
-                .bold()
-
+        OnboardingPage(title: "Welcome to Scout", spacing: 32) {
+            EmptyView()
+        } content: {
             VStack(alignment: .leading, spacing: 20) {
                 featureRow(
                     icon: "list.bullet",
@@ -36,12 +30,6 @@ struct WelcomePage: View {
                 )
             }
             .padding(.horizontal, 32)
-
-            Spacer()
-            Spacer()
-            Spacer()
-            Spacer()
-            Spacer()
         }
     }
 


### PR DESCRIPTION
The three onboarding pages each repeated the same scaffold: a centered `VStack` with a stack of leading and trailing `Spacer`s wrapped around a `.title`-styled heading. This extracts that shared layout into a new `OnboardingPage` view, which owns the centering and the title and exposes an optional `accessory` slot above the heading plus the page-specific `content` below it.

With the scaffold in one place, `WelcomePage`, `SetupPage`, and `ReadyPage` now only describe their own content — the feature rows, the setup steps, and the completion message respectively. `ReadyPage` uses the `accessory` slot for its checkmark image, and each page passes its `spacing` explicitly. Layout and proportions of the pages are unchanged.