### PR TITLE
Fix misplaced release health navigationDestination on Home

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct HomeContent: View {
     @StateObject private var releaseProvider: ReleaseHealthProvider
+    @State private var showReleaseHealth = false
 
     init(releaseProvider: ReleaseHealthProvider = ReleaseHealthProvider()) {
         self._releaseProvider = StateObject(wrappedValue: releaseProvider)
@@ -18,7 +19,10 @@ struct HomeContent: View {
         List {
             HomeStatSection()
             HomeLogSection()
-            HomeReleaseSection(provider: releaseProvider)
+            HomeReleaseSection(provider: releaseProvider, showReleaseHealth: $showReleaseHealth)
+        }
+        .navigationDestination(isPresented: $showReleaseHealth) {
+            ReleaseHealthView()
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)

--- a/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
@@ -11,7 +11,7 @@ struct HomeReleaseSection: View {
     @Environment(\.database) var database
 
     @ObservedObject var provider: ReleaseHealthProvider
-    @State private var showReleaseHealth = false
+    @Binding var showReleaseHealth: Bool
 
     var body: some View {
         Header(title: "Releases") {
@@ -23,9 +23,6 @@ struct HomeReleaseSection: View {
                     .foregroundStyle(.blue)
             }
             .buttonStyle(.plain)
-        }
-        .navigationDestination(isPresented: $showReleaseHealth) {
-            ReleaseHealthView()
         }
         .task {
             await provider.fetchIfNeeded(in: database)
@@ -40,7 +37,7 @@ struct HomeReleaseSection: View {
 #Preview {
     NavigationStack {
         List {
-            HomeReleaseSection(provider: .fixture())
+            HomeReleaseSection(provider: .fixture(), showReleaseHealth: .constant(false))
         }
         .listStyle(.plain)
     }


### PR DESCRIPTION
The `navigationDestination` presenting `ReleaseHealthView` was attached to the Releases `Header` inside Home's `List`. Since lazy containers only realize child views when they need to render, the navigation stack couldn't reliably see the destination and SwiftUI warned it would be ignored in a future release. The fix lifts the `showReleaseHealth` state up into `HomeContent` and attaches the `navigationDestination` to the `List` itself, outside its lazy content, so the destination is always registered while keeping the existing "All" button. Behavior is unchanged and the build succeeds on the iOS simulator.