### PR TITLE
Add Markdown Share/Copy export to crash detail screens

### DIFF
--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -29,6 +29,14 @@ struct CrashDetailView: View {
         .listStyle(.plain)
         .toolbarBackground(Color.red.opacity(0.12), for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItemGroup(placement: .bottomBar) {
+                let text = CrashExport(crash: crash).text
+                ShareLink(item: text)
+                CopyButton(text: text)
+                Spacer()
+            }
+        }
         .navigationTitle(crash.name)
     }
 

--- a/Sources/Scout/UI/Crash/CrashExport.swift
+++ b/Sources/Scout/UI/Crash/CrashExport.swift
@@ -1,0 +1,96 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct CrashExport {
+    let crash: Crash
+
+    var text: String {
+        var lines = ["# Scout Crash — \(crash.name)"]
+
+        if let date = crash.date {
+            lines.append(ExportFormat.timestamp(date))
+        }
+        if let reason = crash.reason {
+            lines.append("")
+            lines.append("Reason: \(reason)")
+        }
+        if crash.stackTrace.count > 0 {
+            lines.append("")
+            lines.append("## Stack Trace")
+            lines.append("```")
+            lines.append(contentsOf: crash.stackTrace)
+            lines.append("```")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+}
+
+struct CrashGroupExport {
+    let group: CrashGroup
+
+    var text: String {
+        var lines = [title, summary]
+
+        if let seen = seenLine {
+            lines.append(seen)
+        }
+        if let reason = group.representative.reason {
+            lines.append("")
+            lines.append("Reason: \(reason)")
+        }
+        if let frame = topFrame {
+            lines.append("")
+            lines.append("Top frame: \(frame)")
+        }
+
+        let rows = group.crashes.compactMap(row)
+        if rows.count > 0 {
+            lines.append("")
+            lines.append("## Occurrences")
+            lines.append(contentsOf: rows)
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private var title: String {
+        "# Scout Crash Issue — \(group.name)"
+    }
+
+    private var summary: String {
+        var parts = [ExportFormat.counted(group.count, "occurrence", "occurrences")]
+        if group.affectedSessions > 0 {
+            parts.append(ExportFormat.counted(group.affectedSessions, "session", "sessions"))
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private var seenLine: String? {
+        guard let first = group.firstDate, let last = group.lastDate else {
+            return nil
+        }
+        return "First seen \(ExportFormat.minute(first)) · Last seen \(ExportFormat.minute(last))"
+    }
+
+    private var topFrame: String? {
+        group.representative.stackTrace.first { !$0.isEmpty }
+    }
+
+    private func row(for crash: Crash) -> String? {
+        guard let date = crash.date else {
+            return nil
+        }
+        let row = "- \(ExportFormat.timestamp(date))"
+        guard let sessionID = crash.sessionID else {
+            return row
+        }
+        return "\(row)  (session \(ExportFormat.shortID(sessionID)))"
+    }
+}

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -26,6 +26,14 @@ struct CrashGroupDetailView: View {
         .listStyle(.plain)
         .toolbarBackground(Color.red.opacity(0.12), for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItemGroup(placement: .bottomBar) {
+                let text = CrashGroupExport(group: group).text
+                ShareLink(item: text)
+                CopyButton(text: text)
+                Spacer()
+            }
+        }
         .navigationTitle(group.name)
     }
 

--- a/Tests/ScoutTests/Stubs/Records/Crash+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Records/Crash+Stub.swift
@@ -14,6 +14,7 @@ extension Crash {
         name: String = "crash",
         fingerprint: String? = nil,
         reason: String? = nil,
+        stackTrace: [String] = [],
         sessionID: UUID? = nil,
         launchID: UUID? = nil,
         installID: UUID? = nil,
@@ -21,9 +22,9 @@ extension Crash {
     ) -> Crash {
         Crash(
             name: name,
-            fingerprint: fingerprint ?? CrashFingerprint(name: name, reason: reason, stackTrace: []).value,
+            fingerprint: fingerprint ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value,
             reason: reason,
-            stackTrace: [],
+            stackTrace: stackTrace,
             date: date,
             id: UUID().uuidString,
             installID: installID,

--- a/Tests/ScoutTests/UI/Crash/CrashExportTests.swift
+++ b/Tests/ScoutTests/UI/Crash/CrashExportTests.swift
@@ -1,0 +1,93 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct CrashExportTests {
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func at(_ seconds: TimeInterval) -> Date {
+        base.addingTimeInterval(seconds)
+    }
+
+    @Test("A single crash renders its date, reason, and fenced stack trace")
+    func testSingleCrashExport() {
+        let crash = Crash.stub(
+            name: "SIGABRT",
+            reason: "found nil",
+            stackTrace: ["0 A 0x1 f + 1", "1 B 0x2 g + 2"],
+            date: at(0)
+        )
+        let text = CrashExport(crash: crash).text
+
+        #expect(text.hasPrefix("# Scout Crash — SIGABRT"))
+        #expect(text.contains(ExportFormat.timestamp(at(0))))
+        #expect(text.contains("Reason: found nil"))
+        #expect(text.contains("## Stack Trace"))
+        #expect(text.contains("0 A 0x1 f + 1"))
+        #expect(text.contains("```"))
+    }
+
+    @Test("A bare crash exports just its title")
+    func testSingleCrashExportOmitsEmptyParts() {
+        let crash = Crash.stub(name: "E", reason: nil, stackTrace: [], date: nil)
+        #expect(CrashExport(crash: crash).text == "# Scout Crash — E")
+    }
+
+    @Test("A group renders its summary, top frame, and occurrence rows")
+    func testGroupExport() {
+        let session = UUID()
+        let crashes = [
+            Crash.stub(
+                name: "NSRangeException",
+                fingerprint: "fp",
+                reason: "index beyond bounds",
+                stackTrace: ["2 Scout 0xabc objectAtIndex + 12"],
+                sessionID: session,
+                date: at(0)
+            ),
+            Crash.stub(
+                name: "NSRangeException",
+                fingerprint: "fp",
+                reason: "index beyond bounds",
+                stackTrace: ["2 Scout 0xdef objectAtIndex + 99"],
+                sessionID: session,
+                date: at(3600)
+            ),
+        ]
+        let group = CrashGroup.groups(from: crashes)[0]
+        let text = CrashGroupExport(group: group).text
+
+        #expect(text.hasPrefix("# Scout Crash Issue — NSRangeException"))
+        #expect(text.contains("2 occurrences · 1 session"))
+        #expect(text.contains("First seen") && text.contains("Last seen"))
+        #expect(text.contains("Reason: index beyond bounds"))
+        #expect(text.contains("Top frame: 2 Scout 0xdef objectAtIndex + 99"))
+        #expect(text.contains("## Occurrences"))
+        #expect(
+            text.contains(
+                "- \(ExportFormat.timestamp(at(3600)))  (session \(ExportFormat.shortID(session)))"
+            )
+        )
+    }
+
+    @Test("Occurrence rows follow the newest-first order")
+    func testGroupExportOrdersOccurrences() throws {
+        let crashes = [
+            Crash.stub(name: "E", fingerprint: "fp", stackTrace: ["1 A 0x1 f + 1"], date: at(0)),
+            Crash.stub(name: "E", fingerprint: "fp", stackTrace: ["1 A 0x2 f + 2"], date: at(7200)),
+        ]
+        let text = CrashGroupExport(group: CrashGroup.groups(from: crashes)[0]).text
+
+        let newer = try #require(text.range(of: ExportFormat.timestamp(at(7200))))
+        let older = try #require(text.range(of: ExportFormat.timestamp(at(0))))
+        #expect(newer.lowerBound < older.lowerBound)
+    }
+}


### PR DESCRIPTION
Restores the ability to share and copy crashes from the crash screens, which had been dropped in an earlier iteration. Both `CrashDetailView` and `CrashGroupDetailView` now show `ShareLink` and `CopyButton` actions in the bottom bar, matching the export affordances already used on the timeline and parameter screens.

The Markdown is produced by two small, testable builders. `CrashExport` renders a single occurrence with its timestamp, reason, and a fenced stack trace, while `CrashGroupExport` renders a grouped issue with a summary of occurrences and sessions, the seen range, the reason, the top frame, and a chronological list of occurrences. Both reuse the shared `ExportFormat` helpers so the output stays consistent with other Scout exports.

The `Crash` test stub gained a `stackTrace` parameter so the new `CrashExportTests` can exercise stack-trace output.