### PR TITLE
Capture crash session ID without deadlocking the signal handler

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/CrashInfo.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashInfo.swift
@@ -17,7 +17,7 @@ struct CrashInfo: Codable {
     let sessionID: UUID
     let appVersion: String?
 
-    init(name: String, reason: String?, stackTrace: [String], sessionID: UUID = IDs.session) {
+    init(name: String, reason: String?, stackTrace: [String], sessionID: UUID = IDs.rawSession) {
         self.name = name
         self.reason = reason
         self.stackTrace = stackTrace

--- a/Sources/Scout/Core/Lifecycle/Base/IDs.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/IDs.swift
@@ -10,7 +10,11 @@ import Foundation
 enum IDs {
     private static let sessionQueue = DispatchQueue(label: "scout.ids.session")
 
-    nonisolated(unsafe) private static var sessionStorage = UUID()
+    // Read directly by crash/signal handlers to capture the session ID without
+    // `sessionQueue.sync`, which is async-signal-unsafe and can deadlock — a
+    // fatal signal on a thread already inside the queue re-enters `sync` on
+    // itself. Writes stay private so rotation still runs through `session`.
+    nonisolated(unsafe) private(set) static var rawSession = UUID()
 
     /// Rotates on every `SessionObject.trigger`. `TrackedObject.awakeFromInsert`
     /// reads it from arbitrary Core Data background contexts, so access is
@@ -18,8 +22,8 @@ enum IDs {
     /// races with concurrent inserts.
     ///
     static var session: UUID {
-        get { sessionQueue.sync { sessionStorage } }
-        set { sessionQueue.sync { sessionStorage = newValue } }
+        get { sessionQueue.sync { rawSession } }
+        set { sessionQueue.sync { rawSession = newValue } }
     }
 
     static let launch = UUID()


### PR DESCRIPTION
CrashInfo defaulted its sessionID to IDs.session, whose getter routes through sessionQueue.sync. Both the signal handler and the uncaught-exception handler build a CrashInfo inside async-signal-unsafe contexts, so when a fatal signal is delivered on a thread that is already inside sessionQueue (rotating the ID on a session trigger, or reading it during a Core Data insert in awakeFromInsert), the handler re-enters sync on the same serial queue and deadlocks — it hangs and the crash report is never written.

The fix reads the backing UUID directly instead of through the queue. sessionStorage is renamed to a private(set) rawSession that crash handlers capture without any synchronization, while normal rotation still goes through the serialised session setter so writes stay ordered. A torn read of the UUID under a racing rotation is harmless next to losing the whole report to a hang. The test target builds and the crash diagnostics tests pass.