### PR TITLE
Count one delivery attempt per sync cycle across channels

### DIFF
--- a/Sources/Scout/Core/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Core/Database/Access/RecordSender.swift
@@ -27,13 +27,10 @@ extension RecordSender {
 
         for object in try syncable.pending(in: context, for: id) {
             if let delivery = object.delivery(for: id), delivery.progress.contains(.raw) {
-                delivery.attempts += 1
                 objects.append(object)
                 deliveries.append(delivery)
             }
         }
-
-        try context.save()
 
         if objects.count > 0 {
             try await database.write(records: objects.map(\.record))

--- a/Sources/Scout/Core/Sync/SyncDelivery+RecordAttempt.swift
+++ b/Sources/Scout/Core/Sync/SyncDelivery+RecordAttempt.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension SyncDelivery {
+    // A single shared increment per cycle, so a record and its matrix don't each spend
+    // the budget and abandon the backend at half the allotted attempts.
+    static func recordAttempt(for backendID: String, in context: NSManagedObjectContext) {
+        let request = NSFetchRequest<SyncDelivery>(entityName: "SyncDelivery")
+        request.predicate = NSPredicate(
+            format: "backendID == %@ AND progressPrimitive != 0 AND attempts < %d",
+            backendID,
+            SyncDelivery.maxAttempts
+        )
+
+        do {
+            for delivery in try context.fetch(request) {
+                delivery.attempts += 1
+            }
+            try context.save()
+        } catch {
+            print("Failed to record delivery attempt: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/Scout/Core/Sync/Synchronize.swift
+++ b/Sources/Scout/Core/Sync/Synchronize.swift
@@ -19,6 +19,8 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
     try await dispatcher.performEnsuringBackground {
         await withTaskGroup(of: Void.self) { group in
             for backend in backends where await backend.checkAvailability() {
+                SyncDelivery.recordAttempt(for: backend.id, in: context)
+
                 let recordSender = RecordSender(backend: backend)
                 let matrixSender = MatrixSender(backend: backend)
 

--- a/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/MatrixSender.swift
@@ -33,13 +33,10 @@ extension MatrixSender {
 
             for object in batch {
                 if let delivery = object.delivery(for: id), delivery.progress.contains(.matrix) {
-                    delivery.attempts += 1
                     objects.append(object)
                     deliveries.append(delivery)
                 }
             }
-
-            try context.save()
 
             let matrix = try T.matrix(of: objects)
             try await aggregator.aggregate(matrix: matrix)

--- a/Tests/ScoutTests/Core/Backend/DeliverTests.swift
+++ b/Tests/ScoutTests/Core/Backend/DeliverTests.swift
@@ -56,6 +56,7 @@ struct DeliverTests {
 
     /// Run both engines for a type the way `synchronize` does: raw records first, then matrices.
     func deliver<T: Syncable & MatrixBatch & RecordEncodable>(_ type: T.Type, to backend: Backend) async throws {
+        SyncDelivery.recordAttempt(for: backend.id, in: context)
         try await RecordSender(backend: backend).deliver(type: type, in: context)
         try await MatrixSender(backend: backend)?.deliver(type: type, in: context)
     }
@@ -142,6 +143,22 @@ struct DeliverTests {
         #expect(event.delivery(for: "server")?.attempts == 0)
         #expect(cloud.records.count(of: "Event") == 1)
         #expect(server.records.count(of: "Event") == 0)
+    }
+
+    @Test("A dual-channel delivery counts one attempt per cycle, not one per channel")
+    func dualChannelCountsOneAttemptPerCycle() async throws {
+        let event = EventObject.stub(name: "login", in: context)
+        try context.save()
+        try SyncableObject.plan(backends: [cloudBackend], in: context)
+
+        // The native backend owes both a raw record and a matrix for this event.
+        #expect(event.delivery(for: "cloud")?.progress == [.raw, .matrix])
+
+        try await deliver(EventObject.self, to: cloudBackend)
+
+        // Both channels ran this cycle, yet the shared budget advanced only once.
+        #expect(event.delivery(for: "cloud")?.isDelivered == true)
+        #expect(event.delivery(for: "cloud")?.attempts == 1)
     }
 
     @Test("A matrix is contributed per native backend, never twice")


### PR DESCRIPTION
A SyncDelivery tracks two independent channels (`.raw` and `.matrix`) in its progress OptionSet but shared a single `attempts` counter, and both RecordSender and MatrixSender bumped it each cycle. For dual-channel deliveries (raw-preferring types on a CloudKit backend) the counter grew by ~2 per cycle, so the delivery hit `maxAttempts` and was abandoned after about five cycles — roughly half the intended retries per channel.

The fix moves the increment out of both senders into `SyncDelivery.recordAttempt`, called once per available backend at the start of each cycle. The shared counter now measures cycles: every outstanding channel is attempted each cycle, so each gets its full `maxAttempts`. Recording the attempt before the senders run also preserves crash safety — the attempt is persisted before any network write, which the per-sender save used to provide. Single-channel deliveries (metrics to CloudKit, everything to a server) are unchanged since only one sender ever touched them. No Core Data schema or predicate changes.

A regression test asserts a dual-channel delivery counts one attempt per cycle rather than two; the full test target (413 tests) passes.