### PR TITLE
Tint crash export toolbar buttons with primary color

### DIFF
--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -30,7 +30,9 @@ struct CrashGroupDetailView: View {
             ToolbarItemGroup(placement: .bottomBar) {
                 let text = CrashGroupExport(group: group).text
                 ShareLink(item: text)
+                    .tint(Color.primary)
                 CopyButton(text: text)
+                    .tint(Color.primary)
                 Spacer()
             }
         }


### PR DESCRIPTION
The crash group detail view tints its content red via `tint.value`, which also colored the Share and Copy toolbar buttons red. This overrides their tint to `Color.primary` so the buttons stay neutral while the rest of the screen keeps its red accent.