### PR TITLE
Add skills lockfile for skill catalog

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,509 @@
+{
+  "version": 1,
+  "skills": {
+    "accessorysetupkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/accessorysetupkit/SKILL.md",
+      "computedHash": "f8096ef719c163694ca03176bcada7a042dd0c4eabf7d431f2a928006426a48b"
+    },
+    "activitykit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/activitykit/SKILL.md",
+      "computedHash": "05e07a71d4d86aca23d9d07b4e300d5109c9de8e45cd1f588ca1caf908396e3f"
+    },
+    "adattributionkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/adattributionkit/SKILL.md",
+      "computedHash": "b5e3bd6bcd1d76f0a8718c91b619297dcb79d9065cdbb906fdd9fa5eca3369ef"
+    },
+    "alarmkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/alarmkit/SKILL.md",
+      "computedHash": "b710183061876b04d41246b433e9495dc5f36af98165555adb73aa56aa027bdd"
+    },
+    "app-clips": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/app-clips/SKILL.md",
+      "computedHash": "b46eccbb94c46e523e9d3d4dbfe77177eb5707b331b4f1b2f752ce7fcc3babb5"
+    },
+    "app-intents": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/app-intents/SKILL.md",
+      "computedHash": "ba47bd4e28b2fe93d6b98f64373217932b303bfe2bfb2b188da1e0927af63760"
+    },
+    "app-store-optimization": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/app-store-optimization/SKILL.md",
+      "computedHash": "054a3e7c396ea58fab88ae97321af6d16e967dc20ee6842e59698f24c7bca957"
+    },
+    "app-store-review": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/app-store-review/SKILL.md",
+      "computedHash": "f153d3d2851501cf5b13e2c398723ccf42b0799b1936a895aa06baed3bffbfc3"
+    },
+    "apple-on-device-ai": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/apple-on-device-ai/SKILL.md",
+      "computedHash": "4395246b8f716ada6612e2f7c779b8e8a57236be56ce3d0cb555415039ff2790"
+    },
+    "appmigrationkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/appmigrationkit/SKILL.md",
+      "computedHash": "5a778af31d013d620c0652c2284a9bf60341d19f3dc3084e3e091dde3c768799"
+    },
+    "audioaccessorykit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/audioaccessorykit/SKILL.md",
+      "computedHash": "2f65e4ff96ee9ab9eb2d4b57aad55997423c3a52f4d0ee3a9597771a20a7a08d"
+    },
+    "authentication": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/authentication/SKILL.md",
+      "computedHash": "db202ef53b71513a1df203934be1ad89c46616f0aa497d00a52c7c1e38a4a6ef"
+    },
+    "avkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/avkit/SKILL.md",
+      "computedHash": "e040830cb39cf33195847476d6dc1538bc931b65711f4765ac6f96564b1145ef"
+    },
+    "background-processing": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/background-processing/SKILL.md",
+      "computedHash": "6eec08d249bbb874b3ade5fcfeadbcbb5ede4854f274da949e71cb66f2175f66"
+    },
+    "browserenginekit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/browserenginekit/SKILL.md",
+      "computedHash": "dc8685f5191785b0ee641c0d11fe301591a89f39d2265044c7a255401950d5ba"
+    },
+    "callkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/callkit/SKILL.md",
+      "computedHash": "a1ee326d1797e0f02d1e16fc55d6851b8c097d41fb2c7b172bd193a2f5858e14"
+    },
+    "carplay": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/carplay/SKILL.md",
+      "computedHash": "3e3bd18ff8d36d20fdf181adcfb0dc3a70fcdf0bb3eeffedd5f245e71eea5105"
+    },
+    "cloudkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cloudkit/SKILL.md",
+      "computedHash": "a1305dd30b71931e943dcd6884ece12889e2eef191ceecb3069c4accd1e8ab7c"
+    },
+    "contacts-framework": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/contacts-framework/SKILL.md",
+      "computedHash": "0668f8ffb109a0d810f781e8997d257db3407a6a16d8b5fd304c61d4694654dd"
+    },
+    "core-bluetooth": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/core-bluetooth/SKILL.md",
+      "computedHash": "ed1f2063acc4ab3631505be374b6207a5b8108130365226727c7cf3eec27ec67"
+    },
+    "core-data": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/core-data/SKILL.md",
+      "computedHash": "62b1b8167dceb086eaa46b4f1bb67b4d9835567c195e495590a5001e635b28a1"
+    },
+    "core-motion": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/core-motion/SKILL.md",
+      "computedHash": "f9bfc40feb85e40e319b8bbb0fdf0ce929b0c3ba76ee55d4f181d733e519393d"
+    },
+    "core-nfc": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/core-nfc/SKILL.md",
+      "computedHash": "4a7da322f890afb79907764923c9de261de6211d477aa0a88889b6191eb21e23"
+    },
+    "coreml": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/coreml/SKILL.md",
+      "computedHash": "ab69097c42fbdf07cb003f0ba2a70cad38c453bf8b9478ddccc2bb9da6cf1771"
+    },
+    "cryptokit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cryptokit/SKILL.md",
+      "computedHash": "ac3a186db2de7fc1fe009b6f828e47010dec21b605f2ea73017cddbf6962f3f2"
+    },
+    "cryptotokenkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cryptotokenkit/SKILL.md",
+      "computedHash": "8830b15abe88a1697a03b650c68f100dfd6fc6c81fd259f22fcfc08b2ba1f3d6"
+    },
+    "debugging-instruments": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/debugging-instruments/SKILL.md",
+      "computedHash": "36b0504aa04b586c926284a825c29fc3596137640d7e7e3f0a46c0e8a9ec72ce"
+    },
+    "device-integrity": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/device-integrity/SKILL.md",
+      "computedHash": "5f7f41c564855b643a25e806fab1f774dfe44ad76b71fe0b2f52e2b16f46eacb"
+    },
+    "dockkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/dockkit/SKILL.md",
+      "computedHash": "cd6854a9eaad69c9ea01f487b3a9d5c68351337f74b07201071821d155d94201"
+    },
+    "energykit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/energykit/SKILL.md",
+      "computedHash": "75cb0a6f2919f5bdf8f1e6bc62b02be75fdf34f167da6c499b4e15cc8070ea66"
+    },
+    "eventkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/eventkit/SKILL.md",
+      "computedHash": "15913ced47d5f4d173f767d732f571e2fad7f25a3b35fc38c170d25651cf9042"
+    },
+    "financekit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/financekit/SKILL.md",
+      "computedHash": "12a3f9ff24f8b8ea4a32ca6b1f48433c56a435361a7440e6d411a08a8ef6db7a"
+    },
+    "focus-engine": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/focus-engine/SKILL.md",
+      "computedHash": "676012857d09a66f05e3424cd70170530dcd2159a690a47d276b5ca9df0a1243"
+    },
+    "gamekit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/gamekit/SKILL.md",
+      "computedHash": "b3ac77ddf7778bab5c74a801105d668239c371f128b2d27a51555b3638c8a62c"
+    },
+    "healthkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/healthkit/SKILL.md",
+      "computedHash": "4a16a82e7a82bab25545da88bc2a9356c3cbe758bee9fe893460596afabb655b"
+    },
+    "homekit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/homekit/SKILL.md",
+      "computedHash": "f4f0cc81f99af7d85feb96addabf7378be6c9870456da325f737d23a6d8c112e"
+    },
+    "ios-accessibility": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/ios-accessibility/SKILL.md",
+      "computedHash": "4308d6edf99a9fac7fbb0389da4977d0a7e05f7986c46618e1d6ef285839a7c4"
+    },
+    "ios-localization": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/ios-localization/SKILL.md",
+      "computedHash": "b14d2111112f4d95c816c5e74448f14b7564a25eb0a002b3ad47ae9f0f4e193e"
+    },
+    "ios-networking": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/ios-networking/SKILL.md",
+      "computedHash": "457b95b2a07508df2599f432d3c0b55dbbe29faaa7811c37d8caa10ee288b3fa"
+    },
+    "ios-simulator": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/ios-simulator/SKILL.md",
+      "computedHash": "4be3ebf3da764dc452b888cf96d78863e618a90550cb5a713aab5c2683407499"
+    },
+    "mapkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/mapkit/SKILL.md",
+      "computedHash": "5a9aee08a1d4b9fcc90ad82d789266fe79d95cf71a7f0092984cbb8fb6c6aff2"
+    },
+    "metrickit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/metrickit/SKILL.md",
+      "computedHash": "92ab2d4185d59c743edabb83ad77e3e90ac11592bfa790f82eddd863755b7c8e"
+    },
+    "musickit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/musickit/SKILL.md",
+      "computedHash": "5a85e412d37a9f5b7d49d35d176f271395682cae81a43e2dd9b6c789cad52341"
+    },
+    "natural-language": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/natural-language/SKILL.md",
+      "computedHash": "9c8d2dee17feacfa9f6d861db9d06740d8feb6733b339e84f11cbfaf15c40dcb"
+    },
+    "paperkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/paperkit/SKILL.md",
+      "computedHash": "fe41af13dcec614d49cec24dcd1e48e7536852c9419b165dfff3df1fc5d1fb24"
+    },
+    "passkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/passkit/SKILL.md",
+      "computedHash": "0246730e1acfc12c0da39aaf9516e566a95e463eba1b22a0beb9ecb7d864799c"
+    },
+    "pdfkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/pdfkit/SKILL.md",
+      "computedHash": "b0ab08bcd8f46827b2799f5677a8b9db72f9bea3f2e5fa0f02ee240f5dac4dc7"
+    },
+    "pencilkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/pencilkit/SKILL.md",
+      "computedHash": "0ccef1c50846c8dce27aebddcd739565f38feb57933619d3d634b263f123266a"
+    },
+    "permissionkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/permissionkit/SKILL.md",
+      "computedHash": "63b95b5c4acaf2ca47193e5dda6ac07fb595affe8aff5d4587f49cc193f351c5"
+    },
+    "photokit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/photokit/SKILL.md",
+      "computedHash": "e468521d2655870357ad0225355ec47992b83ade3163dc7574d51c6ba95ca8f3"
+    },
+    "push-notifications": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/push-notifications/SKILL.md",
+      "computedHash": "7afc693b1c38505f6dd9c78048785bc7f07dcb29f5cd971e08dfe8eaeb6ec7c3"
+    },
+    "realitykit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/realitykit/SKILL.md",
+      "computedHash": "a77720ffd5bcbbad9077fe088290924b9cdc35bde8a4cda6f7ac78becf89bb7e"
+    },
+    "relevancekit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/relevancekit/SKILL.md",
+      "computedHash": "061ae87928afadfd35bd7a626f5629917ef43287c89262cbbaed07e121874132"
+    },
+    "scenekit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/scenekit/SKILL.md",
+      "computedHash": "cc1f02f264de9c06196801d7b68938e0ab0d94f1a0c6a3e5cd8c6dc53094641e"
+    },
+    "sensorkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/sensorkit/SKILL.md",
+      "computedHash": "80dbb9a1d7642570b63744f263e483a3efa73db5b2fd747f990c749105a496d6"
+    },
+    "shareplay-activities": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/shareplay-activities/SKILL.md",
+      "computedHash": "6e9db9c8df4581250c91f83e2a647ed961e17857608e12f150de560292bcd9da"
+    },
+    "speech-recognition": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/speech-recognition/SKILL.md",
+      "computedHash": "f08292501f86dcd7ae2b05f19e4e35af93af32cdd52b6ad8b732c91a5edb787c"
+    },
+    "spritekit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/spritekit/SKILL.md",
+      "computedHash": "2f35eb80b826cb27255130581333e431833797eabc3359958e79ec0f84de67f4"
+    },
+    "storekit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/storekit/SKILL.md",
+      "computedHash": "12569f18bfb65bd2f234eb0e3e07095f5c4198221f486fbb8c748704b9820234"
+    },
+    "swift-api-design-guidelines": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swift-api-design-guidelines/SKILL.md",
+      "computedHash": "ee2f809108c5dcd0398e05e2f6532a98458f132135ffb799d220e0b337492d1f"
+    },
+    "swift-architecture": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swift-architecture/SKILL.md",
+      "computedHash": "5ae1a4ef5a8e435df52d74abb49a458964ad1b381466c28a22cc64657336454c"
+    },
+    "swift-charts": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swift-charts/SKILL.md",
+      "computedHash": "ed8e066f4983ea7c151cb98be6cfa90f3b6c90aa74fbd61efd86339df48eadd3"
+    },
+    "swift-codable": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swift-codable/SKILL.md",
+      "computedHash": "e757d1684bee8f85df110c531b59e36f625b4da90b33269ffd5a5eed532d3410"
+    },
+    "swift-concurrency": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swift-concurrency/SKILL.md",
+      "computedHash": "3404c000fdff4102d3cf702be79b9f30e1a431ae643194ac6f39a42af065afb0"
+    },
+    "swift-formatstyle": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swift-formatstyle/SKILL.md",
+      "computedHash": "d4ee8e89e9e42e73999f748522066c62034fcc6d1d83b00bda39ff4b90ffad38"
+    },
+    "swift-language": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swift-language/SKILL.md",
+      "computedHash": "a5e75d37eec504dd0a47977aaf9ef1e2bfddfdca57aeca081e078a1b4f229f14"
+    },
+    "swift-security": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swift-security/SKILL.md",
+      "computedHash": "bfc8595b5064137d8e0323e8a668c8e05b1a04b4f0653ec0a7e63aac9c23303b"
+    },
+    "swift-testing": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swift-testing/SKILL.md",
+      "computedHash": "8ee6f008a8ec5928a4f259efa6eed38b124bc0720aeb77261fad06a72f2a0189"
+    },
+    "swiftdata": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftdata/SKILL.md",
+      "computedHash": "666ce4bf5ed3756e6148424ee2391d0b5c5d0e4744428c127b12edcbd29ebf89"
+    },
+    "swiftlint": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftlint/SKILL.md",
+      "computedHash": "3493af84a6515d2bf909294ecab0a7bfffe7dfb75467a647f8cec22d63bfe7d9"
+    },
+    "swiftui-animation": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftui-animation/SKILL.md",
+      "computedHash": "d31316ceb76e3e1c109442859f25de8879b486560b549b081b4f87124c8c7a03"
+    },
+    "swiftui-gestures": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftui-gestures/SKILL.md",
+      "computedHash": "426d390493f0e9976513acfe60bc034dfb4678f006b3e74c2ee1fbfce0a78882"
+    },
+    "swiftui-layout-components": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftui-layout-components/SKILL.md",
+      "computedHash": "8d6c59f32eb681459571370b4a3b2b87a8aedaa47741c1a9682212418c9c153a"
+    },
+    "swiftui-liquid-glass": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftui-liquid-glass/SKILL.md",
+      "computedHash": "7019bec86ca1a42156b46b909bc95fc686a84b1d5433b1dcf3b56de1bf125c06"
+    },
+    "swiftui-navigation": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftui-navigation/SKILL.md",
+      "computedHash": "8ffc6f74571897285e7af3de1e878df4345497f6f6d6ccc33da5767aca8c40d4"
+    },
+    "swiftui-patterns": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftui-patterns/SKILL.md",
+      "computedHash": "f29dc5e517f1dc257b7b9648eb8189b6e904eb405f7dfb50e6b6eac61dce5503"
+    },
+    "swiftui-performance": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftui-performance/SKILL.md",
+      "computedHash": "4a4e28f8c2e04c91a70c866fcdfcf95071af214aa36501573be3e2fed1476e25"
+    },
+    "swiftui-uikit-interop": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftui-uikit-interop/SKILL.md",
+      "computedHash": "d1c1acdf0398c8122618e3005ff24b0c291d5874f0e57a64013af35327d6d4f3"
+    },
+    "swiftui-webkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/swiftui-webkit/SKILL.md",
+      "computedHash": "08a604819b46a5cbf2d86c8bf1f7db464d6f60e440df79f7dca33c7271d19cda"
+    },
+    "tabletopkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/tabletopkit/SKILL.md",
+      "computedHash": "e88065f7616fd227ad7b3668cbb6e89006fbfffd567edbb387fe9598e6e97bc5"
+    },
+    "tipkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/tipkit/SKILL.md",
+      "computedHash": "9a52a1fa3c89e71634c990f7cef21d136eb4c731e0a55f0675f504570d9c54ed"
+    },
+    "vision-framework": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/vision-framework/SKILL.md",
+      "computedHash": "2633ba482dca4336b571ed2e6f17ab429ea6c79feb0a043c89654eea51c08452"
+    },
+    "weatherkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/weatherkit/SKILL.md",
+      "computedHash": "c07c57e8ff61cd883eabf1e215e7fae503e4369074b199a2b7a4d32656307be4"
+    },
+    "widgetkit": {
+      "source": "dpearson2699/swift-ios-skills",
+      "sourceType": "github",
+      "skillPath": "skills/widgetkit/SKILL.md",
+      "computedHash": "e7d728d6ff968624243ae0cc805d69ddda184ff4e323911ac47167852e1235bf"
+    }
+  }
+}


### PR DESCRIPTION
Introduce `skills-lock.json` with the full set of tracked iOS skills, their source paths, and computed hashes. This locks the catalog to specific content versions for reproducible skill resolution.