### PR TITLE
Add PR title instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Git & pull requests
+
+- Do not prefix pull request titles with `[codex]`, `Codex:`, or any other agent label.
+- Write PR descriptions without a `Summary` heading and without a `Testing` section.


### PR DESCRIPTION
Adds a root AGENTS.md with repository-level guidance for pull request titles and descriptions.

This makes the expected PR title format explicit by disallowing agent prefixes such as `[codex]`, while preserving the existing description formatting preference.