### PR TITLE
Name time-unit seconds via TimeInterval constants

### DIFF
--- a/Sources/Scout/Core/Utilities/Date/TimeInterval+Units.swift
+++ b/Sources/Scout/Core/Utilities/Date/TimeInterval+Units.swift
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+extension TimeInterval {
+    static let minute: TimeInterval = 60
+    static let hour: TimeInterval = 3_600
+    static let day: TimeInterval = 86_400
+    // Nominal spans for coarse formatting: a 30-day month and a 365-day year.
+    static let month: TimeInterval = 2_592_000
+    static let year: TimeInterval = 31_536_000
+}

--- a/Sources/Scout/Native/Access/NativeActivityReader.swift
+++ b/Sources/Scout/Native/Access/NativeActivityReader.swift
@@ -32,7 +32,7 @@ extension ActivityPoint {
 
         for matrix in matrices {
             for cell in matrix.cells {
-                let day = matrix.date.addingTimeInterval(TimeInterval(cell.day) * 86_400)
+                let day = matrix.date.addingTimeInterval(TimeInterval(cell.day) * .day)
                 let key = day.millisecondsSince1970
 
                 switch cell.period {

--- a/Sources/Scout/Native/Matrix/Cell/GridCell.swift
+++ b/Sources/Scout/Native/Matrix/Cell/GridCell.swift
@@ -17,7 +17,7 @@ struct GridCell<T: MetricScalar>: Hashable, ChartComposing {
 
 extension GridCell {
     var secondsSinceBase: Int {
-        (row - 1) * 86_400 + column * 3_600
+        (row - 1) * Int(TimeInterval.day) + column * Int(TimeInterval.hour)
     }
 }
 

--- a/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
+++ b/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
@@ -78,18 +78,18 @@ extension TimeInterval {
             String(format: "%.0f µs", self * 1_000_000)
         case ..<1:
             String(format: "%.0f ms", self * 1_000)
-        case ..<60:
+        case ..<(.minute):
             String(format: "%.1f s", self)
-        case ..<3600:
-            String(format: "%.0f min %.0f s", floor(self / 60), truncatingRemainder(dividingBy: 60))
-        case ..<86_400:
-            String(format: "%.0f h", self / 3600)
-        case ..<2_592_000:
-            String(format: "%.0f d", self / 86_400)
-        case ..<31_536_000:
-            String(format: "%.0f mo", self / 2_592_000)
+        case ..<(.hour):
+            String(format: "%.0f min %.0f s", floor(self / .minute), truncatingRemainder(dividingBy: .minute))
+        case ..<(.day):
+            String(format: "%.0f h", self / .hour)
+        case ..<(.month):
+            String(format: "%.0f d", self / .day)
+        case ..<(.year):
+            String(format: "%.0f mo", self / .month)
         default:
-            String(format: "%.1f y", self / 31_536_000)
+            String(format: "%.1f y", self / .year)
         }
     }
 }

--- a/Tests/ScoutTests/UI/ExportFormatTests.swift
+++ b/Tests/ScoutTests/UI/ExportFormatTests.swift
@@ -41,7 +41,7 @@ struct ExportFormatTests {
 
     @Test("Multi-day ranges repeat the date in the end bound")
     func testMultiDayRange() {
-        #expect(ExportFormat.range(from: TimelineFixture.baseDate, to: TimelineFixture.at(86_400)) == "2023-11-14 22:13–2023-11-15 22:13")
+        #expect(ExportFormat.range(from: TimelineFixture.baseDate, to: TimelineFixture.at(.day)) == "2023-11-14 22:13–2023-11-15 22:13")
     }
 
     @Test("Open ranges render as their start")

--- a/Tests/ScoutTests/UI/TimelineExportTests.swift
+++ b/Tests/ScoutTests/UI/TimelineExportTests.swift
@@ -114,7 +114,7 @@ struct TimelineExportTests {
     @Test("Session ranges spanning days repeat the date in the end bound")
     func testMultiDayRange() {
         let session = SessionRoot(
-            session: .stub(sessionID: uuid("DDDDDDDD"), startDate: TimelineFixture.at(40), endDate: TimelineFixture.at(40 + 86_400)),
+            session: .stub(sessionID: uuid("DDDDDDDD"), startDate: TimelineFixture.at(40), endDate: TimelineFixture.at(40 + .day)),
             events: [],
             crashes: []
         )


### PR DESCRIPTION
This replaces the scattered raw second counts (\`86_400\`, \`3_600\`, \`60\`, and the nominal month/year spans) with named \`static let\` constants on \`TimeInterval\` — \`minute\`, \`hour\`, \`day\`, \`month\`, and \`year\` — so the meaning of each value is clear at the call site instead of being a bare magic number. \`GridCell.secondsSinceBase\`, \`NativeActivityReader\`, and the \`TimeInterval.duration\` formatter now read through these constants, and the matching export tests use \`.day\` where the offset means one day.

Because these are members of \`TimeInterval\`, most call sites get type inference for free (\`self / .hour\`, \`TimelineFixture.at(.day)\`); \`GridCell\` stays in \`Int\` context so it spells out \`Int(TimeInterval.day)\`, and the one-sided range patterns in the duration formatter wrap the leading-dot operand in parentheses (\`case ..<(.minute):\`) since \`..<\` is a prefix operator.