### PR TITLE
Aggregate sessions and crashes per app version

### DIFF
--- a/Schema
+++ b/Schema
@@ -7,6 +7,7 @@ DEFINE SCHEMA
         "___modTime"    TIMESTAMP,
         "___modifiedBy" REFERENCE,
         "___recordID"   REFERENCE QUERYABLE,
+        app_version     STRING QUERYABLE SEARCHABLE SORTABLE,
         category        STRING QUERYABLE SEARCHABLE SORTABLE,
         cell_1_00       INT64 QUERYABLE SORTABLE,
         cell_1_01       INT64 QUERYABLE SORTABLE,

--- a/Sources/Scout/Core/Diagnostics/Crash/CrashInfo.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashInfo.swift
@@ -7,13 +7,6 @@
 
 import Foundation
 
-/// Snapshot of the identifiers captured at crash time.
-///
-/// Persisted to disk before the process dies and replayed on the next
-/// process start by `logCrash`. The IDs it carries (`installID`,
-/// `launchID`, `sessionID`) must be those of the **crashed** process —
-/// not the recovery process that eventually inserts the `CrashObject`.
-///
 struct CrashInfo: Codable {
     let name: String
     let reason: String?
@@ -22,6 +15,7 @@ struct CrashInfo: Codable {
     let installID: UUID
     let launchID: UUID
     let sessionID: UUID
+    let appVersion: String?
 
     init(name: String, reason: String?, stackTrace: [String], sessionID: UUID = IDs.session) {
         self.name = name
@@ -31,5 +25,6 @@ struct CrashInfo: Codable {
         self.installID = IDs.install
         self.launchID = IDs.launch
         self.sessionID = sessionID
+        self.appVersion = Bundle.main.marketingVersion
     }
 }

--- a/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
@@ -11,6 +11,7 @@ import CoreData
 final class CrashObject: TrackedObject {
     static let recordType = "Crash"
 
+    @NSManaged var appVersion: String?
     @NSManaged var name: String?
     @NSManaged var crashID: UUID
     @NSManaged var fingerprint: String?

--- a/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
@@ -13,6 +13,7 @@ func logCrash(_ crash: CrashInfo, context: NSManagedObjectContext) throws {
 
     object.crashID = UUID()
     object.date = crash.date
+    object.appVersion = crash.appVersion
     object.name = crash.name
     object.fingerprint = CrashFingerprint(name: crash.name, reason: crash.reason, stackTrace: crash.stackTrace).value
     object.reason = crash.reason

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
@@ -14,6 +14,7 @@ extension SessionObject: Monitor {
         let entity = NSEntityDescription.entity(forEntityName: "SessionObject", in: context)!
         let session = SessionObject(entity: entity, insertInto: context)
         session.date = Date()
+        session.appVersion = Bundle.main.marketingVersion
         try context.save()
     }
 

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
@@ -11,6 +11,7 @@ import CoreData
 final class SessionObject: TrackedObject {
     static let recordType = "Session"
 
+    @NSManaged var appVersion: String?
     @NSManaged var endDate: Date?
 
     func launch(in context: NSManagedObjectContext) throws -> LaunchObject? {

--- a/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/.xccurrentversion
+++ b/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Scout 4.xcdatamodel</string>
+	<string>Scout 5.xcdatamodel</string>
 </dict>
 </plist>

--- a/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/Scout 5.xcdatamodel/contents
+++ b/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/Scout 5.xcdatamodel/contents
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CrashObject" representedClassName="CrashObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="crashID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="fingerprint" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="stackTrace" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="DateObject" representedClassName="DateObject" isAbstract="YES" syncable="YES" codeGenerationType="none">
+        <attribute name="datePrimitive" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="day" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="hour" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="month" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="week" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="SyncDelivery" representedClassName="SyncDelivery" syncable="YES" codeGenerationType="none">
+        <attribute name="attempts" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="backendID" attributeType="String"/>
+        <attribute name="progressPrimitive" attributeType="Integer 16" defaultValueString="0" renamingIdentifier="remainingPrimitive" usesScalarValueType="YES"/>
+        <relationship name="object" maxCount="1" deletionRule="Nullify" destinationEntity="SyncableObject" inverseName="deliveries" inverseEntity="SyncableObject"/>
+        <fetchIndex name="byBackend">
+            <fetchIndexElement property="backendID" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="DoubleMetricsObject" representedClassName="DoubleMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="none">
+        <attribute name="value" attributeType="Double" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="EventObject" representedClassName="EventObject" parentEntity="NamedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="eventID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="level" attributeType="String"/>
+        <attribute name="paramCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="params" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="DeviceObject" representedClassName="DeviceObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none"/>
+    <entity name="IDObject" representedClassName="IDObject" isAbstract="YES" parentEntity="DateObject" syncable="YES" codeGenerationType="none">
+        <attribute name="deviceID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="installID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="InstallObject" representedClassName="InstallObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none"/>
+
+    <entity name="IntMetricsObject" representedClassName="IntMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="none">
+        <attribute name="value" attributeType="Integer 64" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="LaunchObject" representedClassName="LaunchObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="MetricsObject" representedClassName="MetricsObject" isAbstract="YES" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="telemetry" attributeType="String"/>
+    </entity>
+    <entity name="NamedObject" representedClassName="NamedObject" isAbstract="YES" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="name" attributeType="String"/>
+    </entity>
+    <entity name="SessionObject" representedClassName="SessionObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="IDObject" syncable="YES" codeGenerationType="none">
+        <relationship name="deliveries" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SyncDelivery" inverseName="object" inverseEntity="SyncDelivery"/>
+    </entity>
+    <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="sessionID" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="VersionObject" representedClassName="VersionObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="buildNumber" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="UserActivityObject" representedClassName="UserActivityObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="dayCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="monthCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="period" attributeType="String"/>
+        <attribute name="userActivityID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="weekCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+</model>

--- a/Sources/Scout/Native/Matrix/Batch/GridBatch.swift
+++ b/Sources/Scout/Native/Matrix/Batch/GridBatch.swift
@@ -23,7 +23,20 @@ extension MatrixBatch where Self: DateObject & GridBatch {
         try Matrix(
             date: batch.seed(\.week),
             name: Self.recordType,
-            cells: batch.grouped(by: \.hour).mapValues(\.count).map(GridCell.init)
+            cells: gridCells(of: batch)
         )
+    }
+
+    static func versionedMatrix(of batch: [Self], appVersion: KeyPath<Self, String?>) throws -> GridMatrix<Int> {
+        try Matrix(
+            date: batch.seed(\.week),
+            name: Self.recordType,
+            version: batch.first?[keyPath: appVersion],
+            cells: gridCells(of: batch)
+        )
+    }
+
+    static func gridCells(of batch: [Self]) throws -> [GridCell<Int>] {
+        try batch.grouped(by: \.hour).mapValues(\.count).map(GridCell.init)
     }
 }

--- a/Sources/Scout/Native/Matrix/Batch/MatrixBatch.swift
+++ b/Sources/Scout/Native/Matrix/Batch/MatrixBatch.swift
@@ -22,6 +22,18 @@ extension NamedObject: MatrixBatch {
     }
 }
 
+extension SessionObject {
+    static func matrix(of batch: [SessionObject]) throws -> GridMatrix<Int> {
+        try versionedMatrix(of: batch, appVersion: \.appVersion)
+    }
+}
+
+extension CrashObject {
+    static func matrix(of batch: [CrashObject]) throws -> GridMatrix<Int> {
+        try versionedMatrix(of: batch, appVersion: \.appVersion)
+    }
+}
+
 extension UserActivityObject: MatrixBatch {
     static func matrix(of batch: [UserActivityObject]) throws -> Matrix<PeriodCell<Int>> {
         try Matrix(

--- a/Sources/Scout/Native/Matrix/Model/Matrix+Lookup.swift
+++ b/Sources/Scout/Native/Matrix/Model/Matrix+Lookup.swift
@@ -23,6 +23,9 @@ extension Matrix {
         if let category {
             filters.append(RecordQuery.Filter(field: "category", op: .equals, value: .string(category)))
         }
+        if let version {
+            filters.append(RecordQuery.Filter(field: "app_version", op: .equals, value: .string(version)))
+        }
         return filters
     }
 }

--- a/Sources/Scout/Native/Matrix/Model/Matrix+Record.swift
+++ b/Sources/Scout/Native/Matrix/Model/Matrix+Record.swift
@@ -16,6 +16,7 @@ extension Matrix {
         self.name = name
         self.baseRecord = record
         self.category = record["category"]
+        self.version = record["app_version"]
 
         let cells = try record.fields
             .filter { $0.key.hasPrefix("cell_") }
@@ -40,6 +41,7 @@ extension Matrix: RecordEncodable {
         record["date"] = date
         record["name"] = name
         record["category"] = category
+        record["app_version"] = version
         for cell in cells {
             record[cell.key] = cell.value
         }

--- a/Sources/Scout/Native/Matrix/Model/Matrix.swift
+++ b/Sources/Scout/Native/Matrix/Model/Matrix.swift
@@ -11,6 +11,7 @@ struct Matrix<T: CellProtocol> {
     let date: Date
     let name: String
     var category: String?
+    var version: String?
     var baseRecord: Record?
     let cells: [T]
 }
@@ -25,7 +26,7 @@ extension Matrix: RecordDecodable {
     }
 
     static var desiredKeys: [String] {
-        ["date", "name", "category"]
+        ["date", "name", "category", "app_version"]
     }
 }
 
@@ -34,6 +35,7 @@ extension Matrix: Combining {
         date == other.date
             && name == other.name
             && category == other.category
+            && version == other.version
     }
 
     static func + (lhs: Self, rhs: Self) -> Self {
@@ -41,6 +43,7 @@ extension Matrix: Combining {
             date: lhs.date,
             name: lhs.name,
             category: lhs.category,
+            version: lhs.version,
             baseRecord: lhs.baseRecord ?? rhs.baseRecord,
             cells: (lhs.cells + rhs.cells).mergeDuplicates()
         )
@@ -52,6 +55,7 @@ extension Matrix: Equatable {
         lhs.date == rhs.date
             && lhs.name == rhs.name
             && lhs.category == rhs.category
+            && lhs.version == rhs.version
             && lhs.cells == rhs.cells
     }
 }

--- a/Sources/Scout/Native/Matrix/Syncable/Syncable.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/Syncable.swift
@@ -22,11 +22,11 @@ extension UserActivityObject: Syncable {
 }
 
 extension CrashObject: Syncable {
-    static var batchKeys: [Key] { [\.week] }
+    static var batchKeys: [Key] { [\.week, \.appVersion] }
 }
 
 extension SessionObject: Syncable {
-    static var batchKeys: [Key] { [\.week] }
+    static var batchKeys: [Key] { [\.week, \.appVersion] }
 }
 
 extension DeviceObject: Syncable {

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
@@ -32,6 +32,28 @@ struct CrashObjectTests {
         #expect(matrix.cells.map(\.value).reduce(0, +) == 3)
     }
 
+    @Test("matrix(of:) carries the app version, leaving category untouched")
+    func testMatrixCarriesVersion() throws {
+        let batch: [CrashObject] = [
+            makeCrashObject(name: "SIGABRT", date: date, appVersion: "3.2.0"),
+            makeCrashObject(name: "SIGSEGV", date: date, appVersion: "3.2.0"),
+        ]
+
+        let matrix = try CrashObject.matrix(of: batch)
+
+        #expect(matrix.version == "3.2.0")
+        #expect(matrix.category == nil)
+    }
+
+    @Test("matrix(of:) leaves the version nil for version-less crashes")
+    func testMatrixWithoutVersionHasNilVersion() throws {
+        let batch = [makeCrashObject(name: "SIGABRT", date: date, appVersion: nil)]
+
+        let matrix = try CrashObject.matrix(of: batch)
+
+        #expect(matrix.version == nil)
+    }
+
     @Test("record includes the crash fingerprint")
     func testRecordIncludesStoredFingerprint() {
         let object = makeCrashObject(name: "SIGABRT", date: date)
@@ -49,12 +71,13 @@ struct CrashObjectTests {
         #expect(object.record["fingerprint"] == CrashFingerprint(name: "SIGABRT", reason: "Fatal error", stackTrace: ["frame0"]).value)
     }
 
-    private func makeCrashObject(name: String, date: Date) -> CrashObject {
+    private func makeCrashObject(name: String, date: Date, appVersion: String? = nil) -> CrashObject {
         let entity = NSEntityDescription.entity(forEntityName: "CrashObject", in: context)!
         let object = CrashObject(entity: entity, insertInto: context)
         object.name = name
         object.date = date
         object.crashID = UUID()
+        object.appVersion = appVersion
         return object
     }
 }

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
@@ -39,6 +39,7 @@ struct LogCrashTests {
         #expect(object.installID == crash.installID)
         #expect(object.launchID == crash.launchID)
         #expect(object.sessionID == crash.sessionID)
+        #expect(object.appVersion == crash.appVersion)
     }
 
     @Test("Preserves sessionID captured at crash time, not the recovery session")

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
@@ -26,6 +26,14 @@ struct SessionObjectMonitorTests {
         #expect(sessions.first?.endDate != nil)
     }
 
+    @Test("trigger stamps the session with the current app version")
+    func triggerStampsAppVersion() throws {
+        try SessionObject.trigger(in: context)
+
+        let session = try #require(try context.fetchAll(SessionObject.self).first)
+        #expect(session.appVersion == Bundle.main.marketingVersion)
+    }
+
     @Test("complete is a no-op when the session is already closed")
     func completeTwiceIsNoop() throws {
         try SessionObject.trigger(in: context)

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
@@ -33,6 +33,30 @@ struct SessionObjectTests {
             ])
     }
 
+    @Test("matrix(of:) carries the app version, leaving category untouched")
+    func testMatrixCarriesVersion() throws {
+        let batch: [SessionObject] = [
+            .stub(date: week, appVersion: "3.2.0", in: context),
+            .stub(date: week, appVersion: "3.2.0", in: context),
+        ]
+
+        let matrix = try SessionObject.matrix(of: batch)
+
+        #expect(matrix.version == "3.2.0")
+        #expect(matrix.category == nil)
+    }
+
+    @Test("matrix(of:) leaves the version nil for version-less sessions")
+    func testMatrixWithoutVersionHasNilVersion() throws {
+        let batch: [SessionObject] = [
+            .stub(date: week, appVersion: nil, in: context)
+        ]
+
+        let matrix = try SessionObject.matrix(of: batch)
+
+        #expect(matrix.version == nil)
+    }
+
     @Test("launch(in:) returns launch matching launchID")
     func testLaunch() throws {
         let session = SessionObject.stub(date: week, in: context)

--- a/Tests/ScoutTests/Native/Matrix/Model/MatrixRecordTests.swift
+++ b/Tests/ScoutTests/Native/Matrix/Model/MatrixRecordTests.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("Matrix+Record")
+struct MatrixRecordTests {
+    let date = Date(year: 2025, month: 1, day: 6)
+
+    @Test("Round-trips the app version through the record")
+    func testVersionRoundTrip() throws {
+        let matrix = Matrix<GridCell<Int>>(
+            date: date,
+            name: "Session",
+            version: "3.2.0",
+            cells: [GridCell(row: 1, column: 0, value: 5)]
+        )
+
+        let decoded = try Matrix<GridCell<Int>>(record: matrix.record)
+
+        #expect(decoded.version == "3.2.0")
+        #expect(decoded.category == nil)
+    }
+
+    @Test("Keeps version and category independent")
+    func testVersionIndependentOfCategory() throws {
+        let matrix = Matrix<GridCell<Int>>(
+            date: date,
+            name: "metric",
+            category: "counter",
+            cells: [GridCell(row: 1, column: 0, value: 1)]
+        )
+
+        let decoded = try Matrix<GridCell<Int>>(record: matrix.record)
+
+        #expect(decoded.category == "counter")
+        #expect(decoded.version == nil)
+    }
+}

--- a/Tests/ScoutTests/Native/Matrix/Syncable/SyncableGroupTests.swift
+++ b/Tests/ScoutTests/Native/Matrix/Syncable/SyncableGroupTests.swift
@@ -30,6 +30,21 @@ struct SyncableGroupTests {
         #expect(Set(batch.map(\.name)).count == 1)
     }
 
+    @Test("Group splits sessions of the same week by app version")
+    func testGroupByAppVersion() throws {
+        let week = Date(timeIntervalSince1970: 1_000_000)
+
+        for version in ["3.2.0", "3.2.0", "3.1.0"] {
+            SessionObject.stub(date: week, appVersion: version, in: context)
+                .seedDelivery([.matrix], for: "b", in: context)
+        }
+        try context.save()
+
+        let batch = try #require(try SessionObject.group(in: context, for: "b"))
+
+        #expect(Set(batch.map(\.appVersion)).count == 1)
+    }
+
     @Test("Returns nil when nothing is owed to the backend")
     func testGroupReturnsNilWhenNoUnsynced() throws {
         EventObject.stub(name: "EventA", synced: true, in: context)

--- a/Tests/ScoutTests/Stubs/Objects/SessionObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/SessionObject+Stub.swift
@@ -14,6 +14,7 @@ extension SessionObject {
         date: Date,
         synced: Bool = false,
         endDate: Date? = nil,
+        appVersion: String? = nil,
         in context: NSManagedObjectContext
     ) -> SessionObject {
         let session = context.insert(SessionObject.self)
@@ -21,6 +22,7 @@ extension SessionObject {
         session.date = date
         session.setSynced(synced, in: context)
         session.endDate = endDate
+        session.appVersion = appVersion
 
         return session
     }


### PR DESCRIPTION
Sessions and crashes are now stamped with the app version at creation — captured at crash time for crashes, the same way their IDs are — and that version is carried through batching into a dedicated version dimension on the grid matrices. The category field stays reserved for metric telemetry, so existing metric and crash counters keep working unchanged.

This ships the Scout 5 model version as a lightweight additive migration and appends app_version to the DateIntMatrix CloudKit schema. It is the write side only: the matrices start accumulating per-version data now, and the read side that uses them to speed up the Home screen's Release Health follows in a separate PR.