### PR TITLE
Add version detail empty graph preview

### DIFF
--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -110,6 +110,11 @@ struct VersionDetailView: View {
         .chartYAxis {
             AxisMarks(position: .leading)
         }
+        .chartBackground { _ in
+            if !dailyCrashes.contains(where: { $0.count > 0 }) {
+                ChartPlaceholder().offset(y: -12)
+            }
+        }
         .frame(height: 170)
         .padding(.vertical, 8)
         .listRowSeparator(.hidden)
@@ -141,6 +146,18 @@ struct VersionDetailView: View {
 #Preview {
     NavigationStack {
         VersionDetailView(release: ReleaseHealth.samples[0], crashProvider: .fixture())
+    }
+    .environmentObject(Tint())
+}
+
+#Preview("Empty graph") {
+    let release = ReleaseHealth.samples[0]
+
+    return NavigationStack {
+        VersionDetailView(
+            release: release,
+            crashProvider: VersionCrashProvider(version: release.id, crashes: [])
+        )
     }
     .environmentObject(Tint())
 }


### PR DESCRIPTION
Adds an empty-state preview for `VersionDetailView` by reusing the existing release sample and providing an empty crash provider.

The crashes-over-time chart now shows the shared `ChartPlaceholder` when all daily crash buckets are empty, with the placeholder shifted slightly upward to better sit in the chart area.

Validation: `swift test` was run, but the package still fails on the existing `PersistentContainer.swift` issue where `Bundle.module` is unavailable while compiling the SwiftPM target. `VersionDetailView.swift` compiles before that failure.