### PR TITLE
Add a Settings screen with live backend health and diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@
 
 - Scout UI strings must always render in source English: use `Text(verbatim: …)` for literals (or `.navigationTitle(en: …)` for titles) so they don't resolve through the host app's `LocalizedStringKey` catalog.
 
+## Lists
+
+- Use only `.listStyle(.plain)` for `List`s; section titles are `Header(title:)` rows (not `Section` headers/footers), with `.listRowSeparator(.hidden)` on non-row content.
+
 ## Sample data
 
 - Sample data in app code is named `sample` (a `static var` for fixed instances, a `static func sample(...)` when parameters are needed), placed in an extension at the end of the type's main file (e.g. `Device.swift`), and built directly via the struct initializer.

--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -13,6 +13,7 @@ public struct Backend: Sendable {
     let checkAvailability: @Sendable () async -> Bool
     let displayName: String
 
+    var serverInfo: ServerInfo? = nil
     var aggregator: (MatrixAggregator)? = nil
     var probeStatus: @Sendable () async -> Status = { .unknown }
     var accountWarning: @Sendable () async -> Bool = { false }
@@ -27,6 +28,12 @@ public struct Backend: Sendable {
         case unknown
 
         var id: Self { self }
+    }
+
+    struct ServerInfo: Sendable {
+        let endpoint: String
+        let hasAPIKey: Bool
+        let isSecure: Bool
     }
 }
 

--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -17,6 +17,8 @@ public struct Backend: Sendable {
     var probeStatus: @Sendable () async -> Status = { .unknown }
     var accountWarning: @Sendable () async -> Bool = { false }
     var verifySchema: @Sendable () async throws -> Void = {}
+    var schemaChecks: @Sendable () async -> [SchemaCheck] = { [] }
+    var runBenchmark: (@Sendable () async -> Bool)? = nil
     var onSetup: @MainActor @Sendable () -> Void = {}
 
     enum Status: CaseIterable, Identifiable, Sendable {
@@ -26,4 +28,11 @@ public struct Backend: Sendable {
 
         var id: Self { self }
     }
+}
+
+struct SchemaCheck: Identifiable, Sendable {
+    let recordType: String
+    let isValid: Bool
+
+    var id: String { recordType }
 }

--- a/Sources/Scout/Hosted/Access/HostedBackend.swift
+++ b/Sources/Scout/Hosted/Access/HostedBackend.swift
@@ -14,6 +14,11 @@ extension Backend {
             database: HTTPDatabase(url: url, apiKey: apiKey),
             checkAvailability: { true },
             displayName: url.host ?? url.absoluteString,
+            serverInfo: ServerInfo(
+                endpoint: url.hostWithPort ?? url.absoluteString,
+                hasAPIKey: apiKey != nil,
+                isSecure: url.scheme?.lowercased() == "https"
+            ),
             probeStatus: {
                 do {
                     try await HTTPDatabase(url: url, apiKey: apiKey).ping()
@@ -28,5 +33,12 @@ extension Backend {
                 }
             }
         )
+    }
+}
+
+extension URL {
+    fileprivate var hostWithPort: String? {
+        guard let host else { return nil }
+        return port.map { "\(host):\($0)" } ?? host
     }
 }

--- a/Sources/Scout/Native/Access/NativeBackend.swift
+++ b/Sources/Scout/Native/Access/NativeBackend.swift
@@ -25,6 +25,8 @@ extension Backend {
                 (try? await container.accountStatus()) != .available
             },
             verifySchema: container.verifySchema,
+            schemaChecks: container.schemaChecks,
+            runBenchmark: { await verifyParallelismBenchmark(container: container) },
             onSetup: container.verifyParallelismIfDue
         )
     }

--- a/Sources/Scout/Native/Schema/CKContainer+Verify.swift
+++ b/Sources/Scout/Native/Schema/CKContainer+Verify.swift
@@ -34,16 +34,12 @@ private let schemaRecordTypes = [
 ]
 
 extension CKContainer {
-    /// Queries each record type to verify the CloudKit schema is up to date.
-    ///
-    /// Throws a `SchemaError` if any record types have schema issues.
-    ///
-    func verifySchema() async throws {
-        guard let status = try? await accountStatus(), status == .available else {
-            return
-        }
+    // Queries each record type; flaky non-schema failures are skipped so one
+    // bad query doesn't abort the rest, and are absent from the result.
+    func schemaChecks() async -> [SchemaCheck] {
+        guard let status = try? await accountStatus(), status == .available else { return [] }
 
-        var invalid: [String] = []
+        var checks: [SchemaCheck] = []
 
         for recordType in schemaRecordTypes {
             let query = CKQuery(recordType: recordType, predicate: NSPredicate(value: true))
@@ -52,17 +48,27 @@ extension CKContainer {
                 try await publicCloudDatabase.runner { database in
                     _ = try await database.records(matching: query, desiredKeys: [], resultsLimit: 1)
                 }
+                checks.append(SchemaCheck(recordType: recordType, isValid: true))
             } catch let error as CKError where error.isSchemaError {
                 print("[Scout] Schema error for '\(recordType)': \(error.localizedDescription)")
-                invalid.append(recordType)
+                checks.append(SchemaCheck(recordType: recordType, isValid: false))
             } catch {
-                // Skip non-schema failures so one flaky query doesn't abort the rest.
                 print("[Scout] Skipping '\(recordType)': \(error.localizedDescription)")
                 continue
             }
         }
 
-        if !invalid.isEmpty {
+        return checks
+    }
+
+    /// Queries each record type to verify the CloudKit schema is up to date.
+    ///
+    /// Throws a `SchemaError` if any record types have schema issues.
+    ///
+    func verifySchema() async throws {
+        let invalid = await schemaChecks().filter { !$0.isValid }.map(\.recordType)
+
+        if invalid.count > 0 {
             let containerID = containerIdentifier ?? "<container-id>"
 
             print("[Scout] Upload the Schema file to '\(containerID)' via CloudKit Console: https://icloud.developer.apple.com/dashboard/")

--- a/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
@@ -9,12 +9,14 @@ import SwiftUI
 
 struct ConnectionMenu: View {
     @Binding var activeID: Connection.ID
+    let onSettings: () -> Void
 
     @State private var connections: [Connection]
     @State private var isPresented = false
 
-    init(connections: [Connection], activeID: Binding<Connection.ID>) {
+    init(connections: [Connection], activeID: Binding<Connection.ID>, onSettings: @escaping () -> Void = {}) {
         _activeID = activeID
+        self.onSettings = onSettings
         _connections = State(initialValue: connections)
     }
 
@@ -34,11 +36,29 @@ struct ConnectionMenu: View {
                         ConnectionRow(
                             connection: connection,
                             isActive: connection.id == activeID,
-                            showsSeparator: connection.id != connections.last?.id
+                            showsSeparator: true
                         )
                     }
                     .buttonStyle(.plain)
                 }
+
+                Button {
+                    isPresented = false
+                    onSettings()
+                } label: {
+                    HStack {
+                        Image(systemName: "slider.horizontal.3")
+                            .imageScale(.medium)
+                            .foregroundStyle(.secondary)
+                        Text(verbatim: "Settings")
+                            .font(.system(size: 16))
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
             }
             .frame(minWidth: 240)
             .task {

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -12,6 +12,7 @@ public struct HomeView: View {
 
     @AppStorage("scout_active_backend") private var activeID = ""
     @StateObject private var tint = Tint()
+    @State private var isSettingsPresented = false
 
     public init(backends: [Backend]) {
         self.backends = backends
@@ -19,6 +20,10 @@ public struct HomeView: View {
 
     private var backend: Backend? {
         backends.first(where: { $0.id == activeID }) ?? backends.first
+    }
+
+    private var activeIDBinding: Binding<String> {
+        Binding(get: { backend?.id ?? "" }, set: { activeID = $0 })
     }
 
     public var body: some View {
@@ -40,13 +45,20 @@ public struct HomeView: View {
             .navigationTitle(en: "Home")
             .dismissable()
             .toolbar {
-                if let backend {
+                if backend != nil {
                     ToolbarItem(placement: .topBarTrailing) {
                         ConnectionMenu(
                             connections: backends.map(Connection.init),
-                            activeID: Binding(get: { backend.id }, set: { activeID = $0 })
+                            activeID: activeIDBinding,
+                            onSettings: { isSettingsPresented = true }
                         )
                     }
+                }
+            }
+            .sheet(isPresented: $isSettingsPresented) {
+                NavigationStack {
+                    SettingsOverviewView(backends: backends, activeID: activeIDBinding)
+                        .dismissable()
                 }
             }
         }

--- a/Sources/Scout/UI/Settings/BackendDetailView.swift
+++ b/Sources/Scout/UI/Settings/BackendDetailView.swift
@@ -1,0 +1,246 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct BackendDetailView: View {
+    @ObservedObject var provider: BackendHealthProvider
+    let id: String
+    @Binding var activeID: String
+
+    @State private var checks: [SchemaCheck]?
+    @State private var isChecking = false
+    @State private var isBenchmarking = false
+    @State private var message: Message?
+
+    private var backend: BackendHealth? {
+        provider.backends.first { $0.id == id }
+    }
+
+    var body: some View {
+        Group {
+            if let backend {
+                content(for: backend)
+            } else {
+                ErrorView(description: Text(verbatim: "This backend is no longer available."), retry: nil)
+            }
+        }
+        .navigationTitle(en: backend?.name ?? "Backend")
+        .inlineNavigationTitle()
+        .message($message)
+    }
+
+    private func content(for backend: BackendHealth) -> some View {
+        List {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 10) {
+                    Image(systemName: backend.status.healthIcon)
+                        .font(.title2)
+                        .foregroundStyle(backend.status.healthColor)
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(verbatim: backend.status.healthLabel)
+                            .font(.headline)
+                        Text(verbatim: backend.engine.label)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Text(verbatim: backend.endpoint)
+                    .codeChipStyle()
+            }
+            .padding(.vertical, 6)
+            .listRowSeparator(.hidden)
+
+            Header(title: "Health")
+
+            DetailValueRow(title: "Latency", value: backend.latencyLabel)
+
+            if let spread = backend.pingSpreadLabel {
+                DetailValueRow(title: "Min / Avg / Max", value: spread)
+            }
+
+            DetailValueRow(title: "Last Checked", value: backend.lastCheckedLabel)
+
+            if backend.pings.count > 0 {
+                HStack {
+                    Text(verbatim: "Recent Pings")
+                    Spacer()
+                    PingSparkline(pings: backend.pings)
+                        .frame(width: 144, height: 28)
+                }
+            }
+
+            switch backend.engine {
+            case .cloudKit:
+                Header(title: "Schema")
+
+                if let checks {
+                    if checks.count > 0 {
+                        ForEach(checks) { check in
+                            HStack(spacing: 12) {
+                                Image(systemName: check.isValid ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                    .foregroundStyle(check.isValid ? .green : .red)
+                                Text(verbatim: check.recordType)
+                                Spacer()
+                                Text(verbatim: check.isValid ? "Deployed" : "Missing")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    } else {
+                        Text(verbatim: "Schema could not be checked. Sign in to iCloud and try again.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .listRowSeparator(.hidden)
+                    }
+                } else {
+                    HStack(spacing: 12) {
+                        ProgressView()
+                        Text(verbatim: "Checking record types…")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .listRowSeparator(.hidden)
+                }
+            case .server:
+                Header(title: "Connection")
+
+                DetailValueRow(title: "API Key", value: backend.hasAPIKey ? "Configured" : "Not set")
+                DetailValueRow(title: "Timeout", value: "10 s")
+                DetailValueRow(title: "Transport", value: backend.isSecure ? "HTTPS" : "HTTP")
+            }
+
+            Header(title: "Actions")
+
+            if backend.id != activeID {
+                Button {
+                    activeID = backend.id
+                } label: {
+                    Text(verbatim: "Use This Backend")
+                        .foregroundStyle(.tint)
+                }
+            }
+
+            Button {
+                isChecking = true
+                Task {
+                    await provider.refresh(id: backend.id)
+                    isChecking = false
+                }
+            } label: {
+                HStack {
+                    Text(verbatim: "Check Now")
+                        .foregroundStyle(.tint)
+                    if isChecking {
+                        Spacer()
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isChecking)
+
+            if let benchmark = backend.runBenchmark {
+                Button {
+                    isBenchmarking = true
+                    Task {
+                        let passed = await benchmark()
+                        isBenchmarking = false
+                        message = Message(
+                            passed
+                                ? "Parallelism limit verified: \(RequestLimiter.requestLimit) in-flight requests hold up."
+                                : "Parallelism check failed — see the console log.",
+                            level: passed ? .success : .warning
+                        )
+                    }
+                } label: {
+                    HStack {
+                        Text(verbatim: "Run Parallelism Benchmark")
+                            .foregroundStyle(.tint)
+                        if isBenchmarking {
+                            Spacer()
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(isBenchmarking)
+
+                Text(verbatim: "The benchmark issues test queries to verify the \(RequestLimiter.requestLimit)-request limit.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .listRowSeparator(.hidden)
+            }
+        }
+        .listStyle(.plain)
+        .task {
+            if backend.engine == .cloudKit, checks == nil {
+                checks = await backend.schemaChecks()
+            }
+        }
+    }
+}
+
+struct DetailValueRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(verbatim: title)
+            Spacer()
+            Text(verbatim: value)
+                .font(.body.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct PingSparkline: View {
+    let pings: [Int]
+
+    var body: some View {
+        GeometryReader { proxy in
+            let peak = Double(pings.max() ?? 1)
+            let step = proxy.size.width / Double(pings.count)
+
+            HStack(alignment: .bottom, spacing: step * 0.382) {
+                ForEach(Array(pings.enumerated()), id: \.offset) { _, ping in
+                    Capsule()
+                        .fill(.tint.opacity(0.6))
+                        .frame(height: max(3, proxy.size.height * Double(ping) / peak))
+                }
+            }
+            .frame(maxHeight: .infinity, alignment: .bottom)
+        }
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, *)
+#Preview("Server") {
+    @Previewable @State var activeID = BackendHealth.samples[0].id
+    NavigationStack {
+        BackendDetailView(provider: .fixture(), id: BackendHealth.samples[0].id, activeID: $activeID)
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, *)
+#Preview("CloudKit") {
+    @Previewable @State var activeID = BackendHealth.samples[0].id
+    NavigationStack {
+        BackendDetailView(provider: .fixture(), id: BackendHealth.samples[1].id, activeID: $activeID)
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, *)
+#Preview("Unreachable") {
+    @Previewable @State var activeID = BackendHealth.samples[0].id
+    NavigationStack {
+        BackendDetailView(provider: .fixture(), id: BackendHealth.samples[3].id, activeID: $activeID)
+    }
+}

--- a/Sources/Scout/UI/Settings/BackendHealth.swift
+++ b/Sources/Scout/UI/Settings/BackendHealth.swift
@@ -31,29 +31,17 @@ struct BackendHealth: Identifiable {
 
 extension BackendHealth {
     init(backend: Backend) {
-        if let database = backend.database as? HTTPDatabase {
-            self.init(
-                id: backend.id,
-                name: backend.displayName,
-                endpoint: database.url.hostWithPort ?? database.url.absoluteString,
-                engine: .server,
-                hasAPIKey: database.apiKey != nil,
-                isSecure: database.url.scheme?.lowercased() == "https",
-                probe: backend.probeStatus,
-                schemaChecks: backend.schemaChecks,
-                runBenchmark: backend.runBenchmark
-            )
-        } else {
-            self.init(
-                id: backend.id,
-                name: backend.displayName,
-                endpoint: backend.id,
-                engine: .cloudKit,
-                probe: backend.probeStatus,
-                schemaChecks: backend.schemaChecks,
-                runBenchmark: backend.runBenchmark
-            )
-        }
+        self.init(
+            id: backend.id,
+            name: backend.displayName,
+            endpoint: backend.serverInfo?.endpoint ?? backend.id,
+            engine: backend.serverInfo == nil ? .cloudKit : .server,
+            hasAPIKey: backend.serverInfo?.hasAPIKey ?? false,
+            isSecure: backend.serverInfo?.isSecure ?? true,
+            probe: backend.probeStatus,
+            schemaChecks: backend.schemaChecks,
+            runBenchmark: backend.runBenchmark
+        )
     }
 
     func recording(status: Backend.Status, latency: Int?, at date: Date) -> BackendHealth {
@@ -68,13 +56,6 @@ extension BackendHealth {
             }
         }
         return health
-    }
-}
-
-extension URL {
-    fileprivate var hostWithPort: String? {
-        guard let host else { return nil }
-        return port.map { "\(host):\($0)" } ?? host
     }
 }
 

--- a/Sources/Scout/UI/Settings/BackendHealth.swift
+++ b/Sources/Scout/UI/Settings/BackendHealth.swift
@@ -1,0 +1,219 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct BackendHealth: Identifiable {
+    let id: String
+    let name: String
+    let endpoint: String
+    let engine: Engine
+    var hasAPIKey = false
+    var isSecure = true
+    var status: Backend.Status = .unknown
+    var latency: Int? = nil
+    var lastChecked: Date? = nil
+    var pings: [Int] = []
+    var probe: @Sendable () async -> Backend.Status = { .unknown }
+    var schemaChecks: @Sendable () async -> [SchemaCheck] = { [] }
+    var runBenchmark: (@Sendable () async -> Bool)? = nil
+
+    enum Engine {
+        case cloudKit
+        case server
+    }
+}
+
+extension BackendHealth {
+    init(backend: Backend) {
+        if let database = backend.database as? HTTPDatabase {
+            self.init(
+                id: backend.id,
+                name: backend.displayName,
+                endpoint: database.url.hostWithPort ?? database.url.absoluteString,
+                engine: .server,
+                hasAPIKey: database.apiKey != nil,
+                isSecure: database.url.scheme?.lowercased() == "https",
+                probe: backend.probeStatus,
+                schemaChecks: backend.schemaChecks,
+                runBenchmark: backend.runBenchmark
+            )
+        } else {
+            self.init(
+                id: backend.id,
+                name: backend.displayName,
+                endpoint: backend.id,
+                engine: .cloudKit,
+                probe: backend.probeStatus,
+                schemaChecks: backend.schemaChecks,
+                runBenchmark: backend.runBenchmark
+            )
+        }
+    }
+
+    func recording(status: Backend.Status, latency: Int?, at date: Date) -> BackendHealth {
+        var health = self
+        health.status = status
+        health.latency = latency
+        health.lastChecked = date
+        if let latency {
+            health.pings.append(latency)
+            if health.pings.count > 12 {
+                health.pings.removeFirst(health.pings.count - 12)
+            }
+        }
+        return health
+    }
+}
+
+extension URL {
+    fileprivate var hostWithPort: String? {
+        guard let host else { return nil }
+        return port.map { "\(host):\($0)" } ?? host
+    }
+}
+
+extension BackendHealth.Engine {
+    var label: String {
+        switch self {
+        case .cloudKit: "CloudKit"
+        case .server: "Scout Server"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .cloudKit: "icloud"
+        case .server: "server.rack"
+        }
+    }
+}
+
+extension Backend.Status {
+    var healthLabel: String {
+        switch self {
+        case .reachable: "Operational"
+        case .unreachable: "Unreachable"
+        case .unknown: "Checking"
+        }
+    }
+
+    var healthColor: Color {
+        switch self {
+        case .reachable: .green
+        case .unreachable: .red
+        case .unknown: .gray
+        }
+    }
+
+    var healthIcon: String {
+        switch self {
+        case .reachable: "checkmark.circle.fill"
+        case .unreachable: "xmark.octagon.fill"
+        case .unknown: "questionmark.circle.fill"
+        }
+    }
+}
+
+extension BackendHealth {
+    var latencyLabel: String {
+        latency.map { "\($0) ms" } ?? "—"
+    }
+
+    var lastCheckedLabel: String {
+        lastChecked?.agoLabel ?? "Never"
+    }
+
+    var pingSpreadLabel: String? {
+        guard let low = pings.min(), let high = pings.max(), pings.count > 0 else { return nil }
+        let average = pings.reduce(0, +) / pings.count
+        return "\(low) / \(average) / \(high) ms"
+    }
+}
+
+extension Date {
+    var agoLabel: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: self, relativeTo: Date())
+    }
+}
+
+extension BackendHealth {
+    static var samples: [BackendHealth] {
+        [
+            BackendHealth(
+                id: "https://api.scout.app",
+                name: "Production",
+                endpoint: "api.scout.app",
+                engine: .server,
+                hasAPIKey: true,
+                status: .reachable,
+                latency: 148,
+                lastChecked: Date(timeIntervalSinceNow: -12),
+                pings: [140, 152, 138, 171, 149, 162, 144, 155, 148, 158, 143, 148],
+                probe: {
+                    try? await Task.sleep(for: .milliseconds(148))
+                    return .reachable
+                }
+            ),
+            BackendHealth(
+                id: "iCloud.com.example.scout",
+                name: "iCloud",
+                endpoint: "iCloud.com.example.scout",
+                engine: .cloudKit,
+                status: .reachable,
+                latency: 264,
+                lastChecked: Date(timeIntervalSinceNow: -47),
+                pings: [251, 244, 302, 268, 259, 281, 247, 322, 264, 255, 273, 264],
+                probe: {
+                    try? await Task.sleep(for: .milliseconds(264))
+                    return .reachable
+                },
+                schemaChecks: { SchemaCheck.samples },
+                runBenchmark: { true }
+            ),
+            BackendHealth(
+                id: "https://staging.scout.app",
+                name: "Staging",
+                endpoint: "staging.scout.app",
+                engine: .server,
+                status: .unknown,
+                probe: { .unknown }
+            ),
+            BackendHealth(
+                id: "http://localhost:8080",
+                name: "Local",
+                endpoint: "localhost:8080",
+                engine: .server,
+                isSecure: false,
+                status: .unreachable,
+                lastChecked: Date(timeIntervalSinceNow: -340),
+                probe: { .unreachable }
+            ),
+        ]
+    }
+}
+
+extension SchemaCheck {
+    static var samples: [SchemaCheck] {
+        [
+            SchemaCheck(recordType: "Event", isValid: true),
+            SchemaCheck(recordType: "Session", isValid: true),
+            SchemaCheck(recordType: "Launch", isValid: true),
+            SchemaCheck(recordType: "Version", isValid: true),
+            SchemaCheck(recordType: "Install", isValid: true),
+            SchemaCheck(recordType: "Device", isValid: true),
+            SchemaCheck(recordType: "Crash", isValid: true),
+            SchemaCheck(recordType: "IntMetric", isValid: true),
+            SchemaCheck(recordType: "DoubleMetric", isValid: true),
+            SchemaCheck(recordType: "DateIntMatrix", isValid: false),
+        ]
+    }
+}

--- a/Sources/Scout/UI/Settings/BackendHealthProvider.swift
+++ b/Sources/Scout/UI/Settings/BackendHealthProvider.swift
@@ -1,0 +1,73 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+@MainActor
+class BackendHealthProvider: ObservableObject {
+    @Published private(set) var backends: [BackendHealth]
+
+    init(backends: [Backend]) {
+        self.backends = backends.map(BackendHealth.init)
+    }
+
+    init(healths: [BackendHealth]) {
+        self.backends = healths
+    }
+
+    func refreshAll() async {
+        await withTaskGroup(of: ProbeResult.self) { group in
+            for health in backends {
+                let id = health.id
+                let probe = health.probe
+                group.addTask {
+                    await Self.measure(id: id, probe: probe)
+                }
+            }
+            for await result in group {
+                apply(result)
+            }
+        }
+    }
+
+    func refresh(id: String) async {
+        guard let probe = backends.first(where: { $0.id == id })?.probe else { return }
+        apply(await Self.measure(id: id, probe: probe))
+    }
+
+    private struct ProbeResult: Sendable {
+        let id: String
+        let status: Backend.Status
+        let latency: Int?
+    }
+
+    private static func measure(id: String, probe: @Sendable () async -> Backend.Status) async -> ProbeResult {
+        let clock = ContinuousClock()
+        let start = clock.now
+        let status = await probe()
+        let elapsed = start.duration(to: clock.now)
+        return ProbeResult(id: id, status: status, latency: status == .reachable ? elapsed.milliseconds : nil)
+    }
+
+    private func apply(_ result: ProbeResult) {
+        guard let index = backends.firstIndex(where: { $0.id == result.id }) else { return }
+        backends[index] = backends[index].recording(status: result.status, latency: result.latency, at: Date())
+    }
+}
+
+extension Duration {
+    var milliseconds: Int {
+        Int(components.seconds) * 1_000 + Int(components.attoseconds / 1_000_000_000_000_000)
+    }
+}
+
+extension BackendHealthProvider {
+    static func fixture() -> BackendHealthProvider {
+        BackendHealthProvider(healths: BackendHealth.samples)
+    }
+}

--- a/Sources/Scout/UI/Settings/GlanceHero.swift
+++ b/Sources/Scout/UI/Settings/GlanceHero.swift
@@ -1,0 +1,79 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct GlanceSummary {
+    let reachable: Int
+    let total: Int
+    let averageLatency: Int?
+
+    init(backends: [BackendHealth]) {
+        reachable = backends.filter { $0.status == .reachable }.count
+        total = backends.count
+        let latencies = backends.compactMap(\.latency)
+        averageLatency = latencies.count > 0 ? latencies.reduce(0, +) / latencies.count : nil
+    }
+
+    var allOperational: Bool { reachable == total }
+
+    var title: String {
+        allOperational ? "All Systems Operational" : "\(reachable) of \(total) Backends Reachable"
+    }
+
+    var detail: String {
+        let count = total == 1 ? "1 backend" : "\(total) backends"
+        return averageLatency.map { "\(count) · \($0) ms average latency" } ?? count
+    }
+
+    var color: Color { allOperational ? .green : .orange }
+
+    var icon: String { allOperational ? "checkmark.seal.fill" : "exclamationmark.triangle.fill" }
+}
+
+struct GlanceHero: View {
+    let summary: GlanceSummary
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: summary.icon)
+                .font(.system(size: 42))
+                .foregroundStyle(summary.color)
+
+            Text(verbatim: summary.title)
+                .font(.title3.weight(.semibold))
+                .multilineTextAlignment(.center)
+
+            Text(verbatim: summary.detail)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 28)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [summary.color.opacity(0.18), summary.color.opacity(0.04)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+        )
+    }
+}
+
+#Preview("Operational") {
+    GlanceHero(summary: GlanceSummary(backends: Array(BackendHealth.samples.prefix(2))))
+        .padding()
+}
+
+#Preview("Degraded") {
+    GlanceHero(summary: GlanceSummary(backends: BackendHealth.samples))
+        .padding()
+}

--- a/Sources/Scout/UI/Settings/SettingsOverviewView.swift
+++ b/Sources/Scout/UI/Settings/SettingsOverviewView.swift
@@ -1,0 +1,133 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct SettingsOverviewView: View {
+    @Binding var activeID: String
+    @StateObject private var provider: BackendHealthProvider
+
+    @State private var isBenchmarking = false
+    @State private var message: Message?
+
+    init(backends: [Backend], activeID: Binding<String>, provider: BackendHealthProvider? = nil) {
+        _activeID = activeID
+        _provider = StateObject(wrappedValue: provider ?? BackendHealthProvider(backends: backends))
+    }
+
+    private var benchmark: (@Sendable () async -> Bool)? {
+        provider.backends.compactMap(\.runBenchmark).first
+    }
+
+    var body: some View {
+        List {
+            GlanceHero(summary: GlanceSummary(backends: provider.backends))
+                .padding(.vertical, 6)
+                .listRowSeparator(.hidden)
+
+            Header(title: "Backends")
+
+            ForEach(provider.backends) { backend in
+                Row {
+                    BackendRow(backend: backend, isActive: backend.id == activeID)
+                } destination: {
+                    BackendDetailView(provider: provider, id: backend.id, activeID: $activeID)
+                }
+            }
+
+            Header(title: "Diagnostics")
+
+            Button {
+                Task { await provider.refreshAll() }
+            } label: {
+                Text(verbatim: "Check All Backends")
+                    .foregroundStyle(.tint)
+            }
+
+            if let benchmark {
+                Button {
+                    isBenchmarking = true
+                    Task {
+                        let passed = await benchmark()
+                        isBenchmarking = false
+                        message = Message(
+                            passed
+                                ? "Parallelism limit verified: \(RequestLimiter.requestLimit) in-flight requests hold up."
+                                : "Parallelism check failed — see the console log.",
+                            level: passed ? .success : .warning
+                        )
+                    }
+                } label: {
+                    HStack {
+                        Text(verbatim: "Run Parallelism Benchmark")
+                            .foregroundStyle(.tint)
+                        if isBenchmarking {
+                            Spacer()
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(isBenchmarking)
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: "Settings")
+        .message($message)
+        .task {
+            await provider.refreshAll()
+        }
+    }
+}
+
+private struct BackendRow: View {
+    let backend: BackendHealth
+    let isActive: Bool
+
+    var body: some View {
+        Circle()
+            .fill(backend.status.healthColor)
+            .frame(width: 8, height: 8)
+
+        Text(verbatim: backend.name)
+
+        if isActive {
+            Text(verbatim: "Active")
+                .font(.caption2.weight(.semibold))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Capsule().fill(.tint.opacity(0.15)))
+                .foregroundStyle(.tint)
+        }
+
+        Spacer()
+
+        Text(verbatim: backend.latencyLabel)
+            .font(.body.monospacedDigit())
+            .foregroundStyle(.secondary)
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, *)
+#Preview("Settings") {
+    @Previewable @State var activeID = BackendHealth.samples[0].id
+    NavigationStack {
+        SettingsOverviewView(backends: [], activeID: $activeID, provider: .fixture())
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, *)
+#Preview("Degraded") {
+    @Previewable @State var activeID = ""
+    NavigationStack {
+        SettingsOverviewView(
+            backends: [],
+            activeID: $activeID,
+            provider: BackendHealthProvider(healths: Array(BackendHealth.samples.suffix(2)))
+        )
+    }
+}

--- a/Tests/ScoutTests/UI/Settings/BackendHealthProviderTests.swift
+++ b/Tests/ScoutTests/UI/Settings/BackendHealthProviderTests.swift
@@ -1,0 +1,72 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("BackendHealthProvider")
+struct BackendHealthProviderTests {
+    @Test("Refresh all probes every backend and records statuses with latency")
+    func refreshesAllBackends() async {
+        let provider = BackendHealthProvider(healths: [
+            makeHealth(id: "up", probe: { .reachable }),
+            makeHealth(id: "down", probe: { .unreachable }),
+        ])
+
+        await provider.refreshAll()
+
+        let up = provider.backends.first { $0.id == "up" }
+        let down = provider.backends.first { $0.id == "down" }
+        #expect(up?.status == .reachable)
+        #expect(up?.latency != nil)
+        #expect(up?.pings.count == 1)
+        #expect(up?.lastChecked != nil)
+        #expect(down?.status == .unreachable)
+        #expect(down?.latency == nil)
+        #expect(down?.pings.count == 0)
+        #expect(down?.lastChecked != nil)
+    }
+
+    @Test("Refreshing a single backend leaves the others untouched")
+    func refreshesSingleBackend() async {
+        let provider = BackendHealthProvider(healths: [
+            makeHealth(id: "up", probe: { .reachable }),
+            makeHealth(id: "idle"),
+        ])
+
+        await provider.refresh(id: "up")
+
+        #expect(provider.backends.first { $0.id == "up" }?.status == .reachable)
+        #expect(provider.backends.first { $0.id == "idle" }?.status == .unknown)
+        #expect(provider.backends.first { $0.id == "idle" }?.lastChecked == nil)
+    }
+
+    @Test("Refreshing an unknown id is a no-op")
+    func ignoresUnknownID() async {
+        let provider = BackendHealthProvider(healths: [makeHealth(id: "up")])
+
+        await provider.refresh(id: "missing")
+
+        #expect(provider.backends.count == 1)
+        #expect(provider.backends[0].status == .unknown)
+    }
+
+    @Test("Initializing from backends maps each one")
+    func initializesFromBackends() {
+        let provider = BackendHealthProvider(backends: [
+            .server(url: URL(string: "https://a.scout.app")!, apiKey: nil),
+            .server(url: URL(string: "https://b.scout.app")!, apiKey: nil),
+        ])
+
+        #expect(provider.backends.count == 2)
+        #expect(provider.backends.allSatisfy { $0.status == .unknown })
+    }
+}

--- a/Tests/ScoutTests/UI/Settings/BackendHealthTests.swift
+++ b/Tests/ScoutTests/UI/Settings/BackendHealthTests.swift
@@ -87,6 +87,8 @@ struct BackendHealthTests {
     }
 }
 
-func makeHealth(id: String = "backend", status: Backend.Status = .unknown, probe: @escaping @Sendable () async -> Backend.Status = { .unknown }) -> BackendHealth {
+typealias StatusProbe = @Sendable () async -> Backend.Status
+
+func makeHealth(id: String = "backend", status: Backend.Status = .unknown, probe: @escaping StatusProbe = { .unknown }) -> BackendHealth {
     BackendHealth(id: id, name: id, endpoint: id, engine: .server, status: status, probe: probe)
 }

--- a/Tests/ScoutTests/UI/Settings/BackendHealthTests.swift
+++ b/Tests/ScoutTests/UI/Settings/BackendHealthTests.swift
@@ -1,0 +1,92 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("BackendHealth")
+struct BackendHealthTests {
+    @Test("Maps a server backend to endpoint, transport, and API key state")
+    func mapsServerBackend() {
+        let backend = Backend.server(url: URL(string: "http://localhost:8080")!, apiKey: "secret")
+        let health = BackendHealth(backend: backend)
+
+        #expect(health.engine == .server)
+        #expect(health.endpoint == "localhost:8080")
+        #expect(health.hasAPIKey)
+        #expect(!health.isSecure)
+        #expect(health.status == .unknown)
+        #expect(health.pings.count == 0)
+    }
+
+    @Test("Marks HTTPS server backends as secure and keyless ones as not set")
+    func mapsSecureServerBackend() {
+        let backend = Backend.server(url: URL(string: "https://api.scout.app")!, apiKey: nil)
+        let health = BackendHealth(backend: backend)
+
+        #expect(health.isSecure)
+        #expect(!health.hasAPIKey)
+        #expect(health.endpoint == "api.scout.app")
+    }
+
+    @Test("Maps a non-server backend to the CloudKit engine with its id as endpoint")
+    func mapsCloudKitBackend() {
+        let health = BackendHealth(backend: makeBackend(id: "iCloud.com.example"))
+
+        #expect(health.engine == .cloudKit)
+        #expect(health.endpoint == "iCloud.com.example")
+    }
+
+    @Test("Recording a reachable probe stores latency and appends a ping")
+    func recordsReachableProbe() {
+        let date = Date(timeIntervalSince1970: 1_000)
+        let health = makeHealth().recording(status: .reachable, latency: 120, at: date)
+
+        #expect(health.status == .reachable)
+        #expect(health.latency == 120)
+        #expect(health.lastChecked == date)
+        #expect(health.pings == [120])
+    }
+
+    @Test("Recording an unreachable probe clears latency but keeps ping history")
+    func recordsUnreachableProbe() {
+        var health = makeHealth().recording(status: .reachable, latency: 120, at: Date())
+        health = health.recording(status: .unreachable, latency: nil, at: Date())
+
+        #expect(health.status == .unreachable)
+        #expect(health.latency == nil)
+        #expect(health.pings == [120])
+    }
+
+    @Test("Ping history is capped at the last 12 samples")
+    func capsPingHistory() {
+        var health = makeHealth()
+        for latency in 1...15 {
+            health = health.recording(status: .reachable, latency: latency, at: Date())
+        }
+
+        #expect(health.pings.count == 12)
+        #expect(health.pings == Array(4...15))
+    }
+
+    @Test("Ping spread reports min, average, and max of the history")
+    func reportsPingSpread() {
+        var health = makeHealth()
+        for latency in [100, 200, 300] {
+            health = health.recording(status: .reachable, latency: latency, at: Date())
+        }
+
+        #expect(health.pingSpreadLabel == "100 / 200 / 300 ms")
+    }
+}
+
+func makeHealth(id: String = "backend", status: Backend.Status = .unknown, probe: @escaping @Sendable () async -> Backend.Status = { .unknown }) -> BackendHealth {
+    BackendHealth(id: id, name: id, endpoint: id, engine: .server, status: status, probe: probe)
+}

--- a/Tests/ScoutTests/UI/Settings/GlanceSummaryTests.swift
+++ b/Tests/ScoutTests/UI/Settings/GlanceSummaryTests.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("GlanceSummary")
+struct GlanceSummaryTests {
+    @Test("All reachable backends read as operational")
+    func allOperational() {
+        let summary = GlanceSummary(backends: [
+            makeHealth(id: "a", status: .reachable),
+            makeHealth(id: "b", status: .reachable),
+        ])
+
+        #expect(summary.allOperational)
+        #expect(summary.title == "All Systems Operational")
+        #expect(summary.icon == "checkmark.seal.fill")
+    }
+
+    @Test("A degraded set reports the reachable count")
+    func degraded() {
+        let summary = GlanceSummary(backends: [
+            makeHealth(id: "a", status: .reachable),
+            makeHealth(id: "b", status: .unreachable),
+            makeHealth(id: "c", status: .unknown),
+        ])
+
+        #expect(!summary.allOperational)
+        #expect(summary.reachable == 1)
+        #expect(summary.total == 3)
+        #expect(summary.title == "1 of 3 Backends Reachable")
+        #expect(summary.icon == "exclamationmark.triangle.fill")
+    }
+
+    @Test("Average latency is computed over backends that reported one")
+    func averageLatency() {
+        var fast = makeHealth(id: "fast", status: .reachable)
+        fast = fast.recording(status: .reachable, latency: 100, at: Date())
+        var slow = makeHealth(id: "slow", status: .reachable)
+        slow = slow.recording(status: .reachable, latency: 300, at: Date())
+        let silent = makeHealth(id: "silent")
+
+        let summary = GlanceSummary(backends: [fast, slow, silent])
+
+        #expect(summary.averageLatency == 200)
+        #expect(summary.detail == "3 backends · 200 ms average latency")
+    }
+
+    @Test("Without latencies the detail only counts backends")
+    func detailWithoutLatency() {
+        let summary = GlanceSummary(backends: [makeHealth(id: "a")])
+
+        #expect(summary.averageLatency == nil)
+        #expect(summary.detail == "1 backend")
+    }
+}


### PR DESCRIPTION
Adds a Settings hub reachable from the connection menu: an overview with a status hero and per-backend rows, and a backend detail screen with measured latency, ping history, per-record-type schema checks for CloudKit, and connection info for hosted servers. Schema verification is refactored into per-type SchemaCheck results that verifySchema now aggregates, and the parallelism benchmark becomes runnable from the UI with its verdict shown as a toast. Backend probing lives in a new BackendHealthProvider covered by unit tests, and CLAUDE.md picks up the plain-list convention the screens follow.