### PR TITLE
Add NSManagedObjectContext.insert(_:) test helper

### DIFF
--- a/Tests/ScoutTests/Stubs/Objects/DeviceObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/DeviceObject+Stub.swift
@@ -15,8 +15,7 @@ extension DeviceObject {
         synced: Bool = false,
         in context: NSManagedObjectContext
     ) -> DeviceObject {
-        let entity = NSEntityDescription.entity(forEntityName: "DeviceObject", in: context)!
-        let device = DeviceObject(entity: entity, insertInto: context)
+        let device = context.insert(DeviceObject.self)
 
         device.date = date
         device.setSynced(synced, in: context)

--- a/Tests/ScoutTests/Stubs/Objects/EventObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/EventObject+Stub.swift
@@ -17,8 +17,7 @@ extension EventObject {
         level: Event.Level = .info,
         in context: NSManagedObjectContext
     ) -> EventObject {
-        let entity = NSEntityDescription.entity(forEntityName: "EventObject", in: context)!
-        let event = EventObject(entity: entity, insertInto: context)
+        let event = context.insert(EventObject.self)
 
         event.name = name
         event.date = date

--- a/Tests/ScoutTests/Stubs/Objects/InstallObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/InstallObject+Stub.swift
@@ -15,8 +15,7 @@ extension InstallObject {
         synced: Bool = false,
         in context: NSManagedObjectContext
     ) -> InstallObject {
-        let entity = NSEntityDescription.entity(forEntityName: "InstallObject", in: context)!
-        let install = InstallObject(entity: entity, insertInto: context)
+        let install = context.insert(InstallObject.self)
 
         install.date = date
         install.setSynced(synced, in: context)

--- a/Tests/ScoutTests/Stubs/Objects/LaunchObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/LaunchObject+Stub.swift
@@ -16,8 +16,7 @@ extension LaunchObject {
         endDate: Date? = nil,
         in context: NSManagedObjectContext
     ) -> LaunchObject {
-        let entity = NSEntityDescription.entity(forEntityName: "LaunchObject", in: context)!
-        let launch = LaunchObject(entity: entity, insertInto: context)
+        let launch = context.insert(LaunchObject.self)
 
         launch.date = date
         launch.setSynced(synced, in: context)

--- a/Tests/ScoutTests/Stubs/Objects/SessionObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/SessionObject+Stub.swift
@@ -16,8 +16,7 @@ extension SessionObject {
         endDate: Date? = nil,
         in context: NSManagedObjectContext
     ) -> SessionObject {
-        let entity = NSEntityDescription.entity(forEntityName: "SessionObject", in: context)!
-        let session = SessionObject(entity: entity, insertInto: context)
+        let session = context.insert(SessionObject.self)
 
         session.date = date
         session.setSynced(synced, in: context)

--- a/Tests/ScoutTests/Stubs/Objects/UserActivityObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/UserActivityObject+Stub.swift
@@ -18,8 +18,7 @@ extension UserActivityObject {
         isSynced: Bool,
         in context: NSManagedObjectContext
     ) -> UserActivityObject {
-        let entity = NSEntityDescription.entity(forEntityName: "UserActivityObject", in: context)!
-        let activity = UserActivityObject(entity: entity, insertInto: context)
+        let activity = context.insert(UserActivityObject.self)
 
         activity.userActivityID = UUID()
         activity.month = month

--- a/Tests/ScoutTests/Stubs/Objects/VersionObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/VersionObject+Stub.swift
@@ -17,8 +17,7 @@ extension VersionObject {
         buildNumber: String? = nil,
         in context: NSManagedObjectContext
     ) -> VersionObject {
-        let entity = NSEntityDescription.entity(forEntityName: "VersionObject", in: context)!
-        let version = VersionObject(entity: entity, insertInto: context)
+        let version = context.insert(VersionObject.self)
 
         version.date = date
         version.setSynced(synced, in: context)

--- a/Tests/ScoutTests/Transient/NSManagedObjectContext+Insert.swift
+++ b/Tests/ScoutTests/Transient/NSManagedObjectContext+Insert.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension NSManagedObjectContext {
+    // Inserts a new managed object of the given type, resolving its entity by
+    // the class's simple name (which matches the Core Data entity name here).
+    func insert<T: NSManagedObject>(_ type: T.Type) -> T {
+        let entity = NSEntityDescription.entity(forEntityName: String(describing: type), in: self)!
+        return NSManagedObject(entity: entity, insertInto: self) as! T
+    }
+}


### PR DESCRIPTION
The managed-object stub factories each repeated the same two lines to resolve an `NSEntityDescription` by name and insert a new object into the context. This introduces an `insert(_:)` helper on `NSManagedObjectContext` that derives the entity name from the class and returns the inserted object, and routes all eight `*+Stub.swift` factories through it so the boilerplate lives in one place.