### PR TITLE
Carry rounded seconds into minutes in duration formatter

### DIFF
--- a/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
+++ b/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
@@ -81,7 +81,7 @@ extension TimeInterval {
         case ..<(.minute):
             String(format: "%.1f s", self)
         case ..<(.hour):
-            String(format: "%.0f min %.0f s", floor(self / .minute), truncatingRemainder(dividingBy: .minute))
+            String(format: "%d min %d s", Int(rounded()) / Int(.minute), Int(rounded()) % Int(.minute))
         case ..<(.day):
             String(format: "%.0f h", self / .hour)
         case ..<(.month):

--- a/Tests/ScoutTests/UI/Metrics/Series/MetricsFormattersTests.swift
+++ b/Tests/ScoutTests/UI/Metrics/Series/MetricsFormattersTests.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct MetricsFormattersTests {
+    @Test("Formats sub-minute and coarse durations", arguments: [
+        (0.0, "0"),
+        (0.00045, "450 µs"),
+        (0.123, "123 ms"),
+        (12.34, "12.3 s"),
+        (125.0, "2 min 5 s"),
+        (7200.0, "2 h"),
+        (172_800.0, "2 d"),
+        (5_184_000.0, "2 mo"),
+        (47_304_000.0, "1.5 y"),
+    ]) func testDuration(seconds: TimeInterval, expected: String) {
+        #expect(seconds.duration == expected)
+    }
+
+    @Test("Rounds the seconds component into minutes instead of emitting 60 s", arguments: [
+        (119.6, "2 min 0 s"),
+        (119.5, "2 min 0 s"),
+        (60.4, "1 min 0 s"),
+        (89.5, "1 min 30 s"),
+    ]) func testDurationSecondsCarry(seconds: TimeInterval, expected: String) {
+        #expect(seconds.duration == expected)
+    }
+}

--- a/Tests/ScoutTests/UI/Metrics/Series/MetricsFormattersTests.swift
+++ b/Tests/ScoutTests/UI/Metrics/Series/MetricsFormattersTests.swift
@@ -11,26 +11,32 @@ import Testing
 @testable import Scout
 
 struct MetricsFormattersTests {
-    @Test("Formats sub-minute and coarse durations", arguments: [
-        (0.0, "0"),
-        (0.00045, "450 µs"),
-        (0.123, "123 ms"),
-        (12.34, "12.3 s"),
-        (125.0, "2 min 5 s"),
-        (7200.0, "2 h"),
-        (172_800.0, "2 d"),
-        (5_184_000.0, "2 mo"),
-        (47_304_000.0, "1.5 y"),
-    ]) func testDuration(seconds: TimeInterval, expected: String) {
+    @Test(
+        "Formats sub-minute and coarse durations",
+        arguments: [
+            (0.0, "0"),
+            (0.00045, "450 µs"),
+            (0.123, "123 ms"),
+            (12.34, "12.3 s"),
+            (125.0, "2 min 5 s"),
+            (7200.0, "2 h"),
+            (172_800.0, "2 d"),
+            (5_184_000.0, "2 mo"),
+            (47_304_000.0, "1.5 y"),
+        ]) func testDuration(seconds: TimeInterval, expected: String)
+    {
         #expect(seconds.duration == expected)
     }
 
-    @Test("Rounds the seconds component into minutes instead of emitting 60 s", arguments: [
-        (119.6, "2 min 0 s"),
-        (119.5, "2 min 0 s"),
-        (60.4, "1 min 0 s"),
-        (89.5, "1 min 30 s"),
-    ]) func testDurationSecondsCarry(seconds: TimeInterval, expected: String) {
+    @Test(
+        "Rounds the seconds component into minutes instead of emitting 60 s",
+        arguments: [
+            (119.6, "2 min 0 s"),
+            (119.5, "2 min 0 s"),
+            (60.4, "1 min 0 s"),
+            (89.5, "1 min 30 s"),
+        ]) func testDurationSecondsCarry(seconds: TimeInterval, expected: String)
+    {
         #expect(seconds.duration == expected)
     }
 }


### PR DESCRIPTION
The duration formatter floored the minutes but rounded the seconds component independently, so a remainder in [59.5, 60) rounded up to 60 and printed values like "1 min 60 s" (e.g. 119.6 s). It now rounds the whole interval to whole seconds once and splits that into minutes and seconds so both parts stay consistent, giving "2 min 0 s". Added MetricsFormattersTests, which previously didn't exist for these formatters, covering the doc-comment examples and the seconds-carry regression.