### PR TITLE
Provide the active backend database to pushed screens

### DIFF
--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -17,10 +17,14 @@ public struct HomeView: View {
         self.backends = backends
     }
 
+    private var backend: Backend? {
+        backends.first(where: { $0.id == activeID }) ?? backends.first
+    }
+
     public var body: some View {
         NavigationStack {
             Group {
-                if let backend = backends.first(where: { $0.id == activeID }) ?? backends.first {
+                if let backend {
                     HomeContent()
                         .id(backend.id)
                         .accountWarning(backend)
@@ -34,7 +38,6 @@ public struct HomeView: View {
                                 )
                             }
                         }
-                        .environment(\.database, backend.database)
                 } else {
                     ErrorView(
                         description: Text(verbatim: "Pass at least one backend to inspect Scout data."),
@@ -46,6 +49,7 @@ public struct HomeView: View {
             .dismissable()
         }
         .tint(tint.value)
+        .environment(\.database, backend?.database ?? DefaultDatabase())
         .environmentObject(tint)
     }
 }


### PR DESCRIPTION
The Events, Metrics, and Crashes screens always came up empty because they were reading from the sample `DefaultDatabase` instead of the live backend. The `.environment(\.database, …)` value was applied to `HomeContent` inside the `NavigationStack`, but a `NavigationStack` renders pushed destinations at the stack level rather than as children of its content, so screens opened via `NavigationLink` never inherited the real database and fell back to the default sample value.

This moves the database injection onto the `NavigationStack` itself so every pushed screen receives the active `backend.database`. The active backend selection is lifted into a `backend` computed property so it can be referenced both inside the stack and for the environment value.