### PR TITLE
Extract shared TimelineFixture for timeline test dates

### DIFF
--- a/Tests/ScoutTests/UI/ExportFormatTests.swift
+++ b/Tests/ScoutTests/UI/ExportFormatTests.swift
@@ -12,44 +12,41 @@ import Testing
 @testable import Scout
 
 struct ExportFormatTests {
-    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)  // 2023-11-14 22:13:20 UTC
-    private func at(_ offset: TimeInterval) -> Date { baseDate.addingTimeInterval(offset) }
-
     @Test("Timestamps render as ISO 8601 in UTC")
     func testTimestamp() {
-        #expect(ExportFormat.timestamp(baseDate) == "2023-11-14T22:13:20Z")
+        #expect(ExportFormat.timestamp(TimelineFixture.baseDate) == "2023-11-14T22:13:20Z")
     }
 
     @Test("Days render as zero-padded year-month-day in UTC")
     func testDay() {
-        #expect(ExportFormat.day(baseDate) == "2023-11-14")
+        #expect(ExportFormat.day(TimelineFixture.baseDate) == "2023-11-14")
         #expect(ExportFormat.day(Date(timeIntervalSince1970: 0)) == "1970-01-01")
     }
 
     @Test("Times render as 24-hour hour and minute in UTC")
     func testTime() {
-        #expect(ExportFormat.time(baseDate) == "22:13")
+        #expect(ExportFormat.time(TimelineFixture.baseDate) == "22:13")
         #expect(ExportFormat.time(Date(timeIntervalSince1970: 0)) == "00:00")
     }
 
     @Test("Minutes combine the day and time")
     func testMinute() {
-        #expect(ExportFormat.minute(baseDate) == "2023-11-14 22:13")
+        #expect(ExportFormat.minute(TimelineFixture.baseDate) == "2023-11-14 22:13")
     }
 
     @Test("Same-day ranges render the end bound as a bare time")
     func testSameDayRange() {
-        #expect(ExportFormat.range(from: baseDate, to: at(360)) == "2023-11-14 22:13–22:19")
+        #expect(ExportFormat.range(from: TimelineFixture.baseDate, to: TimelineFixture.at(360)) == "2023-11-14 22:13–22:19")
     }
 
     @Test("Multi-day ranges repeat the date in the end bound")
     func testMultiDayRange() {
-        #expect(ExportFormat.range(from: baseDate, to: at(86_400)) == "2023-11-14 22:13–2023-11-15 22:13")
+        #expect(ExportFormat.range(from: TimelineFixture.baseDate, to: TimelineFixture.at(86_400)) == "2023-11-14 22:13–2023-11-15 22:13")
     }
 
     @Test("Open ranges render as their start")
     func testOpenRange() {
-        #expect(ExportFormat.range(from: baseDate, to: nil) == "2023-11-14 22:13")
+        #expect(ExportFormat.range(from: TimelineFixture.baseDate, to: nil) == "2023-11-14 22:13")
     }
 
     @Test("Short IDs are the first eight characters, lowercased")

--- a/Tests/ScoutTests/UI/Timeline/RailInitTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/RailInitTests.swift
@@ -11,9 +11,6 @@ import Testing
 @testable import Scout
 
 struct RailInitTests {
-    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
-    private func at(_ offset: TimeInterval) -> Date { baseDate.addingTimeInterval(offset) }
-
     @Test("Device with no children has empty installs")
     func testNoChildren() {
         let rail = Rail(
@@ -57,24 +54,24 @@ struct RailInitTests {
         let rail = Rail(
             device: .stub(deviceID: deviceID),
             installs: [
-                .stub(installID: iID2, deviceID: deviceID, date: at(200)),
-                .stub(installID: iID1, deviceID: deviceID, date: at(100)),
+                .stub(installID: iID2, deviceID: deviceID, date: TimelineFixture.at(200)),
+                .stub(installID: iID1, deviceID: deviceID, date: TimelineFixture.at(100)),
             ],
             launches: [
-                .stub(launchID: lID2, installID: iID1, startDate: at(2000)),
-                .stub(launchID: lID1, installID: iID1, startDate: at(1000)),
+                .stub(launchID: lID2, installID: iID1, startDate: TimelineFixture.at(2000)),
+                .stub(launchID: lID1, installID: iID1, startDate: TimelineFixture.at(1000)),
             ],
             sessions: [
-                .stub(sessionID: sID2, launchID: lID1, startDate: at(20_000)),
-                .stub(sessionID: sID1, launchID: lID1, startDate: at(10_000)),
+                .stub(sessionID: sID2, launchID: lID1, startDate: TimelineFixture.at(20_000)),
+                .stub(sessionID: sID1, launchID: lID1, startDate: TimelineFixture.at(10_000)),
             ],
             events: [
-                .stub(name: "late", sessionID: sID1, date: at(100_002)),
-                .stub(name: "early", sessionID: sID1, date: at(100_001)),
+                .stub(name: "late", sessionID: sID1, date: TimelineFixture.at(100_002)),
+                .stub(name: "early", sessionID: sID1, date: TimelineFixture.at(100_001)),
             ],
             crashes: [
-                .stub(name: "late", sessionID: sID1, date: at(200_002)),
-                .stub(name: "early", sessionID: sID1, date: at(200_001)),
+                .stub(name: "late", sessionID: sID1, date: TimelineFixture.at(200_002)),
+                .stub(name: "early", sessionID: sID1, date: TimelineFixture.at(200_001)),
             ]
         )
 
@@ -117,8 +114,8 @@ struct RailInitTests {
             installs: [.stub(installID: installID, deviceID: deviceID)],
             launches: [.stub(launchID: launchID, installID: installID)],
             sessions: [
-                .stub(sessionID: sessionA, launchID: launchID, startDate: at(0)),
-                .stub(sessionID: sessionB, launchID: launchID, startDate: at(100)),
+                .stub(sessionID: sessionA, launchID: launchID, startDate: TimelineFixture.at(0)),
+                .stub(sessionID: sessionB, launchID: launchID, startDate: TimelineFixture.at(100)),
             ],
             events: [],
             crashes: [.stub(name: "only-on-B", sessionID: sessionB)]

--- a/Tests/ScoutTests/UI/Timeline/RailLaneTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/RailLaneTests.swift
@@ -12,8 +12,6 @@ import Testing
 
 @MainActor
 struct RailLaneTests {
-    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
-
     private let installID = UUID()
     private let launchID = UUID()
     private let sessionID = UUID()
@@ -21,8 +19,8 @@ struct RailLaneTests {
     private func makeDatabase() -> DatabaseStub {
         let database = DatabaseStub()
         database.add(
-            .sessionStub(sessionID: sessionID, launchID: launchID, installID: installID, startDate: baseDate),
-            .eventStub(name: "e", sessionID: sessionID, date: baseDate.addingTimeInterval(10))
+            .sessionStub(sessionID: sessionID, launchID: launchID, installID: installID, startDate: TimelineFixture.baseDate),
+            .eventStub(name: "e", sessionID: sessionID, date: TimelineFixture.baseDate.addingTimeInterval(10))
         )
         return database
     }

--- a/Tests/ScoutTests/UI/Timeline/RailMergeTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/RailMergeTests.swift
@@ -11,12 +11,9 @@ import Testing
 @testable import Scout
 
 struct RailMergeTests {
-    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
-    private func at(_ offset: TimeInterval) -> Date { baseDate.addingTimeInterval(offset) }
-
     @Test("Empty merge returns equivalent tree")
     func testEmptyMerge() {
-        let rail = Rail.stub(baseDate: baseDate)
+        let rail = Rail.stub(baseDate: TimelineFixture.baseDate)
         let merged = rail.merged(sessions: [], events: [])
 
         #expect(merged.device.deviceID == rail.device.deviceID)
@@ -28,12 +25,12 @@ struct RailMergeTests {
 
     @Test("Adds new event to an existing session")
     func testAddsEvent() {
-        let rail = Rail.stub(baseDate: baseDate)
+        let rail = Rail.stub(baseDate: TimelineFixture.baseDate)
         let sessionID = rail.installs[0].launches[0].sessions[0].session.sessionID!
 
         let merged = rail.merged(
             sessions: [],
-            events: [.stub(name: "new-event", sessionID: sessionID, date: at(150))]
+            events: [.stub(name: "new-event", sessionID: sessionID, date: TimelineFixture.at(150))]
         )
 
         let events = merged.installs[0].launches[0].sessions[0].events
@@ -43,10 +40,10 @@ struct RailMergeTests {
 
     @Test("Adds new session under an existing launch")
     func testAddsSession() {
-        let rail = Rail.stub(baseDate: baseDate)
+        let rail = Rail.stub(baseDate: TimelineFixture.baseDate)
         let launchID = rail.installs[0].launches[0].launch.launchID!
 
-        let newSession = Session.stub(launchID: launchID, startDate: at(900))
+        let newSession = Session.stub(launchID: launchID, startDate: TimelineFixture.at(900))
         let merged = rail.merged(sessions: [newSession], events: [])
 
         let sessions = merged.installs[0].launches[0].sessions
@@ -56,7 +53,7 @@ struct RailMergeTests {
 
     @Test("Drops new items whose parent is not in the existing tree")
     func testDropsOrphans() {
-        let rail = Rail.stub(baseDate: baseDate)
+        let rail = Rail.stub(baseDate: TimelineFixture.baseDate)
         let merged = rail.merged(
             sessions: [],
             events: [.stub(name: "orphan", sessionID: UUID())]
@@ -83,7 +80,7 @@ struct RailMergeTests {
             sessions: [.stub(sessionID: sessionID, launchID: launchID)],
             events: [
                 Event(
-                    name: "old-name", level: nil, date: at(10),
+                    name: "old-name", level: nil, date: TimelineFixture.at(10),
                     paramCount: nil, uuid: nil, id: eventID,
                     installID: nil, sessionID: sessionID, deviceID: nil
                 )
@@ -92,7 +89,7 @@ struct RailMergeTests {
         )
 
         let replacement = Event(
-            name: "new-name", level: nil, date: at(10),
+            name: "new-name", level: nil, date: TimelineFixture.at(10),
             paramCount: nil, uuid: nil, id: eventID,
             installID: nil, sessionID: sessionID, deviceID: nil
         )
@@ -105,7 +102,7 @@ struct RailMergeTests {
 
     @Test("Sort order maintained after merge")
     func testSortMaintained() {
-        let rail = Rail.stub(baseDate: baseDate)
+        let rail = Rail.stub(baseDate: TimelineFixture.baseDate)
         let sessionID = rail.installs[0].launches[0].sessions[0].session.sessionID!
         let originalDates = rail.installs[0].launches[0].sessions[0].events.compactMap(\.date)
 

--- a/Tests/ScoutTests/UI/Timeline/RailSplitTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/RailSplitTests.swift
@@ -11,9 +11,6 @@ import Testing
 @testable import Scout
 
 struct RailSplitTests {
-    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
-    private func at(_ offset: TimeInterval) -> Date { baseDate.addingTimeInterval(offset) }
-
     private let deviceID = UUID()
     private let installIDs = [UUID(), UUID(), UUID()]
 
@@ -22,7 +19,7 @@ struct RailSplitTests {
         Rail(
             device: .stub(deviceID: deviceID),
             installs: installIDs.enumerated().map { index, id in
-                .stub(installID: id, deviceID: deviceID, date: at(TimeInterval(index * 100)))
+                .stub(installID: id, deviceID: deviceID, date: TimelineFixture.at(TimeInterval(index * 100)))
             },
             launches: []
         )
@@ -47,7 +44,7 @@ struct RailSplitTests {
 
     @Test("Dated anchor shares its install between both lanes")
     func testDatedAnchor() {
-        let anchor = Event.stub(name: "a", installID: installIDs[1], date: at(150))
+        let anchor = Event.stub(name: "a", installID: installIDs[1], date: TimelineFixture.at(150))
         let split = rail.split(at: anchor)
 
         #expect(split?.older == [installIDs[1], installIDs[0]])
@@ -65,7 +62,7 @@ struct RailSplitTests {
 
     @Test("Anchor in the newest install leaves only it in the newer lane")
     func testNewestAnchor() {
-        let anchor = Event.stub(name: "a", installID: installIDs[2], date: at(250))
+        let anchor = Event.stub(name: "a", installID: installIDs[2], date: TimelineFixture.at(250))
         let split = rail.split(at: anchor)
 
         #expect(split?.older == [installIDs[2], installIDs[1], installIDs[0]])
@@ -74,7 +71,7 @@ struct RailSplitTests {
 
     @Test("Anchor in the oldest install leaves only it in the older lane")
     func testOldestAnchor() {
-        let anchor = Event.stub(name: "a", installID: installIDs[0], date: at(50))
+        let anchor = Event.stub(name: "a", installID: installIDs[0], date: TimelineFixture.at(50))
         let split = rail.split(at: anchor)
 
         #expect(split?.older == [installIDs[0]])

--- a/Tests/ScoutTests/UI/Timeline/TimelineFixture.swift
+++ b/Tests/ScoutTests/UI/Timeline/TimelineFixture.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+enum TimelineFixture {
+    static let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    static func at(_ offset: TimeInterval) -> Date {
+        baseDate.addingTimeInterval(offset)
+    }
+}

--- a/Tests/ScoutTests/UI/Timeline/TimelineItemConnectedTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/TimelineItemConnectedTests.swift
@@ -15,7 +15,7 @@ struct TimelineItemConnectedTests {
         TimelineItem(
             id: UUID().uuidString,
             name: "e",
-            date: Date(timeIntervalSince1970: 1_700_000_000),
+            date: TimelineFixture.baseDate,
             active: active,
             installID: UUID(),
             launchID: UUID(),

--- a/Tests/ScoutTests/UI/Timeline/TimelineProviderTests.swift
+++ b/Tests/ScoutTests/UI/Timeline/TimelineProviderTests.swift
@@ -12,9 +12,6 @@ import Testing
 
 @MainActor
 struct TimelineProviderTests {
-    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
-    private func at(_ offset: TimeInterval) -> Date { baseDate.addingTimeInterval(offset) }
-
     private let deviceID = UUID()
     private let installID = UUID()
     private let launchID = UUID()
@@ -23,11 +20,11 @@ struct TimelineProviderTests {
     private func makeDatabase() -> DatabaseStub {
         let database = DatabaseStub()
         database.add(
-            .deviceStub(deviceID: deviceID, date: baseDate),
-            .installStub(installID: installID, deviceID: deviceID, date: baseDate),
-            .launchStub(launchID: launchID, installID: installID, deviceID: deviceID, startDate: at(10)),
-            .sessionStub(sessionID: sessionID, launchID: launchID, installID: installID, startDate: at(20)),
-            .eventStub(name: "e", sessionID: sessionID, date: at(30))
+            .deviceStub(deviceID: deviceID, date: TimelineFixture.baseDate),
+            .installStub(installID: installID, deviceID: deviceID, date: TimelineFixture.baseDate),
+            .launchStub(launchID: launchID, installID: installID, deviceID: deviceID, startDate: TimelineFixture.at(10)),
+            .sessionStub(sessionID: sessionID, launchID: launchID, installID: installID, startDate: TimelineFixture.at(20)),
+            .eventStub(name: "e", sessionID: sessionID, date: TimelineFixture.at(30))
         )
         return database
     }
@@ -50,7 +47,7 @@ struct TimelineProviderTests {
     @Test("Publishes a result when the anchor's install is not in the rail")
     func testMissingAnchorInstallPublishes() async throws {
         let provider = TimelineProvider()
-        let anchor = Event.stub(name: "a", installID: UUID(), date: at(30))
+        let anchor = Event.stub(name: "a", installID: UUID(), date: TimelineFixture.at(30))
         await start(provider, database: makeDatabase(), anchorEvent: anchor)
 
         let rail = try #require(provider.result).get()
@@ -60,7 +57,7 @@ struct TimelineProviderTests {
     @Test("Anchored start seeds the timeline around the anchor")
     func testAnchoredStart() async throws {
         let provider = TimelineProvider()
-        let anchor = Event.stub(name: "e", sessionID: sessionID, installID: installID, date: at(30))
+        let anchor = Event.stub(name: "e", sessionID: sessionID, installID: installID, date: TimelineFixture.at(30))
         await start(provider, database: makeDatabase(), anchorEvent: anchor)
 
         let rail = try #require(provider.result).get()

--- a/Tests/ScoutTests/UI/TimelineExportTests.swift
+++ b/Tests/ScoutTests/UI/TimelineExportTests.swift
@@ -12,9 +12,6 @@ import Testing
 @testable import Scout
 
 struct TimelineExportTests {
-    private let baseDate = Date(timeIntervalSince1970: 1_700_000_000)  // 2023-11-14 22:13:20 UTC
-    private func at(_ offset: TimeInterval) -> Date { baseDate.addingTimeInterval(offset) }
-
     private func uuid(_ prefix: String) -> UUID {
         UUID(uuidString: "\(prefix)-0000-0000-0000-000000000000")!
     }
@@ -28,19 +25,19 @@ struct TimelineExportTests {
     @Test("Renders the rail as a hierarchical Markdown document")
     func testDocument() {
         let session = SessionRoot(
-            session: .stub(sessionID: uuid("DDDDDDDD"), startDate: at(40), endDate: at(400)),
+            session: .stub(sessionID: uuid("DDDDDDDD"), startDate: TimelineFixture.at(40), endDate: TimelineFixture.at(400)),
             events: [
-                .stub(name: "purchase_completed", date: at(160)),
-                .stub(name: "app_open", date: at(40)),
+                .stub(name: "purchase_completed", date: TimelineFixture.at(160)),
+                .stub(name: "app_open", date: TimelineFixture.at(40)),
             ],
-            crashes: [.stub(name: "EXC_BAD_ACCESS", date: at(100))]
+            crashes: [.stub(name: "EXC_BAD_ACCESS", date: TimelineFixture.at(100))]
         )
         let launch = LaunchRoot(
-            launch: .stub(launchID: uuid("CCCCCCCC"), startDate: baseDate),
+            launch: .stub(launchID: uuid("CCCCCCCC"), startDate: TimelineFixture.baseDate),
             sessions: [session]
         )
         let install = InstallRoot(
-            install: .stub(installID: uuid("BBBBBBBB"), date: baseDate),
+            install: .stub(installID: uuid("BBBBBBBB"), date: TimelineFixture.baseDate),
             launches: [launch]
         )
         let rail = Rail(device: .stub(deviceID: uuid("AAAAAAAA")), installs: [install])
@@ -117,7 +114,7 @@ struct TimelineExportTests {
     @Test("Session ranges spanning days repeat the date in the end bound")
     func testMultiDayRange() {
         let session = SessionRoot(
-            session: .stub(sessionID: uuid("DDDDDDDD"), startDate: at(40), endDate: at(40 + 86_400)),
+            session: .stub(sessionID: uuid("DDDDDDDD"), startDate: TimelineFixture.at(40), endDate: TimelineFixture.at(40 + 86_400)),
             events: [],
             crashes: []
         )
@@ -133,13 +130,13 @@ struct TimelineExportTests {
             name: "SIGABRT",
             reason: "unexpectedly found nil",
             stackTrace: [],
-            date: at(10),
+            date: TimelineFixture.at(10),
             id: "crash",
             installID: nil,
             launchID: nil,
             sessionID: nil
         )
-        let session = SessionRoot(session: .stub(startDate: baseDate), events: [], crashes: [crash])
+        let session = SessionRoot(session: .stub(startDate: TimelineFixture.baseDate), events: [], crashes: [crash])
         let rail = rail(sessions: [session])
 
         let text = TimelineExport(rail: rail).text
@@ -149,9 +146,9 @@ struct TimelineExportTests {
     @Test("Events without a date are omitted")
     func testUndatedEventsOmitted() {
         let session = SessionRoot(
-            session: .stub(startDate: baseDate),
+            session: .stub(startDate: TimelineFixture.baseDate),
             events: [
-                .stub(name: "dated", date: at(40)),
+                .stub(name: "dated", date: TimelineFixture.at(40)),
                 .stub(name: "undated", date: nil),
             ],
             crashes: []
@@ -174,11 +171,11 @@ struct TimelineExportTests {
         // instead of re-sorting, so feed it unsorted input.
         let rail = Rail(
             device: .stub(deviceID: deviceID),
-            installs: [.stub(installID: installID, deviceID: deviceID, date: baseDate)],
-            launches: [.stub(launchID: launchID, installID: installID, startDate: baseDate)],
+            installs: [.stub(installID: installID, deviceID: deviceID, date: TimelineFixture.baseDate)],
+            launches: [.stub(launchID: launchID, installID: installID, startDate: TimelineFixture.baseDate)],
             sessions: [
-                .stub(launchID: launchID, startDate: at(2800)),
-                .stub(launchID: launchID, startDate: at(40)),
+                .stub(launchID: launchID, startDate: TimelineFixture.at(2800)),
+                .stub(launchID: launchID, startDate: TimelineFixture.at(40)),
             ]
         )
 
@@ -191,8 +188,8 @@ struct TimelineExportTests {
 
     /// Wraps the given sessions in a single-install, single-launch rail.
     private func rail(sessions: [SessionRoot]) -> Rail {
-        let launch = LaunchRoot(launch: .stub(startDate: baseDate), sessions: sessions)
-        let install = InstallRoot(install: .stub(date: baseDate), launches: [launch])
+        let launch = LaunchRoot(launch: .stub(startDate: TimelineFixture.baseDate), sessions: sessions)
+        let install = InstallRoot(install: .stub(date: TimelineFixture.baseDate), launches: [launch])
         return Rail(device: .stub(), installs: [install])
     }
 }


### PR DESCRIPTION
Each timeline and export suite carried its own private `baseDate` anchored at the same epoch plus an `at(_:)` offset helper, copied verbatim across the files. This introduces a shared `TimelineFixture` enum exposing `baseDate` and `at(_:)` and routes those suites through it, so the anchor date lives in one place and the per-file copies go away.