### PR TITLE
Group release health by version, not version+build

### DIFF
--- a/Sources/Scout/UI/ReleaseHealth/ReleaseHealth+Build.swift
+++ b/Sources/Scout/UI/ReleaseHealth/ReleaseHealth+Build.swift
@@ -8,62 +8,55 @@
 import Foundation
 
 extension ReleaseHealth {
-    private struct Key: Hashable {
-        let version: String
-        let build: String
-    }
-
     static func build(versions: [Version], crashes: [Crash], sessions: [Session], range: Range<Date>) -> [ReleaseHealth] {
-        var keyByLaunch: [UUID: Key] = [:]
-        var latestDate: [Key: Date] = [:]
+        var versionByLaunch: [UUID: String] = [:]
+        var latestDate: [String: Date] = [:]
 
         for version in versions {
             if let launchID = version.launchID, let appVersion = version.appVersion {
-                let key = Key(version: appVersion, build: version.buildNumber ?? "")
-                keyByLaunch[launchID] = key
+                versionByLaunch[launchID] = appVersion
 
-                if let date = version.date, date > (latestDate[key] ?? .distantPast) {
-                    latestDate[key] = date
+                if let date = version.date, date > (latestDate[appVersion] ?? .distantPast) {
+                    latestDate[appVersion] = date
                 }
             }
         }
 
-        var sessionsByKey: [Key: [Session]] = [:]
+        var sessionsByVersion: [String: [Session]] = [:]
         for session in sessions {
-            if let launchID = session.launchID, let key = keyByLaunch[launchID] {
-                sessionsByKey[key, default: []].append(session)
+            if let launchID = session.launchID, let version = versionByLaunch[launchID] {
+                sessionsByVersion[version, default: []].append(session)
             }
         }
 
-        var crashesByKey: [Key: [Crash]] = [:]
+        var crashesByVersion: [String: [Crash]] = [:]
         for crash in crashes {
-            if let launchID = crash.launchID, let key = keyByLaunch[launchID] {
-                crashesByKey[key, default: []].append(crash)
+            if let launchID = crash.launchID, let version = versionByLaunch[launchID] {
+                crashesByVersion[version, default: []].append(crash)
             }
         }
 
-        let totalSessions = sessionsByKey.values.reduce(0) { $0 + sessionCount($1) }
-        let keys = Set(sessionsByKey.keys).union(crashesByKey.keys)
+        let totalSessions = sessionsByVersion.values.reduce(0) { $0 + sessionCount($1) }
+        let releaseVersions = Set(sessionsByVersion.keys).union(crashesByVersion.keys)
 
-        return keys.sorted {
+        return releaseVersions.sorted {
             (latestDate[$0] ?? .distantPast) > (latestDate[$1] ?? .distantPast)
-        }.map { key in
-            let keySessions = sessionsByKey[key] ?? []
-            let keyCrashes = crashesByKey[key] ?? []
-            let sessions = sessionCount(keySessions)
-            let crashedSessions = Set(keyCrashes.compactMap(\.sessionID)).count
-            let installs = Set(keySessions.compactMap(\.installID)).count
-            let crashedInstalls = Set(keyCrashes.compactMap(\.installID)).count
+        }.map { version in
+            let versionSessions = sessionsByVersion[version] ?? []
+            let versionCrashes = crashesByVersion[version] ?? []
+            let sessions = sessionCount(versionSessions)
+            let crashedSessions = Set(versionCrashes.compactMap(\.sessionID)).count
+            let installs = Set(versionSessions.compactMap(\.installID)).count
+            let crashedInstalls = Set(versionCrashes.compactMap(\.installID)).count
 
             return ReleaseHealth(
-                version: key.version,
-                build: key.build,
+                version: version,
                 crashFreeSessions: crashFree(crashedSessions, of: sessions),
                 crashFreeUsers: crashFree(crashedInstalls, of: installs),
-                crashes: keyCrashes,
+                crashes: versionCrashes,
                 sessions: sessions,
                 adoption: totalSessions > 0 ? Double(sessions) / Double(totalSessions) : 0,
-                trend: trend(of: keyCrashes, in: range)
+                trend: trend(of: versionCrashes, in: range)
             )
         }
     }

--- a/Sources/Scout/UI/ReleaseHealth/ReleaseHealth.swift
+++ b/Sources/Scout/UI/ReleaseHealth/ReleaseHealth.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct ReleaseHealth: Identifiable {
     let version: String
-    let build: String
     let crashFreeSessions: Double
     let crashFreeUsers: Double
     let crashes: [Crash]
@@ -47,7 +46,6 @@ extension ReleaseHealth {
     static let samples: [ReleaseHealth] = [
         ReleaseHealth(
             version: "3.2.0",
-            build: "412",
             crashFreeSessions: 0.9982,
             crashFreeUsers: 0.9991,
             crashes: sampleCrashes(["NSRangeException": 8, "Fatal error": 4, "SIGSEGV": 2]),
@@ -57,7 +55,6 @@ extension ReleaseHealth {
         ),
         ReleaseHealth(
             version: "3.1.4",
-            build: "405",
             crashFreeSessions: 0.9967,
             crashFreeUsers: 0.9975,
             crashes: sampleCrashes(["NSRangeException": 16, "Fatal error": 9, "SIGSEGV": 6]),
@@ -67,7 +64,6 @@ extension ReleaseHealth {
         ),
         ReleaseHealth(
             version: "3.1.0",
-            build: "390",
             crashFreeSessions: 0.9921,
             crashFreeUsers: 0.9943,
             crashes: sampleCrashes(["NSRangeException": 30, "Fatal error": 18, "SIGSEGV": 10]),
@@ -77,7 +73,6 @@ extension ReleaseHealth {
         ),
         ReleaseHealth(
             version: "3.0.2",
-            build: "360",
             crashFreeSessions: 0.9890,
             crashFreeUsers: 0.9905,
             crashes: sampleCrashes(["NSRangeException": 22, "Fatal error": 12, "SIGSEGV": 8]),
@@ -87,7 +82,6 @@ extension ReleaseHealth {
         ),
         ReleaseHealth(
             version: "2.9.9",
-            build: "333",
             crashFreeSessions: 0.9710,
             crashFreeUsers: 0.9802,
             crashes: sampleCrashes(["NSRangeException": 35, "Fatal error": 22, "SIGSEGV": 16]),

--- a/Tests/ScoutTests/UI/ReleaseHealth/ReleaseHealthBuildTests.swift
+++ b/Tests/ScoutTests/UI/ReleaseHealth/ReleaseHealthBuildTests.swift
@@ -68,6 +68,27 @@ struct ReleaseHealthBuildTests {
         #expect(abs(previous.adoption - 1.0 / 3.0) < 1e-9)
     }
 
+    @Test("Different builds of the same version merge into one release") func testBuildsMergeByVersion() {
+        let launchEarly = UUID()
+        let launchLate = UUID()
+
+        let versions = [
+            Version.stub(appVersion: "4.0", buildNumber: "100", launchID: launchEarly, date: Date(timeIntervalSince1970: 100_000)),
+            Version.stub(appVersion: "4.0", buildNumber: "101", launchID: launchLate, date: Date(timeIntervalSince1970: 200_000)),
+        ]
+
+        let sessions = [
+            Session.stub(launchID: launchEarly, installID: UUID()),
+            Session.stub(launchID: launchLate, installID: UUID()),
+        ]
+
+        let releases = ReleaseHealth.build(versions: versions, crashes: [], sessions: sessions, range: range)
+
+        #expect(releases.count == 1)
+        #expect(releases[0].version == "4.0")
+        #expect(releases[0].sessions == 2)
+    }
+
     @Test("Crashes and sessions on unknown launches are ignored") func testUnknownLaunchIgnored() {
         let launch = UUID()
 


### PR DESCRIPTION
The Home RELEASES list showed the same version twice (e.g. "4.0" appearing as two identical-looking rows) because rows display only the version string while the grouping keyed on version+build, so different builds of one version became separate entries. This groups release health by version alone, aggregating sessions, crashes, crash-free rates, adoption, and trend across all builds of a version. The build field is removed since it was never displayed and only lived inside the old grouping key — dropping it also fixes the duplicate Identifiable id that the same version could produce. Added a test covering that different builds of the same version merge into one release.