### PR TITLE
Gate crash list animation on the crashes value

### DIFF
--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -31,7 +31,7 @@ struct CrashListView: View {
                         }
                     }
                     .listStyle(.plain)
-                    .animation(nil, value: UUID())
+                    .animation(nil, value: crashes)
                 }
             } else {
                 ProgressView().frame(maxHeight: .infinity)


### PR DESCRIPTION
The crash list disabled implicit animation with `.animation(nil, value: UUID())`, but a fresh `UUID()` is created on every render, so SwiftUI always saw the tracked value change and the modifier never did what it was meant to. This gates the modifier on the `crashes` array instead, so animation is suppressed when the list of crashes actually changes. `Crash` conforms to `Hashable` (and thus `Equatable`), so `[Crash]` is a valid value to track.