### PR TITLE
Fix crash pipeline reliability bugs

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/CrashArchive.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashArchive.swift
@@ -60,8 +60,9 @@ struct CrashArchive {
             }
 
             do {
+                let id = UUID(uuidString: file.deletingPathExtension().lastPathComponent) ?? UUID()
                 try await persistentContainer.performBackgroundTask { context in
-                    try logCrash(crash, context: context)
+                    try logCrash(crash, id: id, context: context)
                 }
                 try FileManager.default.removeItem(at: file)
             } catch {

--- a/Sources/Scout/Core/Diagnostics/Crash/CrashFingerprint.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashFingerprint.swift
@@ -23,6 +23,7 @@ extension CrashFingerprint {
     fileprivate static func signature(name: String, reason: String?, stackTrace: [String]) -> String {
         let normalizedFrames =
             stackTrace
+            .lazy
             .map(normalizeFrame)
             .filter { !$0.isEmpty }
             .prefix(maximumFrameCount)

--- a/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
@@ -30,6 +30,7 @@ extension CrashObject: RecordEncodable {
         record["date"] = date
         record["uuid"] = crashID.uuidString
         record["app_version"] = appVersion
+        record["session_id"] = sessionID.uuidString
 
         record.setValues(metadata)
 
@@ -37,7 +38,9 @@ extension CrashObject: RecordEncodable {
     }
 
     private var decodedStackTrace: [String] {
-        guard let stackTrace, let decoded = try? JSONDecoder().decode([String].self, from: stackTrace) else { return [] }
+        guard let stackTrace, let decoded = try? JSONDecoder().decode([String].self, from: stackTrace) else {
+            return []
+        }
         return decoded
     }
 }

--- a/Sources/Scout/Core/Diagnostics/Crash/ExceptionHandler.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/ExceptionHandler.swift
@@ -8,9 +8,16 @@
 import Foundation
 
 private nonisolated(unsafe) var previousExceptionHandler: NSUncaughtExceptionHandler?
+private nonisolated(unsafe) var isInstalled = false
 
 /// Installs a handler for uncaught NSExceptions.
 func installExceptionHandler() {
+    // Guard against re-installation (e.g. a retried setup): a second install
+    // would capture Scout's own handler as the "previous" one and recurse
+    // on a real exception.
+    guard !isInstalled else { return }
+    isInstalled = true
+
     previousExceptionHandler = NSGetUncaughtExceptionHandler()
     NSSetUncaughtExceptionHandler { exception in
         let crash = CrashInfo(
@@ -20,9 +27,10 @@ func installExceptionHandler() {
         )
         CrashArchive.system.write(crash)
 
-        // Reset SIGABRT to default so the abort() that follows
-        // doesn't produce a duplicate crash report.
-        signal(SIGABRT, SIG_DFL)
+        // Restore the pre-Scout SIGABRT handler so the abort() that follows
+        // doesn't produce a duplicate crash report but still reaches any
+        // previously installed third-party reporter.
+        restorePreviousSignalHandler(SIGABRT)
 
         previousExceptionHandler?(exception)
     }

--- a/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
@@ -7,11 +7,19 @@
 
 import CoreData
 
-func logCrash(_ crash: CrashInfo, context: NSManagedObjectContext) throws {
+func logCrash(_ crash: CrashInfo, id: UUID = UUID(), context: NSManagedObjectContext) throws {
+    // The id doubles as the archive file's UUID, so a flush interrupted
+    // between the save and the file removal doesn't insert a duplicate
+    // on the next launch.
+    let request = NSFetchRequest<CrashObject>(entityName: "CrashObject")
+    request.predicate = NSPredicate(format: "crashID == %@", id as CVarArg)
+    request.fetchLimit = 1
+    guard try context.count(for: request) == 0 else { return }
+
     let entity = NSEntityDescription.entity(forEntityName: "CrashObject", in: context)!
     let object = CrashObject(entity: entity, insertInto: context)
 
-    object.crashID = UUID()
+    object.crashID = id
     object.date = crash.date
     object.appVersion = crash.appVersion
     object.name = crash.name

--- a/Sources/Scout/Core/Diagnostics/Crash/SignalHandler.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/SignalHandler.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 private nonisolated(unsafe) var previousSignalHandlers: [Int32: sig_t] = [:]
+private nonisolated(unsafe) var isInstalled = false
 
 private let fatalSignals: [(signal: Int32, name: String)] = [
     (SIGABRT, "SIGABRT"),
@@ -20,6 +21,12 @@ private let fatalSignals: [(signal: Int32, name: String)] = [
 
 /// Installs handlers for fatal signals (SIGABRT, SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGTRAP).
 func installSignalHandler() {
+    // Guard against re-installation (e.g. a retried setup): a second install
+    // would save Scout's own handler as the "previous" one and loop forever
+    // on a real signal.
+    guard !isInstalled else { return }
+    isInstalled = true
+
     for (sig, _) in fatalSignals {
         previousSignalHandlers[sig] = signal(sig) { sig in
             let crash = CrashInfo(
@@ -29,11 +36,14 @@ func installSignalHandler() {
             )
             CrashArchive.system.write(crash)
 
-            let handler = previousSignalHandlers[sig] ?? SIG_DFL
-            signal(sig, handler)
+            restorePreviousSignalHandler(sig)
             raise(sig)
         }
     }
+}
+
+func restorePreviousSignalHandler(_ sig: Int32) {
+    signal(sig, previousSignalHandlers[sig] ?? SIG_DFL)
 }
 
 private func signalName(_ sig: Int32) -> String {

--- a/Sources/Scout/UI/Crash/CrashExport.swift
+++ b/Sources/Scout/UI/Crash/CrashExport.swift
@@ -87,9 +87,7 @@ struct CrashGroupExport {
     }
 
     private func row(for crash: Crash) -> String? {
-        guard let date = crash.date else {
-            return nil
-        }
+        guard let date = crash.date else { return nil }
 
         var ids: [String] = []
         if let deviceID = crash.deviceID {

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -67,7 +67,7 @@ struct CrashGroupDetailView: View {
                 Spacer()
 
                 if let sessionID = crash.sessionID {
-                    Text(sessionID.uuidString.prefix(8))
+                    Text(ExportFormat.shortID(sessionID))
                         .font(.system(size: 13))
                         .monospaced()
                         .foregroundStyle(Color.gray)

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -38,6 +38,7 @@ struct CrashListView: View {
             }
         }
         .navigationTitle(en: "Crashes")
+        .message($provider.message)
         .task {
             await provider.fetch(in: database)
         }

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -11,6 +11,7 @@ import SwiftUI
 class CrashProvider: ObservableObject {
     @Published var crashes: [Crash]?
     @Published var cursor: RecordCursor?
+    @Published var message: Message?
 
     var groups: [CrashGroup]? {
         crashes.map(CrashGroup.groups(from:))
@@ -32,7 +33,7 @@ class CrashProvider: ObservableObject {
             self.cursor = results.cursor
             self.crashes = try results.records.map(Crash.init)
         } catch {
-            self.crashes = []
+            self.message = Message(error.localizedDescription, level: .error)
         }
     }
 
@@ -46,6 +47,7 @@ class CrashProvider: ObservableObject {
             self.cursor = results.cursor
             self.crashes?.append(contentsOf: try results.records.map(Crash.init))
         } catch {
+            self.message = Message(error.localizedDescription, level: .error)
         }
     }
 }

--- a/Sources/Scout/UI/Releases/View/VersionCrashProvider.swift
+++ b/Sources/Scout/UI/Releases/View/VersionCrashProvider.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @MainActor
 class VersionCrashProvider: ObservableObject {
     @Published var crashes: [Crash]?
+    @Published var message: Message?
 
     let version: String
 
@@ -25,37 +26,21 @@ class VersionCrashProvider: ObservableObject {
     }
 
     func fetch(in database: DatabaseReader) async {
-        let range = Calendar.utc.defaultRange
-
         do {
-            async let crashes: [Crash] = database.readAll(
-                matching: RecordQuery(recordType: Crash.self, filters: range.dateFilters),
+            let query = RecordQuery(
+                recordType: Crash.self,
+                filters: Calendar.utc.defaultRange.dateFilters + [
+                    RecordQuery.Filter(field: "app_version", op: .equals, value: .string(version))
+                ]
+            )
+
+            crashes = try await database.readAll(
+                matching: query,
                 fields: Crash.desiredKeys
             )
-            async let versions: [Version] = database.readAll(
-                matching: RecordQuery(recordType: Version.self, filters: range.dateFilters),
-                fields: Version.desiredKeys
-            )
-
-            let versionIndex = versionIndex(of: try await versions)
-            self.crashes = try await crashes.filter { crash in
-                crash.launchID.flatMap { versionIndex[$0] } == version
-            }
         } catch {
-            crashes = []
+            message = Message(error.localizedDescription, level: .error)
         }
-    }
-
-    private func versionIndex(of versions: [Version]) -> [UUID: String] {
-        Dictionary(
-            versions.compactMap { version in
-                guard let launchID = version.launchID, let appVersion = version.appVersion else {
-                    return nil
-                }
-                return (launchID, appVersion)
-            },
-            uniquingKeysWith: { first, _ in first }
-        )
     }
 }
 

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -37,6 +37,7 @@ struct VersionDetailView: View {
         .toolbarBackground(release.freeSessions.color.opacity(0.12), for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .navigationTitle(en: release.id)
+        .message($crashProvider.message)
         .task {
             await crashProvider.fetchIfNeeded(in: database)
         }

--- a/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
+++ b/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
@@ -138,6 +138,28 @@ struct ServerContractTests {
         #expect(matrix.cells.map(\.value).reduce(0, +) == 2)
     }
 
+    @Test("Crashes filter by app version on the server")
+    func crashesByVersion() async throws {
+        let database = try makeDatabase()
+        // A unique version isolates these crashes from any shared server data.
+        let version = "contract-\(UUID().uuidString)"
+
+        try await database.write(records: [
+            makeCrash(appVersion: version),
+            makeCrash(appVersion: version),
+            makeCrash(appVersion: "other-\(UUID().uuidString)"),
+        ])
+
+        let query = RecordQuery(
+            recordType: Crash.self,
+            filters: [RecordQuery.Filter(field: "app_version", op: .equals, value: .string(version))]
+        )
+        let crashes: [Crash] = try await database.readAll(matching: query, fields: Crash.desiredKeys)
+
+        #expect(crashes.count == 2)
+        #expect(crashes.allSatisfy { $0.name == "SIGSEGV" })
+    }
+
     @Test("A reachability ping succeeds against a live server")
     func reachabilityPing() async throws {
         let database = try makeDatabase()
@@ -171,6 +193,15 @@ struct ServerContractTests {
         record["session_id"] = UUID().uuidString
         record["install_id"] = installID
         record["start_date"] = startDate
+        return record
+    }
+
+    private func makeCrash(appVersion: String) -> Record {
+        var record = Record(recordType: "Crash", recordID: "contract-\(UUID().uuidString)")
+        record["name"] = "SIGSEGV"
+        record["app_version"] = appVersion
+        record["session_id"] = UUID().uuidString
+        record["date"] = eventDate
         return record
     }
 

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
@@ -62,6 +62,15 @@ struct CrashObjectTests {
         #expect(object.record["fingerprint"] == "stored-fingerprint")
     }
 
+    @Test("record includes the session ID")
+    func testRecordIncludesSessionID() {
+        let object = makeCrashObject(name: "SIGABRT", date: date)
+        let sessionID = UUID()
+        object.sessionID = sessionID
+
+        #expect(object.record["session_id"] == sessionID.uuidString)
+    }
+
     @Test("record computes a fallback fingerprint for migrated crashes")
     func testRecordComputesFallbackFingerprint() throws {
         let object = makeCrashObject(name: "SIGABRT", date: date)

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
@@ -90,4 +90,15 @@ struct LogCrashTests {
 
         #expect(!context.hasChanges)
     }
+
+    @Test("Skips crashes already logged under the same id")
+    func skipsDuplicateID() throws {
+        let crash = makeCrashInfo(name: "SIGSEGV", reason: nil, stackTrace: [])
+        let id = UUID()
+
+        try logCrash(crash, id: id, context: context)
+        try logCrash(crash, id: id, context: context)
+
+        #expect(try context.fetchAll(CrashObject.self).count == 1)
+    }
 }

--- a/Tests/ScoutTests/UI/Releases/View/VersionCrashProviderTests.swift
+++ b/Tests/ScoutTests/UI/Releases/View/VersionCrashProviderTests.swift
@@ -14,18 +14,13 @@ import Testing
 struct VersionCrashProviderTests {
     private let date = Date().addingTimeInterval(-3600)
 
-    @Test("Fetches only crashes whose launch maps to the requested version")
+    @Test("Fetches only crashes recorded for the requested version")
     func fetchFiltersByVersion() async throws {
-        let launchLatest = UUID()
-        let launchOld = UUID()
-
         let database = DatabaseStub()
         database.add(
-            versionRecord(appVersion: "2.0", launchID: launchLatest),
-            versionRecord(appVersion: "1.0", launchID: launchOld),
-            crashRecord(launchID: launchLatest),
-            crashRecord(launchID: launchLatest),
-            crashRecord(launchID: launchOld)
+            crashRecord(appVersion: "2.0"),
+            crashRecord(appVersion: "2.0"),
+            crashRecord(appVersion: "1.0")
         )
 
         let provider = VersionCrashProvider(version: "2.0")
@@ -35,10 +30,10 @@ struct VersionCrashProviderTests {
         #expect(crashes.count == 2)
     }
 
-    @Test("Ignores crashes on unknown launches")
-    func fetchIgnoresUnknownLaunch() async throws {
+    @Test("Ignores crashes without a version")
+    func fetchIgnoresMissingVersion() async throws {
         let database = DatabaseStub()
-        database.add(crashRecord(launchID: UUID()))
+        database.add(crashRecord(appVersion: nil))
 
         let provider = VersionCrashProvider(version: "2.0")
         await provider.fetchIfNeeded(in: database)
@@ -46,18 +41,10 @@ struct VersionCrashProviderTests {
         #expect(provider.crashes?.isEmpty == true)
     }
 
-    private func versionRecord(appVersion: String, launchID: UUID) -> Record {
-        var record = Record(recordType: "Version", recordID: UUID().uuidString)
-        record["app_version"] = appVersion
-        record["launch_id"] = launchID.uuidString
-        record["date"] = date
-        return record
-    }
-
-    private func crashRecord(launchID: UUID) -> Record {
+    private func crashRecord(appVersion: String?) -> Record {
         var record = Record(recordType: "Crash", recordID: UUID().uuidString)
         record["name"] = "SIGSEGV"
-        record["launch_id"] = launchID.uuidString
+        record["app_version"] = appVersion
         record["session_id"] = UUID().uuidString
         record["date"] = date
         return record


### PR DESCRIPTION
## Summary

A code review of the crash-reporting functionality (`Core/Diagnostics/Crash`, `UI/Crash`, `VersionCrashProvider`) surfaced several reliability bugs, now fixed:

- Signal/exception handler installation guards against re-entry — a retried `setup()` previously could re-install handlers that chained to themselves, looping forever on a real crash instead of terminating.
- The exception handler restores the previously installed SIGABRT handler instead of forcing `SIG_DFL`, so a third-party crash reporter installed before Scout is no longer bypassed.
- `CrashObject` now writes `session_id` on the record — it was captured and stored locally but never uploaded, so affected-session counts and the session UI/export were always empty.
- `CrashArchive.flush()` derives `crashID` from the archived file's UUID and skips re-insertion, making it idempotent if the app dies between the Core Data save and the file removal (previously produced duplicate crash records).
- `VersionCrashProvider` filters crashes by the queryable `app_version` field instead of joining crashes to `Version` records by `launchID` — the join silently dropped crashes from any launch after a version's first, or when the first-launch `Version` record fell outside the default date range.
- `CrashProvider`/`VersionCrashProvider` surface fetch errors as a `Message` instead of collapsing failures into an empty crash list, which previously rendered a false "No crashes" placeholder on network/database errors.
- Minor cleanups: lazy frame normalization in `CrashFingerprint`, inline guard formatting, reuse of `ExportFormat.shortID` for session IDs in `CrashGroupDetailView`.

A `ServerContractTests` case (`crashesByVersion`) was added to guard the `app_version` filter against a live scout-server; if scout-server doesn't yet mark `app_version` queryable for `Crash`, the Server workflow will flag it and a companion PR would be needed there.

## Test plan

- [x] `xcodebuild build-for-testing -scheme Scout` succeeds
- [x] `xcodebuild test-without-building -scheme Scout -only-testing:ScoutTests` — 427 tests passing
- [ ] CI `Server` workflow confirms the new `crashesByVersion` contract test against a live scout-server
