### PR TITLE
Add a stability-based Metric initializer

### DIFF
--- a/Sources/Scout/UI/Primitives/Controls/Metric.swift
+++ b/Sources/Scout/UI/Primitives/Controls/Metric.swift
@@ -24,3 +24,9 @@ struct Metric: View {
         }
     }
 }
+
+extension Metric {
+    init(title: String, stability: Stability) {
+        self.init(title: title, value: stability.formatted, color: stability.color)
+    }
+}

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -45,17 +45,9 @@ struct VersionDetailView: View {
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 24) {
-                Metric(
-                    title: "Crash-free sessions",
-                    value: release.freeSessions.formatted,
-                    color: release.freeSessions.color
-                )
+                Metric(title: "Crash-free sessions", stability: release.freeSessions)
                 if let freeUsers = release.freeUsers {
-                    Metric(
-                        title: "Crash-free users",
-                        value: freeUsers.formatted,
-                        color: freeUsers.color
-                    )
+                    Metric(title: "Crash-free users", stability: freeUsers)
                 }
             }
 


### PR DESCRIPTION
Metric already renders a formatted value with a color, and Stability exposes exactly those two things, so every stability metric was unpacking `formatted` and `color` by hand. This adds a `Metric(title:stability:)` convenience initializer that does the unpacking, and simplifies the crash-free sessions/users metrics in VersionDetailView to pass their Stability directly. The initializer lives in an extension so the synthesized memberwise `init(title:value:color:)` stays available for the plain value metrics (Crashes, Sessions, Adoption, etc.).