### PR TITLE
Skip non-schema errors when verifying CloudKit schema

### DIFF
--- a/Sources/Scout/Native/Schema/CKContainer+Verify.swift
+++ b/Sources/Scout/Native/Schema/CKContainer+Verify.swift
@@ -55,6 +55,10 @@ extension CKContainer {
             } catch let error as CKError where error.isSchemaError {
                 print("[Scout] Schema error for '\(recordType)': \(error.localizedDescription)")
                 invalid.append(recordType)
+            } catch {
+                // Skip non-schema failures so one flaky query doesn't abort the rest.
+                print("[Scout] Skipping '\(recordType)': \(error.localizedDescription)")
+                continue
             }
         }
 


### PR DESCRIPTION
The per-record-type catch in `verifySchema()` only handled `CKError.isSchemaError`, so any other failure — a transient network error, throttling, or a non-schema `CKError` — propagated out and aborted the loop before the remaining record types were checked. That meant a single flaky query on an early type could mask a genuine schema problem on a later one, and the aborted error was silently swallowed by the `catch {}` in `SchemaWarning`, so no warning ever surfaced.

Now a non-schema failure is caught per iteration, logged, and skipped with `continue`, so verification always covers every record type. Behavior on real schema errors is unchanged — they're still collected into `invalid` and raised as a `SchemaError`. Verified with a simulator build.