### PR TITLE
Document the no-backfill delivery-planning predicate

### DIFF
--- a/Sources/Scout/Core/Sync/SyncableObject+Plan.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Plan.swift
@@ -10,6 +10,8 @@ import CoreData
 extension SyncableObject {
     static func plan(backends: [Backend], in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
+        // deliveries.@count == 0: a newly added backend only receives objects
+        // created after it was added; existing history is intentionally not backfilled.
         request.predicate = NSPredicate(format: "deliveries.@count == 0")
 
         for object in try context.fetch(request) {


### PR DESCRIPTION
SyncableObject.plan filters objects on deliveries.@count == 0, so once an object has any delivery row it's never re-planned. A backend added to an already-running install therefore never receives deliveries for objects that predate it — it only picks up events created after it was added. That's the intended behaviour (we don't want to backfill history into a newly added backend), but the bare predicate reads like an oversight and got flagged as a possible bug. This adds a short comment recording the intent so it isn't re-litigated on review. No behaviour change.