### PR TITLE
Share the record write-batch size as RecordWriter.maxBatchSize

### DIFF
--- a/Sources/Scout/Core/Database/Access/RecordWriter.swift
+++ b/Sources/Scout/Core/Database/Access/RecordWriter.swift
@@ -12,6 +12,12 @@ protocol RecordWriter: Sendable {
     func write(records: [Record]) async throws
 }
 
+extension RecordWriter {
+    // Records are written in batches no larger than this; the backends cap a single
+    // save/modify request at 400 records.
+    static var maxBatchSize: Int { 400 }
+}
+
 struct RecordConflictError: LocalizedError {
     let serverRecord: Record
     let errorDescription: String? = "The record was changed on the server"

--- a/Sources/Scout/Hosted/Access/HostedRecordWriter.swift
+++ b/Sources/Scout/Hosted/Access/HostedRecordWriter.swift
@@ -7,15 +7,13 @@
 
 import Foundation
 
-private let maxBatchSize = 400
-
 extension HTTPDatabase: RecordWriter {
     func write(record: Record) async throws {
         try await write(records: [record])
     }
 
     func write(records: [Record]) async throws {
-        for chunk in records.chunked(into: maxBatchSize) {
+        for chunk in records.chunked(into: Self.maxBatchSize) {
             let request = HTTPWriteRequest(records: chunk.map(HTTPRecord.init))
             try await send(request, to: "api/v1/records", into: HTTPWriteAck.self)
         }

--- a/Sources/Scout/Native/Access/NativeRecordWriter.swift
+++ b/Sources/Scout/Native/Access/NativeRecordWriter.swift
@@ -7,8 +7,6 @@
 
 import CloudKit
 
-private let maxBatchSize = 400
-
 extension CKDatabase: RecordWriter {
     func write(record: Record) async throws {
         do {
@@ -24,7 +22,7 @@ extension CKDatabase: RecordWriter {
     }
 
     func write(records: [Record]) async throws {
-        for chunk in records.chunked(into: maxBatchSize) {
+        for chunk in records.chunked(into: Self.maxBatchSize) {
             try await runner { database in
                 try await database.modifyRecords(
                     saving: chunk.map(\.ckRecord),


### PR DESCRIPTION
The native (`CKDatabase`) and hosted (`HTTPDatabase`) record writers each declared their own private `maxBatchSize = 400` to chunk batched writes, duplicating the same backend limit in two places. This consolidates them into a single `maxBatchSize` constant on the `RecordWriter` protocol, which both writers now reference via `Self.maxBatchSize`. The read-side page size is a separate concern and is intentionally left untouched.