### PR TITLE
Attach the connection menu inside HomeView's NavigationStack

### DIFF
--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -28,14 +28,14 @@ public struct HomeView: View {
                 .navigationTitle(en: "Home")
                 .backendWarnings(activeBackend)
                 .dismissable()
-        }
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                ConnectionMenu(
-                    connections: backends.map(Connection.init),
-                    activeID: Binding(get: { activeBackend.id }, set: { activeID = $0 })
-                )
-            }
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        ConnectionMenu(
+                            connections: backends.map(Connection.init),
+                            activeID: Binding(get: { activeBackend.id }, set: { activeID = $0 })
+                        )
+                    }
+                }
         }
         .onboardingSheet()
         .tint(tint.value)


### PR DESCRIPTION
The server-selection gear could fail to appear because `HomeView` attached its `.toolbar` to the `NavigationStack` from the outside, while every other toolbar item (`backendWarnings`, `dismissable`) is declared on `HomeContent` inside the stack. A toolbar attached to the navigation container from outside does not reliably place its items into the navigation bar, so the `ConnectionMenu` button went missing even with a backend loaded.

This moves the `ConnectionMenu` toolbar onto `HomeContent`, alongside the other toolbar modifiers, so the gear lands in the navigation bar consistently. The change is purely structural.