### PR TITLE
Isolate Box to the main actor for safe @Published mutation

### DIFF
--- a/Sources/Scout/UI/Utilities/Box.swift
+++ b/Sources/Scout/UI/Utilities/Box.swift
@@ -7,17 +7,12 @@
 
 import SwiftUI
 
+@MainActor
 class Box<T>: ObservableObject {
     @Published var value: T
 
     init(_ value: T) {
         self.value = value
-    }
-}
-
-extension Box: Equatable where T: Equatable {
-    static func == (lhs: Box<T>, rhs: Box<T>) -> Bool {
-        lhs.value == rhs.value
     }
 }
 


### PR DESCRIPTION
`Box` is an `ObservableObject` whose `@Published value` was being mutated without main-actor isolation, so its `objectWillChange` could fire off the main thread. This annotates `Box` with `@MainActor`, which is correct since every `tint.value` mutation already happens inside SwiftUI view bodies and lifecycle callbacks that run on the main actor.

The previous `Equatable` conformance had to go: its `nonisolated` `==` requirement read the now-isolated `value`, which Swift 6 rejects as a potential data race. The conformance was unused anywhere in the module, so it is removed rather than worked around. The unrelated test helper of the same name (`Tests/ScoutTests/Utilities/Box.swift`) is a separate type and is untouched.