### PR TITLE
Fix and guard the Server contract path filter

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -6,10 +6,12 @@ name: Server
 # on top of PostgreSQL and runs ServerContractTests through HTTPDatabase.
 #
 # The expensive `contract` job runs only when the wire surface changes — the
-# Core/Backend and Core/Database/Record code that travels over it (HTTPDatabase
-# rides on the RecordReader/RecordWriter/RecordChunk/RecordCursor pagination and
-# cursor semantics), the contract tests, or this workflow — or when scout-server
-# pushes to main (repository_dispatch from its Notify workflow).
+# Hosted transport/access code that travels over it (HTTPDatabase, the
+# HTTPQueryCoding/HTTPRecordCoding wire coders, and the HostedRecord readers and
+# writers), the Core/Database record model and the RecordReader/RecordChunk/
+# RecordCursor pagination and cursor semantics they ride on, the contract tests,
+# or this workflow — or when scout-server pushes to main (repository_dispatch
+# from its Notify workflow).
 #
 # A required status check must report on every PR, but a path-filtered job never
 # reports on PRs outside its paths, which would wedge them forever. So the PR
@@ -21,8 +23,8 @@ on:
   push:
     branches: [main]
     paths:
-      - "Sources/Scout/Core/Backend/**"
-      - "Sources/Scout/Core/Database/Record/**"
+      - "Sources/Scout/Hosted/**"
+      - "Sources/Scout/Core/Database/**"
       - "Tests/ScoutTests/Core/Backend/**"
       - ".github/workflows/server.yml"
   pull_request:
@@ -60,7 +62,7 @@ jobs:
           fi
           base="${{ github.event.pull_request.base.sha }}"
           if git diff --name-only "$base"...HEAD \
-            | grep -qE '^(Sources/Scout/Core/Backend/|Sources/Scout/Core/Database/Record/|Tests/ScoutTests/Core/Backend/|\.github/workflows/server\.yml$)'; then
+            | grep -qE '^(Sources/Scout/Hosted/|Sources/Scout/Core/Database/|Tests/ScoutTests/Core/Backend/|\.github/workflows/server\.yml$)'; then
             echo "backend=true" >> "$GITHUB_OUTPUT"
           else
             echo "backend=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -53,6 +53,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Tripwire against filter drift. The path filter below duplicates the
+      # knowledge of where the wire code lives, so a future move out of the
+      # watched directories would silently stop triggering `contract` while the
+      # gate stays green. Symbol names outlive folder layout, so assert the wire
+      # code still sits under a watched root and fail loudly (red PR) when it
+      # escapes — that is the signal to widen the filter. The HTTP* coders are
+      # wire-specific, so any mention pins them down; the Record pagination types
+      # are shared infra used all over the app, so only their definition sites
+      # matter (their use sites legitimately live outside the watched roots).
+      - name: Guard the filter covers the wire code
+        run: |
+          escaped="$(
+            {
+              grep -rlE 'HTTPDatabase|HTTPQueryCoding|HTTPRecordCoding' Sources
+              grep -rlE '(struct|enum|final class|class) +(RecordReader|RecordChunk|RecordCursor)\b' Sources
+            } | sort -u | grep -vE '^Sources/Scout/(Hosted/|Core/Database/)' || true
+          )"
+          if [ -n "$escaped" ]; then
+            echo "::error::Wire-contract code lives outside the Server filter's watched paths; update the paths in this workflow to cover:"
+            echo "$escaped"
+            exit 1
+          fi
+
       - name: Detect wire-surface changes
         id: filter
         run: |


### PR DESCRIPTION
The `Server` workflow only runs the expensive `contract` job when a PR touches the HTTP wire surface shared with scout-server, and its `changes` job (plus the `push` trigger) decides that by path. Since the filter was last updated, the wire code moved: `HTTPDatabase`, the `HTTPQueryCoding`/`HTTPRecordCoding` coders and the `HostedRecordReader`/`HostedRecordWriter` types now live under `Sources/Scout/Hosted/`, and the `RecordReader`/`RecordChunk`/`RecordCursor` pagination under `Sources/Scout/Core/Database/Access/`. The filter still watched `Core/Backend` and `Core/Database/Record`, which no longer hold any wire code, so a PR changing the actual wire format set `backend=false`, skipped `contract`, and let `contract-gate` pass green without ever running the contract tests against the server.

The first change widens the filter to `Sources/Scout/Hosted/**` and `Sources/Scout/Core/Database/**` in both the `push` paths and the `changes` grep, and refreshes the header comment to match.

Because a path filter inherently drifts when code moves, the second change adds a tripwire step to the `changes` job that asserts the wire code still sits under the watched roots and fails the PR loudly when it escapes — turning a silent skip behind a green gate into a red signal to widen the filter. The `HTTP*` coders are wire-specific so any mention pins them down, while the shared `Record` pagination types are matched only at their definition sites since their use sites legitimately live elsewhere.