### PR TITLE
Use the MonitorError literal in error messages

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Base/MonitorError.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/MonitorError.swift
@@ -14,9 +14,9 @@ enum MonitorError: LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .notFound:
-            "\(type(of: self)) not found in the context"
+            "MonitorError not found in the context"
         case .alreadyCompleted(let date):
-            "\(type(of: self)) already completed on \(date)"
+            "MonitorError already completed on \(date)"
         }
     }
 


### PR DESCRIPTION
The `errorDescription` strings interpolated `type(of: self)`, but the dynamic type of an enum value is always the enum itself, so this only ever rendered the literal `MonitorError`. The indirection was misleading and looked like it might surface a more specific type at runtime, which it never could. This replaces the interpolation with the plain `MonitorError` literal, leaving the produced messages unchanged.