### PR TITLE
Add chart image export with PNG/PDF sharing

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Activity/ActivityView.swift
@@ -43,6 +43,14 @@ struct ActivityView: View {
                 }
                 .listStyle(.plain)
                 .scrollDisabled(true)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        ChartExportButton(title: "Active Users", rangeLabel: extent.domain.label(using: rangeDateFormatter)) {
+                            ChartView(segment: extent.segment(from: data.points(on: extent.period)), timing: extent)
+                                .foregroundStyle(.green)
+                        }
+                    }
+                }
             }
         }
         .navigationTitle(en: "Active Users")

--- a/Sources/Scout/UI/Export/ChartExportButton.swift
+++ b/Sources/Scout/UI/Export/ChartExportButton.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct ChartExportButton<ChartContent: View>: View {
+    let title: String
+    let rangeLabel: String
+
+    @ViewBuilder let chart: () -> ChartContent
+
+    @State private var isExporting = false
+
+    var body: some View {
+        Button {
+            isExporting = true
+        } label: {
+            Image(systemName: "square.and.arrow.up")
+        }
+        .sheet(isPresented: $isExporting) {
+            NavigationStack {
+                ChartExportSheet(title: title, rangeLabel: rangeLabel, chart: chart)
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        Text(verbatim: "Content")
+            .navigationTitle(en: "Chart Export Button")
+            .inlineNavigationTitle()
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    ChartExportButton(title: "app_launch", rangeLabel: "Jun 2 – Jul 2, 2026") {
+                        ChartView(segment: .sample, timing: ChartExtent(period: Period.month))
+                    }
+                }
+            }
+    }
+}

--- a/Sources/Scout/UI/Export/ChartExportFile.swift
+++ b/Sources/Scout/UI/Export/ChartExportFile.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+struct ChartExportFile {
+    let data: Data
+    let name: String
+    let format: ChartExportFormat
+
+    var filename: String {
+        let trimmed = name.replacingOccurrences(of: "/", with: "-").trimmingCharacters(in: .whitespacesAndNewlines)
+        let base = trimmed.count > 0 ? trimmed : "Chart"
+        return "\(base).\(format.fileExtension)"
+    }
+
+    func write() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+}

--- a/Sources/Scout/UI/Export/ChartExportOptions.swift
+++ b/Sources/Scout/UI/Export/ChartExportOptions.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct ChartExportOptions: Equatable {
+    var format: ChartExportFormat = .png
+    var appearance: ChartExportAppearance = .system
+    var includesTitle = true
+    var includesRange = true
+}
+
+enum ChartExportFormat: String, CaseIterable, Identifiable {
+    case png = "PNG"
+    case pdf = "PDF"
+
+    var id: Self { self }
+
+    var fileExtension: String {
+        rawValue.lowercased()
+    }
+}
+
+enum ChartExportAppearance: String, CaseIterable, Identifiable {
+    case system = "System"
+    case light = "Light"
+    case dark = "Dark"
+
+    var id: Self { self }
+
+    func resolvedScheme(current: ColorScheme) -> ColorScheme {
+        switch self {
+        case .system:
+            current
+        case .light:
+            .light
+        case .dark:
+            .dark
+        }
+    }
+}

--- a/Sources/Scout/UI/Export/ChartExportRenderer.swift
+++ b/Sources/Scout/UI/Export/ChartExportRenderer.swift
@@ -1,0 +1,59 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+@MainActor
+enum ChartExportRenderer {
+    static let width: CGFloat = 480
+
+    static func data(for content: some View, format: ChartExportFormat, scale: CGFloat) -> Data? {
+        let renderer = ImageRenderer(content: content)
+        renderer.proposedSize = ProposedViewSize(width: width, height: nil)
+
+        switch format {
+        case .png:
+            renderer.scale = scale
+            return pngData(from: renderer)
+        case .pdf:
+            return pdfData(from: renderer)
+        }
+    }
+
+    private static func pngData(from renderer: ImageRenderer<some View>) -> Data? {
+        #if os(iOS)
+            return renderer.uiImage?.pngData()
+        #else
+            guard let image = renderer.nsImage, let tiff = image.tiffRepresentation, let bitmap = NSBitmapImageRep(data: tiff) else {
+                return nil
+            }
+            return bitmap.representation(using: .png, properties: [:])
+        #endif
+    }
+
+    private static func pdfData(from renderer: ImageRenderer<some View>) -> Data? {
+        var data: Data?
+
+        renderer.render { size, draw in
+            let pdf = NSMutableData()
+            var box = CGRect(origin: .zero, size: size)
+
+            guard let consumer = CGDataConsumer(data: pdf as CFMutableData), let context = CGContext(consumer: consumer, mediaBox: &box, nil) else {
+                return
+            }
+
+            context.beginPDFPage(nil)
+            draw(context)
+            context.endPDFPage()
+            context.closePDF()
+            data = pdf as Data
+        }
+
+        return data
+    }
+}

--- a/Sources/Scout/UI/Export/ChartExportSheet.swift
+++ b/Sources/Scout/UI/Export/ChartExportSheet.swift
@@ -22,9 +22,16 @@ struct ChartExportSheet<ChartContent: View>: View {
 
     var body: some View {
         List {
-            ChartSnapshot(title: title, rangeLabel: rangeLabel, showsTitle: options.includesTitle, showsRange: options.includesRange, fadesHeader: true, chart: chart)
-                .listRowSeparator(.hidden)
-                .listRowInsets(EdgeInsets())
+            ChartSnapshot(
+                title: title,
+                rangeLabel: rangeLabel,
+                showsTitle: options.includesTitle,
+                showsRange: options.includesRange,
+                fadesHeader: true,
+                chart: chart
+            )
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets())
 
             Header(title: "Format")
                 .listRowSeparator(.hidden, edges: .top)
@@ -91,9 +98,19 @@ struct ChartExportSheet<ChartContent: View>: View {
     }
 
     @ViewBuilder private var shareButton: some View {
-        if #available(iOS 26, macOS 26, *) {
-            glassShareButton
-        } else if let fileURL {
+        #if compiler(>=6.2)
+            if #available(iOS 26.0, macOS 26.0, *) {
+                glassShareButton
+            } else {
+                pillShareButton
+            }
+        #else
+            pillShareButton
+        #endif
+    }
+
+    @ViewBuilder private var pillShareButton: some View {
+        if let fileURL {
             ShareLink(item: fileURL) {
                 Text(verbatim: "Share Image")
             }
@@ -101,19 +118,21 @@ struct ChartExportSheet<ChartContent: View>: View {
         }
     }
 
-    @available(iOS 26, macOS 26, *)
-    @ViewBuilder private var glassShareButton: some View {
-        if let fileURL {
-            ShareLink(item: fileURL) {
-                Text(verbatim: "Share Image")
-                    .bold()
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
+    #if compiler(>=6.2)
+        @available(iOS 26.0, macOS 26.0, *)
+        @ViewBuilder private var glassShareButton: some View {
+            if let fileURL {
+                ShareLink(item: fileURL) {
+                    Text(verbatim: "Share Image")
+                        .bold()
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                }
+                .buttonStyle(.glassProminent)
+                .tint(.blue)
             }
-            .buttonStyle(.glassProminent)
-            .tint(.blue)
         }
-    }
+    #endif
 
     private func exportURL() -> URL? {
         guard let data = ChartExportRenderer.data(for: exportView, format: options.format, scale: displayScale) else {
@@ -126,10 +145,16 @@ struct ChartExportSheet<ChartContent: View>: View {
     private var exportView: some View {
         let scheme = options.appearance.resolvedScheme(current: colorScheme)
 
-        return ChartSnapshot(title: title, rangeLabel: rangeLabel, showsTitle: options.includesTitle, showsRange: options.includesRange, chart: chart)
-            .frame(width: ChartExportRenderer.width)
-            .background(scheme == .dark ? Color.black : Color.white)
-            .environment(\.colorScheme, scheme)
+        return ChartSnapshot(
+            title: title,
+            rangeLabel: rangeLabel,
+            showsTitle: options.includesTitle,
+            showsRange: options.includesRange,
+            chart: chart
+        )
+        .frame(width: ChartExportRenderer.width)
+        .background(scheme == .dark ? Color.black : Color.white)
+        .environment(\.colorScheme, scheme)
     }
 }
 

--- a/Sources/Scout/UI/Export/ChartExportSheet.swift
+++ b/Sources/Scout/UI/Export/ChartExportSheet.swift
@@ -1,0 +1,145 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct ChartExportSheet<ChartContent: View>: View {
+    let title: String
+    let rangeLabel: String
+
+    @ViewBuilder let chart: () -> ChartContent
+
+    @State private var options = ChartExportOptions()
+    @State private var fileURL: URL?
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.displayScale) private var displayScale
+
+    var body: some View {
+        List {
+            ChartSnapshot(title: title, rangeLabel: rangeLabel, showsTitle: options.includesTitle, showsRange: options.includesRange, fadesHeader: true, chart: chart)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
+
+            Header(title: "Format")
+                .listRowSeparator(.hidden, edges: .top)
+
+            HStack {
+                Text(verbatim: "File Type")
+                Spacer()
+                Picker(selection: $options.format) {
+                    ForEach(ChartExportFormat.allCases) { format in
+                        Text(verbatim: format.rawValue).tag(format)
+                    }
+                } label: {
+                    EmptyView()
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 140)
+            }
+            .frame(height: 22)
+
+            HStack {
+                Text(verbatim: "Appearance")
+                Spacer()
+                Picker(selection: $options.appearance) {
+                    ForEach(ChartExportAppearance.allCases) { appearance in
+                        Text(verbatim: appearance.rawValue).tag(appearance)
+                    }
+                } label: {
+                    EmptyView()
+                }
+                .pickerStyle(.menu)
+            }
+            .frame(height: 22)
+            .listRowSeparator(.visible, edges: .bottom)
+
+            Header(title: "Content")
+                .listRowSeparator(.hidden, edges: .top)
+
+            Toggle(isOn: $options.includesTitle) {
+                Text(verbatim: "Chart Title")
+            }
+
+            Toggle(isOn: $options.includesRange) {
+                Text(verbatim: "Period Label")
+            }
+        }
+        .listStyle(.plain)
+        .safeAreaInset(edge: .bottom) {
+            shareButton.padding()
+        }
+        .task(id: options) {
+            fileURL = exportURL()
+        }
+        .navigationTitle(en: "Export Image")
+        .inlineNavigationTitle()
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Text(verbatim: "Cancel")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var shareButton: some View {
+        if #available(iOS 26, macOS 26, *) {
+            glassShareButton
+        } else if let fileURL {
+            ShareLink(item: fileURL) {
+                Text(verbatim: "Share Image")
+            }
+            .buttonStyle(.pill)
+        }
+    }
+
+    @available(iOS 26, macOS 26, *)
+    @ViewBuilder private var glassShareButton: some View {
+        if let fileURL {
+            ShareLink(item: fileURL) {
+                Text(verbatim: "Share Image")
+                    .bold()
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+            }
+            .buttonStyle(.glassProminent)
+            .tint(.blue)
+        }
+    }
+
+    private func exportURL() -> URL? {
+        guard let data = ChartExportRenderer.data(for: exportView, format: options.format, scale: displayScale) else {
+            return nil
+        }
+        let file = ChartExportFile(data: data, name: title, format: options.format)
+        return try? file.write()
+    }
+
+    private var exportView: some View {
+        let scheme = options.appearance.resolvedScheme(current: colorScheme)
+
+        return ChartSnapshot(title: title, rangeLabel: rangeLabel, showsTitle: options.includesTitle, showsRange: options.includesRange, chart: chart)
+            .frame(width: ChartExportRenderer.width)
+            .background(scheme == .dark ? Color.black : Color.white)
+            .environment(\.colorScheme, scheme)
+    }
+}
+
+#Preview("Chart Export Sheet") {
+    Color.clear
+        .sheet(isPresented: .constant(true)) {
+            NavigationStack {
+                ChartExportSheet(title: "app_launch", rangeLabel: "Jun 2 – Jul 2, 2026") {
+                    ChartView(segment: .sample, timing: ChartExtent(period: Period.month))
+                }
+            }
+        }
+}

--- a/Sources/Scout/UI/Export/ChartSnapshot.swift
+++ b/Sources/Scout/UI/Export/ChartSnapshot.swift
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct ChartSnapshot<ChartContent: View>: View {
+    let title: String
+    let rangeLabel: String
+    let showsTitle: Bool
+    let showsRange: Bool
+    var fadesHeader = false
+
+    @ViewBuilder let chart: () -> ChartContent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if fadesHeader {
+                fadingHeader
+            } else if showsTitle || showsRange {
+                staticHeader
+            }
+
+            chart()
+        }
+    }
+
+    private var fadingHeader: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            titleText.opacity(showsTitle ? 1 : 0)
+            rangeText.opacity(showsRange ? 1 : 0)
+        }
+        .padding([.top, .horizontal])
+        .animation(.easeInOut(duration: 0.25), value: showsTitle)
+        .animation(.easeInOut(duration: 0.25), value: showsRange)
+    }
+
+    private var staticHeader: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if showsTitle {
+                titleText
+            }
+            if showsRange {
+                rangeText
+            }
+        }
+        .padding([.top, .horizontal])
+    }
+
+    private var titleText: some View {
+        Text(verbatim: title).font(.headline)
+    }
+
+    private var rangeText: some View {
+        Text(verbatim: rangeLabel)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+}

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -45,6 +45,15 @@ struct MetricsView<T: ChartNumeric>: View {
         .listStyle(.plain)
         .navigationTitle(group.name)
         .scrollDisabled(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                ChartExportButton(title: group.name, rangeLabel: extent.domain.label(using: rangeDateFormatter)) {
+                    ChartView(segment: extent.segment(from: group.points), timing: extent)
+                        .chartYAxis(content: { formattedMarks })
+                        .foregroundStyle(.blue)
+                }
+            }
+        }
     }
 
     private var formattedMarks: some AxisContent {

--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -39,6 +39,14 @@ struct StatView: View {
                 }
                 .listStyle(.plain)
                 .scrollDisabled(true)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        ChartExportButton(title: stat.eventName, rangeLabel: extent.domain.label(using: rangeDateFormatter)) {
+                            ChartView(segment: extent.segment(from: data.flatMap(\.points)), timing: extent)
+                                .foregroundStyle(color)
+                        }
+                    }
+                }
             }
         }
         .resetsTint()

--- a/Tests/ScoutTests/UI/Export/ChartExportFileTests.swift
+++ b/Tests/ScoutTests/UI/Export/ChartExportFileTests.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct ChartExportFileTests {
+    @Test("Filename joins name and extension") func testFilename() {
+        let file = ChartExportFile(data: Data(), name: "app_launch", format: .png)
+
+        #expect(file.filename == "app_launch.png")
+    }
+
+    @Test("Filename sanitizes slashes and whitespace") func testSanitizedFilename() {
+        let file = ChartExportFile(data: Data(), name: "  a/b  ", format: .pdf)
+
+        #expect(file.filename == "a-b.pdf")
+    }
+
+    @Test("Filename falls back for an empty name") func testEmptyName() {
+        let file = ChartExportFile(data: Data(), name: "   ", format: .png)
+
+        #expect(file.filename == "Chart.png")
+    }
+
+    @Test("Write stores the data at the returned URL") func testWrite() throws {
+        let data = Data([1, 2, 3])
+        let file = ChartExportFile(data: data, name: "export-test", format: .png)
+
+        let url = try file.write()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(url.lastPathComponent == "export-test.png")
+        #expect(try Data(contentsOf: url) == data)
+    }
+}

--- a/Tests/ScoutTests/UI/Export/ChartExportOptionsTests.swift
+++ b/Tests/ScoutTests/UI/Export/ChartExportOptionsTests.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+import Testing
+
+@testable import Scout
+
+struct ChartExportOptionsTests {
+    @Test("PNG file extension") func testPNGExtension() {
+        #expect(ChartExportFormat.png.fileExtension == "png")
+    }
+
+    @Test("PDF file extension") func testPDFExtension() {
+        #expect(ChartExportFormat.pdf.fileExtension == "pdf")
+    }
+
+    @Test("System appearance keeps the current scheme") func testSystemScheme() {
+        #expect(ChartExportAppearance.system.resolvedScheme(current: .dark) == .dark)
+        #expect(ChartExportAppearance.system.resolvedScheme(current: .light) == .light)
+    }
+
+    @Test("Light appearance overrides the current scheme") func testLightScheme() {
+        #expect(ChartExportAppearance.light.resolvedScheme(current: .dark) == .light)
+    }
+
+    @Test("Dark appearance overrides the current scheme") func testDarkScheme() {
+        #expect(ChartExportAppearance.dark.resolvedScheme(current: .light) == .dark)
+    }
+
+    @Test("Defaults include the full header as PNG") func testDefaults() {
+        let options = ChartExportOptions()
+
+        #expect(options.format == .png)
+        #expect(options.appearance == .system)
+        #expect(options.includesTitle)
+        #expect(options.includesRange)
+    }
+}

--- a/Tests/ScoutTests/UI/Export/ChartExportRendererTests.swift
+++ b/Tests/ScoutTests/UI/Export/ChartExportRendererTests.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+import Testing
+
+@testable import Scout
+
+@MainActor
+struct ChartExportRendererTests {
+    @Test("Renders PNG data") func testPNG() {
+        let data = ChartExportRenderer.data(for: Text(verbatim: "Chart"), format: .png, scale: 2)
+
+        #expect(data?.prefix(4) == Data([0x89, 0x50, 0x4E, 0x47]))
+    }
+
+    @Test("Renders PDF data") func testPDF() {
+        let data = ChartExportRenderer.data(for: Text(verbatim: "Chart"), format: .pdf, scale: 2)
+
+        let header = data.map { String(decoding: $0.prefix(4), as: UTF8.self) }
+        #expect(header == "%PDF")
+    }
+}


### PR DESCRIPTION
Charts can now be shared as images: StatView, ActivityView, and MetricsView gain a toolbar export button that opens a sheet with a live preview and options for file type (PNG/PDF), light/dark appearance, and whether the chart title and period label are included. The image is rendered offscreen with ImageRenderer at a fixed width, written to a temporary file named after the chart, and shared via ShareLink (with a Liquid Glass button on iOS 26+ and a pill fallback earlier). Rendering, file naming, and option mapping are covered by unit tests.