### PR TITLE
Force English date labels in Release Health crash chart

### DIFF
--- a/Sources/Scout/UI/ReleaseHealth/VersionDetailView.swift
+++ b/Sources/Scout/UI/ReleaseHealth/VersionDetailView.swift
@@ -97,7 +97,7 @@ struct VersionDetailView: View {
             AxisMarks(values: .stride(by: .day, count: 3)) { _ in
                 AxisGridLine()
                 AxisTick()
-                AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                AxisValueLabel(format: Calendar.Component.day.chartFormat)
             }
         }
         .chartYAxis {


### PR DESCRIPTION
The Crashes Over Time axis in the version detail screen used `.dateTime.month(.abbreviated).day()`, which resolves through the device locale and rendered the dates in the host language (e.g. "16 июня"). I reused `Calendar.Component.day.chartFormat` — the en_GB format style the other charts already use — so the axis labels stay in source English like the rest of the UI.