### PR TITLE
Keep chart date range on one line, shrinking font to fit

### DIFF
--- a/Sources/Scout/UI/Chart/Range/RangeControl.swift
+++ b/Sources/Scout/UI/Chart/Range/RangeControl.swift
@@ -20,6 +20,8 @@ struct RangeControl<T: ChartTimeScale>: View {
             Text(extent.domain.label(using: rangeDateFormatter))
                 .font(.system(size: 16))
                 .monospaced()
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
                 .frame(height: 44)
                 .frame(maxWidth: .infinity)
 


### PR DESCRIPTION
The date range header in the chart range control could wrap onto two lines when the period spanned two months (e.g. "May 29, 2026 — Jun 28, 2026"). Constrain the label to a single line and let it scale down to half size when it doesn't fit, so it stays on one line instead of wrapping.