### PR TITLE
Separate toolbar actions

### DIFF
--- a/Sources/Scout/UI/Home/Modifier/Dismissable.swift
+++ b/Sources/Scout/UI/Home/Modifier/Dismissable.swift
@@ -25,6 +25,12 @@ private struct DismissableModifier: ViewModifier {
                     Text(verbatim: "Close")
                 }
             }
+
+            #if compiler(>=6.3)
+                if #available(iOS 26.0, macOS 26.0, *) {
+                    ToolbarSpacer(.fixed, placement: .topBarTrailing)
+                }
+            #endif
         }
     }
 }


### PR DESCRIPTION
## What changed

- Add a fixed toolbar spacer after the Close action in the dismissable home modifier.
- Keep the gear and Close toolbar actions in separate visual groups on iOS/macOS 26.

## Why

SwiftUI groups adjacent trailing toolbar items together. The spacer asks SwiftUI to keep the connection gear and Close action visually separated.

## Validation

- `git diff --check`
- `swift test` was run, but the package still fails at `Sources/Scout/Core/Persistence/PersistentContainer.swift:24` because `Bundle.module` is unavailable in the current package resource setup.
