### PR TITLE
Scope sync batch fetches to the owed delivery channel

### DIFF
--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -37,6 +37,8 @@ final class SyncDelivery: NSManagedObject {
 
         static let raw = Progress(rawValue: 1 << 0)
         static let matrix = Progress(rawValue: 1 << 1)
+
+        static let all: Progress = [.raw, .matrix]
     }
 }
 

--- a/Sources/Scout/Native/Matrix/Syncable/Syncable+Group.swift
+++ b/Sources/Scout/Native/Matrix/Syncable/Syncable+Group.swift
@@ -10,28 +10,25 @@ import CoreData
 extension Syncable {
     static func pending(in context: NSManagedObjectContext, for backendID: String) throws -> [Self] {
         let request = NSFetchRequest<Self>(entityName: String(describing: Self.self))
-        request.predicate = .actionable(for: backendID)
+        request.predicate = NSPredicate(.raw, to: backendID)
         return try context.fetch(request)
     }
 
     static func group(in context: NSManagedObjectContext, for backendID: String) throws -> [Self]? {
         let entityName = String(describing: Self.self)
-        let actionable = NSPredicate.actionable(for: backendID)
+        let seedPredicate = NSPredicate(.matrix, to: backendID)
 
         let seedRequest = NSFetchRequest<Self>(entityName: entityName)
-        seedRequest.predicate = actionable
+        seedRequest.predicate = seedPredicate
         seedRequest.fetchLimit = 1
 
         guard let seed = try context.fetch(seedRequest).first else {
             return nil
         }
 
-        var predicates = [actionable]
+        var predicates = [seedPredicate]
 
-        for keyPath in batchKeys {
-            guard let key = keyPath._kvcKeyPathString else {
-                continue
-            }
+        for key in batchKeys.compactMap(\._kvcKeyPathString) {
             if let value = seed.value(forKey: key) as? NSObject {
                 predicates.append(NSPredicate(format: "%K == %@", key, value))
             } else {
@@ -47,11 +44,20 @@ extension Syncable {
 }
 
 extension NSPredicate {
-    fileprivate static func actionable(for backendID: String) -> NSPredicate {
-        NSPredicate(
-            format: "SUBQUERY(deliveries, $d, $d.backendID == %@ AND $d.progressPrimitive != 0 AND $d.attempts < %d).@count > 0",
+    fileprivate convenience init(_ progress: SyncDelivery.Progress, to backendID: String) {
+        self.init(
+            format: "SUBQUERY(deliveries, $d, $d.backendID == %@ AND $d.progressPrimitive IN %@ AND $d.attempts < %d).@count > 0",
             backendID,
+            progress.owingStates,
             SyncDelivery.maxAttempts
         )
+    }
+}
+
+extension SyncDelivery.Progress {
+    fileprivate var owingStates: [Int16] {
+        (0...Self.all.rawValue)
+            .filter { Self(rawValue: $0).contains(self) }
+            .map { Int16($0) }
     }
 }

--- a/Tests/ScoutTests/Core/Backend/DeliverTests.swift
+++ b/Tests/ScoutTests/Core/Backend/DeliverTests.swift
@@ -161,6 +161,34 @@ struct DeliverTests {
         #expect(event.delivery(for: "cloud")?.attempts == 1)
     }
 
+    @Test("A matrix delivery over a raw-only row is a no-op, not a failure")
+    func matrixOverRawOnlyRow() async throws {
+        let event = EventObject.stub(name: "login", in: context)
+        event.seedDelivery([.raw], for: "cloud", in: context)
+        try context.save()
+
+        try await MatrixSender(backend: cloudBackend)?.deliver(type: EventObject.self, in: context)
+
+        #expect(event.delivery(for: "cloud")?.progress == [.raw])
+        #expect(cloud.records.count(of: Int.recordType) == 0)
+    }
+
+    @Test("A raw-only row doesn't derail matrices owed by other batches")
+    func rawOnlyRowDoesNotBlockOtherMatrices() async throws {
+        let week = Date(timeIntervalSince1970: 1_000_000)
+        let settled = EventObject.stub(name: "login", date: week, in: context)
+        settled.seedDelivery([.raw], for: "cloud", in: context)
+        let owed = EventObject.stub(name: "login", date: week.addingWeek(), in: context)
+        owed.seedDelivery([.matrix], for: "cloud", in: context)
+        try context.save()
+
+        try await MatrixSender(backend: cloudBackend)?.deliver(type: EventObject.self, in: context)
+
+        #expect(settled.delivery(for: "cloud")?.progress == [.raw])
+        #expect(owed.delivery(for: "cloud")?.progress == [])
+        #expect(cloud.records.count(of: Int.recordType) == 1)
+    }
+
     @Test("A matrix is contributed per native backend, never twice")
     func matrixPerNativeBackend() async throws {
         let event = EventObject.stub(name: "login", synced: true, in: context)

--- a/Tests/ScoutTests/Native/Matrix/Syncable/SyncableGroupTests.swift
+++ b/Tests/ScoutTests/Native/Matrix/Syncable/SyncableGroupTests.swift
@@ -21,7 +21,7 @@ struct SyncableGroupTests {
         let weekB = weekA.addingWeek()
 
         for (name, date) in [("EventA", weekA), ("EventA", weekA), ("EventB", weekB)] {
-            EventObject.stub(name: name, date: date, in: context).seedDelivery([.raw], for: "b", in: context)
+            EventObject.stub(name: name, date: date, in: context).seedDelivery([.matrix], for: "b", in: context)
         }
         try context.save()
 
@@ -75,12 +75,21 @@ struct SyncableGroupTests {
         let week = Date()
         EventObject.stub(name: "EventC", date: week, synced: true, in: context)
         let event = EventObject.stub(name: "EventC", date: week, in: context)
-        event.seedDelivery([.raw], for: "b", in: context)
+        event.seedDelivery([.matrix], for: "b", in: context)
         try context.save()
 
         let batch = try #require(try EventObject.group(in: context, for: "b"))
 
         #expect(batch.count == 1)
         #expect(batch.first === event)
+    }
+
+    @Test("Group skips rows that owe only their raw record")
+    func testGroupIgnoresRawOnlyRows() throws {
+        let event = EventObject.stub(name: "EventA", in: context)
+        event.seedDelivery([.raw], for: "b", in: context)
+        try context.save()
+
+        #expect(try EventObject.group(in: context, for: "b") == nil)
     }
 }


### PR DESCRIPTION
Matrix delivery could abort mid-run. `group()` fetched rows with any outstanding progress, so a batch that owed only its raw record filtered down to nothing and `matrix(of: [])` threw `SeedError.emptyArray` — swallowed by the `try?` in `synchronize`, silently skipping the remaining matrix batches for that type. Since the raw and matrix channels finish independently, this hit the common case and made multi-group matrix delivery order-dependent, so aggregated CloudKit data could quietly lag behind whenever raw delivery was slow or failing.

This scopes the fetches per progress channel: `pending()` asks for rows owing `.raw` and `group()` for rows owing `.matrix`, via an `IN` predicate over the states that still contain the requested bit. The matrix loop now only ever sees real work and terminates cleanly instead of throwing on an empty batch. Regression tests cover raw-only rows: a matrix pass over one is a no-op, and it no longer derails matrices owed by other batches.