### PR TITLE
fix home background

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -22,6 +22,12 @@ struct HomeContent: View {
             HomeLogSection()
         }
         .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background {
+            Rectangle()
+                .fill(.background)
+                .ignoresSafeArea()
+        }
     }
 
     private var statSection: some View {


### PR DESCRIPTION
## Summary
- Pin the Home screen list to an opaque system background.
- Hide the list scroll content background and draw a background that covers safe areas.

## Why
After interacting with the toolbar popover, SwiftUI can rebuild the plain list/navigation presentation with a transparent list background. The Home screen then visually loses its expected background.

## Validation
- `swift test` was run, but the package currently fails before completing because `Sources/Scout/Core/Persistence/Scout.xcdatamodeld` is not declared as a SwiftPM resource, leaving `Bundle.module` unavailable in `PersistentContainer.swift`. The changed `HomeContent.swift` compiles before that existing failure.