### PR TITLE
Remove stray comment above the MetricsView copyright header

### DIFF
--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -1,3 +1,4 @@
+//
 // Copyright 2025 Mikhail Kasianov
 //
 // Use of this source code is governed by an MIT-style

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -1,4 +1,3 @@
-// wrap both previews into a VStack to avoid truncation
 // Copyright 2025 Mikhail Kasianov
 //
 // Use of this source code is governed by an MIT-style


### PR DESCRIPTION
Cleans up the file header of `MetricsView.swift`. A stray `// wrap both previews into a VStack to avoid truncation` comment had taken the place of the header's leading `//` line, so it both added noise and left the header inconsistent with every other file. Removing the comment and restoring the leading `//` brings the header back in line with the rest of the sources.