### PR TITLE
Document samples and fixture naming conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@
 ## Sample data
 
 - Sample data in app code is named `sample` (a `static var` for fixed instances, a `static func sample(...)` when parameters are needed), placed in an extension at the end of the type's main file (e.g. `Device.swift`), and built directly via the struct initializer.
+- A collection of sample instances is named `samples` (plural) — e.g. `static let samples: [Release]`.
 - Tests use a different naming convention — `make<Name>(...)` factory functions.
 
 ## Core Data migrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@
 
 - Sample data in app code is named `sample` (a `static var` for fixed instances, a `static func sample(...)` when parameters are needed), placed in an extension at the end of the type's main file (e.g. `Device.swift`), and built directly via the struct initializer.
 - A collection of sample instances is named `samples` (plural) — e.g. `static let samples: [Release]`.
+- An `ObservableObject` provider or view model exposes a `static func fixture()` returning an instance preloaded with sample data for previews — e.g. `static func fixture() -> ReleaseHealthProvider`, injected via the view's initializer.
 - Tests use a different naming convention — `make<Name>(...)` factory functions.
 
 ## Core Data migrations


### PR DESCRIPTION
Extends the `CLAUDE.md` sample-data conventions with two naming rules: a collection of sample instances is named `samples` (plural), e.g. `static let samples: [Release]`; and an `ObservableObject` provider or view model exposes a `static func fixture()` returning an instance preloaded with sample data for previews, injected through the view's initializer. Both complement the existing singular `sample` rule.