### PR TITLE
Scope home log fetches to the selected period

### DIFF
--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -7,12 +7,29 @@
 
 import Foundation
 
-class HomeLogProvider: ObservableObject, Provider {
-    @Published var result: ProviderResult<([GridMatrix<Int>], [GridMatrix<Double>])>?
+@MainActor
+class HomeLogProvider: ObservableObject {
+    typealias Output = ([GridMatrix<Int>], [GridMatrix<Double>])
 
-    func fetch(in database: DatabaseReader) async throws -> ([GridMatrix<Int>], [GridMatrix<Double>]) {
-        async let intMatrices = matrices(of: Int.self, in: database)
-        async let doubleMatrices = matrices(of: Double.self, in: database)
+    @Published private var results: [Period: ProviderResult<Output>] = [:]
+
+    func result(for period: Period) -> ProviderResult<Output>? {
+        results[period]
+    }
+
+    func fetchIfNeeded(for period: Period, in database: DatabaseReader) async {
+        guard results[period] == nil else { return }
+        do {
+            results[period] = .success(try await fetch(for: period, in: database))
+        } catch {
+            results[period] = .failure(error)
+        }
+    }
+
+    private func fetch(for period: Period, in database: DatabaseReader) async throws -> Output {
+        let range = period.initialRange
+        async let intMatrices = matrices(of: Int.self, in: range, from: database)
+        async let doubleMatrices = matrices(of: Double.self, in: range, from: database)
 
         return try await (intMatrices.filter { !lifecycleNames.contains($0.name) }, doubleMatrices)
     }
@@ -26,10 +43,12 @@ private let lifecycleNames = [
     VersionObject.recordType,
 ]
 
-private func matrices<T: MetricScalar>(of type: T.Type, in database: DatabaseReader) async throws -> [GridMatrix<T>] {
+private func matrices<T: MetricScalar>(of type: T.Type, in range: Range<Date>, from database: DatabaseReader) async throws -> [GridMatrix<T>] {
+    // Matrices are dated at the start of their week, so the query widens the
+    // lower bound to the week start to catch the matrix holding the range's first days.
     let query = RecordQuery(
         recordType: GridMatrix<T>.self,
-        filters: Calendar.utc.defaultRange.dateFilters
+        filters: (range.lowerBound.startOfWeek..<range.upperBound).dateFilters
     )
     let matrices: [GridMatrix<T>] = try await database.readAll(matching: query)
     return matrices.mergeDuplicates()

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -16,8 +16,8 @@ struct HomeLogSection: View {
         Header(title: "Log") {
             CompactPeriodPicker(selection: $period)
         }
-        .task {
-            await provider.fetchIfNeeded(in: database)
+        .task(id: period) {
+            await provider.fetchIfNeeded(for: period, in: database)
         }
 
         HomeLogRow(
@@ -44,7 +44,7 @@ struct HomeLogSection: View {
     }
 
     private var spans: (int: MatrixSpan<Int>, double: MatrixSpan<Double>)? {
-        guard let result = try? provider.result?.get() else {
+        guard let result = try? provider.result(for: period)?.get() else {
             return nil
         }
 

--- a/Tests/ScoutTests/UI/Home/Section/Log/HomeLogProviderTests.swift
+++ b/Tests/ScoutTests/UI/Home/Section/Log/HomeLogProviderTests.swift
@@ -25,8 +25,8 @@ struct HomeLogProviderTests {
         )
 
         let provider = HomeLogProvider()
-        await provider.fetchIfNeeded(in: database)
-        let result = try #require(try provider.result?.get())
+        await provider.fetchIfNeeded(for: .today, in: database)
+        let result = try #require(try provider.result(for: .today)?.get())
 
         let ints = MatrixSpan(matrices: result.0, range: allTime)
         let doubles = MatrixSpan(matrices: result.1, range: allTime)
@@ -49,8 +49,8 @@ struct HomeLogProviderTests {
         )
 
         let provider = HomeLogProvider()
-        await provider.fetchIfNeeded(in: database)
-        let result = try #require(try provider.result?.get())
+        await provider.fetchIfNeeded(for: .today, in: database)
+        let result = try #require(try provider.result(for: .today)?.get())
 
         #expect(Set(result.0.map(\.name)) == ["login", "Crash"])
     }
@@ -65,11 +65,45 @@ struct HomeLogProviderTests {
         )
 
         let provider = HomeLogProvider()
-        await provider.fetchIfNeeded(in: database)
-        let result = try #require(try provider.result?.get())
+        await provider.fetchIfNeeded(for: .today, in: database)
+        let result = try #require(try provider.result(for: .today)?.get())
 
         #expect(result.0.count == 1)
         #expect(MatrixSpan(matrices: result.0, range: allTime).total { $0 != CrashObject.recordType } == 7)
+    }
+
+    @Test("Each period fetches only its own range")
+    func fetchesSelectedPeriodOnly() async throws {
+        let database = DatabaseStub()
+        database.add(
+            makeRecord(type: Int.recordType, name: "recent", date: Date().addingDay(-2).startOfWeek, value: 3),
+            makeRecord(type: Int.recordType, name: "old", date: Date().addingDay(-60).startOfWeek, value: 4)
+        )
+
+        let provider = HomeLogProvider()
+        await provider.fetchIfNeeded(for: .month, in: database)
+        await provider.fetchIfNeeded(for: .year, in: database)
+
+        let month = try #require(try provider.result(for: .month)?.get())
+        let year = try #require(try provider.result(for: .year)?.get())
+
+        #expect(Set(month.0.map(\.name)) == ["recent"])
+        #expect(Set(year.0.map(\.name)) == ["recent", "old"])
+    }
+
+    @Test("Switching periods keeps earlier results cached")
+    func cachesResultsPerPeriod() async throws {
+        let database = DatabaseStub()
+        database.add(makeRecord(type: Int.recordType, name: "login", value: 3))
+
+        let provider = HomeLogProvider()
+        await provider.fetchIfNeeded(for: .today, in: database)
+        await provider.fetchIfNeeded(for: .week, in: database)
+        await provider.fetchIfNeeded(for: .today, in: database)
+
+        #expect(database.readCount(of: Int.recordType) == 2)
+        #expect(provider.result(for: .today) != nil)
+        #expect(provider.result(for: .week) != nil)
     }
 
     private func makeRecord(type: String, name: String, category: String? = nil, date: Date = Date(), value: any RecordValueConvertible) -> Record {


### PR DESCRIPTION
The home Log section used to fetch a full year of matrices in one query and only filter by the selected period at display time. HomeLogProvider now caches results per period and queries just the selected period's range (widened to the week start, since matrices are dated at the start of their week), mirroring the fetch-once-per-option behavior of the users/sessions/crashes picker: switching periods loads each period on first use and keeps previously loaded ones cached. Existing provider tests are adapted to the new API, with new tests covering the per-period range and cache.