### PR TITLE
Read the keyPath once in Array.unique

### DIFF
--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.Suggestion.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.Suggestion.swift
@@ -28,7 +28,7 @@ extension AnalyticsView {
 extension Array {
     func unique(by path: KeyPath<Element, String>, max: Int) -> [String] {
         let all = reduce(into: [:]) { dict, event in
-            dict[event[keyPath: path]] = (dict[event[keyPath: path]] ?? 0) + 1
+            dict[event[keyPath: path], default: 0] += 1
         }
         .sorted { lhs, rhs in
             lhs.value > rhs.value


### PR DESCRIPTION
The frequency-counting reduce in `Array.unique(by:max:)` read `event[keyPath: path]` twice per element — once to look up the current count and again to write it back. This collapses both into a single `dict[event[keyPath: path], default: 0] += 1`, which reads the key once and is the idiomatic way to express the increment. Behavior is unchanged.