### PR TITLE
Add NSManagedObjectContext.fetchAll(_:) test helper

### DIFF
--- a/Tests/ScoutTests/Core/Activity/UserActivityObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Activity/UserActivityObjectMonitorTests.swift
@@ -18,8 +18,7 @@ struct UserActivityObjectMonitorTests {
     @Test("Trigger") func trigger() async throws {
         try UserActivityObject.trigger(date: Date(year: 2025, month: 1, day: 1), in: context)
 
-        let request = NSFetchRequest<UserActivityObject>(entityName: "UserActivityObject")
-        let activities = try context.fetch(request)
+        let activities = try context.fetchAll(UserActivityObject.self)
 
         let days = activities.days.map(\.dayCount)
         let weeks = activities.weeks.map(\.weekCount)
@@ -34,8 +33,7 @@ struct UserActivityObjectMonitorTests {
         try UserActivityObject.trigger(date: Date(year: 2025, month: 1, day: 1), in: context)
         try UserActivityObject.trigger(date: Date(year: 2025, month: 1, day: 2), in: context)
 
-        let request = NSFetchRequest<UserActivityObject>(entityName: "UserActivityObject")
-        let activities = try context.fetch(request)
+        let activities = try context.fetchAll(UserActivityObject.self)
 
         let days = activities.days.map(\.dayCount)
         let weeks = activities.weeks.map(\.weekCount)
@@ -50,8 +48,7 @@ struct UserActivityObjectMonitorTests {
         try UserActivityObject.trigger(date: Date(year: 2025, month: 1, day: 1), in: context)
         try UserActivityObject.trigger(date: Date(year: 2025, month: 1, day: 3), in: context)
 
-        let request = NSFetchRequest<UserActivityObject>(entityName: "UserActivityObject")
-        let activities = try context.fetch(request)
+        let activities = try context.fetchAll(UserActivityObject.self)
 
         let days = activities.days.map(\.dayCount)
         let weeks = activities.weeks.map(\.weekCount)

--- a/Tests/ScoutTests/Core/Backend/DeliverTests.swift
+++ b/Tests/ScoutTests/Core/Backend/DeliverTests.swift
@@ -219,10 +219,10 @@ struct DeliverTests {
 
         // While the server is configured, the outstanding row keeps the record...
         try SyncableObject.cleanup(backends: backends, in: context)
-        #expect(try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject")).count == 1)
+        #expect(try context.fetchAll(EventObject.self).count == 1)
 
         // ...but once it is dropped from the config, cleanup reclaims it.
         try SyncableObject.cleanup(backends: [cloudBackend], in: context)
-        #expect(try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject")).isEmpty)
+        #expect(try context.fetchAll(EventObject.self).isEmpty)
     }
 }

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
@@ -26,8 +26,7 @@ struct LogCrashTests {
 
         try logCrash(crash, context: context)
 
-        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
-        let results = try context.fetch(request)
+        let results = try context.fetchAll(CrashObject.self)
 
         #expect(results.count == 1)
 
@@ -53,7 +52,7 @@ struct LogCrashTests {
 
         try logCrash(crash, context: context)
 
-        let object = try #require(try context.fetch(NSFetchRequest<CrashObject>(entityName: "CrashObject")).first)
+        let object = try #require(try context.fetchAll(CrashObject.self).first)
         #expect(object.sessionID == crashedSessionID)
     }
 
@@ -63,8 +62,7 @@ struct LogCrashTests {
 
         try logCrash(crash, context: context)
 
-        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
-        let object = try #require(try context.fetch(request).first)
+        let object = try #require(try context.fetchAll(CrashObject.self).first)
 
         let data = try #require(object.stackTrace)
         let decoded = try JSONDecoder().decode([String].self, from: data)
@@ -77,8 +75,7 @@ struct LogCrashTests {
 
         try logCrash(crash, context: context)
 
-        let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
-        let object = try #require(try context.fetch(request).first)
+        let object = try #require(try context.fetchAll(CrashObject.self).first)
         #expect(object.reason == nil)
     }
 

--- a/Tests/ScoutTests/Core/Diagnostics/Log/LogTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Log/LogTests.swift
@@ -31,8 +31,7 @@ private func makeEvent(
         context: context
     )
 
-    let fetchRequest: NSFetchRequest<EventObject> = NSFetchRequest<EventObject>(entityName: "EventObject")
-    let events = try context.fetch(fetchRequest)
+    let events = try context.fetchAll(EventObject.self)
 
     #expect(events.count == 1)
 
@@ -60,7 +59,7 @@ private func makeEvent(
 
     try log(makeEvent("Array Event", metadata: metadata), date: Date(), context: context)
 
-    let events = try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject"))
+    let events = try context.fetchAll(EventObject.self)
     let paramData = try #require(events.first?.params)
     let params = try JSONDecoder().decode([String: String].self, from: paramData)
 
@@ -76,7 +75,7 @@ private func makeEvent(
 
     try log(makeEvent("Dict Event", metadata: metadata), date: Date(), context: context)
 
-    let events = try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject"))
+    let events = try context.fetchAll(EventObject.self)
     let paramData = try #require(events.first?.params)
     let params = try JSONDecoder().decode([String: String].self, from: paramData)
 
@@ -94,7 +93,7 @@ private func makeEvent(
 
     try log(makeEvent("Mixed Event", metadata: metadata), date: Date(), context: context)
 
-    let events = try context.fetch(NSFetchRequest<EventObject>(entityName: "EventObject"))
+    let events = try context.fetchAll(EventObject.self)
     let paramData = try #require(events.first?.params)
     let params = try JSONDecoder().decode([String: String].self, from: paramData)
 

--- a/Tests/ScoutTests/Core/Diagnostics/Metrics/SaveMetricsTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Metrics/SaveMetricsTests.swift
@@ -21,8 +21,7 @@ struct SaveMetricsTests {
     func persistsIntMetrics() throws {
         try saveMetrics("api_calls", date: date, telemetry: .counter, value: 5, context)
 
-        let request = NSFetchRequest<IntMetricsObject>(entityName: "IntMetricsObject")
-        let results = try context.fetch(request)
+        let results = try context.fetchAll(IntMetricsObject.self)
 
         #expect(results.count == 1)
 
@@ -37,8 +36,7 @@ struct SaveMetricsTests {
     func persistsDoubleMetrics() throws {
         try saveMetrics("response_time", date: date, telemetry: .timer, value: 1.5, context)
 
-        let request = NSFetchRequest<DoubleMetricsObject>(entityName: "DoubleMetricsObject")
-        let results = try context.fetch(request)
+        let results = try context.fetchAll(DoubleMetricsObject.self)
 
         #expect(results.count == 1)
 

--- a/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectMonitorTests.swift
@@ -19,7 +19,7 @@ struct InstallObjectMonitorTests {
     func createsFirst() throws {
         try InstallObject.trigger(in: context)
 
-        let installs = try context.fetch(NSFetchRequest<InstallObject>(entityName: "InstallObject"))
+        let installs = try context.fetchAll(InstallObject.self)
         #expect(installs.count == 1)
         #expect(installs.first?.installID == IDs.install)
     }
@@ -30,7 +30,7 @@ struct InstallObjectMonitorTests {
         try InstallObject.trigger(in: context)
         try InstallObject.trigger(in: context)
 
-        let installs = try context.fetch(NSFetchRequest<InstallObject>(entityName: "InstallObject"))
+        let installs = try context.fetchAll(InstallObject.self)
         #expect(installs.count == 1)
     }
 
@@ -42,7 +42,7 @@ struct InstallObjectMonitorTests {
 
         try InstallObject.trigger(in: context)
 
-        let installs = try context.fetch(NSFetchRequest<InstallObject>(entityName: "InstallObject"))
+        let installs = try context.fetchAll(InstallObject.self)
         #expect(installs.count == 2)
         #expect(installs.contains { $0.installID == IDs.install })
     }

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectMonitorTests.swift
@@ -19,7 +19,7 @@ struct LaunchObjectMonitorTests {
     func createsLaunch() throws {
         try LaunchObject.trigger(in: context)
 
-        let launches = try context.fetch(NSFetchRequest<LaunchObject>(entityName: "LaunchObject"))
+        let launches = try context.fetchAll(LaunchObject.self)
         #expect(launches.count == 1)
         #expect(launches.first?.launchID == IDs.launch)
         #expect(launches.first?.endDate == nil)
@@ -31,7 +31,7 @@ struct LaunchObjectMonitorTests {
         try SessionObject.trigger(in: context)
         try SessionObject.complete(in: context)
 
-        let launches = try context.fetch(NSFetchRequest<LaunchObject>(entityName: "LaunchObject"))
+        let launches = try context.fetchAll(LaunchObject.self)
         #expect(launches.first?.endDate == nil)
     }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
@@ -21,7 +21,7 @@ struct SessionObjectMonitorTests {
 
         try SessionObject.complete(in: context)
 
-        let sessions = try context.fetch(NSFetchRequest<SessionObject>(entityName: "SessionObject"))
+        let sessions = try context.fetchAll(SessionObject.self)
         #expect(sessions.count == 1)
         #expect(sessions.first?.endDate != nil)
     }
@@ -31,12 +31,11 @@ struct SessionObjectMonitorTests {
         try SessionObject.trigger(in: context)
         try SessionObject.complete(in: context)
 
-        let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
-        let firstEndDate = try #require(try context.fetch(request).first?.endDate)
+        let firstEndDate = try #require(try context.fetchAll(SessionObject.self).first?.endDate)
 
         try SessionObject.complete(in: context)
 
-        let session = try #require(try context.fetch(request).first)
+        let session = try #require(try context.fetchAll(SessionObject.self).first)
         #expect(session.endDate == firstEndDate)
     }
 

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectMonitorTests.swift
@@ -19,7 +19,7 @@ struct VersionObjectMonitorTests {
     func firstTrigger() throws {
         try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
 
-        let versions = try context.fetch(NSFetchRequest<VersionObject>(entityName: "VersionObject"))
+        let versions = try context.fetchAll(VersionObject.self)
         #expect(versions.count == 1)
         #expect(versions.first?.appVersion == "1.0")
         #expect(versions.first?.buildNumber == "1")
@@ -31,7 +31,7 @@ struct VersionObjectMonitorTests {
         try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
         try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
 
-        let versions = try context.fetch(NSFetchRequest<VersionObject>(entityName: "VersionObject"))
+        let versions = try context.fetchAll(VersionObject.self)
         #expect(versions.count == 1)
     }
 
@@ -69,7 +69,7 @@ struct VersionObjectMonitorTests {
 
         try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)
 
-        let versions = try context.fetch(NSFetchRequest<VersionObject>(entityName: "VersionObject"))
+        let versions = try context.fetchAll(VersionObject.self)
         #expect(versions.count == 2)
     }
 }

--- a/Tests/ScoutTests/Core/Sync/SyncableObjectCleanupTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncableObjectCleanupTests.swift
@@ -23,8 +23,7 @@ struct SyncableObjectCleanupTests {
 
         try SyncableObject.cleanup(backends: [], in: context)
 
-        let request = NSFetchRequest<EventObject>(entityName: "EventObject")
-        #expect(try context.fetch(request).isEmpty)
+        #expect(try context.fetchAll(EventObject.self).isEmpty)
     }
 
     @Test("Deletes synced launches older than 7 days")
@@ -35,8 +34,7 @@ struct SyncableObjectCleanupTests {
 
         try SyncableObject.cleanup(backends: [], in: context)
 
-        let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
-        #expect(try context.fetch(request).isEmpty)
+        #expect(try context.fetchAll(LaunchObject.self).isEmpty)
     }
 
     @Test("Keeps synced objects newer than 7 days")
@@ -47,8 +45,7 @@ struct SyncableObjectCleanupTests {
 
         try SyncableObject.cleanup(backends: [], in: context)
 
-        let request = NSFetchRequest<EventObject>(entityName: "EventObject")
-        #expect(try context.fetch(request).count == 1)
+        #expect(try context.fetchAll(EventObject.self).count == 1)
     }
 
     @Test("Keeps objects with outstanding work regardless of age")
@@ -62,7 +59,6 @@ struct SyncableObjectCleanupTests {
 
         try SyncableObject.cleanup(backends: [makeBackend(id: "cloud")], in: context)
 
-        let request = NSFetchRequest<EventObject>(entityName: "EventObject")
-        #expect(try context.fetch(request).count == 1)
+        #expect(try context.fetchAll(EventObject.self).count == 1)
     }
 }

--- a/Tests/ScoutTests/Transient/NSManagedObjectContext+FetchAll.swift
+++ b/Tests/ScoutTests/Transient/NSManagedObjectContext+FetchAll.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension NSManagedObjectContext {
+    // Fetches every object of the given type, resolving its entity by the
+    // class's simple name (which matches the Core Data entity name here).
+    func fetchAll<T: NSManagedObject>(_ type: T.Type) throws -> [T] {
+        try fetch(NSFetchRequest<T>(entityName: String(describing: type)))
+    }
+}


### PR DESCRIPTION
Many tests built an `NSFetchRequest` by entity-name string just to read back every object of a type, repeating the same verbose construction across the lifecycle, diagnostics, sync, and backend suites. This adds a `fetchAll(_:)` helper on `NSManagedObjectContext` that derives the entity name from the class and fetches all of its objects, and routes those call sites through it. The two sites in `VersionObjectMonitorTests` that attach `sortDescriptors` keep their explicit request since they need more than a plain fetch.