### PR TITLE
Group bar geometry into a ChartGeometry namespace

### DIFF
--- a/Sources/Scout/UI/Chart/Comparison/ComparisonPair.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonPair.swift
@@ -7,12 +7,6 @@
 
 import Foundation
 
-/// Horizontal portion of each bucket slot occupied by a bar, derived from
-/// `chartBarRatio` and applied through `barStart`/`barEnd`, so the marks and
-/// the `ReferenceOverlay` place bar edges identically.
-///
-let barSlot: ClosedRange<Double> = (0.5 - chartBarRatio / 2)...(0.5 + chartBarRatio / 2)
-
 /// One bucket of the comparison: the current value and the previous-period
 /// value it is compared against, both on the current bucket's date.
 ///
@@ -31,10 +25,10 @@ struct ComparisonPair<T: ChartNumeric>: Identifiable {
 
 extension ComparisonPair {
     /// Date of the bar's leading edge within the bucket slot.
-    var barStart: Date { slotDate(at: barSlot.lowerBound) }
+    var barStart: Date { slotDate(at: ChartGeometry.barStart) }
 
     /// Date of the bar's trailing edge within the bucket slot.
-    var barEnd: Date { slotDate(at: barSlot.upperBound) }
+    var barEnd: Date { slotDate(at: ChartGeometry.barEnd) }
 
     /// Date at the center of the bucket slot.
     var binCenter: Date { slotDate(at: 0.5) }

--- a/Sources/Scout/UI/Chart/View/ChartGeometry.swift
+++ b/Sources/Scout/UI/Chart/View/ChartGeometry.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+enum ChartGeometry {
+    // Fraction of its slot a bar occupies.
+    //
+    // Pinned explicitly on both the plain bar marks and the comparison chart's
+    // geometry, so the two modes render identical bars regardless of the
+    // framework's default width.
+    static let barRatio: Double = 0.7
+
+    // Fraction across a bucket slot where the bar's leading edge sits.
+    static var barStart: Double { barSlot.lowerBound }
+
+    // Fraction across a bucket slot where the bar's trailing edge sits.
+    static var barEnd: Double { barSlot.upperBound }
+
+    // Horizontal portion of each bucket slot occupied by a bar, derived from
+    // `barRatio` and applied through `barStart`/`barEnd`, so the marks and the
+    // `ReferenceOverlay` place bar edges identically.
+    private static let barSlot: ClosedRange<Double> = (0.5 - barRatio / 2)...(0.5 + barRatio / 2)
+}

--- a/Sources/Scout/UI/Chart/View/ChartView.swift
+++ b/Sources/Scout/UI/Chart/View/ChartView.swift
@@ -8,14 +8,6 @@
 import Charts
 import SwiftUI
 
-/// Fraction of its slot a bar occupies.
-///
-/// Pinned explicitly on both the plain bar marks and the comparison chart's
-/// geometry, so the two modes render identical bars regardless of the
-/// framework's default width.
-///
-let chartBarRatio: Double = 0.7
-
 struct ChartView<T: ChartNumeric>: View {
     let segment: [ChartPoint<T>]
     let timing: ChartTiming
@@ -27,7 +19,7 @@ struct ChartView<T: ChartNumeric>: View {
             BarMark(
                 x: .value("X", point.date, unit: unit),
                 y: .value("Y", point.count),
-                width: .ratio(chartBarRatio)
+                width: .ratio(ChartGeometry.barRatio)
             )
         }
         .chartXAxis {

--- a/Tests/ScoutTests/UI/Chart/ComparisonPairTests.swift
+++ b/Tests/ScoutTests/UI/Chart/ComparisonPairTests.swift
@@ -57,10 +57,10 @@ struct ComparisonPairTests {
         let pair = makeSegment(days: 1, count: 1).paired(with: [], unit: .day)[0]
         let length = pair.bin.upperBound.timeIntervalSince(pair.bin.lowerBound)
 
-        #expect(abs(pair.barStart.timeIntervalSince(pair.bin.lowerBound) - length * barSlot.lowerBound) < 0.001)
-        #expect(abs(pair.barEnd.timeIntervalSince(pair.bin.lowerBound) - length * barSlot.upperBound) < 0.001)
+        #expect(abs(pair.barStart.timeIntervalSince(pair.bin.lowerBound) - length * ChartGeometry.barStart) < 0.001)
+        #expect(abs(pair.barEnd.timeIntervalSince(pair.bin.lowerBound) - length * ChartGeometry.barEnd) < 0.001)
         #expect(abs(pair.binCenter.timeIntervalSince(pair.bin.lowerBound) - length / 2) < 0.001)
-        #expect(abs(pair.barEnd.timeIntervalSince(pair.barStart) - length * chartBarRatio) < 0.001)
+        #expect(abs(pair.barEnd.timeIntervalSince(pair.barStart) - length * ChartGeometry.barRatio) < 0.001)
     }
 
     func makeSegment(days: Int, count: Int) -> [ChartPoint<Int>] {


### PR DESCRIPTION
The bar geometry that controls how chart bars are sized lived as two free-floating globals — `chartBarRatio` in `ChartView` and `barSlot` in `ComparisonPair`. This collects both into a single `ChartGeometry` namespace so the plain bar chart and the comparison chart draw from one place. `barRatio` stays the shared knob, the bar edges are now read through `barStart`/`barEnd`, and the `barSlot` range it derives from becomes a `private` implementation detail rather than a global anyone can reach for.

`ComparisonPair` and `ComparisonPairTests` now reference the geometry through `ChartGeometry`, and the rendered bars are unchanged — the comparison-pair tests confirm the bar edges still split each bucket slot by the same ratio.