### PR TITLE
Unify the timeline supersession tokens into one Epoch type

### DIFF
--- a/Sources/Scout/UI/Timeline/Pagination/Epoch.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/Epoch.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+// A fresh identity minted on each reload or lane reset. An in-flight async
+// step snapshots the current epoch, then compares its snapshot against the
+// live value after each suspension to tell whether a newer reload has
+// superseded it and the step should bail out.
+struct Epoch: Equatable {
+    private let id = UUID()
+}

--- a/Sources/Scout/UI/Timeline/Pagination/RailLane.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/RailLane.swift
@@ -11,7 +11,7 @@ import Foundation
 final class RailLane: ObservableObject {
     var eventName: String? {
         didSet {
-            generation += 1
+            generation = Epoch()
             pendingInstalls = []
             cursor = nil
             anchorDate = nil
@@ -35,10 +35,10 @@ final class RailLane: ObservableObject {
 
     private var cursor: RecordCursor?
 
-    /// Bumped by every reset; an in-flight load compares against it after each
-    /// suspension and bails out instead of mixing a stale chunk (or a wiped
-    /// cursor) into the fresh timeline.
-    private var generation = 0
+    // Renewed by every reset; an in-flight load compares against it after each
+    // suspension and bails out instead of mixing a stale chunk (or a wiped
+    // cursor) into the fresh timeline.
+    private var generation = Epoch()
 
     /// Whether a load currently holds the cursor; concurrent `loadMore` calls
     /// wait for it instead of racing the cursor and dropping a chunk.

--- a/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
+++ b/Sources/Scout/UI/Timeline/Provider/TimelineProvider.swift
@@ -29,12 +29,12 @@ final class TimelineProvider: ObservableObject {
     let older = RailLane(ascending: false)
     let newer = RailLane(ascending: true)
 
-    /// Identifies the latest `start` call; a superseded call that survives its
-    /// awaits must not publish a result over the newer one's.
-    private var startToken = UUID()
+    // Identifies the latest `start` call; a superseded call that survives its
+    // awaits must not publish a result over the newer one's.
+    private var startToken = Epoch()
 
     func start(feed: TimelineFeed, anchorEvent: Event?, eventName: String?) async {
-        let token = UUID()
+        let token = Epoch()
         startToken = token
 
         result = nil


### PR DESCRIPTION
Both `TimelineProvider.startToken` and `RailLane.generation` were ad-hoc tokens for detecting when a newer reload has superseded an in-flight async step, but they used different types — a `UUID` in one place and an `Int` counter in the other — even though every use was a plain equality comparison. This replaces both with a single Equatable `Epoch` value type so the two sites share one consistent, self-documenting concept.

The two tokens move in lockstep, since every `start` mints a fresh `startToken` and resets each lane's `generation`, so this is behavior-preserving. They are kept as separate instances rather than collapsed into one shared value because `RailLane` detects resets independently during scroll pagination, where the provider's token isn't in scope, so each must own its own. The private fields also had their `///` doc comments switched to `//` to match the convention that doc comments are reserved for public API.