### PR TITLE
Prevent awkward code-snippet wrapping on the Quick Setup page

### DIFF
--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -16,7 +16,11 @@ struct SetupPage: View {
                 Step(
                     number: 1,
                     label: "Initialize Scout in your app",
-                    code: "try await setup(backends: [.cloudKit(container: .default())])"
+                    code: """
+                        try await setup(
+                            backends: [.cloudKit(container: .default())]
+                        )
+                        """
                 )
                 Step(
                     number: 2,
@@ -51,6 +55,10 @@ struct SetupPage: View {
                         .fontWeight(.medium)
                 }
                 Text(code.swiftSyntax)
+                    .lineLimit(code.reduce(into: 1) { count, character in
+                        if character == "\n" { count += 1 }
+                    })
+                    .minimumScaleFactor(0.6)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .codeChipStyle()
                     .padding(.leading, 32)

--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -42,6 +42,10 @@ struct SetupPage: View {
         let label: String
         let code: String
 
+        private var lineCount: Int {
+            code.filter { $0 == "\n" }.count + 1
+        }
+
         var body: some View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 10) {
@@ -55,9 +59,7 @@ struct SetupPage: View {
                         .fontWeight(.medium)
                 }
                 Text(code.swiftSyntax)
-                    .lineLimit(code.reduce(into: 1) { count, character in
-                        if character == "\n" { count += 1 }
-                    })
+                    .lineLimit(lineCount)
                     .minimumScaleFactor(0.6)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .codeChipStyle()


### PR DESCRIPTION
The setup snippet on the Quick Setup onboarding page wrapped by word in a fixed-width chip, pushing the closing paren onto its own line. This reformats the long snippet as multi-line code with sensible break points, and caps each chip's line limit to its actual line count alongside a minimum scale factor so a too-wide line shrinks to fit rather than re-wrapping on narrow screens or large Dynamic Type. The line limit is derived from the code itself, so it adjusts automatically when a snippet changes.