### PR TITLE
Track unique devices per crash group

### DIFF
--- a/Sources/Scout/UI/Crash/Crash.swift
+++ b/Sources/Scout/UI/Crash/Crash.swift
@@ -14,6 +14,7 @@ struct Crash: Identifiable, Hashable {
     let stackTrace: [String]
     let date: Date?
     let id: String
+    let deviceID: UUID?
     let installID: UUID?
     let launchID: UUID?
     let sessionID: UUID?
@@ -35,6 +36,7 @@ extension Crash: RecordDecodable {
         "stack_trace",
         "date",
         "uuid",
+        "device_id",
         "install_id",
         "launch_id",
         "session_id",
@@ -47,6 +49,7 @@ extension Crash {
         reason = record["reason"]
         date = record["date"]
         id = record.recordID
+        deviceID = record["device_id"].flatMap(UUID.init)
         installID = record["install_id"].flatMap(UUID.init)
         launchID = record["launch_id"].flatMap(UUID.init)
         sessionID = record["session_id"].flatMap(UUID.init)
@@ -73,6 +76,7 @@ extension Crash {
             stackTrace: [],
             date: date,
             id: UUID().uuidString,
+            deviceID: nil,
             installID: nil,
             launchID: nil,
             sessionID: sessionID
@@ -80,6 +84,9 @@ extension Crash {
     }
 
     static var sampleRecords: [Record] {
+        let deviceX = UUID()
+        let deviceY = UUID()
+
         let sessionA = UUID()
         let sessionB = UUID()
         let sessionC = UUID()
@@ -88,60 +95,60 @@ extension Crash {
             sampleRecord(
                 name: "NSRangeException",
                 reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
-                fingerprint: "range",
                 minutesAgo: 6,
+                deviceID: deviceX,
                 sessionID: sessionA,
                 stackTrace: rangeStackTrace
             ),
             sampleRecord(
                 name: "NSRangeException",
                 reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
-                fingerprint: "range",
                 minutesAgo: 95,
+                deviceID: deviceX,
                 sessionID: sessionB,
                 stackTrace: rangeStackTrace
             ),
             sampleRecord(
                 name: "NSRangeException",
                 reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
-                fingerprint: "range",
                 minutesAgo: 340,
+                deviceID: deviceX,
                 sessionID: sessionA,
                 stackTrace: rangeStackTrace
             ),
             sampleRecord(
                 name: "Fatal error",
                 reason: "Index out of range",
-                fingerprint: "fatal",
                 minutesAgo: 42,
+                deviceID: deviceX,
                 sessionID: sessionB,
                 stackTrace: fatalStackTrace
             ),
             sampleRecord(
                 name: "Fatal error",
                 reason: "Index out of range",
-                fingerprint: "fatal",
                 minutesAgo: 220,
+                deviceID: deviceY,
                 sessionID: sessionC,
                 stackTrace: fatalStackTrace
             ),
             sampleRecord(
                 name: "SIGSEGV",
                 reason: "Segmentation fault: 11",
-                fingerprint: "segv",
                 minutesAgo: 1500,
+                deviceID: deviceY,
                 sessionID: sessionC,
                 stackTrace: segvStackTrace
             ),
         ]
     }
 
-    private static func sampleRecord(name: String, reason: String, fingerprint: String, minutesAgo: Double, sessionID: UUID, stackTrace: [String]) -> Record {
+    private static func sampleRecord(name: String, reason: String, minutesAgo: Double, deviceID: UUID, sessionID: UUID, stackTrace: [String]) -> Record {
         var record = Record(recordType: recordType, recordID: UUID().uuidString)
         record["name"] = name
         record["reason"] = reason
-        record["fingerprint"] = fingerprint
         record["date"] = Date(timeIntervalSinceNow: -minutesAgo * 60)
+        record["device_id"] = deviceID.uuidString
         record["session_id"] = sessionID.uuidString
         record["install_id"] = UUID().uuidString
         record["launch_id"] = UUID().uuidString

--- a/Sources/Scout/UI/Crash/CrashExport.swift
+++ b/Sources/Scout/UI/Crash/CrashExport.swift
@@ -66,6 +66,9 @@ struct CrashGroupExport {
 
     private var summary: String {
         var parts = [ExportFormat.counted(group.count, "occurrence", "occurrences")]
+        if group.affectedDevices > 0 {
+            parts.append(ExportFormat.counted(group.affectedDevices, "device", "devices"))
+        }
         if group.affectedSessions > 0 {
             parts.append(ExportFormat.counted(group.affectedSessions, "session", "sessions"))
         }
@@ -87,10 +90,16 @@ struct CrashGroupExport {
         guard let date = crash.date else {
             return nil
         }
-        let row = "- \(ExportFormat.timestamp(date))"
-        guard let sessionID = crash.sessionID else {
-            return row
+
+        var ids: [String] = []
+        if let deviceID = crash.deviceID {
+            ids.append("device \(ExportFormat.shortID(deviceID))")
         }
-        return "\(row)  (session \(ExportFormat.shortID(sessionID)))"
+        if let sessionID = crash.sessionID {
+            ids.append("session \(ExportFormat.shortID(sessionID))")
+        }
+
+        let row = "- \(ExportFormat.timestamp(date))"
+        return ids.count > 0 ? "\(row)  (\(ids.joined(separator: ", ")))" : row
     }
 }

--- a/Sources/Scout/UI/Crash/CrashGroup.swift
+++ b/Sources/Scout/UI/Crash/CrashGroup.swift
@@ -28,6 +28,10 @@ extension CrashGroup {
         crashes.count
     }
 
+    var affectedDevices: Int {
+        Set(crashes.compactMap(\.deviceID)).count
+    }
+
     var affectedSessions: Int {
         Set(crashes.compactMap(\.sessionID)).count
     }

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -41,6 +41,7 @@ struct CrashGroupDetailView: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 24) {
                 metric(title: "Occurrences", value: "\(group.count)")
+                metric(title: "Devices", value: "\(group.affectedDevices)")
                 metric(title: "Sessions", value: "\(group.affectedSessions)")
             }
 

--- a/Tests/ScoutTests/Stubs/Records/Crash+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Records/Crash+Stub.swift
@@ -15,6 +15,7 @@ extension Crash {
         fingerprint: String? = nil,
         reason: String? = nil,
         stackTrace: [String] = [],
+        deviceID: UUID? = nil,
         sessionID: UUID? = nil,
         launchID: UUID? = nil,
         installID: UUID? = nil,
@@ -27,6 +28,7 @@ extension Crash {
             stackTrace: stackTrace,
             date: date,
             id: UUID().uuidString,
+            deviceID: deviceID,
             installID: installID,
             launchID: launchID,
             sessionID: sessionID

--- a/Tests/ScoutTests/UI/Crash/CrashExportTests.swift
+++ b/Tests/ScoutTests/UI/Crash/CrashExportTests.swift
@@ -43,6 +43,7 @@ struct CrashExportTests {
 
     @Test("A group renders its summary, top frame, and occurrence rows")
     func testGroupExport() {
+        let device = UUID()
         let session = UUID()
         let crashes = [
             Crash.stub(
@@ -50,6 +51,7 @@ struct CrashExportTests {
                 fingerprint: "fp",
                 reason: "index beyond bounds",
                 stackTrace: ["2 Scout 0xabc objectAtIndex + 12"],
+                deviceID: device,
                 sessionID: session,
                 date: at(0)
             ),
@@ -58,6 +60,7 @@ struct CrashExportTests {
                 fingerprint: "fp",
                 reason: "index beyond bounds",
                 stackTrace: ["2 Scout 0xdef objectAtIndex + 99"],
+                deviceID: device,
                 sessionID: session,
                 date: at(3600)
             ),
@@ -66,14 +69,14 @@ struct CrashExportTests {
         let text = CrashGroupExport(group: group).text
 
         #expect(text.hasPrefix("# Scout Crash Issue — NSRangeException"))
-        #expect(text.contains("2 occurrences · 1 session"))
+        #expect(text.contains("2 occurrences · 1 device · 1 session"))
         #expect(text.contains("First seen") && text.contains("Last seen"))
         #expect(text.contains("Reason: index beyond bounds"))
         #expect(text.contains("Top frame: 2 Scout 0xdef objectAtIndex + 99"))
         #expect(text.contains("## Occurrences"))
         #expect(
             text.contains(
-                "- \(ExportFormat.timestamp(at(3600)))  (session \(ExportFormat.shortID(session)))"
+                "- \(ExportFormat.timestamp(at(3600)))  (device \(ExportFormat.shortID(device)), session \(ExportFormat.shortID(session)))"
             )
         )
     }

--- a/Tests/ScoutTests/UI/Crash/CrashGroupTests.swift
+++ b/Tests/ScoutTests/UI/Crash/CrashGroupTests.swift
@@ -72,4 +72,18 @@ struct CrashGroupTests {
 
         #expect(group.affectedSessions == 2)
     }
+
+    @Test("Affected devices count distinct devices") func testAffectedDevices() {
+        let device = UUID()
+        let crashes = [
+            Crash.stub(fingerprint: "fp", deviceID: device),
+            Crash.stub(fingerprint: "fp", deviceID: device),
+            Crash.stub(fingerprint: "fp", deviceID: UUID()),
+            Crash.stub(fingerprint: "fp", deviceID: nil),
+        ]
+
+        let group = CrashGroup.groups(from: crashes)[0]
+
+        #expect(group.affectedDevices == 2)
+    }
 }

--- a/Tests/ScoutTests/UI/TimelineExportTests.swift
+++ b/Tests/ScoutTests/UI/TimelineExportTests.swift
@@ -133,6 +133,7 @@ struct TimelineExportTests {
             stackTrace: [],
             date: TimelineFixture.at(10),
             id: "crash",
+            deviceID: nil,
             installID: nil,
             launchID: nil,
             sessionID: nil


### PR DESCRIPTION
Crash records now carry a `device_id`, fetched through `desiredKeys` and parsed alongside the existing install, launch, and session identifiers. `CrashGroup` gains an `affectedDevices` count derived from the distinct device ids, and the crash group header surfaces it as a `Devices` metric next to `Sessions` so you can tell how many devices a fingerprint affects rather than only how many sessions.

Building on the Markdown export added in #676, `CrashGroupExport` now includes affected devices in the group summary and a device identifier on each occurrence row. This branch sits on top of #676, so its diff is just the device-tracking additions.