### PR TITLE
Add no-comments code style rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,10 @@
 
 # Swift code style
 
+## Comments
+
+- Don't add comments. The only allowed comments are doc comments (`///`) on public API (see below) and rare inline `//` notes that explain something genuinely critical and non-obvious (a subtle "why", a non-obvious invariant, a workaround). Never add comments that restate what the code already says.
+
 ## Doc comments
 
 - Document only public API: write doc comments (`///`) for `public`/`open` declarations only, and leave `internal`, `private`, and `fileprivate` declarations undocumented (an inline `//` note for genuinely non-obvious logic is still fine).


### PR DESCRIPTION
Adds a `Comments` rule to the Swift code style section of `CLAUDE.md` stating that comments should not be added beyond doc comments on public API and rare inline notes for genuinely critical, non-obvious logic, and that comments must never restate the code.