### PR TITLE
Count distinct installs per version for crash-free users

### DIFF
--- a/Sources/Scout/Core/Activity/VersionMarker+Monitor.swift
+++ b/Sources/Scout/Core/Activity/VersionMarker+Monitor.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension VersionMarker: PartialMonitor {
+    static func trigger(in context: NSManagedObjectContext) throws {
+        try mark(name: installName, installID: IDs.install, appVersion: Bundle.main.marketingVersion, in: context)
+
+        if context.hasChanges {
+            try context.save()
+        }
+    }
+
+    static func mark(name: String, installID: UUID, appVersion: String?, in context: NSManagedObjectContext) throws {
+        guard let appVersion else { return }
+
+        let request = NSFetchRequest<VersionMarker>(entityName: "VersionMarker")
+        request.predicate = NSPredicate(
+            format: "installID == %@ AND name == %@ AND appVersion == %@",
+            installID as CVarArg,
+            name,
+            appVersion
+        )
+        request.fetchLimit = 1
+
+        guard try context.fetch(request).first == nil else {
+            return
+        }
+
+        let entity = NSEntityDescription.entity(forEntityName: "VersionMarker", in: context)!
+        let marker = VersionMarker(entity: entity, insertInto: context)
+        marker.markerID = UUID()
+        marker.name = name
+        marker.appVersion = appVersion
+        marker.date = Date()
+        marker.installID = installID
+    }
+}

--- a/Sources/Scout/Core/Activity/VersionMarker.swift
+++ b/Sources/Scout/Core/Activity/VersionMarker.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+@objc(VersionMarker)
+final class VersionMarker: SyncableObject {
+    override class var prefersRawDelivery: Bool? { false }
+
+    static let installName = "VersionInstall"
+    static let crashName = "VersionCrash"
+
+    @NSManaged var appVersion: String?
+    @NSManaged var markerID: UUID
+    @NSManaged var name: String?
+}

--- a/Sources/Scout/Core/Backend/ActionTable.swift
+++ b/Sources/Scout/Core/Backend/ActionTable.swift
@@ -33,7 +33,8 @@ extension ActionTable {
         AppLifecycle.willEnterForeground: {
             try await persistentContainer.performBackgroundTasks(
                 SessionObject.trigger,
-                UserActivityObject.trigger
+                UserActivityObject.trigger,
+                VersionMarker.trigger
             )
         },
         AppLifecycle.didEnterBackground: {

--- a/Sources/Scout/Core/Backend/Setup.swift
+++ b/Sources/Scout/Core/Backend/Setup.swift
@@ -59,7 +59,8 @@ public func setup(backends: [Backend]) async throws {
         VersionObject.trigger,
         LaunchObject.trigger,
         SessionObject.trigger,
-        UserActivityObject.trigger
+        UserActivityObject.trigger,
+        VersionMarker.trigger
     )
 
     LoggingSystem.bootstrap { CKLogHandler(sync: sync, label: $0) }

--- a/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
@@ -24,5 +24,12 @@ func logCrash(_ crash: CrashInfo, context: NSManagedObjectContext) throws {
     object.launchID = crash.launchID
     object.sessionID = crash.sessionID
 
+    try VersionMarker.mark(
+        name: VersionMarker.crashName,
+        installID: crash.installID,
+        appVersion: crash.appVersion,
+        in: context
+    )
+
     try context.save()
 }

--- a/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/.xccurrentversion
+++ b/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Scout 5.xcdatamodel</string>
+	<string>Scout 6.xcdatamodel</string>
 </dict>
 </plist>

--- a/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/Scout 6.xcdatamodel/contents
+++ b/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/Scout 6.xcdatamodel/contents
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CrashObject" representedClassName="CrashObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="crashID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="fingerprint" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="stackTrace" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="DateObject" representedClassName="DateObject" isAbstract="YES" syncable="YES" codeGenerationType="none">
+        <attribute name="datePrimitive" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="day" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="hour" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="month" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="week" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="SyncDelivery" representedClassName="SyncDelivery" syncable="YES" codeGenerationType="none">
+        <attribute name="attempts" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="backendID" attributeType="String"/>
+        <attribute name="progressPrimitive" attributeType="Integer 16" defaultValueString="0" renamingIdentifier="remainingPrimitive" usesScalarValueType="YES"/>
+        <relationship name="object" maxCount="1" deletionRule="Nullify" destinationEntity="SyncableObject" inverseName="deliveries" inverseEntity="SyncableObject"/>
+        <fetchIndex name="byBackend">
+            <fetchIndexElement property="backendID" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="DoubleMetricsObject" representedClassName="DoubleMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="none">
+        <attribute name="value" attributeType="Double" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="EventObject" representedClassName="EventObject" parentEntity="NamedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="eventID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="level" attributeType="String"/>
+        <attribute name="paramCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="params" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="DeviceObject" representedClassName="DeviceObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none"/>
+    <entity name="IDObject" representedClassName="IDObject" isAbstract="YES" parentEntity="DateObject" syncable="YES" codeGenerationType="none">
+        <attribute name="deviceID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="installID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="InstallObject" representedClassName="InstallObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none"/>
+
+    <entity name="IntMetricsObject" representedClassName="IntMetricsObject" parentEntity="MetricsObject" syncable="YES" codeGenerationType="none">
+        <attribute name="value" attributeType="Integer 64" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="LaunchObject" representedClassName="LaunchObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="MetricsObject" representedClassName="MetricsObject" isAbstract="YES" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="telemetry" attributeType="String"/>
+    </entity>
+    <entity name="NamedObject" representedClassName="NamedObject" isAbstract="YES" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="name" attributeType="String"/>
+    </entity>
+    <entity name="SessionObject" representedClassName="SessionObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="IDObject" syncable="YES" codeGenerationType="none">
+        <relationship name="deliveries" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SyncDelivery" inverseName="object" inverseEntity="SyncDelivery"/>
+    </entity>
+    <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="sessionID" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="VersionObject" representedClassName="VersionObject" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="buildNumber" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="UserActivityObject" representedClassName="UserActivityObject" parentEntity="TrackedObject" syncable="YES" codeGenerationType="none">
+        <attribute name="dayCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="monthCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="period" attributeType="String"/>
+        <attribute name="userActivityID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="weekCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="VersionMarker" representedClassName="VersionMarker" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="markerID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+    </entity>
+</model>

--- a/Sources/Scout/Core/Sync/Synchronize.swift
+++ b/Sources/Scout/Core/Sync/Synchronize.swift
@@ -41,6 +41,7 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
                 deliver(IntMetricsObject.self)
                 deliver(DoubleMetricsObject.self)
                 deliver(UserActivityObject.self)
+                deliver(VersionMarker.self)
             }
         }
         try Task.checkCancellation()

--- a/Sources/Scout/Native/Matrix/Batch/MatrixBatch.swift
+++ b/Sources/Scout/Native/Matrix/Batch/MatrixBatch.swift
@@ -34,6 +34,17 @@ extension CrashObject {
     }
 }
 
+extension VersionMarker: MatrixBatch {
+    static func matrix(of batch: [VersionMarker]) throws -> GridMatrix<Int> {
+        try Matrix(
+            date: batch.seed(\.week),
+            name: batch.seed(\.name),
+            version: batch.first?.appVersion,
+            cells: batch.grouped(by: \.hour).mapValues(\.count).map(GridCell.init)
+        )
+    }
+}
+
 extension UserActivityObject: MatrixBatch {
     static func matrix(of batch: [UserActivityObject]) throws -> Matrix<PeriodCell<Int>> {
         try Matrix(

--- a/Sources/Scout/Native/Matrix/Syncable/Syncable.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/Syncable.swift
@@ -21,6 +21,10 @@ extension UserActivityObject: Syncable {
     static var batchKeys: [Key] { [\.month] }
 }
 
+extension VersionMarker: Syncable {
+    static var batchKeys: [Key] { [\.week, \.name, \.appVersion] }
+}
+
 extension CrashObject: Syncable {
     static var batchKeys: [Key] { [\.week, \.appVersion] }
 }

--- a/Sources/Scout/UI/Releases/Health/ReleaseReport.swift
+++ b/Sources/Scout/UI/Releases/Health/ReleaseReport.swift
@@ -7,27 +7,32 @@
 
 import Foundation
 
-func releaseReport(sessions: [GridMatrix<Int>], crashes: [GridMatrix<Int>], range: Range<Date>) -> [ReleaseHealth] {
+typealias IntMatrices = [GridMatrix<Int>]
+
+func releaseReport(sessions: IntMatrices, crashes: IntMatrices, installs: IntMatrices, crashedInstalls: IntMatrices, range: Range<Date>) -> [ReleaseHealth] {
     let sessionCounts = sessions.points(in: range).mapValues(\.total)
     let crashPoints = crashes.points(in: range)
-    let totalSessions = sessionCounts.values.reduce(0, +)
+    let installCounts = installs.points(in: range).mapValues(\.total)
+    let crashedInstallCounts = crashedInstalls.points(in: range).mapValues(\.total)
 
     let versions = Set(sessionCounts.keys)
         .union(crashPoints.keys)
+        .union(installCounts.keys)
         .sorted(by: versionDescending)
 
     return versions.map { version in
         let sessions = sessionCounts[version] ?? 0
         let crashPoints = crashPoints[version] ?? []
         let crashes = crashPoints.total
+        let installs = installCounts[version] ?? 0
 
         return ReleaseHealth(
             id: version,
             freeSessions: Stability(of: crashes, in: sessions),
-            freeUsers: nil,
+            freeUsers: Stability.optional(of: crashedInstallCounts[version] ?? 0, in: installs),
             crashes: crashes,
             sessions: sessions,
-            adoption: Adoption(of: sessions, in: totalSessions),
+            adoption: Adoption(of: sessions, in: sessionCounts.values.reduce(0, +)),
             trend: crashPoints.trend(in: range)
         )
     }

--- a/Sources/Scout/UI/Releases/Health/Stability.swift
+++ b/Sources/Scout/UI/Releases/Health/Stability.swift
@@ -46,4 +46,8 @@ extension Stability {
             value = 1
         }
     }
+
+    static func optional(of affected: Int, in total: Int) -> Stability? {
+        total > 0 ? Stability(of: affected, in: total) : nil
+    }
 }

--- a/Sources/Scout/UI/Releases/View/ReleaseHealthProvider.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseHealthProvider.swift
@@ -25,10 +25,26 @@ class ReleaseHealthProvider: ObservableObject {
         let range = Calendar.utc.defaultRange
 
         do {
-            async let sessions: [GridMatrix<Int>] = database.readAll(matching: query(name: SessionObject.recordType, in: range))
-            async let crashes: [GridMatrix<Int>] = database.readAll(matching: query(name: CrashObject.recordType, in: range))
+            async let sessions: IntMatrices = database.readAll(
+                matching: query(name: SessionObject.recordType, in: range)
+            )
+            async let crashes: IntMatrices = database.readAll(
+                matching: query(name: CrashObject.recordType, in: range)
+            )
+            async let installs: IntMatrices = database.readAll(
+                matching: query(name: VersionMarker.installName, in: range)
+            )
+            async let crashedInstalls: IntMatrices = database.readAll(
+                matching: query(name: VersionMarker.crashName, in: range)
+            )
 
-            releases = try await releaseReport(sessions: sessions, crashes: crashes, range: range)
+            releases = try await releaseReport(
+                sessions: sessions,
+                crashes: crashes,
+                installs: installs,
+                crashedInstalls: crashedInstalls,
+                range: range
+            )
         } catch {
             releases = []
         }

--- a/Tests/ScoutTests/Core/Activity/VersionMarkerMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Activity/VersionMarkerMonitorTests.swift
@@ -1,0 +1,48 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("VersionMarker+Monitor")
+struct VersionMarkerMonitorTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+
+    @Test("mark records one marker per install, name and version")
+    func markIsIdempotent() throws {
+        let install = UUID()
+
+        try VersionMarker.mark(name: VersionMarker.installName, installID: install, appVersion: "2.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.installName, installID: install, appVersion: "2.0", in: context)
+
+        let markers = try context.fetchAll(VersionMarker.self)
+        #expect(markers.count == 1)
+        #expect(markers.first?.installID == install)
+        #expect(markers.first?.appVersion == "2.0")
+    }
+
+    @Test("Different versions, names or installs get their own markers")
+    func markDistinguishes() throws {
+        let install = UUID()
+
+        try VersionMarker.mark(name: VersionMarker.installName, installID: install, appVersion: "2.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.installName, installID: install, appVersion: "3.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.crashName, installID: install, appVersion: "2.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.installName, installID: UUID(), appVersion: "2.0", in: context)
+
+        #expect(try context.fetchAll(VersionMarker.self).count == 4)
+    }
+
+    @Test("mark ignores a missing version")
+    func markSkipsNilVersion() throws {
+        try VersionMarker.mark(name: VersionMarker.installName, installID: UUID(), appVersion: nil, in: context)
+        #expect(try context.fetchAll(VersionMarker.self).isEmpty)
+    }
+}

--- a/Tests/ScoutTests/Core/Activity/VersionMarkerTests.swift
+++ b/Tests/ScoutTests/Core/Activity/VersionMarkerTests.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("VersionMarker")
+struct VersionMarkerTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let date = Date(year: 2025, month: 1, day: 6)
+
+    @Test("matrix(of:) carries the marker name and version, counting markers")
+    func testMatrix() throws {
+        let batch = [
+            stub(name: VersionMarker.installName, version: "2.0"),
+            stub(name: VersionMarker.installName, version: "2.0"),
+        ]
+
+        let matrix = try VersionMarker.matrix(of: batch)
+
+        #expect(matrix.name == VersionMarker.installName)
+        #expect(matrix.version == "2.0")
+        #expect(matrix.cells.map(\.value).reduce(0, +) == 2)
+    }
+
+    private func stub(name: String, version: String) -> VersionMarker {
+        let marker = context.insert(VersionMarker.self)
+        marker.markerID = UUID()
+        marker.name = name
+        marker.appVersion = version
+        marker.date = date
+        return marker
+    }
+}

--- a/Tests/ScoutTests/UI/ReleaseHealth/ReleaseReportTests.swift
+++ b/Tests/ScoutTests/UI/ReleaseHealth/ReleaseReportTests.swift
@@ -18,6 +18,8 @@ struct ReleaseReportTests {
         let releases = releaseReport(
             sessions: [sessionMatrix("2.0", count: 2), sessionMatrix("1.0", count: 1)],
             crashes: [crashMatrix("2.0", count: 1)],
+            installs: [],
+            crashedInstalls: [],
             range: range
         )
 
@@ -37,6 +39,19 @@ struct ReleaseReportTests {
         #expect(abs(previous.adoption.value - 1.0 / 3.0) < 1e-9)
     }
 
+    @Test("Crash-free users come from distinct install markers")
+    func testFreeUsersFromInstallMarkers() {
+        let releases = releaseReport(
+            sessions: [sessionMatrix("2.0", count: 10)],
+            crashes: [],
+            installs: [installMatrix("2.0", count: 4)],
+            crashedInstalls: [crashedInstallMatrix("2.0", count: 1)],
+            range: range
+        )
+
+        #expect(releases[0].freeUsers?.value == 0.75)
+    }
+
     @Test("Crash trend is bucketed from the matrix cell dates")
     func testCrashTrendFromMatrix() {
         let start = Date(timeIntervalSince1970: 0)
@@ -54,6 +69,8 @@ struct ReleaseReportTests {
         let releases = releaseReport(
             sessions: [sessionMatrix("5.0", count: 10)],
             crashes: [crashes],
+            installs: [],
+            crashedInstalls: [],
             range: start..<start.addingTimeInterval(7 * 86_400)
         )
 
@@ -78,6 +95,8 @@ struct ReleaseReportTests {
         let releases = releaseReport(
             sessions: [matrix],
             crashes: [],
+            installs: [],
+            crashedInstalls: [],
             range: start..<start.addingTimeInterval(86_400)
         )
 
@@ -87,7 +106,7 @@ struct ReleaseReportTests {
 
     @Test("No data yields no releases")
     func testEmpty() {
-        let releases = releaseReport(sessions: [], crashes: [], range: range)
+        let releases = releaseReport(sessions: [], crashes: [], installs: [], crashedInstalls: [], range: range)
         #expect(releases.isEmpty)
     }
 
@@ -96,6 +115,8 @@ struct ReleaseReportTests {
         let releases = releaseReport(
             sessions: [sessionMatrix("3.9", count: 1), sessionMatrix("3.10", count: 1), sessionMatrix("4.0", count: 1)],
             crashes: [],
+            installs: [],
+            crashedInstalls: [],
             range: range
         )
 
@@ -108,6 +129,14 @@ struct ReleaseReportTests {
 
     private func crashMatrix(_ version: String, count: Int) -> GridMatrix<Int> {
         matrix(name: CrashObject.recordType, version: version, count: count)
+    }
+
+    private func installMatrix(_ version: String, count: Int) -> GridMatrix<Int> {
+        matrix(name: VersionMarker.installName, version: version, count: count)
+    }
+
+    private func crashedInstallMatrix(_ version: String, count: Int) -> GridMatrix<Int> {
+        matrix(name: VersionMarker.crashName, version: version, count: count)
     }
 
     private func matrix(name: String, version: String, count: Int) -> GridMatrix<Int> {


### PR DESCRIPTION
Restores crash-free users to release health by counting distinct installs per app version.

A new `VersionMarker` entity records one idempotent marker per (install, version) for "ran version X" and per (install, version) for "crashed on version X". Because each install contributes exactly one marker, the cross-device matrix sum equals the distinct install count over the whole range — the same technique `UserActivityObject` uses for DAU/WAU/MAU, and the only way to get a distinct cardinality out of additive matrices without re-fetching raw records. Release health reads the resulting VersionInstall and VersionCrash matrices and fills in `freeUsers` per version (nil when a version has no marker data yet, so the metric is hidden rather than shown as 100%).

Ships the Scout 6 model version (new entity — a lightweight, additive migration). The markers are matrix-only (`prefersRawDelivery == false`), so there is no raw-record or scout-server schema change. Trigger fires on launch and foreground alongside the other lifecycle monitors; the crash marker is set in logCrash from the version captured at crash time.

Stacked on #695 (typed readAll) — based on that branch so the diff is just the version-marker work; GitHub will retarget to main once #695 merges.