### PR TITLE
Handle empty backend state in HomeView

### DIFF
--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -17,39 +17,39 @@ public struct HomeView: View {
         self.backends = backends
     }
 
-    private var activeBackend: Backend {
-        backends.first { $0.id == activeID } ?? backends.first!
-    }
-
     public var body: some View {
         NavigationStack {
-            HomeContent()
-                .id(activeBackend.id)
-                .navigationTitle(en: "Home")
-                .backendWarnings(activeBackend)
-                .dismissable()
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        ConnectionMenu(
-                            connections: backends.map(Connection.init),
-                            activeID: Binding(get: { activeBackend.id }, set: { activeID = $0 })
-                        )
-                    }
+            Group {
+                if let backend = backends.first(where: { $0.id == activeID }) ?? backends.first {
+                    HomeContent()
+                        .id(backend.id)
+                        .accountWarning(backend)
+                        .schemaWarning(backend)
+                        .onboardingSheet()
+                        .toolbar {
+                            ToolbarItem(placement: .topBarTrailing) {
+                                ConnectionMenu(
+                                    connections: backends.map(Connection.init),
+                                    activeID: Binding(get: { backend.id }, set: { activeID = $0 })
+                                )
+                            }
+                        }
+                        .environment(\.database, backend.database)
+                } else {
+                    ErrorView(
+                        description: Text(verbatim: "Pass at least one backend to inspect Scout data."),
+                        retry: nil
+                    )
                 }
+            }
+            .navigationTitle(en: "Home")
+            .dismissable()
         }
-        .onboardingSheet()
         .tint(tint.value)
         .environmentObject(tint)
-        .environment(\.database, activeBackend.database)
     }
 }
 
-extension View {
-    @ViewBuilder fileprivate func backendWarnings(_ backend: Backend?) -> some View {
-        if let backend {
-            accountWarning(backend).schemaWarning(backend)
-        } else {
-            self
-        }
-    }
+#Preview("No Backends") {
+    HomeView(backends: [])
 }


### PR DESCRIPTION
## Summary
- Replace the forced backend lookup in `HomeView` with conditional rendering
- Show `ErrorView` when no backends are available instead of crashing
- Keep warnings, onboarding, and database environment scoped to the resolved backend
- Add a preview for the no-backend state

## Testing
- Not run (not requested)