### PR TITLE
Group crashes by fingerprint in the crash UI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,9 @@ let package = Package(
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics")
+            ],
+            resources: [
+                .process("Core/Persistence/Scout.xcdatamodeld")
             ]
         ),
         .testTarget(

--- a/Sources/Scout/UI/Crash/Crash.swift
+++ b/Sources/Scout/UI/Crash/Crash.swift
@@ -19,6 +19,11 @@ struct Crash: Identifiable, Hashable {
     let sessionID: UUID?
 }
 
+struct CrashGroup: Identifiable, Hashable {
+    let fingerprint: String
+    let crashes: [Crash]
+}
+
 extension Crash: RecordDecodable {
     static let recordType = CrashObject.recordType
     static let sampleRecords: [Record] = []
@@ -55,17 +60,119 @@ extension Crash {
     }
 }
 
+extension CrashGroup {
+    var id: String { fingerprint }
+
+    var name: String {
+        representative.name
+    }
+
+    var reason: String? {
+        representative.reason
+    }
+
+    var stackTrace: [String] {
+        representative.stackTrace
+    }
+
+    var count: Int {
+        crashes.count
+    }
+
+    var affectedSessions: Int {
+        Set(crashes.compactMap(\.sessionID)).count
+    }
+
+    var firstDate: Date? {
+        crashes.compactMap(\.date).min()
+    }
+
+    var lastDate: Date? {
+        crashes.compactMap(\.date).max()
+    }
+
+    var representative: Crash {
+        crashes.first ?? .sample(name: "Unknown crash", fingerprint: fingerprint)
+    }
+
+    static func groups(from crashes: [Crash]) -> [CrashGroup] {
+        Dictionary(grouping: crashes, by: \.groupingFingerprint)
+            .map { fingerprint, crashes in
+                CrashGroup(
+                    fingerprint: fingerprint,
+                    crashes: crashes.sorted(by: Self.recentFirst)
+                )
+            }
+            .sorted(by: Self.recentFirst)
+    }
+
+    private static func recentFirst(_ lhs: CrashGroup, _ rhs: CrashGroup) -> Bool {
+        switch (lhs.lastDate, rhs.lastDate) {
+        case let (lhs?, rhs?):
+            if lhs != rhs {
+                return lhs > rhs
+            }
+        case (_?, nil):
+            return true
+        case (nil, _?):
+            return false
+        case (nil, nil):
+            break
+        }
+
+        if lhs.count != rhs.count {
+            return lhs.count > rhs.count
+        }
+
+        return lhs.name < rhs.name
+    }
+
+    private static func recentFirst(_ lhs: Crash, _ rhs: Crash) -> Bool {
+        switch (lhs.date, rhs.date) {
+        case let (lhs?, rhs?):
+            if lhs != rhs {
+                return lhs > rhs
+            }
+        case (_?, nil):
+            return true
+        case (nil, _?):
+            return false
+        case (nil, nil):
+            break
+        }
+
+        return lhs.id < rhs.id
+    }
+}
+
+extension Crash {
+    var groupingFingerprint: String {
+        fingerprint ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value
+    }
+}
+
 extension Crash {
     static var sample: Crash {
         Self.sample("NSRangeException", at: Date())
     }
 
-    static func sample(_ name: String, at date: Date, sessionID: UUID? = nil) -> Crash {
+    static func sample(_ name: String, at date: Date = Date(), sessionID: UUID? = nil) -> Crash {
+        sample(name: name, fingerprint: nil, reason: nil, stackTrace: [], date: date, sessionID: sessionID)
+    }
+
+    static func sample(
+        name: String,
+        fingerprint: String? = nil,
+        reason: String? = nil,
+        stackTrace: [String] = [],
+        date: Date? = Date(),
+        sessionID: UUID? = nil
+    ) -> Crash {
         Crash(
             name: name,
-            fingerprint: nil,
-            reason: nil,
-            stackTrace: [],
+            fingerprint: fingerprint,
+            reason: reason,
+            stackTrace: stackTrace,
             date: date,
             id: UUID().uuidString,
             installID: nil,

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -1,0 +1,108 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct CrashGroupDetailView: View {
+    let group: CrashGroup
+
+    var body: some View {
+        List {
+            headerSection
+
+            Header(title: "Occurrences")
+
+            ForEach(group.crashes) { crash in
+                Row {
+                    CrashOccurrenceRow(crash: crash)
+                } destination: {
+                    CrashDetailView(crash: crash)
+                }
+            }
+
+            if !group.stackTrace.isEmpty {
+                stackTraceSection
+            }
+        }
+        .listStyle(.plain)
+        .toolbarBackground(Color.red.opacity(0.12), for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .navigationTitle(en: group.name)
+    }
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let reason = group.reason {
+                Text(reason)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color.red)
+            }
+
+            HStack(spacing: 24) {
+                CrashGroupMetric(title: "Crashes", value: "\(group.count)")
+                CrashGroupMetric(title: "Sessions", value: "\(group.affectedSessions)")
+
+                if let firstDate = group.firstDate {
+                    CrashGroupMetric(title: "First", value: firstDate.relativeString)
+                }
+
+                if let lastDate = group.lastDate {
+                    CrashGroupMetric(title: "Last", value: lastDate.relativeString)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var stackTraceSection: some View {
+        Header(title: "Stack Trace")
+
+        ForEach(Array(group.stackTrace.enumerated()), id: \.offset) { _, frame in
+            Text(frame)
+                .font(.system(size: 12))
+                .monospaced()
+                .lineLimit(2)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        CrashGroupDetailView(
+            group: CrashGroup.groups(
+                from: [
+                    .sample(
+                        name: "NSRangeException",
+                        fingerprint: "range",
+                        reason: "Index 7 beyond bounds [0 .. 5]",
+                        stackTrace: [
+                            "0 Scout CrashListView.row(for:)",
+                            "1 SwiftUI ListCore.updateVisibleRows()",
+                            "2 UIKitCore UIApplicationMain",
+                        ],
+                        date: Date().addingTimeInterval(-300),
+                        sessionID: UUID()
+                    ),
+                    .sample(
+                        name: "NSRangeException",
+                        fingerprint: "range",
+                        reason: "Index 7 beyond bounds [0 .. 5]",
+                        stackTrace: [
+                            "0 Scout CrashListView.row(for:)",
+                            "1 SwiftUI ListCore.updateVisibleRows()",
+                            "2 UIKitCore UIApplicationMain",
+                        ],
+                        date: Date().addingTimeInterval(-3600),
+                        sessionID: UUID()
+                    ),
+                ]
+            )[0]
+        )
+    }
+    .environmentObject(Tint())
+}

--- a/Sources/Scout/UI/Crash/CrashGroupMetric.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupMetric.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct CrashGroupMetric: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title.uppercased())
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(Color.secondary)
+
+            Text(value)
+                .font(.system(size: 15, weight: .semibold))
+                .lineLimit(1)
+        }
+    }
+}

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -13,8 +13,8 @@ struct CrashListView: View {
 
     var body: some View {
         Group {
-            if let crashes = provider.crashes {
-                if crashes.isEmpty {
+            if let groups = provider.groups {
+                if groups.isEmpty {
                     Placeholder(
                         text: "No crashes",
                         systemImage: "checkmark.shield",
@@ -22,7 +22,7 @@ struct CrashListView: View {
                     )
                 } else {
                     List {
-                        ForEach(crashes, content: row)
+                        ForEach(groups, content: row)
 
                         if let cursor = provider.cursor {
                             PaginationFooter {
@@ -31,7 +31,7 @@ struct CrashListView: View {
                         }
                     }
                     .listStyle(.plain)
-                    .animation(nil, value: crashes)
+                    .animation(nil, value: groups)
                 }
             } else {
                 ProgressView().frame(maxHeight: .infinity)
@@ -43,22 +43,41 @@ struct CrashListView: View {
         }
     }
 
-    private func row(for crash: Crash) -> some View {
+    private func row(for group: CrashGroup) -> some View {
         Row {
-            Text(crash.name)
-                .font(.system(size: 17))
-                .lineLimit(1)
-                .monospaced()
+            VStack(alignment: .leading, spacing: 5) {
+                Text(group.name)
+                    .font(.system(size: 17, weight: .semibold))
+                    .lineLimit(1)
+                    .monospaced()
+
+                if let reason = group.reason {
+                    Text(reason)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.gray)
+                        .lineLimit(1)
+                }
+
+                Text(verbatim: "\(group.affectedSessions) sessions")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color.secondary)
+            }
 
             Spacer()
 
-            if let date = crash.date {
-                Text(verbatim: date.relativeString)
-                    .font(.system(size: 15))
-                    .foregroundStyle(Color.gray)
+            VStack(alignment: .trailing, spacing: 5) {
+                Text(verbatim: "\(group.count)")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(Color.red)
+
+                if let date = group.lastDate {
+                    Text(verbatim: date.relativeString)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.gray)
+                }
             }
         } destination: {
-            CrashDetailView(crash: crash)
+            CrashGroupDetailView(group: group)
         }
     }
 }

--- a/Sources/Scout/UI/Crash/CrashOccurrenceRow.swift
+++ b/Sources/Scout/UI/Crash/CrashOccurrenceRow.swift
@@ -1,0 +1,45 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct CrashOccurrenceRow: View {
+    let crash: Crash
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 14) {
+            if let date = crash.date {
+                Text(verbatim: date.relativeString)
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.gray)
+                    .frame(width: 76, alignment: .leading)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(crash.name)
+                    .font(.system(size: 15, weight: .medium))
+                    .lineLimit(1)
+                    .monospaced()
+
+                HStack(spacing: 6) {
+                    if let sessionID = crash.sessionID {
+                        Text(verbatim: "Session \(sessionID.uuidString.prefix(4))")
+                    }
+
+                    if let launchID = crash.launchID {
+                        Text(verbatim: "Launch \(launchID.uuidString.prefix(4))")
+                    }
+                }
+                .font(.system(size: 12))
+                .foregroundStyle(Color.secondary)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 3)
+    }
+}

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -9,8 +9,9 @@ import SwiftUI
 
 @MainActor
 class CrashProvider: ObservableObject {
-    @Published var crashes: [Crash]?
+    @Published var groups: [CrashGroup]?
     @Published var cursor: RecordCursor?
+    private var crashes: [Crash] = []
 
     func fetch(in database: DatabaseReader) async {
         do {
@@ -27,8 +28,10 @@ class CrashProvider: ObservableObject {
 
             self.cursor = results.cursor
             self.crashes = try results.records.map(Crash.init)
+            self.groups = CrashGroup.groups(from: crashes)
         } catch {
             self.crashes = []
+            self.groups = []
         }
     }
 
@@ -40,7 +43,8 @@ class CrashProvider: ObservableObject {
             )
 
             self.cursor = results.cursor
-            self.crashes?.append(contentsOf: try results.records.map(Crash.init))
+            self.crashes.append(contentsOf: try results.records.map(Crash.init))
+            self.groups = CrashGroup.groups(from: crashes)
         } catch {
         }
     }

--- a/Tests/ScoutTests/UI/Crash/CrashGroupTests.swift
+++ b/Tests/ScoutTests/UI/Crash/CrashGroupTests.swift
@@ -1,0 +1,70 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct CrashGroupTests {
+    @MainActor
+    @Test("Provider exposes grouped crashes")
+    func providerExposesGroupedCrashes() async throws {
+        let database = DatabaseStub()
+        database.add(
+            makeRecord(name: "NSRangeException", fingerprint: "range", date: Date().addingTimeInterval(-20)),
+            makeRecord(name: "NSRangeException", fingerprint: "range", date: Date().addingTimeInterval(-10)),
+            makeRecord(name: "Fatal error", fingerprint: "fatal", date: Date().addingTimeInterval(-5))
+        )
+
+        let provider = CrashProvider()
+        await provider.fetch(in: database)
+
+        let groups = try #require(provider.groups)
+        #expect(groups.map(\.fingerprint) == ["fatal", "range"])
+        #expect(groups.first(where: { $0.fingerprint == "range" })?.count == 2)
+        #expect(database.readCount(of: Crash.recordType) == 1)
+    }
+
+    @Test("Groups crashes by fingerprint")
+    func groupsCrashesByFingerprint() {
+        let sessionID = UUID()
+        let crashes = [
+            Crash.sample(name: "NSRangeException", fingerprint: "range", date: Date(timeIntervalSince1970: 10), sessionID: sessionID),
+            Crash.sample(name: "NSRangeException", fingerprint: "range", date: Date(timeIntervalSince1970: 20), sessionID: sessionID),
+            Crash.sample(name: "Fatal error", fingerprint: "fatal", date: Date(timeIntervalSince1970: 30), sessionID: UUID()),
+        ]
+
+        let groups = CrashGroup.groups(from: crashes)
+
+        #expect(groups.count == 2)
+        #expect(groups.first?.fingerprint == "fatal")
+        #expect(groups.first(where: { $0.fingerprint == "range" })?.count == 2)
+        #expect(groups.first(where: { $0.fingerprint == "range" })?.affectedSessions == 1)
+    }
+
+    @Test("Sorts occurrences in each group by recency")
+    func sortsOccurrencesByRecency() throws {
+        let older = Crash.sample(name: "NSRangeException", fingerprint: "range", date: Date(timeIntervalSince1970: 10))
+        let newer = Crash.sample(name: "NSRangeException", fingerprint: "range", date: Date(timeIntervalSince1970: 20))
+
+        let group = try #require(CrashGroup.groups(from: [older, newer]).first)
+
+        #expect(group.crashes.map(\.id) == [newer.id, older.id])
+        #expect(group.firstDate == older.date)
+        #expect(group.lastDate == newer.date)
+    }
+
+    private func makeRecord(name: String, fingerprint: String, date: Date) -> Record {
+        var record = Record(recordType: Crash.recordType, recordID: UUID().uuidString)
+        record["name"] = name
+        record["fingerprint"] = fingerprint
+        record["date"] = date
+        record["uuid"] = record.recordID
+        return record
+    }
+}


### PR DESCRIPTION
- Group crash records into reusable `CrashGroup` models keyed by fingerprint.
- Update the crash list to show grouped counts, session coverage, and latest activity instead of individual rows.
- Add a crash group detail view with per-occurrence drill-down and shared stack trace context.
- Include crash grouping tests for sorting, aggregation, and provider behavior.
- Add the Core Data model resource to the Swift package target so persistence-backed crash data is available at runtime.