### PR TITLE
Show an empty state in the home Releases section

### DIFF
--- a/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
@@ -18,9 +18,11 @@ struct HomeReleaseSection: View {
             Button {
                 showReleaseHealth = true
             } label: {
-                Text(verbatim: "All".uppercased())
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundStyle(.blue)
+                if let releases = provider.releases, releases.count > 0 {
+                    Text(verbatim: "All".uppercased())
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(.blue)
+                }
             }
             .buttonStyle(.plain)
         }
@@ -29,8 +31,16 @@ struct HomeReleaseSection: View {
         }
 
         if let releases = provider.releases {
-            ForEach(releases.prefix(3)) { release in
-                ReleaseRow(release: release)
+            if releases.count > 0 {
+                ForEach(releases.prefix(3)) { release in
+                    ReleaseRow(release: release)
+                }
+            } else {
+                Text(verbatim: "No results")
+                    .placeholderTextStyle()
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 20)
+                    .listRowSeparator(.hidden)
             }
         } else {
             ForEach(0..<3, id: \.self) { _ in
@@ -44,6 +54,7 @@ struct HomeReleaseSection: View {
     NavigationStack {
         List {
             HomeReleaseSection(provider: .fixture(), showReleaseHealth: .constant(false))
+            HomeReleaseSection(provider: ReleaseHealthProvider(releases: []), showReleaseHealth: .constant(false))
         }
         .listStyle(.plain)
     }

--- a/Sources/Scout/UI/Primitives/Controls/Placeholder.swift
+++ b/Sources/Scout/UI/Primitives/Controls/Placeholder.swift
@@ -22,8 +22,7 @@ struct Placeholder: View {
             }
 
             Text(text)
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(.gray.opacity(0.7))
+                .placeholderTextStyle()
 
             if let description {
                 Text(description)

--- a/Sources/Scout/UI/Primitives/Modifiers/View+PlaceholderText.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/View+PlaceholderText.swift
@@ -7,10 +7,9 @@
 
 import SwiftUI
 
-/// "No results" placeholder shown over an empty chart's plot area.
-struct ChartPlaceholder: View {
-    var body: some View {
-        Text(verbatim: "No results")
-            .placeholderTextStyle()
+extension View {
+    func placeholderTextStyle() -> some View {
+        font(.system(size: 18, weight: .semibold))
+            .foregroundStyle(.gray.opacity(0.7))
     }
 }


### PR DESCRIPTION
When release health loads with no versions, the home Releases section rendered nothing beneath its header. It now shows a "No results" placeholder styled like the chart empty state, and the "All" button is hidden while there's nothing to navigate to.

To keep the empty states consistent, the shared placeholder text styling (semibold 18, dimmed gray) previously duplicated in `Placeholder` and `ChartPlaceholder` is extracted into a `placeholderTextStyle()` modifier, which all three now use. The home section preview also gains an empty-provider variant alongside the populated one.