### PR TITLE
Drop @unchecked Sendable from the sync senders

### DIFF
--- a/Sources/Scout/Core/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Core/Database/Access/RecordSender.swift
@@ -7,23 +7,21 @@
 
 import CoreData
 
-struct RecordSender: @unchecked Sendable {
+struct RecordSender: Sendable {
     let id: String
     let database: any Database
-    let context: NSManagedObjectContext
 }
 
 extension RecordSender {
-    init(backend: Backend, context: NSManagedObjectContext) {
+    init(backend: Backend) {
         self.id = backend.id
         self.database = backend.database
-        self.context = context
     }
 }
 
 @MainActor
 extension RecordSender {
-    func deliver<T: Syncable & RecordEncodable>(type syncable: T.Type) async throws {
+    func deliver<T: Syncable & RecordEncodable>(type syncable: T.Type, in context: NSManagedObjectContext) async throws {
         var objects: [T] = []
         var deliveries: [SyncDelivery] = []
 

--- a/Sources/Scout/Core/Sync/Synchronize.swift
+++ b/Sources/Scout/Core/Sync/Synchronize.swift
@@ -19,16 +19,16 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
     try await dispatcher.performEnsuringBackground {
         await withTaskGroup(of: Void.self) { group in
             for backend in backends where await backend.checkAvailability() {
-                let recordSender = RecordSender(backend: backend, context: context)
-                let matrixSender = MatrixSender(backend: backend, context: context)
+                let recordSender = RecordSender(backend: backend)
+                let matrixSender = MatrixSender(backend: backend)
 
                 func deliver<T: Syncable & MatrixBatch & RecordEncodable>(_ type: T.Type) {
-                    group.addTask { try? await recordSender.deliver(type: type) }
-                    group.addTask { try? await matrixSender?.deliver(type: type) }
+                    group.addTask { try? await recordSender.deliver(type: type, in: context) }
+                    group.addTask { try? await matrixSender?.deliver(type: type, in: context) }
                 }
 
                 func deliver<T: Syncable & MatrixBatch>(_ type: T.Type) {
-                    group.addTask { try? await matrixSender?.deliver(type: type) }
+                    group.addTask { try? await matrixSender?.deliver(type: type, in: context) }
                 }
 
                 deliver(EventObject.self)

--- a/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
@@ -7,26 +7,24 @@
 
 import CoreData
 
-struct MatrixSender: @unchecked Sendable {
+struct MatrixSender: Sendable {
     let id: String
     let aggregator: any MatrixAggregator
-    let context: NSManagedObjectContext
 }
 
 extension MatrixSender {
-    init?(backend: Backend, context: NSManagedObjectContext) {
+    init?(backend: Backend) {
         guard let aggregator = backend.aggregator else {
             return nil
         }
         self.id = backend.id
         self.aggregator = aggregator
-        self.context = context
     }
 }
 
 @MainActor
 extension MatrixSender {
-    func deliver<T: Syncable & MatrixBatch>(type syncable: T.Type) async throws {
+    func deliver<T: Syncable & MatrixBatch>(type syncable: T.Type, in context: NSManagedObjectContext) async throws {
         while let batch = try syncable.group(in: context, for: id) {
             try Task.checkCancellation()
 

--- a/Tests/ScoutTests/Core/Backend/DeliverTests.swift
+++ b/Tests/ScoutTests/Core/Backend/DeliverTests.swift
@@ -54,8 +54,8 @@ struct DeliverTests {
 
     /// Run both engines for a type the way `synchronize` does: raw records first, then matrices.
     func deliver<T: Syncable & MatrixBatch & RecordEncodable>(_ type: T.Type, to backend: Backend) async throws {
-        try await RecordSender(backend: backend, context: context).deliver(type: type)
-        try await MatrixSender(backend: backend, context: context)?.deliver(type: type)
+        try await RecordSender(backend: backend).deliver(type: type, in: context)
+        try await MatrixSender(backend: backend)?.deliver(type: type, in: context)
     }
 
     @Test("Events go raw to every backend, matrices only to CloudKit")


### PR DESCRIPTION
`RecordSender` and `MatrixSender` previously claimed `@unchecked Sendable` purely so they could be handed to the sync task group, even though they stored a non-`Sendable` `NSManagedObjectContext`. That suppressed the compiler's concurrency checking and left the safety of the conformance resting on an unwritten invariant.

Both types now hold only `Sendable` state (`id` plus the `Database`/`MatrixAggregator`, which are themselves `Sendable`), so they are plainly `Sendable` without any escape hatch. The `NSManagedObjectContext` is handed to the `deliver` methods at the call site instead of being stored, keeping every access to it confined to the `@MainActor` extensions where it already lived.

This supersedes #637 and #638, which were two alternative approaches to the same change; both are closed in favor of this one.