### PR TITLE
Name the shared lifecycle test date as TestDate.reference

### DIFF
--- a/Tests/ScoutTests/Core/Diagnostics/Log/EventObjectTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Log/EventObjectTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("EventObject")
 struct EventObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
-    let date = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
+    let date = TestDate.reference.startOfWeek
 
     @Test("matrix(of:) produces correct GridCell<Int> counts by hour")
     func testMatrixOf() throws {

--- a/Tests/ScoutTests/Core/Lifecycle/Device/DeviceObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Device/DeviceObjectTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("DeviceObject")
 struct DeviceObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
-    let week = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
+    let week = TestDate.reference.startOfWeek
 
     @Test("installs(in:) returns installs matching deviceID")
     func testInstalls() throws {

--- a/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("InstallObject")
 struct InstallObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
-    let week = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
+    let week = TestDate.reference.startOfWeek
 
     @Test("versions(in:) returns versions matching installID")
     func testVersions() throws {

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectRecoveryTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectRecoveryTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("LaunchObject+Recovery")
 struct LaunchObjectRecoveryTests {
     let context = NSManagedObjectContext.inMemoryContext()
-    let date = Date(timeIntervalSince1970: 1_724_457_600)
+    let date = TestDate.reference
 
     @Test("Closes launches from previous launches")
     func closesStale() throws {

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("LaunchObject")
 struct LaunchObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
-    let week = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
+    let week = TestDate.reference.startOfWeek
 
     @Test("matrix(of:) produces correct GridCell<Int> counts by date")
     func testMatrixOf() throws {

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectRecoveryTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectRecoveryTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("SessionObject+Recovery")
 struct SessionObjectRecoveryTests {
     let context = NSManagedObjectContext.inMemoryContext()
-    let date = Date(timeIntervalSince1970: 1_724_457_600)
+    let date = TestDate.reference
 
     @Test("Closes sessions from previous launches")
     func closesStale() throws {

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("SessionObject")
 struct SessionObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
-    let week = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
+    let week = TestDate.reference.startOfWeek
 
     @Test("matrix(of:) produces correct GridCell<Int> counts by date")
     func testMatrixOf() throws {

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("VersionObject")
 struct VersionObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
-    let week = Date(timeIntervalSince1970: 1_724_457_600).startOfWeek
+    let week = TestDate.reference.startOfWeek
 
     @Test("matrix(of:) produces correct GridCell<Int> counts by date")
     func testMatrixOf() throws {

--- a/Tests/ScoutTests/Core/Sync/StableRecordIDTests.swift
+++ b/Tests/ScoutTests/Core/Sync/StableRecordIDTests.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("Stable record IDs")
 struct StableRecordIDTests {
     let context = NSManagedObjectContext.inMemoryContext()
-    let date = Date(timeIntervalSince1970: 1_724_457_600)
+    let date = TestDate.reference
 
     @Test("DeviceObject.record is stable across calls")
     func deviceStable() {

--- a/Tests/ScoutTests/Utilities/TestDate.swift
+++ b/Tests/ScoutTests/Utilities/TestDate.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+enum TestDate {
+    // A fixed reference instant (2024-08-24 00:00:00 UTC) for tests that need a
+    // stable, arbitrary date.
+    static let reference = Date(timeIntervalSince1970: 1_724_457_600)
+}


### PR DESCRIPTION
The lifecycle, diagnostics, and sync object tests each hardcoded the same `Date(timeIntervalSince1970: 1_724_457_600)` epoch literal as their reference instant, leaving the meaning of the magic number implicit at every site. This introduces a `TestDate` enum with a named `reference` constant and routes those tests through it. Only this shared lifecycle date is folded in; the one-off timestamps in the wire-format and edge-case tests keep their own literals.