### PR TITLE
Simplify duplicated UI primitives and dead state across the app

### DIFF
--- a/Sources/Scout/Core/Utilities/Date/Calendar+UTC.swift
+++ b/Sources/Scout/Core/Utilities/Date/Calendar+UTC.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 extension Calendar {
-    static var utc: Calendar {
+    static let utc: Calendar = {
         var calendar = Calendar(identifier: .iso8601)
         calendar.firstWeekday = 1
         calendar.timeZone = TimeZone(identifier: "UTC")!
         return calendar
-    }
+    }()
 }

--- a/Sources/Scout/Core/Utilities/Dispatcher/Coalescer.swift
+++ b/Sources/Scout/Core/Utilities/Dispatcher/Coalescer.swift
@@ -20,13 +20,7 @@ actor Coalescer: Dispatcher {
 
         while let next = pending {
             pending = nil
-
-            do {
-                try await next()
-            } catch {
-                pending = nil
-                throw error
-            }
+            try await next()
         }
     }
 }

--- a/Sources/Scout/Native/Matrix/Batch/GridBatch.swift
+++ b/Sources/Scout/Native/Matrix/Batch/GridBatch.swift
@@ -18,6 +18,12 @@ extension SessionObject: GridBatch {}
 extension VersionObject: GridBatch {}
 extension CrashObject: GridBatch {}
 
+extension MatrixBatch where Self: DateObject {
+    static func gridCells(of batch: [Self]) throws -> [GridCell<Int>] {
+        try batch.grouped(by: \.hour).mapValues(\.count).map(GridCell.init)
+    }
+}
+
 extension MatrixBatch where Self: DateObject & GridBatch {
     static func matrix(of batch: [Self]) throws -> GridMatrix<Int> {
         try Matrix(
@@ -34,9 +40,5 @@ extension MatrixBatch where Self: DateObject & GridBatch {
             version: batch.first?[keyPath: appVersion],
             cells: gridCells(of: batch)
         )
-    }
-
-    static func gridCells(of batch: [Self]) throws -> [GridCell<Int>] {
-        try batch.grouped(by: \.hour).mapValues(\.count).map(GridCell.init)
     }
 }

--- a/Sources/Scout/Native/Matrix/Batch/MatrixBatch.swift
+++ b/Sources/Scout/Native/Matrix/Batch/MatrixBatch.swift
@@ -17,7 +17,7 @@ extension NamedObject: MatrixBatch {
         try Matrix(
             date: batch.seed(\.week),
             name: batch.seed(\.name),
-            cells: batch.grouped(by: \.hour).mapValues(\.count).map(GridCell.init)
+            cells: gridCells(of: batch)
         )
     }
 }
@@ -40,7 +40,7 @@ extension VersionMarker: MatrixBatch {
             date: batch.seed(\.week),
             name: batch.seed(\.name),
             version: batch.first?.appVersion,
-            cells: batch.grouped(by: \.hour).mapValues(\.count).map(GridCell.init)
+            cells: gridCells(of: batch)
         )
     }
 }

--- a/Sources/Scout/UI/Chart/Model/ChartPoint.swift
+++ b/Sources/Scout/UI/Chart/Model/ChartPoint.swift
@@ -10,8 +10,7 @@ import Foundation
 
 typealias ChartNumeric = Plottable & SeriesScalar
 
-struct ChartPoint<T: ChartNumeric>: Identifiable, ChartSeries {
-    let id = UUID()
+struct ChartPoint<T: ChartNumeric>: ChartSeries {
     let date: Date
     let count: T
 }

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 struct CrashDetailView: View {
     let crash: Crash
 
-    @EnvironmentObject var tint: Tint
-
     var body: some View {
         List {
             headerSection
@@ -20,15 +18,8 @@ struct CrashDetailView: View {
                 stackTraceSection
             }
         }
-        .onAppear {
-            tint.value = .red
-        }
-        .onDisappear {
-            tint.value = nil
-        }
         .listStyle(.plain)
-        .toolbarBackground(Color.red.opacity(0.12), for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
+        .navigationTint(.red)
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
                 let text = CrashExport(crash: crash).text

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -77,7 +77,6 @@ struct CrashGroupDetailView: View {
             }
         }
     }
-
 }
 
 #Preview {

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -10,22 +10,13 @@ import SwiftUI
 struct CrashGroupDetailView: View {
     let group: CrashGroup
 
-    @EnvironmentObject var tint: Tint
-
     var body: some View {
         List {
             headerSection
             occurrencesSection
         }
-        .onAppear {
-            tint.value = .red
-        }
-        .onDisappear {
-            tint.value = nil
-        }
         .listStyle(.plain)
-        .toolbarBackground(Color.red.opacity(0.12), for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
+        .navigationTint(.red)
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
                 let text = CrashGroupExport(group: group).text
@@ -42,9 +33,9 @@ struct CrashGroupDetailView: View {
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 24) {
-                metric(title: "Occurrences", value: "\(group.count)")
-                metric(title: "Devices", value: "\(group.affectedDevices)")
-                metric(title: "Sessions", value: "\(group.affectedSessions)")
+                Metric(title: "Occurrences", value: "\(group.count)")
+                Metric(title: "Devices", value: "\(group.affectedDevices)")
+                Metric(title: "Sessions", value: "\(group.affectedSessions)")
             }
 
             if let reason = group.representative.reason {
@@ -87,16 +78,6 @@ struct CrashGroupDetailView: View {
         }
     }
 
-    private func metric(title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(value)
-                .font(.system(size: 22, weight: .bold))
-                .monospacedDigit()
-            Text(title.uppercased())
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(Color.gray)
-        }
-    }
 }
 
 #Preview {

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -51,7 +51,7 @@ struct CrashListView: View {
                 .monospaced()
 
             if group.count > 1 {
-                CrashCountBadge(count: group.count)
+                CountBadge(count: group.count, prefix: "×")
             }
 
             Spacer()
@@ -64,20 +64,6 @@ struct CrashListView: View {
         } destination: {
             CrashGroupDetailView(group: group)
         }
-    }
-}
-
-private struct CrashCountBadge: View {
-    let count: Int
-
-    var body: some View {
-        Text(verbatim: "×\(count)")
-            .font(.caption.weight(.semibold))
-            .monospacedDigit()
-            .foregroundStyle(.red)
-            .padding(.horizontal, 7)
-            .padding(.vertical, 3)
-            .background(Color.red.opacity(0.13), in: Capsule())
     }
 }
 

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -14,7 +14,6 @@ struct AnalyticsView: View {
     @StateObject private var search = EventProvider()
 
     @Environment(\.database) var database
-    @EnvironmentObject private var tint: Tint
 
     var body: some View {
         Group {
@@ -53,9 +52,7 @@ struct AnalyticsView: View {
             search.events?.removeAll()
         }
         .navigationTitle(en: "Events")
-        .onAppear {
-            tint.value = nil
-        }
+        .resetsTint()
         .message($provider.message)
     }
 

--- a/Sources/Scout/UI/Event/Detail/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.Sections.swift
@@ -18,16 +18,19 @@ extension EventView {
         @Environment(\.database) var database
 
         var body: some View {
+            let items = try? param.result?.get()
+            let canSeeAll = items != nil && count > Self.previewLimit
+
             Header(title: "Params") {
-                if let seeAll {
-                    SeeAllButton(action: seeAll)
+                if canSeeAll {
+                    SeeAllButton { isParamPresented = true }
                 }
             }
             .task {
                 await param.fetchIfNeeded(in: database)
             }
 
-            if let items = try? param.result?.get() {
+            if let items {
                 ForEach(items.prefix(Self.previewLimit)) { item in
                     ParamRow(item: item)
                 }
@@ -35,14 +38,6 @@ extension EventView {
                 ForEach(0..<min(Self.previewLimit, count), id: \.self) { _ in
                     ParamRow(item: nil)
                 }
-            }
-        }
-
-        var seeAll: (() -> Void)? {
-            if (try? param.result?.get()) != nil, count > Self.previewLimit {
-                { isParamPresented = true }
-            } else {
-                nil
             }
         }
     }

--- a/Sources/Scout/UI/Event/Detail/EventView.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct EventView: View {
     let event: Event
 
-    @EnvironmentObject var tint: Tint
     @StateObject private var param: ParamProvider
     @State private var isParamPresented = false
 
@@ -36,15 +35,8 @@ struct EventView: View {
             StatSection(eventName: event.name)
             HistorySection(event: event)
         }
-        .onAppear {
-            tint.value = color
-        }
-        .onDisappear {
-            tint.value = nil
-        }
         .listStyle(.plain)
-        .toolbarBackground(color?.opacity(0.12) ?? .clear, for: .navigationBar)
-        .toolbarBackground(color == nil ? .automatic : .visible, for: .navigationBar)
+        .navigationTint(color)
         .navigationTitle(event.name)
         .navigationDestination(isPresented: $isParamPresented) {
             if let items = try? param.result?.get() {

--- a/Sources/Scout/UI/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Event/Param/ParamList.swift
@@ -10,8 +10,6 @@ import SwiftUI
 struct ParamList: View {
     let items: [ParamProvider.Item]
 
-    @EnvironmentObject var tint: Tint
-
     /// All parameters as `key: value` lines, used for sharing and copying.
     private var text: String {
         items.map(\.description).joined(separator: "\n")
@@ -32,9 +30,7 @@ struct ParamList: View {
                 Spacer()
             }
         }
-        .onAppear {
-            tint.value = nil
-        }
+        .resetsTint()
     }
 }
 

--- a/Sources/Scout/UI/Event/Param/ParamView.swift
+++ b/Sources/Scout/UI/Event/Param/ParamView.swift
@@ -12,8 +12,6 @@ struct ParamView: View {
     private let value: ParamValue
     private let raw: String
 
-    @EnvironmentObject var tint: Tint
-
     /// Shows a fetched parameter, keeping its raw text for sharing.
     init(item: ParamProvider.Item) {
         key = item.key
@@ -56,9 +54,7 @@ struct ParamView: View {
                 Spacer()
             }
         }
-        .onAppear {
-            tint.value = nil
-        }
+        .resetsTint()
     }
 }
 

--- a/Sources/Scout/UI/Primitives/Controls/CountBadge.swift
+++ b/Sources/Scout/UI/Primitives/Controls/CountBadge.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct CountBadge: View {
+    let count: Int
+    var prefix: String = ""
+    var color: Color = .red
+
+    var body: some View {
+        Text(verbatim: "\(prefix)\(count)")
+            .font(.caption.weight(.semibold))
+            .monospacedDigit()
+            .foregroundStyle(color)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.13), in: Capsule())
+    }
+}

--- a/Sources/Scout/UI/Primitives/Controls/Metric.swift
+++ b/Sources/Scout/UI/Primitives/Controls/Metric.swift
@@ -1,0 +1,26 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct Metric: View {
+    let title: String
+    let value: String
+    var color: Color = .primary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(verbatim: value)
+                .font(.system(size: 22, weight: .bold))
+                .monospacedDigit()
+                .foregroundStyle(color)
+            Text(verbatim: title.uppercased())
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.gray)
+        }
+    }
+}

--- a/Sources/Scout/UI/Primitives/Modifiers/View+NavigationTint.swift
+++ b/Sources/Scout/UI/Primitives/Modifiers/View+NavigationTint.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+private struct NavigationTint: ViewModifier {
+    let color: Color?
+
+    @EnvironmentObject private var tint: Tint
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { tint.value = color }
+            .onDisappear { tint.value = nil }
+            .toolbarBackground(color?.opacity(0.12) ?? .clear, for: .navigationBar)
+            .toolbarBackground(color == nil ? .automatic : .visible, for: .navigationBar)
+    }
+}
+
+private struct TintReset: ViewModifier {
+    @EnvironmentObject private var tint: Tint
+
+    func body(content: Content) -> some View {
+        content.onAppear { tint.value = nil }
+    }
+}
+
+extension View {
+    func navigationTint(_ color: Color?) -> some View {
+        modifier(NavigationTint(color: color))
+    }
+
+    func resetsTint() -> some View {
+        modifier(TintReset())
+    }
+}

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -8,21 +8,6 @@
 import Charts
 import SwiftUI
 
-private struct CountBadge: View {
-    let count: Int
-    var color: Color = .red
-
-    var body: some View {
-        Text(verbatim: "\(count)")
-            .font(.caption.weight(.semibold))
-            .monospacedDigit()
-            .foregroundStyle(color)
-            .padding(.horizontal, 7)
-            .padding(.vertical, 3)
-            .background(color.opacity(0.13), in: Capsule())
-    }
-}
-
 struct VersionDetailView: View {
     @Environment(\.database) var database
 
@@ -60,18 +45,24 @@ struct VersionDetailView: View {
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 24) {
-                metric(
-                    title: "Crash-free sessions", value: release.freeSessions.formatted,
-                    color: release.freeSessions.color)
+                Metric(
+                    title: "Crash-free sessions",
+                    value: release.freeSessions.formatted,
+                    color: release.freeSessions.color
+                )
                 if let freeUsers = release.freeUsers {
-                    metric(title: "Crash-free users", value: freeUsers.formatted, color: freeUsers.color)
+                    Metric(
+                        title: "Crash-free users",
+                        value: freeUsers.formatted,
+                        color: freeUsers.color
+                    )
                 }
             }
 
             HStack(spacing: 24) {
-                metric(title: "Crashes", value: "\(release.crashes)")
-                metric(title: "Sessions", value: release.sessions.compact)
-                metric(title: "Adoption", value: release.adoption.formatted)
+                Metric(title: "Crashes", value: "\(release.crashes)")
+                Metric(title: "Sessions", value: release.sessions.compact)
+                Metric(title: "Adoption", value: release.adoption.formatted)
             }
         }
         .padding(.vertical, 4)
@@ -146,17 +137,6 @@ struct VersionDetailView: View {
         }
     }
 
-    private func metric(title: String, value: String, color: Color = .primary) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(verbatim: value)
-                .font(.system(size: 22, weight: .bold))
-                .monospacedDigit()
-                .foregroundStyle(color)
-            Text(verbatim: title.uppercased())
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(Color.gray)
-        }
-    }
 }
 
 #Preview {

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -136,7 +136,6 @@ struct VersionDetailView: View {
             }
         }
     }
-
 }
 
 #Preview {

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -14,7 +14,6 @@ struct StatView: View {
     @State var extent: ChartExtent<Period>
     @State private var isComparing = false
     @ObservedObject var stat: StatProvider
-    @EnvironmentObject var tint: Tint
     @Environment(\.chartColor) var color
 
     var body: some View {
@@ -42,9 +41,7 @@ struct StatView: View {
                 .scrollDisabled(true)
             }
         }
-        .onAppear {
-            tint.value = nil
-        }
+        .resetsTint()
     }
 
     func total(count: Int) -> some View {


### PR DESCRIPTION
A project-wide cleanup pass for reuse, simplification, and efficiency — no behavior changes. The repeated tint-reset-plus-toolbar idiom that was copy-pasted across seven detail and list views now lives in `navigationTint`/`resetsTint` modifiers, and the duplicated stat-cell and count-capsule views collapse into shared `Metric` and `CountBadge` primitives. Along the way I dropped `ChartPoint`'s unused `id`/`Identifiable` (charts key by date, so the per-point UUID was pure waste), made `Calendar.utc` a stored `static let` instead of rebuilding it on every access, relaxed the `gridCells` constraint to `DateObject` so `NamedObject` and `VersionMarker` stop re-inlining the same bucketing, decoded the param result once per render in `EventView.ParamSection`, and removed a dead `pending` reset in `Coalescer`. Net −94 lines; the app and all 412 tests build and pass.

Larger findings were left for their own focused PRs: conforming the release/crash/timeline providers to the shared `Provider` protocol (it changes error handling), the Core Data insert/recovery dedup helpers (entity-name reflection needs care), and moving `Version.swift` next to its only consumer in `Releases/`.