### PR TITLE
Collapse Record.setValues into a single merge call

### DIFF
--- a/Sources/Scout/Core/Database/Record/Record.swift
+++ b/Sources/Scout/Core/Database/Record/Record.swift
@@ -20,11 +20,7 @@ struct Record: Equatable, Sendable {
     }
 
     mutating func setValues(_ values: [String: Any]) {
-        for (key, value) in values {
-            if let value = RecordValue(any: value) {
-                fields[key] = value
-            }
-        }
+        fields.merge(values.compactMapValues(RecordValue.init(any:))) { _, new in new }
     }
 }
 


### PR DESCRIPTION
Replaces the manual key-by-key loop in `Record.setValues` with a single `fields.merge` call. `compactMapValues(RecordValue.init(any:))` drops the values that don't convert (matching the old `if let` guard), and the `{ _, new in new }` resolver preserves the previous overwrite semantics for existing keys. Behavior is unchanged; the body is just shorter and clearer.