### PR TITLE
Remove unused protocol conformances

### DIFF
--- a/Sources/Scout/Core/Database/Record/Record.swift
+++ b/Sources/Scout/Core/Database/Record/Record.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Record: Equatable, Sendable {
+struct Record: Sendable {
     let recordType: String
     let recordID: String
 

--- a/Sources/Scout/Core/Utilities/Date/DateObject.swift
+++ b/Sources/Scout/Core/Utilities/Date/DateObject.swift
@@ -8,7 +8,7 @@
 import CoreData
 
 @objc(DateObject)
-class DateObject: NSManagedObject, Identifiable {
+class DateObject: NSManagedObject {
     static let datePrimitiveKey = "datePrimitive"
 
     @NSManaged var datePrimitive: Date?

--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -19,7 +19,7 @@ protocol ActivityReader: RecordReader {
     func activity(in range: Range<Date>) async throws -> [ActivityPoint]
 }
 
-struct ActivityPoint: Decodable, Equatable {
+struct ActivityPoint: Decodable {
     let date: Int64
     let dau: Int
     let wau: Int

--- a/Sources/Scout/UI/Chart/Model/ChartPoint.swift
+++ b/Sources/Scout/UI/Chart/Model/ChartPoint.swift
@@ -21,12 +21,6 @@ extension ChartPoint: Comparable {
     }
 }
 
-extension ChartPoint: Equatable {
-    static func == (lhs: ChartPoint, rhs: ChartPoint) -> Bool {
-        lhs.date == rhs.date && lhs.count == rhs.count
-    }
-}
-
 extension ChartPoint {
     static func + (lhs: ChartPoint, rhs: ChartPoint) -> ChartPoint {
         ChartPoint(date: lhs.date, count: lhs.count + rhs.count)

--- a/Sources/Scout/UI/Chart/Model/MiniChartSeries.swift
+++ b/Sources/Scout/UI/Chart/Model/MiniChartSeries.swift
@@ -11,7 +11,7 @@ import Foundation
 /// The points of a Home row's period compressed into a fixed number of
 /// equal time slices, ready to be drawn as an inline mini-chart.
 ///
-struct MiniChartSeries: Equatable {
+struct MiniChartSeries {
     /// Number of slices a mini-chart compresses its period into.
     static let sliceCount = 7
 

--- a/Sources/Scout/UI/Crash/Crash.swift
+++ b/Sources/Scout/UI/Crash/Crash.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Crash: Identifiable, Hashable {
+struct Crash: Identifiable {
     let name: String
     let fingerprint: String
     let reason: String?

--- a/Sources/Scout/UI/Crash/CrashGroup.swift
+++ b/Sources/Scout/UI/Crash/CrashGroup.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CrashGroup: Identifiable, Hashable {
+struct CrashGroup: Identifiable {
     let crashes: [Crash]
 
     var id: String {

--- a/Sources/Scout/UI/Event/Model/Event.swift
+++ b/Sources/Scout/UI/Event/Model/Event.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Event: Identifiable, Hashable {
+struct Event: Identifiable {
     let name: String
     let level: Level?
     let date: Date?

--- a/Sources/Scout/UI/Releases/Health/Adoption.swift
+++ b/Sources/Scout/UI/Releases/Health/Adoption.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Adoption: Equatable, ExpressibleByFloatLiteral {
+struct Adoption: ExpressibleByFloatLiteral {
     let value: Double
 
     init(_ value: Double) {

--- a/Sources/Scout/UI/Releases/Health/Stability.swift
+++ b/Sources/Scout/UI/Releases/Health/Stability.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Stability: Equatable {
+struct Stability {
     let value: Double
 
     init(_ value: Double) {

--- a/Sources/Scout/UI/Timeline/Item/TimelineItem.swift
+++ b/Sources/Scout/UI/Timeline/Item/TimelineItem.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct TimelineItem: Identifiable {
+struct TimelineItem {
     let id: String
     let name: String
     let date: Date

--- a/Sources/Scout/UI/Timeline/Rail/Device.swift
+++ b/Sources/Scout/UI/Timeline/Rail/Device.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Device: Identifiable {
+struct Device {
     let date: Date?
     let id: String
     let deviceID: UUID?

--- a/Sources/Scout/UI/Timeline/Rail/Install.swift
+++ b/Sources/Scout/UI/Timeline/Rail/Install.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Install: Identifiable, Hashable {
+struct Install {
     let date: Date?
     let id: String
     let installID: UUID?

--- a/Sources/Scout/UI/Timeline/Rail/Launch.swift
+++ b/Sources/Scout/UI/Timeline/Rail/Launch.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Launch: Identifiable, Hashable {
+struct Launch {
     let startDate: Date?
     let endDate: Date?
     let id: String

--- a/Sources/Scout/UI/Timeline/Rail/Rail.swift
+++ b/Sources/Scout/UI/Timeline/Rail/Rail.swift
@@ -5,28 +5,28 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-struct Rail: Identifiable {
+struct Rail {
     let device: Device
     var installs: [InstallRoot]
 
     var id: String { device.id }
 }
 
-struct InstallRoot: Identifiable {
+struct InstallRoot {
     let install: Install
     let launches: [LaunchRoot]
 
     var id: String { install.id }
 }
 
-struct LaunchRoot: Identifiable {
+struct LaunchRoot {
     let launch: Launch
     let sessions: [SessionRoot]
 
     var id: String { launch.id }
 }
 
-struct SessionRoot: Identifiable {
+struct SessionRoot {
     let session: Session
     let events: [Event]
     let crashes: [Crash]

--- a/Sources/Scout/UI/Timeline/Rail/Session.swift
+++ b/Sources/Scout/UI/Timeline/Rail/Session.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Session: Identifiable, Hashable {
+struct Session: Identifiable {
     let startDate: Date?
     let endDate: Date?
     let id: String

--- a/Sources/Scout/UI/Timeline/Rail/Version.swift
+++ b/Sources/Scout/UI/Timeline/Rail/Version.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Version: Identifiable, Hashable {
+struct Version {
     let appVersion: String?
     let buildNumber: String?
     let launchID: UUID?


### PR DESCRIPTION
Several model and value types carried protocol conformances whose capability was never exercised — `Identifiable` on types never placed in a `ForEach`/`List` without an explicit `id`, `Hashable` on types never used as `Set` or dictionary keys, and `Equatable` on types never compared. This drops those dead conformances across the timeline rail models, the crash/event models, the release-health value types, `Record`, `ActivityPoint`, `MiniChartSeries` and a few others, keeping only what is actually used or required (the `Equatable` that `RecordDecodable` refines stays, now synthesized). `ChartPoint`'s separate `Equatable` extension and its hand-written `==` go too, since `Comparable` already refines `Equatable` and the synthesized `==` is identical.

Kept `Session: Identifiable` (used by the generic `dedup`), `MetricValue: Equatable` (compared in tests) and `ParamValue: Hashable` (required by `Entry`'s synthesized `Hashable`), and left the HTTP wire types' symmetric `Codable` alone as a deliberate convention. Verified with `build-for-testing` and the full 424-test suite on the iOS simulator; swift-format lint is clean.