### PR TITLE
Document building the test target locally on signature changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@
 - Extract logic and computations out of SwiftUI views into separate types covered by unit tests.
 - Keep views from bloating: when a view accumulates non-trivial logic, computations, or repeated layout, extract them into model types or subviews.
 
+# Building & testing
+
+- When a change touches a declaration the tests reference (renaming or re-typing a function/initializer/property, changing a signature, or moving a symbol), build the test target locally with `build-for-testing`, not just the app target — building the app alone misses test-only call sites and lets the breakage surface in CI instead.
+
 # Swift code style
 
 ## Doc comments


### PR DESCRIPTION
Adds a project rule under a new `Building & testing` section of `CLAUDE.md`: when a change touches a declaration the tests reference, build the test target with `build-for-testing` rather than only the app target. Building the app alone misses test-only call sites, so a signature change can pass locally yet break the test build in CI.