### PR TITLE
Extract ReleaseHealth construction into a custom initializer

### DIFF
--- a/Sources/Scout/UI/Releases/Health/ReleaseHealth+Summaries.swift
+++ b/Sources/Scout/UI/Releases/Health/ReleaseHealth+Summaries.swift
@@ -34,26 +34,36 @@ extension ReleaseHealth {
         let releaseVersions = Set(sessionIndex.keys).union(crashIndex.keys).map { ReleaseVersion($0) }
 
         return releaseVersions.sorted().reversed().map { version in
-            let versionSessions = sessionIndex[version.version] ?? []
-            let versionCrashes = crashIndex[version.version] ?? []
-            let sessions = sessionCount(versionSessions)
-            let crashedSessions = Set(versionCrashes.compactMap(\.sessionID)).count
-            let installs = Set(versionSessions.compactMap(\.installID)).count
-            let crashedInstalls = Set(versionCrashes.compactMap(\.installID)).count
-
-            return ReleaseHealth(
+            ReleaseHealth(
                 version: version,
-                crashFreeSessions: CrashFreeRate(affected: crashedSessions, total: sessions),
-                crashFreeUsers: CrashFreeRate(affected: crashedInstalls, total: installs),
-                crashes: versionCrashes,
-                sessions: sessions,
-                adoption: Adoption(totalSessions > 0 ? Double(sessions) / Double(totalSessions) : 0),
-                trend: crashTrend(of: versionCrashes, in: range)
+                sessions: sessionIndex[version.version] ?? [],
+                crashes: crashIndex[version.version] ?? [],
+                totalSessions: totalSessions,
+                range: range
             )
         }
     }
 
     private static func sessionCount(_ sessions: [Session]) -> Int {
         Set(sessions.compactMap(\.sessionID)).count
+    }
+}
+
+extension ReleaseHealth {
+    init(version: ReleaseVersion, sessions versionSessions: [Session], crashes versionCrashes: [Crash], totalSessions: Int, range: Range<Date>) {
+        let sessions = Self.sessionCount(versionSessions)
+        let crashedSessions = Set(versionCrashes.compactMap(\.sessionID)).count
+        let installs = Set(versionSessions.compactMap(\.installID)).count
+        let crashedInstalls = Set(versionCrashes.compactMap(\.installID)).count
+
+        self.init(
+            version: version,
+            crashFreeSessions: CrashFreeRate(affected: crashedSessions, total: sessions),
+            crashFreeUsers: CrashFreeRate(affected: crashedInstalls, total: installs),
+            crashes: versionCrashes,
+            sessions: sessions,
+            adoption: Adoption(totalSessions > 0 ? Double(sessions) / Double(totalSessions) : 0),
+            trend: crashTrend(of: versionCrashes, in: range)
+        )
     }
 }


### PR DESCRIPTION
Moves the per-version derived-stats computation out of `ReleaseHealth.summaries` and into a custom `ReleaseHealth` initializer that takes the raw session and crash arrays for a version. The initializer computes the crash-free rates for sessions and users, adoption, and the crash trend internally, so `summaries` now just indexes the data and constructs one health value per version. No behavior change — the build passes.