### PR TITLE
Route the datePrimitive sort-key through a shared constant

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
@@ -19,7 +19,7 @@ class TrackedObject: SyncableObject {
     func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
         let request = NSFetchRequest<TrackedObject>(entityName: "TrackedObject")
         request.predicate = NSPredicate(format: "sessionID == %@", sessionID as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
         request.fetchLimit = 1
         return try context.fetch(request).first?.date
     }

--- a/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
@@ -14,7 +14,7 @@ final class DeviceObject: SyncableObject {
     func installs(in context: NSManagedObjectContext) throws -> [InstallObject] {
         let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
         request.predicate = NSPredicate(format: "deviceID == %@", deviceID as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
         return try context.fetch(request)
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
@@ -14,7 +14,7 @@ final class InstallObject: SyncableObject {
     func versions(in context: NSManagedObjectContext) throws -> [VersionObject] {
         let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
         request.predicate = NSPredicate(format: "installID == %@", installID as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
         return try context.fetch(request)
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Recovery.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Recovery.swift
@@ -34,7 +34,7 @@ extension LaunchObject: RecoveryMonitor {
     private func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
         let request = NSFetchRequest<IDObject>(entityName: "IDObject")
         request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
         request.fetchLimit = 1
 
         return try context.fetch(request).first?.date

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
@@ -16,7 +16,7 @@ final class LaunchObject: SyncableObject {
     func sessions(in context: NSManagedObjectContext) throws -> [SessionObject] {
         let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
         request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
         return try context.fetch(request)
     }
 

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
@@ -19,7 +19,7 @@ extension SessionObject: Monitor {
 
     static func complete(in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
         request.predicate = NSPredicate(format: "launchID == %@", IDs.launch as CVarArg)
         request.fetchLimit = 1
 

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject+Monitor.swift
@@ -19,7 +19,7 @@ extension VersionObject: PartialMonitor {
     static func trigger(appVersion: String?, buildNumber: String?, in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
         request.predicate = NSPredicate(format: "installID == %@", IDs.install as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: false)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
         request.fetchLimit = 1
         let latest = try context.fetch(request).first
 

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
@@ -29,7 +29,7 @@ final class VersionObject: SyncableObject {
 
         let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
         request.predicate = NSPredicate(format: "launchID IN %@", launchIDs)
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
         return try context.fetch(request)
     }
 }

--- a/Sources/Scout/Core/Utilities/Date/DateObject.swift
+++ b/Sources/Scout/Core/Utilities/Date/DateObject.swift
@@ -9,6 +9,8 @@ import CoreData
 
 @objc(DateObject)
 class DateObject: NSManagedObject, Identifiable {
+    static let datePrimitiveKey = "datePrimitive"
+
     @NSManaged var datePrimitive: Date?
     @NSManaged var day: Date?
     @NSManaged var hour: Date?

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectMonitorTests.swift
@@ -41,7 +41,7 @@ struct VersionObjectMonitorTests {
         try VersionObject.trigger(appVersion: "2.0", buildNumber: "1", in: context)
 
         let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
         let versions = try context.fetch(request)
 
         #expect(versions.count == 2)
@@ -54,7 +54,7 @@ struct VersionObjectMonitorTests {
         try VersionObject.trigger(appVersion: "1.0", buildNumber: "2", in: context)
 
         let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        request.sortDescriptors = [NSSortDescriptor(key: "datePrimitive", ascending: true)]
+        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
         let versions = try context.fetch(request)
 
         #expect(versions.count == 2)


### PR DESCRIPTION
The Core Data attribute name `datePrimitive` was hard-coded as an `NSSortDescriptor` key string in eight lifecycle fetch sites (and two matching tests), which made the literal easy to mistype and tedious to keep in sync. This introduces a single `datePrimitiveKey` constant on `DateObject`, where the attribute itself is declared, and routes every sort-key through it. The attribute name in the Core Data model is unchanged.