### PR TITLE
Swap Close button and connection menu in Home toolbar

### DIFF
--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -30,14 +30,6 @@ public struct HomeView: View {
                         .accountWarning(backend)
                         .schemaWarning(backend)
                         .onboardingSheet()
-                        .toolbar {
-                            ToolbarItem(placement: .topBarTrailing) {
-                                ConnectionMenu(
-                                    connections: backends.map(Connection.init),
-                                    activeID: Binding(get: { backend.id }, set: { activeID = $0 })
-                                )
-                            }
-                        }
                 } else {
                     ErrorView(
                         description: Text(verbatim: "Pass at least one backend to inspect Scout data."),
@@ -47,6 +39,16 @@ public struct HomeView: View {
             }
             .navigationTitle(en: "Home")
             .dismissable()
+            .toolbar {
+                if let backend {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        ConnectionMenu(
+                            connections: backends.map(Connection.init),
+                            activeID: Binding(get: { backend.id }, set: { activeID = $0 })
+                        )
+                    }
+                }
+            }
         }
         .tint(tint.value)
         .environment(\.database, backend?.database ?? DefaultDatabase())

--- a/Sources/Scout/UI/Home/Modifier/Dismissable.swift
+++ b/Sources/Scout/UI/Home/Modifier/Dismissable.swift
@@ -18,6 +18,12 @@ private struct DismissableModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content.toolbar {
+            #if compiler(>=6.3)
+                if #available(iOS 26.0, macOS 26.0, *) {
+                    ToolbarSpacer(.fixed, placement: .topBarTrailing)
+                }
+            #endif
+
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     dismiss()
@@ -25,12 +31,6 @@ private struct DismissableModifier: ViewModifier {
                     Text(verbatim: "Close")
                 }
             }
-
-            #if compiler(>=6.3)
-                if #available(iOS 26.0, macOS 26.0, *) {
-                    ToolbarSpacer(.fixed, placement: .topBarTrailing)
-                }
-            #endif
         }
     }
 }


### PR DESCRIPTION
Swaps the positions of the Close button and the connection menu (gear) in the Home toolbar so the gear sits on the left and Close on the right. The connection menu is now applied as the outer trailing toolbar item, and the fixed spacer moves ahead of the Close button so it keeps separating the two.