### PR TITLE
Map records to models with a typed readAll overload

### DIFF
--- a/Sources/Scout/Core/Database/Access/RecordReader.swift
+++ b/Sources/Scout/Core/Database/Access/RecordReader.swift
@@ -28,6 +28,10 @@ extension RecordReader {
         }
         return chunk.records
     }
+
+    func readAll<T: RecordDecodable>(matching query: RecordQuery, fields: [String]? = nil) async throws -> [T] {
+        try await readAll(matching: query, fields: fields).map(T.init)
+    }
 }
 
 struct RecordCursor: Sendable {

--- a/Sources/Scout/Native/Access/NativeActivityReader.swift
+++ b/Sources/Scout/Native/Access/NativeActivityReader.swift
@@ -16,12 +16,7 @@ extension ActivityReader {
             filters: range.dateFilters
         )
 
-        let matrices = try await readAll(
-            matching: query,
-            fields: nil
-        )
-        .map(PeriodMatrix.init)
-
+        let matrices: [PeriodMatrix] = try await readAll(matching: query)
         return ActivityPoint.points(from: matrices)
     }
 }

--- a/Sources/Scout/Native/Access/NativeMetricReader.swift
+++ b/Sources/Scout/Native/Access/NativeMetricReader.swift
@@ -22,9 +22,8 @@ extension MetricReader {
             filters: range.dateFilters + [categoryFilter]
         )
 
-        return try await readAll(matching: query, fields: nil)
-            .map(GridMatrix<T>.init)
-            .map(MetricSeries.init)
+        let matrices: [GridMatrix<T>] = try await readAll(matching: query)
+        return matrices.map(MetricSeries.init)
     }
 }
 

--- a/Sources/Scout/Native/Matrix/Model/Matrix+Lookup.swift
+++ b/Sources/Scout/Native/Matrix/Model/Matrix+Lookup.swift
@@ -10,9 +10,8 @@ import Foundation
 extension Matrix {
     func lookupExisting(in database: RecordReader) async throws -> Self? {
         let query = RecordQuery(recordType: Self.self, filters: filters)
-        return try await database.readAll(matching: query, fields: nil)
-            .randomElement()
-            .map(Matrix.init)
+        let matrices: [Self] = try await database.readAll(matching: query)
+        return matrices.randomElement()
     }
 
     private var filters: [RecordQuery.Filter] {

--- a/Sources/Scout/UI/Database/QueryProvider.swift
+++ b/Sources/Scout/UI/Database/QueryProvider.swift
@@ -21,9 +21,7 @@ class QueryProvider<T: Combining & RecordDecodable>: ObservableObject, Provider 
     }
 
     func fetch(in database: DatabaseReader) async throws -> [T] {
-        try await database
-            .readAll(matching: queryBuilder(), fields: nil)
-            .map { try T(record: $0) }
-            .mergeDuplicates()
+        let records: [T] = try await database.readAll(matching: queryBuilder())
+        return records.mergeDuplicates()
     }
 }

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -31,9 +31,6 @@ private func matrices<T: MetricScalar>(of type: T.Type, in database: DatabaseRea
         recordType: GridMatrix<T>.self,
         filters: Calendar.utc.defaultRange.dateFilters
     )
-    return
-        try await database
-        .readAll(matching: query, fields: nil)
-        .map { try GridMatrix<T>(record: $0) }
-        .mergeDuplicates()
+    let matrices: [GridMatrix<T>] = try await database.readAll(matching: query)
+    return matrices.mergeDuplicates()
 }

--- a/Sources/Scout/UI/Primitives/Modifiers/NSColor+macOS.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/NSColor+macOS.swift
@@ -17,5 +17,13 @@
                     : NSColor(red: 199 / 255, green: 199 / 255, blue: 204 / 255, alpha: 1)
             }
         }
+
+        static var systemGray5: NSColor {
+            NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                    ? NSColor(red: 44 / 255, green: 44 / 255, blue: 46 / 255, alpha: 1)
+                    : NSColor(red: 229 / 255, green: 229 / 255, blue: 234 / 255, alpha: 1)
+            }
+        }
     }
 #endif

--- a/Sources/Scout/UI/Releases/View/ReleaseHealthProvider.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseHealthProvider.swift
@@ -25,19 +25,10 @@ class ReleaseHealthProvider: ObservableObject {
         let range = Calendar.utc.defaultRange
 
         do {
-            async let sessions = database.readAll(
-                matching: query(name: SessionObject.recordType, in: range),
-                fields: nil
-            )
-            async let crashes = database.readAll(
-                matching: query(name: CrashObject.recordType, in: range),
-                fields: nil
-            )
-            releases = try await releaseReport(
-                sessions: sessions.map(GridMatrix<Int>.init),
-                crashes: crashes.map(GridMatrix<Int>.init),
-                range: range
-            )
+            async let sessions: [GridMatrix<Int>] = database.readAll(matching: query(name: SessionObject.recordType, in: range))
+            async let crashes: [GridMatrix<Int>] = database.readAll(matching: query(name: CrashObject.recordType, in: range))
+
+            releases = try await releaseReport(sessions: sessions, crashes: crashes, range: range)
         } catch {
             releases = []
         }

--- a/Sources/Scout/UI/Releases/View/VersionCrashProvider.swift
+++ b/Sources/Scout/UI/Releases/View/VersionCrashProvider.swift
@@ -28,17 +28,17 @@ class VersionCrashProvider: ObservableObject {
         let range = Calendar.utc.defaultRange
 
         do {
-            async let crashes = database.readAll(
+            async let crashes: [Crash] = database.readAll(
                 matching: RecordQuery(recordType: Crash.self, filters: range.dateFilters),
                 fields: Crash.desiredKeys
             )
-            async let versions = database.readAll(
+            async let versions: [Version] = database.readAll(
                 matching: RecordQuery(recordType: Version.self, filters: range.dateFilters),
                 fields: Version.desiredKeys
             )
 
-            let versionIndex = versionIndex(of: try await versions.map(Version.init))
-            self.crashes = try await crashes.map(Crash.init).filter { crash in
+            let versionIndex = versionIndex(of: try await versions)
+            self.crashes = try await crashes.filter { crash in
                 crash.launchID.flatMap { versionIndex[$0] } == version
             }
         } catch {

--- a/Sources/Scout/UI/Timeline/Pagination/Event+Fetch.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/Event+Fetch.swift
@@ -16,10 +16,7 @@ extension Event {
         let ids = sessionIDs.map(\.uuidString)
         let query = RecordQuery(recordType: Event.self, filters: filters(ids: ids, name: name))
 
-        return
-            try await database
-            .readAll(matching: query, fields: Event.desiredKeys)
-            .map(Event.init)
+        return try await database.readAll(matching: query, fields: Event.desiredKeys)
     }
 
     private static func filters(ids: [String], name: String?) -> [RecordQuery.Filter] {

--- a/Sources/Scout/UI/Timeline/Provider/TimelineFeed.swift
+++ b/Sources/Scout/UI/Timeline/Provider/TimelineFeed.swift
@@ -31,10 +31,7 @@ struct TimelineFeed {
             recordType: Install.self,
             filters: [RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))]
         )
-        return
-            try await database
-            .readAll(matching: query, fields: Install.desiredKeys)
-            .map(Install.init)
+        return try await database.readAll(matching: query, fields: Install.desiredKeys)
     }
 
     func launches() async throws -> [Launch] {
@@ -42,9 +39,6 @@ struct TimelineFeed {
             recordType: Launch.self,
             filters: [RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))]
         )
-        return
-            try await database
-            .readAll(matching: query, fields: Launch.desiredKeys)
-            .map(Launch.init)
+        return try await database.readAll(matching: query, fields: Launch.desiredKeys)
     }
 }


### PR DESCRIPTION
Adds a generic `readAll<T: RecordDecodable>` that reads records and maps them to the model in a single call. Call sites no longer repeat `.map(Model.init)` or `.map { try T(record:) }` — the model type is inferred from context (the binding annotation or the function's return type), and `fields` defaults to nil.

Applies it across the record-reading call sites: release health, home log, the generic query provider, version crash lookup, timeline event/install/launch fetches, native activity and metric readers, and matrix lookup.