### PR TITLE
Delegate test date helpers to the shared Date(year:) initializer

### DIFF
--- a/Tests/ScoutTests/Core/Activity/ActivityReaderTests.swift
+++ b/Tests/ScoutTests/Core/Activity/ActivityReaderTests.swift
@@ -59,7 +59,7 @@ struct ActivityReaderTests {
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
-        DateComponents(calendar: .utc, year: year, month: month, day: day).date!
+        Date(year: year, month: month, day: day)
     }
 
     private func ms(_ year: Int, _ month: Int, _ day: Int) -> Int64 {

--- a/Tests/ScoutTests/Core/Diagnostics/Metrics/MetricReaderTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Metrics/MetricReaderTests.swift
@@ -68,7 +68,7 @@ struct MetricReaderTests {
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0) -> Date {
-        DateComponents(calendar: .utc, year: year, month: month, day: day, hour: hour).date!
+        Date(year: year, month: month, day: day, hour: hour)
     }
 
     private func ms(_ year: Int, _ month: Int, _ day: Int, _ hour: Int) -> Int64 {

--- a/Tests/ScoutTests/UI/Activity/ActivityProviderTests.swift
+++ b/Tests/ScoutTests/UI/Activity/ActivityProviderTests.swift
@@ -50,7 +50,7 @@ struct ActivityProviderTests {
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
-        DateComponents(calendar: .utc, year: year, month: month, day: day).date!
+        Date(year: year, month: month, day: day)
     }
 
     private func ms(_ year: Int, _ month: Int, _ day: Int) -> Int64 {

--- a/Tests/ScoutTests/UI/Metrics/MetricsProviderTests.swift
+++ b/Tests/ScoutTests/UI/Metrics/MetricsProviderTests.swift
@@ -63,7 +63,7 @@ struct MetricsProviderTests {
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int) -> Date {
-        DateComponents(calendar: .utc, year: year, month: month, day: day, hour: hour).date!
+        Date(year: year, month: month, day: day, hour: hour)
     }
 
     private func ms(_ year: Int, _ month: Int, _ day: Int, _ hour: Int) -> Int64 {


### PR DESCRIPTION
The metric and activity reader/provider suites each grew their own `date()` helper that rebuilt a UTC `Date` from `DateComponents`, duplicating logic the shared `Date(year:month:day:…)` initializer already provides and letting the variants drift apart. This points each `date()` helper at that initializer, so the `ms()` helpers that build on it inherit the single construction path while the call sites stay unchanged.