### PR TITLE
Show loading, not false "No results", while editing an event search

### DIFF
--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -49,7 +49,7 @@ struct AnalyticsView: View {
             }
         }
         .onChange(of: filter.text) { _ in
-            search.events?.removeAll()
+            search.events = nil
         }
         .navigationTitle(en: "Events")
         .resetsTint()


### PR DESCRIPTION
Editing the search text on the Events screen after a query had already returned results cleared the results array in place with `removeAll()`. Since `EventList` treats a non-nil but empty array as its "No results" state, the placeholder appeared for the new query before it was ever submitted — a false negative while the user was still typing. This resets the results to `nil` instead, so the search shows a neutral loading state until submit, consistent with the existing `onSubmit` handler which already sets `search.events = nil` before fetching.