### PR TITLE
Group syncable batches by nil batch-key values

### DIFF
--- a/Sources/Scout/Native/Matrix/Syncable/Syncable+Group.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/Syncable+Group.swift
@@ -29,8 +29,13 @@ extension Syncable {
         var predicates = [actionable]
 
         for keyPath in batchKeys {
-            if let key = keyPath._kvcKeyPathString, let value = seed.value(forKey: key) as? NSObject {
+            guard let key = keyPath._kvcKeyPathString else {
+                continue
+            }
+            if let value = seed.value(forKey: key) as? NSObject {
                 predicates.append(NSPredicate(format: "%K == %@", key, value))
+            } else {
+                predicates.append(NSPredicate(format: "%K == nil", key))
             }
         }
 

--- a/Tests/ScoutTests/Native/Matrix/Syncable/SyncableGroupTests.swift
+++ b/Tests/ScoutTests/Native/Matrix/Syncable/SyncableGroupTests.swift
@@ -45,6 +45,21 @@ struct SyncableGroupTests {
         #expect(Set(batch.map(\.appVersion)).count == 1)
     }
 
+    @Test("Group isolates sessions with no app version from versioned ones")
+    func testGroupByNilAppVersion() throws {
+        let week = Date(timeIntervalSince1970: 1_000_000)
+
+        for version in [nil, nil, "3.2.0"] as [String?] {
+            SessionObject.stub(date: week, appVersion: version, in: context)
+                .seedDelivery([.matrix], for: "b", in: context)
+        }
+        try context.save()
+
+        let batch = try #require(try SessionObject.group(in: context, for: "b"))
+
+        #expect(Set(batch.map(\.appVersion)).count == 1)
+    }
+
     @Test("Returns nil when nothing is owed to the backend")
     func testGroupReturnsNilWhenNoUnsynced() throws {
         EventObject.stub(name: "EventA", synced: true, in: context)


### PR DESCRIPTION
When a syncable seed record had a nil batch-key value — most notably a `SessionObject` or `CrashObject` with no `appVersion` — `Syncable.group` skipped the equality predicate for that key, so the batch swept in records of every version that shared the same week. That mixed batch was then handed to `versionedMatrix`, whose version comes from `batch.first`, collapsing all versions into a single matrix attributed to an arbitrary/nil version and distorting per-version session and crash metrics. The fix emits an explicit `key == nil` predicate (Core Data `IS NULL`) when the seed value is nil, so nil-valued records only group with other nil-valued records.

Added a regression test that mixes two version-less sessions with a versioned one in the same week; it fails on the old code with the reported symptom (two versions in one batch) and passes with the fix. Whole `Syncable+Group` suite is green on the iPhone 17 Pro simulator.