### PR TITLE
Log lifecycle trigger errors and never skip the follow-up sync

### DIFF
--- a/Sources/Scout/Core/Backend/ActionTable.swift
+++ b/Sources/Scout/Core/Backend/ActionTable.swift
@@ -20,11 +20,19 @@ struct ActionTable {
         for (name, action) in actions {
             NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil) { _ in
                 Task {
-                    try await action()
-                    try await completion()
+                    await run(action)
+                    await run(completion)
                 }
             }
         }
+    }
+}
+
+private func run(_ action: ActionTable.Action) async {
+    do {
+        try await action()
+    } catch {
+        print(error.localizedDescription)
     }
 }
 


### PR DESCRIPTION
The app-lifecycle notification observer in `ActionTable` ran its trigger and the sync completion inside a fire-and-forget `Task` chained with `try/await`. A throwing trigger was therefore unobserved (swallowed) and short-circuited the chain, so the follow-up sync never ran and already-pending records went undelivered on that lifecycle event.

Both the trigger and the completion now go through a `fileprivate run(_:)` helper that catches and prints the error, matching the pattern used in the other Task-based backend handlers (`CKLogHandler.log`, `logMetrics`). Since the two calls are independent, a trigger failure is logged but still lets the sync proceed. Print is used rather than the Scout logger to avoid recursing back through `CKLogHandler` into another sync. No behavior change on the success path; builds for the iOS Simulator.