### PR TITLE
Report zero crash-free stability for a crashing version with no sessions

### DIFF
--- a/Sources/Scout/UI/Releases/Health/Stability.swift
+++ b/Sources/Scout/UI/Releases/Health/Stability.swift
@@ -38,6 +38,8 @@ extension Stability {
     init(of affected: Int, in total: Int) {
         if total > 0 {
             value = max(0, 1 - Double(affected) / Double(total))
+        } else if affected > 0 {
+            value = 0
         } else {
             value = 1
         }

--- a/Tests/ScoutTests/UI/Releases/Health/StabilityTests.swift
+++ b/Tests/ScoutTests/UI/Releases/Health/StabilityTests.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Testing
+
+@testable import Scout
+
+struct StabilityTests {
+    @Test("Crash-free fraction is derived from affected sessions")
+    func testFraction() {
+        #expect(Stability(of: 1, in: 4).value == 0.75)
+        #expect(Stability(of: 0, in: 4).value == 1)
+    }
+
+    @Test("No sessions and no crashes reads as fully stable")
+    func testEmptyIsStable() {
+        #expect(Stability(of: 0, in: 0).value == 1)
+    }
+
+    @Test("Crashes without recorded sessions read as zero crash-free, not perfect")
+    func testCrashesWithoutSessions() {
+        #expect(Stability(of: 3, in: 0).value == 0)
+    }
+}


### PR DESCRIPTION
`Stability.init(of:in:)` returned 100% crash-free whenever `total == 0`, ignoring `affected`. Because `releaseReport` builds its version set by unioning the crash-matrix keys, a version present only through crashes lands with `sessions == 0` and `crashes > 0`, so it was rendered as a perfectly stable green 100% — the exact opposite of reality. The sessions and crashes matrices are aggregated independently, so nothing guarantees crashes ⊆ sessions.

Now the zero-total branch distinguishes the two degenerate cases: crashes but no sessions reads as 0% (red), while genuinely empty data (no crashes, no sessions) stays at 100%. The sibling `freeUsers` metric already sidestepped this via `Stability.optional`, which returns nil for no data.

Added StabilityTests covering the fraction case and both zero-total cases.