### PR TITLE
Drive the release ring by adoption, colored by crash rate

### DIFF
--- a/Sources/Scout/UI/Releases/Health/Stability.swift
+++ b/Sources/Scout/UI/Releases/Health/Stability.swift
@@ -26,10 +26,6 @@ struct Stability: Equatable {
     var formatted: String {
         String(format: "%.2f%%", value * 100)
     }
-
-    var ringTrim: Double {
-        max(0, min(1, (value - 0.95) / 0.05))
-    }
 }
 
 extension Stability: ExpressibleByFloatLiteral {

--- a/Sources/Scout/UI/Releases/View/ReleaseRow.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseRow.swift
@@ -12,7 +12,7 @@ struct ReleaseRow: View {
 
     var body: some View {
         Row {
-            CompactRing(adoption: release.adoption, color: release.freeSessions.color)
+            CompactRing(release: release)
 
             Text(verbatim: release.id)
                 .font(.system(size: 17))
@@ -35,6 +35,15 @@ struct ReleaseRow: View {
 private struct CompactRing: View {
     let adoption: Adoption
     let color: Color
+
+    init(adoption: Adoption, color: Color) {
+        self.adoption = adoption
+        self.color = color
+    }
+
+    init(release: ReleaseHealth) {
+        self.init(adoption: release.adoption, color: release.freeSessions.color)
+    }
 
     var body: some View {
         ZStack {

--- a/Sources/Scout/UI/Releases/View/ReleaseRow.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseRow.swift
@@ -12,7 +12,7 @@ struct ReleaseRow: View {
 
     var body: some View {
         Row {
-            CompactRing(rate: release.freeSessions)
+            CompactRing(adoption: release.adoption, color: release.freeSessions.color)
 
             Text(verbatim: release.id)
                 .font(.system(size: 17))
@@ -33,15 +33,16 @@ struct ReleaseRow: View {
 }
 
 private struct CompactRing: View {
-    let rate: Stability
+    let adoption: Adoption
+    let color: Color
 
     var body: some View {
         ZStack {
             Circle()
                 .stroke(Color(.systemGray5), lineWidth: 2)
             Circle()
-                .trim(from: 0, to: rate.ringTrim)
-                .stroke(.blue, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .trim(from: 0, to: adoption.value)
+                .stroke(color, style: StrokeStyle(lineWidth: 2, lineCap: .round))
                 .rotationEffect(.degrees(-90))
         }
         .frame(width: 16, height: 16)
@@ -52,7 +53,7 @@ private struct CompactRing: View {
 struct ReleaseRowPlaceholder: View {
     var body: some View {
         HStack {
-            CompactRing(rate: 0.95)
+            CompactRing(adoption: 1.0, color: .gray)
 
             Text(verbatim: "3.2.1")
                 .font(.system(size: 17))

--- a/Sources/Scout/UI/Releases/View/ReleaseRow.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseRow.swift
@@ -36,15 +36,6 @@ private struct CompactRing: View {
     let adoption: Adoption
     let color: Color
 
-    init(adoption: Adoption, color: Color) {
-        self.adoption = adoption
-        self.color = color
-    }
-
-    init(release: ReleaseHealth) {
-        self.init(adoption: release.adoption, color: release.freeSessions.color)
-    }
-
     var body: some View {
         ZStack {
             Circle()
@@ -56,6 +47,12 @@ private struct CompactRing: View {
         }
         .frame(width: 16, height: 16)
         .padding(.horizontal, 4)
+    }
+}
+
+extension CompactRing {
+    init(release: ReleaseHealth) {
+        self.init(adoption: release.adoption, color: release.freeSessions.color)
     }
 }
 


### PR DESCRIPTION
The compact ring in the Home screen's RELEASES rows was bound to crash-free sessions and remapped through a 95–100% window, so a 96.55% release only filled about a third of the circle while the number right next to it read 96.55% — the ring looked wrong. It also duplicated the metric already shown as text.

Now the ring's fill maps linearly to the release's adoption and its stroke is colored by the crash-free rate, so length answers "how widely adopted" and color answers "how stable", while the crash-free percentage stays as the adjacent text. Removed the now-unused Stability.ringTrim.