### PR TITLE
Cover per-version session matrices in the server contract

### DIFF
--- a/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
+++ b/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
@@ -111,6 +111,33 @@ struct ServerContractTests {
         #expect(point.mau >= 1)
     }
 
+    @Test("Sessions aggregate into a per-version matrix")
+    func versionedSessionMatrix() async throws {
+        let database = try makeDatabase()
+        // A unique version isolates this matrix from any shared server data.
+        let version = "contract-\(UUID().uuidString)"
+
+        var first = makeSession(installID: UUID().uuidString, startDate: eventDate)
+        first["app_version"] = version
+        var second = makeSession(installID: UUID().uuidString, startDate: eventDate)
+        second["app_version"] = version
+        try await database.write(records: [first, second])
+
+        let query = RecordQuery(
+            recordType: GridMatrix<Int>.self,
+            filters: [
+                RecordQuery.Filter(field: "name", op: .equals, value: .string("Session")),
+                RecordQuery.Filter(field: "app_version", op: .equals, value: .string(version)),
+            ]
+        )
+        let matrices: [GridMatrix<Int>] = try await database.readAll(matching: query)
+
+        #expect(matrices.count == 1)
+        let matrix = try #require(matrices.first)
+        #expect(matrix.version == version)
+        #expect(matrix.cells.map(\.value).reduce(0, +) == 2)
+    }
+
     @Test("A reachability ping succeeds against a live server")
     func reachabilityPing() async throws {
         let database = try makeDatabase()


### PR DESCRIPTION
Adds a ServerContractTests case that writes Session records carrying an app_version and asserts the live scout-server aggregates them into a per-version DateIntMatrix (one matrix, tagged with the version, summing to the session count).

This locks the wire contract for the per-version aggregation scout-server now performs (kasianov-mikhail/scout-server#40). The test is gated on SCOUT_SERVER_URL, so it only runs in the Server workflow against a booted server; it is skipped in the regular unit runs.