### PR TITLE
Add a billions branch to compact number formatting

### DIFF
--- a/Sources/Scout/UI/Utilities/Int+Compact.swift
+++ b/Sources/Scout/UI/Utilities/Int+Compact.swift
@@ -9,8 +9,11 @@ import Foundation
 
 extension Int {
     var compact: String {
+        // Thresholds sit just below each round boundary so `%.1f` rounding rolls a
+        // value up to the next unit instead of overflowing it (999_999 → "1.0M", not "1000.0K").
         switch self {
-        case 1_000_000...: String(format: "%.1fM", Double(self) / 1_000_000)
+        case 999_950_000...: String(format: "%.1fB", Double(self) / 1_000_000_000)
+        case 999_950...: String(format: "%.1fM", Double(self) / 1_000_000)
         case 1_000...: String(format: "%.1fK", Double(self) / 1_000)
         default: "\(self)"
         }

--- a/Tests/ScoutTests/UI/Utilities/CompactTests.swift
+++ b/Tests/ScoutTests/UI/Utilities/CompactTests.swift
@@ -21,11 +21,22 @@ struct CompactTests {
         #expect(1_000.compact == "1.0K")
         #expect(1_500.compact == "1.5K")
         #expect(48_210.compact == "48.2K")
-        #expect(999_999.compact == "1000.0K")
+        #expect(999_949.compact == "999.9K")
     }
 
     @Test("Millions use the M suffix") func millions() {
         #expect(1_000_000.compact == "1.0M")
         #expect(2_500_000.compact == "2.5M")
+        #expect(999_949_999.compact == "999.9M")
+    }
+
+    @Test("Billions use the B suffix") func billions() {
+        #expect(1_000_000_000.compact == "1.0B")
+        #expect(2_500_000_000.compact == "2.5B")
+    }
+
+    @Test("Rounding rolls up to the next unit instead of overflowing") func rounding() {
+        #expect(999_999.compact == "1.0M")
+        #expect(999_999_999.compact == "1.0B")
     }
 }


### PR DESCRIPTION
The `Int.compact` formatter had no billions branch and could overflow a unit at the rounding boundary — 999_999 rendered as "1000.0K" instead of "1.0M", and anything from a billion up showed as "1000.0M". This shifts the K/M thresholds just below their round boundary so `%.1f` rounding rolls a value up to the next unit, and adds a B branch so billions render as "1.0B". Tests cover the billions suffix and the rollover cases.