### PR TITLE
Extract compact number formatting into an Int extension

### DIFF
--- a/Sources/Scout/UI/Releases/Health/ReleaseHealth.swift
+++ b/Sources/Scout/UI/Releases/Health/ReleaseHealth.swift
@@ -18,16 +18,6 @@ struct ReleaseHealth: Identifiable {
 }
 
 extension ReleaseHealth {
-    static func compact(_ value: Int) -> String {
-        switch value {
-        case 1_000_000...: String(format: "%.1fM", Double(value) / 1_000_000)
-        case 1_000...: String(format: "%.1fK", Double(value) / 1_000)
-        default: "\(value)"
-        }
-    }
-}
-
-extension ReleaseHealth {
     static let samples: [ReleaseHealth] = [
         ReleaseHealth(
             id: "3.2.0",

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -70,7 +70,7 @@ struct VersionDetailView: View {
 
             HStack(spacing: 24) {
                 metric(title: "Crashes", value: "\(release.crashes)")
-                metric(title: "Sessions", value: ReleaseHealth.compact(release.sessions))
+                metric(title: "Sessions", value: release.sessions.compact)
                 metric(title: "Adoption", value: release.adoption.formatted)
             }
         }

--- a/Sources/Scout/UI/Utilities/Int+Compact.swift
+++ b/Sources/Scout/UI/Utilities/Int+Compact.swift
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension Int {
+    var compact: String {
+        switch self {
+        case 1_000_000...: String(format: "%.1fM", Double(self) / 1_000_000)
+        case 1_000...: String(format: "%.1fK", Double(self) / 1_000)
+        default: "\(self)"
+        }
+    }
+}

--- a/Tests/ScoutTests/UI/Utilities/CompactTests.swift
+++ b/Tests/ScoutTests/UI/Utilities/CompactTests.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct CompactTests {
+    @Test("Values below a thousand are unchanged") func belowThousand() {
+        #expect(0.compact == "0")
+        #expect(42.compact == "42")
+        #expect(999.compact == "999")
+    }
+
+    @Test("Thousands use the K suffix") func thousands() {
+        #expect(1_000.compact == "1.0K")
+        #expect(1_500.compact == "1.5K")
+        #expect(48_210.compact == "48.2K")
+        #expect(999_999.compact == "1000.0K")
+    }
+
+    @Test("Millions use the M suffix") func millions() {
+        #expect(1_000_000.compact == "1.0M")
+        #expect(2_500_000.compact == "2.5M")
+    }
+}


### PR DESCRIPTION
Moves the K/M number-shortening logic off `ReleaseHealth` and onto a generic `Int.compact` computed property in `UI/Utilities`. The function never depended on `ReleaseHealth`, so it read oddly as `ReleaseHealth.compact(release.sessions)`; `release.sessions.compact` is clearer and the utility is now reusable for other count displays. Pure refactor with no behavior change. Adds `CompactTests` covering the sub-thousand, K, and M branches and rounding. `xcodebuild -scheme Scout` builds, the new tests pass, and swift-format lint is clean.