### PR TITLE
Unify the activity and metrics server stubs into one ServerStub

### DIFF
--- a/Tests/ScoutTests/Stubs/Records/ServerStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/ServerStub.swift
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+@testable import Scout
+
+// A `DatabaseReader` standing in for a Scout server backend: it returns the
+// activity and metric series it is seeded with, and empty results for every
+// other query.
+final class ServerStub: DatabaseReader, @unchecked Sendable {
+    let activitySeries: [ActivityPoint]
+    let metricsSeries: [MetricSeries]
+
+    init(activity: [ActivityPoint] = [], metrics: [MetricSeries] = []) {
+        self.activitySeries = activity
+        self.metricsSeries = metrics
+    }
+
+    func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
+        activitySeries
+    }
+
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+        metricsSeries
+    }
+
+    func lookup(recordName: String, fields: [String]?) async throws -> Record {
+        throw RecordNotFoundError()
+    }
+
+    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
+        RecordChunk(records: [], cursor: nil)
+    }
+}

--- a/Tests/ScoutTests/UI/Activity/ActivityProviderTests.swift
+++ b/Tests/ScoutTests/UI/Activity/ActivityProviderTests.swift
@@ -14,7 +14,7 @@ import Testing
 struct ActivityProviderTests {
     @Test("Returns the native series from a Scout server unchanged")
     func fetchUsesServerSeries() async throws {
-        let database = ServerStub(series: [
+        let database = ServerStub(activity: [
             ActivityPoint(date: ms(2026, 6, 10), dau: 2, wau: 2, mau: 2),
             ActivityPoint(date: ms(2026, 6, 11), dau: 1, wau: 3, mau: 2),
             ActivityPoint(date: ms(2026, 7, 1), dau: 0, wau: 0, mau: 5),
@@ -55,36 +55,5 @@ struct ActivityProviderTests {
 
     private func ms(_ year: Int, _ month: Int, _ day: Int) -> Int64 {
         Int64((date(year, month, day).timeIntervalSince1970 * 1000).rounded())
-    }
-}
-
-/// A `DatabaseReader` that returns a native active-user series, standing in for a
-/// Scout server backend.
-///
-private final class ServerStub: DatabaseReader, @unchecked Sendable {
-    let series: [ActivityPoint]
-
-    init(series: [ActivityPoint]) {
-        self.series = series
-    }
-
-    func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
-        series
-    }
-
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
-        []
-    }
-
-    func lookup(recordName: String, fields: [String]?) async throws -> Record {
-        throw RecordNotFoundError()
-    }
-
-    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
-        RecordChunk(records: [], cursor: nil)
-    }
-
-    func readMore(from cursor: RecordCursor, fields: [String]?) async throws -> RecordChunk {
-        RecordChunk(records: [], cursor: nil)
     }
 }

--- a/Tests/ScoutTests/UI/Metrics/MetricsProviderTests.swift
+++ b/Tests/ScoutTests/UI/Metrics/MetricsProviderTests.swift
@@ -14,7 +14,7 @@ import Testing
 struct MetricsProviderTests {
     @Test("Returns the native series from a Scout server unchanged")
     func fetchUsesServerSeries() async throws {
-        let database = MetricsServerStub(series: [
+        let database = ServerStub(metrics: [
             MetricSeries(
                 name: "api_calls",
                 category: "counter",
@@ -68,36 +68,5 @@ struct MetricsProviderTests {
 
     private func ms(_ year: Int, _ month: Int, _ day: Int, _ hour: Int) -> Int64 {
         Int64((date(year, month, day, hour).timeIntervalSince1970 * 1000).rounded())
-    }
-}
-
-/// A `DatabaseReader` that returns a native metric series, standing in for a
-/// Scout server backend.
-///
-private final class MetricsServerStub: DatabaseReader, @unchecked Sendable {
-    let series: [MetricSeries]
-
-    init(series: [MetricSeries]) {
-        self.series = series
-    }
-
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
-        series
-    }
-
-    func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
-        []
-    }
-
-    func lookup(recordName: String, fields: [String]?) async throws -> Record {
-        throw RecordNotFoundError()
-    }
-
-    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
-        RecordChunk(records: [], cursor: nil)
-    }
-
-    func readMore(from cursor: RecordCursor, fields: [String]?) async throws -> RecordChunk {
-        RecordChunk(records: [], cursor: nil)
     }
 }


### PR DESCRIPTION
The activity and metrics provider tests each defined their own private `DatabaseReader` stub that stood in for a Scout server backend, and the two differed only in which series they returned — the `lookup`, `read`, and `readMore` boilerplate was identical in both. This replaces them with a single shared `ServerStub` seeded with optional activity and metric series, relying on the existing `readMore` default rather than restating it. Both test files now construct that one stub instead of carrying their own copy.