### PR TITLE
Group crashes by fingerprint in the crash list

### DIFF
--- a/Sources/Scout/UI/Crash/Crash.swift
+++ b/Sources/Scout/UI/Crash/Crash.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Crash: Identifiable, Hashable {
     let name: String
-    let fingerprint: String?
+    let fingerprint: String
     let reason: String?
     let stackTrace: [String]
     let date: Date?
@@ -19,9 +19,14 @@ struct Crash: Identifiable, Hashable {
     let sessionID: UUID?
 }
 
+extension Crash: Comparable {
+    static func < (lhs: Crash, rhs: Crash) -> Bool {
+        (lhs.date ?? .distantPast) > (rhs.date ?? .distantPast)
+    }
+}
+
 extension Crash: RecordDecodable {
     static let recordType = CrashObject.recordType
-    static let sampleRecords: [Record] = []
 
     static let desiredKeys = [
         "name",
@@ -63,7 +68,7 @@ extension Crash {
     static func sample(_ name: String, at date: Date, sessionID: UUID? = nil) -> Crash {
         Crash(
             name: name,
-            fingerprint: nil,
+            fingerprint: CrashFingerprint(name: name, reason: nil, stackTrace: []).value,
             reason: nil,
             stackTrace: [],
             date: date,
@@ -73,4 +78,92 @@ extension Crash {
             sessionID: sessionID
         )
     }
+
+    static var sampleRecords: [Record] {
+        let sessionA = UUID()
+        let sessionB = UUID()
+        let sessionC = UUID()
+
+        return [
+            sampleRecord(
+                name: "NSRangeException",
+                reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
+                fingerprint: "range",
+                minutesAgo: 6,
+                sessionID: sessionA,
+                stackTrace: rangeStackTrace
+            ),
+            sampleRecord(
+                name: "NSRangeException",
+                reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
+                fingerprint: "range",
+                minutesAgo: 95,
+                sessionID: sessionB,
+                stackTrace: rangeStackTrace
+            ),
+            sampleRecord(
+                name: "NSRangeException",
+                reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
+                fingerprint: "range",
+                minutesAgo: 340,
+                sessionID: sessionA,
+                stackTrace: rangeStackTrace
+            ),
+            sampleRecord(
+                name: "Fatal error",
+                reason: "Index out of range",
+                fingerprint: "fatal",
+                minutesAgo: 42,
+                sessionID: sessionB,
+                stackTrace: fatalStackTrace
+            ),
+            sampleRecord(
+                name: "Fatal error",
+                reason: "Index out of range",
+                fingerprint: "fatal",
+                minutesAgo: 220,
+                sessionID: sessionC,
+                stackTrace: fatalStackTrace
+            ),
+            sampleRecord(
+                name: "SIGSEGV",
+                reason: "Segmentation fault: 11",
+                fingerprint: "segv",
+                minutesAgo: 1500,
+                sessionID: sessionC,
+                stackTrace: segvStackTrace
+            ),
+        ]
+    }
+
+    private static func sampleRecord(name: String, reason: String, fingerprint: String, minutesAgo: Double, sessionID: UUID, stackTrace: [String]) -> Record {
+        var record = Record(recordType: recordType, recordID: UUID().uuidString)
+        record["name"] = name
+        record["reason"] = reason
+        record["fingerprint"] = fingerprint
+        record["date"] = Date(timeIntervalSinceNow: -minutesAgo * 60)
+        record["session_id"] = sessionID.uuidString
+        record["install_id"] = UUID().uuidString
+        record["launch_id"] = UUID().uuidString
+        record["stack_trace"] = try? JSONEncoder().encode(stackTrace)
+        return record
+    }
+
+    private static let rangeStackTrace = [
+        "0   CoreFoundation        0x0 __exceptionPreprocess + 164",
+        "1   libobjc.A.dylib       0x0 objc_exception_throw + 60",
+        "2   CoreFoundation        0x0 -[__NSArrayM objectAtIndex:] + 1228",
+        "3   Scout                 0x0 FeedViewController.row(at:) + 88",
+    ]
+
+    private static let fatalStackTrace = [
+        "0   Scout                 0x0 Scout.Cart.total.getter + 240",
+        "1   Scout                 0x0 Scout.CheckoutView.body.getter + 132",
+        "2   SwiftUI               0x0 closure #1 in ViewBody.render + 96",
+    ]
+
+    private static let segvStackTrace = [
+        "0   Scout                 0x0 ImageLoader.decode(_:) + 512",
+        "1   Scout                 0x0 closure #1 in ImageLoader.load() + 96",
+    ]
 }

--- a/Sources/Scout/UI/Crash/CrashGroup.swift
+++ b/Sources/Scout/UI/Crash/CrashGroup.swift
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct CrashGroup: Identifiable, Hashable {
+    let crashes: [Crash]
+
+    var id: String {
+        representative.fingerprint
+    }
+
+    var name: String {
+        representative.name
+    }
+}
+
+extension CrashGroup {
+    var representative: Crash {
+        crashes[0]
+    }
+
+    var count: Int {
+        crashes.count
+    }
+
+    var affectedSessions: Int {
+        Set(crashes.compactMap(\.sessionID)).count
+    }
+
+    var firstDate: Date? {
+        crashes.compactMap(\.date).min()
+    }
+
+    var lastDate: Date? {
+        crashes.compactMap(\.date).max()
+    }
+}
+
+extension CrashGroup: Comparable {
+    static func < (lhs: CrashGroup, rhs: CrashGroup) -> Bool {
+        if lhs.lastDate != rhs.lastDate {
+            return (lhs.lastDate ?? .distantPast) > (rhs.lastDate ?? .distantPast)
+        }
+        if lhs.count != rhs.count {
+            return lhs.count > rhs.count
+        }
+        return lhs.name < rhs.name
+    }
+}
+
+extension CrashGroup {
+    static func groups(from crashes: [Crash]) -> [CrashGroup] {
+        Dictionary(grouping: crashes, by: \.fingerprint)
+            .values
+            .map { CrashGroup(crashes: $0.sorted()) }
+            .sorted()
+    }
+}

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -1,0 +1,101 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct CrashGroupDetailView: View {
+    let group: CrashGroup
+
+    @EnvironmentObject var tint: Tint
+
+    var body: some View {
+        List {
+            headerSection
+            occurrencesSection
+        }
+        .onAppear {
+            tint.value = .red
+        }
+        .onDisappear {
+            tint.value = nil
+        }
+        .listStyle(.plain)
+        .toolbarBackground(Color.red.opacity(0.12), for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .navigationTitle(group.name)
+    }
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 24) {
+                metric(title: "Occurrences", value: "\(group.count)")
+                metric(title: "Sessions", value: "\(group.affectedSessions)")
+            }
+
+            if let reason = group.representative.reason {
+                Text(verbatim: "REASON:   ").fontWeight(.bold)
+                    + Text(reason).fontWeight(.bold).foregroundColor(.red)
+            }
+
+            if let first = group.firstDate, let last = group.lastDate {
+                Text(verbatim: "First seen \(first.relativeString) · Last seen \(last.relativeString)")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.gray)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var occurrencesSection: some View {
+        Header(title: "Occurrences")
+
+        ForEach(group.crashes) { crash in
+            Row {
+                if let date = crash.date {
+                    Text(utcDateFormatter.string(from: date) + " UTC")
+                        .font(.system(size: 14))
+                        .monospaced()
+                }
+
+                Spacer()
+
+                if let sessionID = crash.sessionID {
+                    Text(sessionID.uuidString.prefix(8))
+                        .font(.system(size: 13))
+                        .monospaced()
+                        .foregroundStyle(Color.gray)
+                }
+            } destination: {
+                CrashDetailView(crash: crash)
+            }
+        }
+    }
+
+    private func metric(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(value)
+                .font(.system(size: 22, weight: .bold))
+                .monospacedDigit()
+            Text(title.uppercased())
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.gray)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        CrashGroupDetailView(
+            group: CrashGroup(crashes: [
+                .sample("NSRangeException", at: Date()),
+                .sample("NSRangeException", at: Date().addingTimeInterval(-3600)),
+            ])
+        )
+    }
+    .environmentObject(Tint())
+}

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -13,8 +13,8 @@ struct CrashListView: View {
 
     var body: some View {
         Group {
-            if let crashes = provider.crashes {
-                if crashes.isEmpty {
+            if let groups = provider.groups {
+                if groups.isEmpty {
                     Placeholder(
                         text: "No crashes",
                         systemImage: "checkmark.shield",
@@ -22,7 +22,7 @@ struct CrashListView: View {
                     )
                 } else {
                     List {
-                        ForEach(crashes, content: row)
+                        ForEach(groups, content: row)
 
                         if let cursor = provider.cursor {
                             PaginationFooter {
@@ -31,7 +31,7 @@ struct CrashListView: View {
                         }
                     }
                     .listStyle(.plain)
-                    .animation(nil, value: crashes)
+                    .animation(nil, value: groups)
                 }
             } else {
                 ProgressView().frame(maxHeight: .infinity)
@@ -43,23 +43,41 @@ struct CrashListView: View {
         }
     }
 
-    private func row(for crash: Crash) -> some View {
+    private func row(for group: CrashGroup) -> some View {
         Row {
-            Text(crash.name)
+            Text(group.name)
                 .font(.system(size: 17))
                 .lineLimit(1)
                 .monospaced()
 
+            if group.count > 1 {
+                CrashCountBadge(count: group.count)
+            }
+
             Spacer()
 
-            if let date = crash.date {
+            if let date = group.lastDate {
                 Text(verbatim: date.relativeString)
                     .font(.system(size: 15))
                     .foregroundStyle(Color.gray)
             }
         } destination: {
-            CrashDetailView(crash: crash)
+            CrashGroupDetailView(group: group)
         }
+    }
+}
+
+private struct CrashCountBadge: View {
+    let count: Int
+
+    var body: some View {
+        Text(verbatim: "×\(count)")
+            .font(.caption.weight(.semibold))
+            .monospacedDigit()
+            .foregroundStyle(.red)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(Color.red.opacity(0.13), in: Capsule())
     }
 }
 

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -12,6 +12,10 @@ class CrashProvider: ObservableObject {
     @Published var crashes: [Crash]?
     @Published var cursor: RecordCursor?
 
+    var groups: [CrashGroup]? {
+        crashes.map(CrashGroup.groups(from:))
+    }
+
     func fetch(in database: DatabaseReader) async {
         do {
             let query = RecordQuery(

--- a/Tests/ScoutTests/Stubs/Records/Crash+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Records/Crash+Stub.swift
@@ -12,6 +12,8 @@ import Foundation
 extension Crash {
     @discardableResult static func stub(
         name: String = "crash",
+        fingerprint: String? = nil,
+        reason: String? = nil,
         sessionID: UUID? = nil,
         launchID: UUID? = nil,
         installID: UUID? = nil,
@@ -19,8 +21,8 @@ extension Crash {
     ) -> Crash {
         Crash(
             name: name,
-            fingerprint: nil,
-            reason: nil,
+            fingerprint: fingerprint ?? CrashFingerprint(name: name, reason: reason, stackTrace: []).value,
+            reason: reason,
             stackTrace: [],
             date: date,
             id: UUID().uuidString,

--- a/Tests/ScoutTests/UI/Crash/CrashGroupTests.swift
+++ b/Tests/ScoutTests/UI/Crash/CrashGroupTests.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct CrashGroupTests {
+    @Test("Crashes sharing a fingerprint collapse into one group") func testGroupingByFingerprint() {
+        let crashes = [
+            Crash.stub(name: "A", fingerprint: "fp1"),
+            Crash.stub(name: "A", fingerprint: "fp1"),
+            Crash.stub(name: "B", fingerprint: "fp2"),
+        ]
+
+        let groups = CrashGroup.groups(from: crashes)
+
+        #expect(groups.count == 2)
+        #expect(groups.map(\.count).sorted() == [1, 2])
+    }
+
+    @Test("The representative is the most recent crash in the group") func testRepresentativeIsLatest() {
+        let old = Crash.stub(fingerprint: "fp", date: Date(timeIntervalSince1970: 1000))
+        let new = Crash.stub(fingerprint: "fp", date: Date(timeIntervalSince1970: 2000))
+
+        let group = CrashGroup.groups(from: [old, new])[0]
+
+        #expect(group.representative.id == new.id)
+        #expect(group.firstDate == old.date)
+        #expect(group.lastDate == new.date)
+    }
+
+    @Test("Groups are ordered by most recent occurrence first") func testGroupOrderByRecency() {
+        let crashes = [
+            Crash.stub(fingerprint: "old", date: Date(timeIntervalSince1970: 1000)),
+            Crash.stub(fingerprint: "new", date: Date(timeIntervalSince1970: 2000)),
+        ]
+
+        let groups = CrashGroup.groups(from: crashes)
+
+        #expect(groups.map(\.representative.fingerprint) == ["new", "old"])
+    }
+
+    @Test("Ties on recency are broken by occurrence count") func testTieBreakByCount() {
+        let date = Date(timeIntervalSince1970: 1000)
+        let crashes = [
+            Crash.stub(fingerprint: "single", date: date),
+            Crash.stub(fingerprint: "double", date: date),
+            Crash.stub(fingerprint: "double", date: date),
+        ]
+
+        let groups = CrashGroup.groups(from: crashes)
+
+        #expect(groups.map(\.representative.fingerprint) == ["double", "single"])
+    }
+
+    @Test("Affected sessions count distinct sessions") func testAffectedSessions() {
+        let session = UUID()
+        let crashes = [
+            Crash.stub(fingerprint: "fp", sessionID: session),
+            Crash.stub(fingerprint: "fp", sessionID: session),
+            Crash.stub(fingerprint: "fp", sessionID: UUID()),
+            Crash.stub(fingerprint: "fp", sessionID: nil),
+        ]
+
+        let group = CrashGroup.groups(from: crashes)[0]
+
+        #expect(group.affectedSessions == 2)
+    }
+}

--- a/Tests/ScoutTests/UI/TimelineExportTests.swift
+++ b/Tests/ScoutTests/UI/TimelineExportTests.swift
@@ -128,7 +128,7 @@ struct TimelineExportTests {
     func testCrashReason() {
         let crash = Crash(
             name: "SIGABRT",
-            fingerprint: nil,
+            fingerprint: CrashFingerprint(name: "SIGABRT", reason: "unexpectedly found nil", stackTrace: []).value,
             reason: "unexpectedly found nil",
             stackTrace: [],
             date: TimelineFixture.at(10),


### PR DESCRIPTION
The crash list previously showed every crash as a separate row, so a single recurring crash flooded the list with near-identical entries. This change groups crashes by their `fingerprint` so each distinct issue appears once, with the latest occurrence representing the group and a badge showing how many times it recurred.

Tapping a group opens a new `CrashGroupDetailView` that summarizes the issue — total occurrences, number of affected sessions, and the span between the first and last occurrence — and lists every individual crash, each still linking through to the existing `CrashDetailView`.

The grouping and ordering logic lives in a new `CrashGroup` type (kept out of the views and covered by unit tests), and both `Crash` and `CrashGroup` now conform to `Comparable` so the sort order is expressed once on the types rather than inline. The `Crash.fingerprint` field is now non-optional since a fingerprint is always derived when decoding, and `Crash.sampleRecords` is populated so the list preview renders realistic grouped data.