### PR TITLE
Reuse the loaded provider for the Release Health screen

### DIFF
--- a/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
@@ -25,7 +25,7 @@ struct HomeReleaseSection: View {
             .buttonStyle(.plain)
         }
         .navigationDestination(isPresented: $showReleaseHealth) {
-            ReleaseHealthView()
+            ReleaseHealthView(provider: provider)
         }
         .task {
             await provider.fetchIfNeeded(in: database)


### PR DESCRIPTION
Tapping ALL on the Home releases section pushed a ReleaseHealthView that spun up its own empty ReleaseHealthProvider and refetched from scratch, instead of reusing the provider the section had already loaded. This passes that provider through, so the detail screen shows the releases instantly without a redundant fetch or a loading spinner.

This is a complementary improvement, not the bug fix for the empty Release Health screen — the root cause is the database environment not reaching pushed screens, which #681 fixes by injecting the active backend on the NavigationStack itself. With #681 the fresh provider would fetch correctly anyway; reusing the loaded one is just better UX on top of that.