### PR TITLE
Unify the fatal-signal list into a single (Int32, String) table

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/SignalHandler.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/SignalHandler.swift
@@ -9,18 +9,18 @@ import Foundation
 
 private nonisolated(unsafe) var previousSignalHandlers: [Int32: sig_t] = [:]
 
-private let signals: [Int32] = [
-    SIGABRT,
-    SIGSEGV,
-    SIGBUS,
-    SIGFPE,
-    SIGILL,
-    SIGTRAP,
+private let fatalSignals: [(signal: Int32, name: String)] = [
+    (SIGABRT, "SIGABRT"),
+    (SIGSEGV, "SIGSEGV"),
+    (SIGBUS, "SIGBUS"),
+    (SIGFPE, "SIGFPE"),
+    (SIGILL, "SIGILL"),
+    (SIGTRAP, "SIGTRAP"),
 ]
 
 /// Installs handlers for fatal signals (SIGABRT, SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGTRAP).
 func installSignalHandler() {
-    for sig in signals {
+    for (sig, _) in fatalSignals {
         previousSignalHandlers[sig] = signal(sig) { sig in
             let crash = CrashInfo(
                 name: signalName(sig),
@@ -37,20 +37,5 @@ func installSignalHandler() {
 }
 
 private func signalName(_ sig: Int32) -> String {
-    switch sig {
-    case SIGABRT:
-        "SIGABRT"
-    case SIGSEGV:
-        "SIGSEGV"
-    case SIGBUS:
-        "SIGBUS"
-    case SIGFPE:
-        "SIGFPE"
-    case SIGILL:
-        "SIGILL"
-    case SIGTRAP:
-        "SIGTRAP"
-    default:
-        "SIGNAL_\(sig)"
-    }
+    fatalSignals.first { $0.signal == sig }?.name ?? "SIGNAL_\(sig)"
 }


### PR DESCRIPTION
The fatal-signal set in `SignalHandler` was declared twice — once as the `signals` array used to install handlers, and again as the `switch` inside `signalName(_:)` that mapped each signal to its display name. Keeping the two in sync was easy to get wrong: adding a signal required editing both places.

This collapses them into one `fatalSignals` table of `(signal: Int32, name: String)` tuples. `installSignalHandler()` iterates the table to install handlers, and `signalName(_:)` looks the name up in the same table, keeping the `"SIGNAL_\(sig)"` fallback for anything unknown. Adding or removing a fatal signal is now a one-line change.