### PR TITLE
Pin the Home navigation bar background so it survives a server switch

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -22,6 +22,7 @@ struct HomeContent: View {
             HomeLogSection()
         }
         .listStyle(.plain)
+        .toolbarBackground(.visible, for: .navigationBar)
     }
 
     private var statSection: some View {


### PR DESCRIPTION
Switching the active server rebuilds `HomeContent` through the `.id(activeBackend.id)` identity on `HomeView`, which resets the list back to the top and drops the scrolled state that made the navigation bar show its opaque material. As a result the grey navigation-bar tone behind the `Home` title and the section picker disappeared after every server switch.

This pins the bar background explicitly with `.toolbarBackground(.visible, for: .navigationBar)` on `HomeContent`, so the tone no longer depends on scroll position or on the view being recreated and stays in place when the server changes.