### PR TITLE
Route ParamRow and EventList through the shared Row primitive

### DIFF
--- a/Sources/Scout/UI/Event/List/EventList.swift
+++ b/Sources/Scout/UI/Event/List/EventList.swift
@@ -41,7 +41,7 @@ struct EventList: View {
     }
 
     func row(for event: Event) -> some View {
-        ZStack {
+        Row {
             HStack(spacing: 12) {
                 Text(event.name)
                     .font(.system(size: 17))
@@ -58,18 +58,10 @@ struct EventList: View {
                     .foregroundStyle(Color.gray)
                 }
             }
-
-            NavigationLink {
-                EventView(event: event)
-            } label: {
-                EmptyView()
-            }
-            .opacity(0)
+        } destination: {
+            EventView(event: event)
         }
         .listRowBackground(event.level?.color?.opacity(0.12) ?? .clear)
-        .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-            dimension[.trailing]
-        }
     }
 }
 

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -42,30 +42,27 @@ struct ParamRow: View {
     let item: ParamProvider.Item?
 
     var body: some View {
-        ZStack {
+        Group {
             if let item {
                 let value = ParamValue(parsing: item.value)
 
-                HStack(spacing: 13) {
-                    ParamIcon(value: value)
+                Row {
+                    HStack(spacing: 13) {
+                        ParamIcon(value: value)
 
-                    Text(item.key)
-                        .foregroundStyle(.secondary)
+                        Text(item.key)
+                            .foregroundStyle(.secondary)
 
-                    Spacer()
+                        Spacer()
 
-                    Text(value.summary)
-                        .monospaced()
-                        .font(.system(size: 16))
-                        .foregroundStyle(value.isContainer ? .secondary : .primary)
-                }
-
-                NavigationLink {
+                        Text(value.summary)
+                            .monospaced()
+                            .font(.system(size: 16))
+                            .foregroundStyle(value.isContainer ? .secondary : .primary)
+                    }
+                } destination: {
                     ParamView(item: item)
-                } label: {
-                    EmptyView()
                 }
-                .opacity(0)
             } else {
                 HStack(spacing: 13) {
                     Redacted(length: 2)
@@ -78,12 +75,12 @@ struct ParamRow: View {
 
                     Redacted(length: 8).opacity(0.5)
                 }
+                .alignmentGuide(.listRowSeparatorTrailing) { dimension in
+                    dimension[.trailing]
+                }
             }
         }
         .lineLimit(1)
-        .alignmentGuide(.listRowSeparatorTrailing) { dimension in
-            dimension[.trailing]
-        }
     }
 }
 


### PR DESCRIPTION
The hidden-`NavigationLink`-over-content idiom — a `ZStack` placing tappable content beneath a `NavigationLink` whose `EmptyView` label is hidden with `.opacity(0)` — was hand-rolled in the Event-region rows even though the `Row` primitive already encapsulates exactly that pattern. This routes `ParamRow` and `EventList`'s row through `Row` so the navigation behaviour lives in one place. The row content keeps using `ParamValueRow` and the inline event `HStack`; only the surrounding idiom is replaced.

The migration is deliberate rather than mechanical, since each site differs. `ParamRow` keeps its redacted placeholder branch as a plain `HStack` (it has no destination) and applies `trailingRowSeparator()` to it directly, while `lineLimit(1)` is lifted onto the shared `Group`. `EventList` keeps its `listRowBackground` on the `Row`. Because `Row` already applies `trailingRowSeparator()` internally, the separate call on these rows is dropped.

The container list in `ParamView` is intentionally left on the hand-rolled idiom: `Row` always applies a trailing separator `alignmentGuide` that this list never had, so routing it through `Row` would extend its separators to the trailing edge and change the rendering. Keeping it as-is preserves the existing separator inset.
