### PR TITLE
Render home counters with compact K/M/B abbreviations

### DIFF
--- a/Sources/Scout/UI/Primitives/Controls/RedactedText.swift
+++ b/Sources/Scout/UI/Primitives/Controls/RedactedText.swift
@@ -12,7 +12,7 @@ struct RedactedText: View {
 
     var body: some View {
         if let count = count {
-            Text(count == 0 ? "—" : "\(count)")
+            Text(count == 0 ? "—" : count.compact)
         } else {
             Redacted(length: 5)
         }


### PR DESCRIPTION
The Home screen counters (Events, Metrics, Crashes under LOG, and the Daily/Weekly/Monthly user counts) rendered raw integers, so a large value like the legacy Events count showed as an unreadable eleven-digit number. They all display through RedactedText, which now formats the count with the existing .compact formatter, so big values collapse to K/M/B (e.g. 118.6B) while anything under a thousand and the zero dash stay exactly as before.