### PR TITLE
Isolate sync senders to @MainActor instead of @unchecked Sendable

### DIFF
--- a/Sources/Scout/Core/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Core/Database/Access/RecordSender.swift
@@ -11,11 +11,11 @@ import CoreData
 struct RecordSender {
     let id: String
     let database: any Database
-    nonisolated(unsafe) let context: NSManagedObjectContext
+    let context: NSManagedObjectContext
 }
 
 extension RecordSender {
-    nonisolated init(backend: Backend, context: NSManagedObjectContext) {
+    init(backend: Backend, context: NSManagedObjectContext) {
         self.id = backend.id
         self.database = backend.database
         self.context = context

--- a/Sources/Scout/Core/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Core/Database/Access/RecordSender.swift
@@ -7,21 +7,21 @@
 
 import CoreData
 
-struct RecordSender: @unchecked Sendable {
+@MainActor
+struct RecordSender {
     let id: String
     let database: any Database
     let context: NSManagedObjectContext
 }
 
 extension RecordSender {
-    init(backend: Backend, context: NSManagedObjectContext) {
+    nonisolated init(backend: Backend, context: NSManagedObjectContext) {
         self.id = backend.id
         self.database = backend.database
         self.context = context
     }
 }
 
-@MainActor
 extension RecordSender {
     func deliver<T: Syncable & RecordEncodable>(type syncable: T.Type) async throws {
         var objects: [T] = []

--- a/Sources/Scout/Core/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Core/Database/Access/RecordSender.swift
@@ -11,7 +11,7 @@ import CoreData
 struct RecordSender {
     let id: String
     let database: any Database
-    let context: NSManagedObjectContext
+    nonisolated(unsafe) let context: NSManagedObjectContext
 }
 
 extension RecordSender {

--- a/Sources/Scout/Core/Sync/Synchronize.swift
+++ b/Sources/Scout/Core/Sync/Synchronize.swift
@@ -19,8 +19,12 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
     try await dispatcher.performEnsuringBackground {
         await withTaskGroup(of: Void.self) { group in
             for backend in backends where await backend.checkAvailability() {
-                let recordSender = RecordSender(backend: backend, context: context)
-                let matrixSender = MatrixSender(backend: backend, context: context)
+                let (recordSender, matrixSender) = await MainActor.run {
+                    (
+                        RecordSender(backend: backend, context: context),
+                        MatrixSender(backend: backend, context: context)
+                    )
+                }
 
                 func deliver<T: Syncable & MatrixBatch & RecordEncodable>(_ type: T.Type) {
                     group.addTask { try? await recordSender.deliver(type: type) }

--- a/Sources/Scout/Core/Sync/Synchronize.swift
+++ b/Sources/Scout/Core/Sync/Synchronize.swift
@@ -19,12 +19,8 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
     try await dispatcher.performEnsuringBackground {
         await withTaskGroup(of: Void.self) { group in
             for backend in backends where await backend.checkAvailability() {
-                let (recordSender, matrixSender) = await MainActor.run {
-                    (
-                        RecordSender(backend: backend, context: context),
-                        MatrixSender(backend: backend, context: context)
-                    )
-                }
+                let recordSender = await RecordSender(backend: backend, context: context)
+                let matrixSender = await MatrixSender(backend: backend, context: context)
 
                 func deliver<T: Syncable & MatrixBatch & RecordEncodable>(_ type: T.Type) {
                     group.addTask { try? await recordSender.deliver(type: type) }

--- a/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
@@ -11,7 +11,7 @@ import CoreData
 struct MatrixSender {
     let id: String
     let aggregator: any MatrixAggregator
-    let context: NSManagedObjectContext
+    nonisolated(unsafe) let context: NSManagedObjectContext
 }
 
 extension MatrixSender {

--- a/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
@@ -11,11 +11,11 @@ import CoreData
 struct MatrixSender {
     let id: String
     let aggregator: any MatrixAggregator
-    nonisolated(unsafe) let context: NSManagedObjectContext
+    let context: NSManagedObjectContext
 }
 
 extension MatrixSender {
-    nonisolated init?(backend: Backend, context: NSManagedObjectContext) {
+    init?(backend: Backend, context: NSManagedObjectContext) {
         guard let aggregator = backend.aggregator else {
             return nil
         }

--- a/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
@@ -7,14 +7,15 @@
 
 import CoreData
 
-struct MatrixSender: @unchecked Sendable {
+@MainActor
+struct MatrixSender {
     let id: String
     let aggregator: any MatrixAggregator
     let context: NSManagedObjectContext
 }
 
 extension MatrixSender {
-    init?(backend: Backend, context: NSManagedObjectContext) {
+    nonisolated init?(backend: Backend, context: NSManagedObjectContext) {
         guard let aggregator = backend.aggregator else {
             return nil
         }
@@ -24,7 +25,6 @@ extension MatrixSender {
     }
 }
 
-@MainActor
 extension MatrixSender {
     func deliver<T: Syncable & MatrixBatch>(type syncable: T.Type) async throws {
         while let batch = try syncable.group(in: context, for: id) {


### PR DESCRIPTION
Both `MatrixSender` and `RecordSender` carried an `@unchecked Sendable` conformance purely to smuggle a non-`Sendable` `NSManagedObjectContext` across concurrency boundaries, with their `deliver` methods separately pinned to `@MainActor`. This isolates each struct to `@MainActor` instead, which makes the type implicitly `Sendable` without the unchecked override and lets the now-redundant `@MainActor` annotation on the `deliver` extensions go away.

Because the senders are now main-actor isolated, `synchronize` constructs them with an awaited `@MainActor` initializer inside the background sync task so the hop to the main actor happens implicitly, rather than relying on any unchecked or unsafe escape hatch.