### PR TITLE
Adopt a custom ring indicator for loading and pull-to-refresh

### DIFF
--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -34,7 +34,7 @@ struct CrashListView: View {
                     .animation(nil, value: groups)
                 }
             } else {
-                ProgressView().frame(maxHeight: .infinity)
+                RingIndicator().frame(maxHeight: .infinity)
             }
         }
         .navigationTitle(en: "Crashes")

--- a/Sources/Scout/UI/Database/ProviderView.swift
+++ b/Sources/Scout/UI/Database/ProviderView.swift
@@ -16,7 +16,7 @@ struct ProviderView<P: Provider, Content: View>: View {
     var body: some View {
         switch provider.result {
         case nil:
-            ProgressView().frame(maxHeight: .infinity).tint(nil)
+            RingIndicator().frame(maxHeight: .infinity)
         case .success(let data):
             content(data)
         case .failure(let error):

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -57,7 +57,7 @@ struct AnalyticsView: View {
     }
 
     var eventList: some View {
-        EventList(provider: provider)
+        EventList(provider: provider, refresh: fetch)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     FilterButton(levels: $filter.levels)
@@ -65,9 +65,6 @@ struct AnalyticsView: View {
             }
             .task {
                 await provider.fetchIfNeeded(for: filter, in: database)
-            }
-            .refreshable {
-                await fetch()
             }
             .onChange(of: filter.levels) { _ in
                 Task {

--- a/Sources/Scout/UI/Event/List/EventList.swift
+++ b/Sources/Scout/UI/Event/List/EventList.swift
@@ -13,6 +13,8 @@ struct EventList: View {
     @Environment(\.database) var database
     @ObservedObject var provider: EventProvider
 
+    var refresh: (() async -> Void)?
+
     var body: some View {
         if let events = provider.events {
             if events.isEmpty {
@@ -22,21 +24,31 @@ struct EventList: View {
                     description: "Events will appear here once your app starts logging",
                     code: "logger.info(\"button_tapped\")"
                 )
+            } else if let refresh {
+                RefreshableList(action: refresh) {
+                    rows(for: events)
+                }
+                .animation(nil, value: UUID())
             } else {
                 List {
-                    ForEach(events, content: row)
-
-                    if let cursor = provider.cursor {
-                        PaginationFooter {
-                            await provider.fetchMore(cursor: cursor, in: database)
-                        }
-                    }
+                    rows(for: events)
                 }
                 .listStyle(.plain)
                 .animation(nil, value: UUID())
             }
         } else {
-            ProgressView().frame(maxHeight: .infinity)
+            RingIndicator().frame(maxHeight: .infinity)
+        }
+    }
+
+    @ViewBuilder
+    private func rows(for events: [Event]) -> some View {
+        ForEach(events, content: row)
+
+        if let cursor = provider.cursor {
+            PaginationFooter {
+                await provider.fetchMore(cursor: cursor, in: database)
+            }
         }
     }
 

--- a/Sources/Scout/UI/Event/List/EventStatList.swift
+++ b/Sources/Scout/UI/Event/List/EventStatList.swift
@@ -23,11 +23,8 @@ struct EventStatList: View {
 
     var body: some View {
         VStack {
-            EventList(provider: provider)
+            EventList(provider: provider, refresh: fetch)
                 .task {
-                    await fetch()
-                }
-                .refreshable {
                     await fetch()
                 }
                 .navigationTitle(range.label(using: formatter))

--- a/Sources/Scout/UI/Primitives/Rows/PaginationFooter.swift
+++ b/Sources/Scout/UI/Primitives/Rows/PaginationFooter.swift
@@ -13,7 +13,7 @@ struct PaginationFooter: View {
     let action: () async -> Void
 
     var body: some View {
-        ProgressView()
+        RingIndicator(size: 22)
             .task {
                 await action()
             }

--- a/Sources/Scout/UI/Primitives/States/RefreshableList.swift
+++ b/Sources/Scout/UI/Primitives/States/RefreshableList.swift
@@ -1,0 +1,171 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct RefreshableList<Content: View>: View {
+    private enum Phase {
+        case idle
+        case refreshing
+        case finishing
+
+        var isRefreshing: Bool {
+            self == .refreshing
+        }
+
+        var isSpinning: Bool {
+            self != .idle
+        }
+    }
+
+    private let indicatorSize: CGFloat = 28
+    private let retractDuration = 0.3
+
+    private let action: () async -> Void
+    private let content: Content
+
+    @State private var tracker = PullTracker(threshold: 80, releaseVelocity: 150)
+    @State private var gap: CGFloat = 0
+    @State private var phase: Phase = .idle
+
+    init(action: @escaping () async -> Void, @ViewBuilder content: () -> Content) {
+        self.action = action
+        self.content = content()
+    }
+
+    var body: some View {
+        GeometryReader { outer in
+            let viewportTop = outer.frame(in: .global).minY
+            let pull = phase.isSpinning ? 0 : max(tracker.offset, 0)
+            let arcProgress = pull / tracker.threshold
+            let topInset: CGFloat = phase.isRefreshing ? tracker.threshold : 0
+
+            List {
+                Section {
+                    content
+                } header: {
+                    // The header rides the top of the content to measure
+                    // the pull.
+                    Color.clear
+                        .frame(height: 1)
+                        .listRowInsets(EdgeInsets())
+                        .background {
+                            GeometryReader { geo in
+                                let pulled = geo.frame(in: .global).minY - viewportTop
+
+                                Color.clear
+                                    .onAppear { handle(offset: pulled) }
+                                    .onChange(of: pulled) { handle(offset: $0) }
+                            }
+                        }
+                }
+            }
+            .alwaysBounceVertically()
+            .listStyle(.plain)
+            .environment(\.defaultMinListHeaderHeight, 0)
+            .padding(.top, topInset)
+            .overlay(alignment: .top) {
+                let progress = min(arcProgress, 1)
+                let revealed = max(gap, 0)
+
+                RingIndicator(size: indicatorSize, progress: phase.isSpinning ? nil : arcProgress)
+                    .scaleEffect(phase.isRefreshing ? 1 : 0.4 + 0.6 * progress)
+                    .opacity(phase.isRefreshing ? 1 : progress)
+                    .offset(y: revealed / 2 - indicatorSize / 2)
+            }
+        }
+    }
+
+    private func handle(offset value: CGFloat) {
+        gap = value
+
+        // The top padding shifts the whole list while refreshing, so samples
+        // taken mid-cycle would read the inset as a new pull and re-fire;
+        // the tracker only listens while idle.
+        guard phase == .idle, tracker.update(offset: value, at: Date.timeIntervalSinceReferenceDate) else {
+            return
+        }
+
+        // The inset is applied without animation: it lands in the same layout
+        // pass that clamps the interrupted bounce, so the content is caught
+        // near the release point instead of dipping to zero first.
+        phase = .refreshing
+
+        Task {
+            await action()
+
+            withAnimation(.easeInOut(duration: retractDuration)) {
+                phase = .finishing
+            }
+
+            try? await Task.sleep(for: .seconds(retractDuration))
+            phase = .idle
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    fileprivate func alwaysBounceVertically() -> some View {
+        if #available(iOS 16.4, macOS 13.3, *) {
+            self.scrollBounceBehavior(.always)
+        } else {
+            self
+        }
+    }
+}
+
+struct PullTracker {
+    let threshold: CGFloat
+    let releaseVelocity: CGFloat
+
+    private(set) var offset: CGFloat = 0
+    private var baseline: CGFloat?
+    private var timestamp: TimeInterval?
+    private var armed = false
+
+    init(threshold: CGFloat, releaseVelocity: CGFloat) {
+        self.threshold = threshold
+        self.releaseVelocity = releaseVelocity
+    }
+
+    mutating func update(offset raw: CGFloat, at time: TimeInterval) -> Bool {
+        let base = baseline ?? raw
+        baseline = base
+
+        let value = raw - base
+        let elapsed = time - (timestamp ?? time)
+        let velocity = elapsed > 0 ? (offset - value) / elapsed : 0
+
+        timestamp = time
+        offset = value
+
+        // A released pull snaps back ballistically while a finger walking
+        // the list back moves slowly, so the speed at which the threshold
+        // is crossed tells a release from a cancelled pull.
+        if armed, value < threshold {
+            armed = false
+            return velocity > releaseVelocity
+        }
+
+        if value >= threshold {
+            armed = true
+        }
+
+        return false
+    }
+}
+
+#Preview {
+    RefreshableList {
+        try? await Task.sleep(for: .seconds(1.5))
+    } content: {
+        ForEach(0..<40, id: \.self) { index in
+            Text(verbatim: "Item \(index)")
+        }
+    }
+}

--- a/Sources/Scout/UI/Primitives/States/RingIndicator.swift
+++ b/Sources/Scout/UI/Primitives/States/RingIndicator.swift
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct RingIndicator: View {
+    static let lineWidth: CGFloat = 3
+
+    var size: CGFloat = 44
+    var progress: Double?
+
+    var body: some View {
+        Circle()
+            .stroke(Color(white: 0.8), lineWidth: Self.lineWidth)
+            .overlay { arc }
+            .frame(width: size, height: size)
+    }
+
+    @ViewBuilder
+    private var arc: some View {
+        if let progress {
+            blueArc.rotationEffect(.degrees(progress * 360))
+        } else {
+            TimelineView(.animation) { context in
+                blueArc.rotationEffect(.degrees(context.date.timeIntervalSinceReferenceDate * 400))
+            }
+        }
+    }
+
+    private var blueArc: some View {
+        Circle()
+            .trim(from: 0, to: 0.3)
+            .stroke(.blue, style: StrokeStyle(lineWidth: Self.lineWidth, lineCap: .round))
+    }
+}
+
+#Preview("Indeterminate") {
+    RingIndicator()
+}
+
+#Preview("Determinate") {
+    RingIndicator(progress: 0.6)
+}

--- a/Sources/Scout/UI/Releases/View/ReleaseHealthView.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseHealthView.swift
@@ -34,7 +34,7 @@ struct ReleaseHealthView: View {
                     .listStyle(.plain)
                 }
             } else {
-                ProgressView().frame(maxHeight: .infinity)
+                RingIndicator().frame(maxHeight: .infinity)
             }
         }
         .navigationTitle(en: "Releases")

--- a/Sources/Scout/UI/Timeline/Pagination/RailPagination.swift
+++ b/Sources/Scout/UI/Timeline/Pagination/RailPagination.swift
@@ -19,7 +19,7 @@ struct RailPagination: View {
         if lane.pendingInstalls.isEmpty {
             EmptyView()
         } else if lane.isLoading {
-            ProgressView().frame(height: 72).frame(maxWidth: .infinity)
+            RingIndicator(size: 22).frame(height: 72).frame(maxWidth: .infinity)
         } else {
             Color.clear.frame(height: 1).background {
                 GeometryReader { geo in

--- a/Sources/Scout/UI/Timeline/View/Timeline.swift
+++ b/Sources/Scout/UI/Timeline/View/Timeline.swift
@@ -22,7 +22,7 @@ struct Timeline: View {
         Group {
             switch provider.result {
             case nil:
-                ProgressView().frame(maxHeight: .infinity)
+                RingIndicator().frame(maxHeight: .infinity)
             case .failure(let error):
                 errorView(Text(verbatim: error.localizedDescription))
             case .success where provider.items.count == 0:

--- a/Tests/ScoutTests/UI/Primitives/States/PullTrackerTests.swift
+++ b/Tests/ScoutTests/UI/Primitives/States/PullTrackerTests.swift
@@ -1,0 +1,91 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct PullTrackerTests {
+    private func makeTracker() -> PullTracker {
+        PullTracker(threshold: 80, releaseVelocity: 150)
+    }
+
+    private func update(_ tracker: inout PullTracker, _ offset: CGFloat, at time: TimeInterval) -> Bool {
+        tracker.update(offset: offset, at: time)
+    }
+
+    @Test("First sample becomes the baseline and reads as zero")
+    func testBaselineCalibration() {
+        var tracker = makeTracker()
+
+        #expect(!update(&tracker, 25, at: 0))
+        #expect(tracker.offset == 0)
+
+        #expect(!update(&tracker, 75, at: 1))
+        #expect(tracker.offset == 50)
+    }
+
+    @Test("A fast snap-back through the threshold fires")
+    func testFiresOnRelease() {
+        var tracker = makeTracker()
+
+        #expect(!update(&tracker, 0, at: 0))
+        #expect(!update(&tracker, 100, at: 0.5))
+        #expect(update(&tracker, 70, at: 0.51))
+    }
+
+    @Test("A slow return through the threshold does not fire")
+    func testIgnoresSlowReturn() {
+        var tracker = makeTracker()
+
+        #expect(!update(&tracker, 0, at: 0))
+        #expect(!update(&tracker, 100, at: 1))
+        #expect(!update(&tracker, 79, at: 2))
+    }
+
+    @Test("Releasing after a slow return does not fire")
+    func testNoFireAfterCancelledPull() {
+        var tracker = makeTracker()
+
+        #expect(!update(&tracker, 0, at: 0))
+        #expect(!update(&tracker, 100, at: 1))
+        #expect(!update(&tracker, 79, at: 2))
+        #expect(!update(&tracker, 40, at: 2.01))
+        #expect(!update(&tracker, 0, at: 2.02))
+    }
+
+    @Test("A pull short of the threshold never fires")
+    func testIgnoresShortPull() {
+        var tracker = makeTracker()
+
+        #expect(!update(&tracker, 0, at: 0))
+        #expect(!update(&tracker, 79, at: 1))
+        #expect(!update(&tracker, 0, at: 1.01))
+    }
+
+    @Test("The gesture rearms after a cancelled pull")
+    func testRearmsAfterCancel() {
+        var tracker = makeTracker()
+
+        #expect(!update(&tracker, 0, at: 0))
+        #expect(!update(&tracker, 100, at: 1))
+        #expect(!update(&tracker, 79, at: 2))
+
+        #expect(!update(&tracker, 100, at: 3))
+        #expect(update(&tracker, 70, at: 3.01))
+    }
+
+    @Test("Samples sharing a timestamp read as zero velocity")
+    func testZeroElapsedIsSafe() {
+        var tracker = makeTracker()
+
+        #expect(!update(&tracker, 0, at: 0))
+        #expect(!update(&tracker, 100, at: 1))
+        #expect(!update(&tracker, 70, at: 1))
+    }
+}


### PR DESCRIPTION
Replaces the system ProgressView at every loading state with RingIndicator, a ring spinner drawn from a gray track and a rotating blue arc that also renders determinate progress. Pagination footers use a half-size ring. Event lists gain RefreshableList, a List-backed pull-to-refresh container: a section-header anchor measures the pull, a velocity threshold tells a genuine release from a cancelled drag (pulling past the threshold and walking back with the finger no longer fires), and the indicator stays centered in the measured gap through the pull, the pinned refresh inset, and the animated retract. The gesture state machine lives in PullTracker, a pure type covered by unit tests.