### PR TITLE
Add a conversion funnel screen

### DIFF
--- a/Sources/Scout/UI/Event/Model/Event.swift
+++ b/Sources/Scout/UI/Event/Model/Event.swift
@@ -52,7 +52,7 @@ extension Event {
 }
 
 extension Event {
-    static func sample(_ name: String, at date: Date) -> Event {
+    static func sample(_ name: String, at date: Date, sessionID: UUID? = nil) -> Event {
         Event(
             name: name,
             level: nil,
@@ -61,7 +61,7 @@ extension Event {
             uuid: nil,
             id: UUID().uuidString,
             installID: nil,
-            sessionID: nil,
+            sessionID: sessionID,
             deviceID: nil
         )
     }

--- a/Sources/Scout/UI/Funnel/Funnel.swift
+++ b/Sources/Scout/UI/Funnel/Funnel.swift
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct Funnel: Hashable {
+    static let stepLimit = 2...6
+
+    enum CorrelationKey: String, CaseIterable, Identifiable {
+        case session
+        case install
+
+        var id: Self { self }
+
+        var title: String {
+            switch self {
+            case .session: "Session"
+            case .install: "Install"
+            }
+        }
+
+        var field: String {
+            switch self {
+            case .session: "session_id"
+            case .install: "install_id"
+            }
+        }
+
+        func groupID(of event: Event) -> UUID? {
+            switch self {
+            case .session: event.sessionID
+            case .install: event.installID
+            }
+        }
+    }
+
+    var stepNames: [String] = []
+    var key = CorrelationKey.session
+
+    var isRunnable: Bool {
+        Funnel.stepLimit.contains(stepNames.count)
+    }
+
+    func steps(from events: [Event]) -> [FunnelStep] {
+        let depths = Array(depths(from: events).values)
+        return stepNames.enumerated().map { index, name in
+            FunnelStep(name: name, count: depths.filter { $0 > index }.count)
+        }
+    }
+
+    func droppedIDs(before index: Int, from events: [Event]) -> [UUID] {
+        guard index > 0 else { return [] }
+        return depths(from: events)
+            .filter { $0.value == index }
+            .map(\.key)
+            .sorted { $0.uuidString < $1.uuidString }
+    }
+
+    private func depths(from events: [Event]) -> [UUID: Int] {
+        var groups: [UUID: [Event]] = [:]
+        for event in events {
+            guard let id = key.groupID(of: event) else { continue }
+            groups[id, default: []].append(event)
+        }
+        return groups.mapValues(depth)
+    }
+
+    private func depth(of events: [Event]) -> Int {
+        var depth = 0
+        let sorted = events.sorted { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
+        for event in sorted where depth < stepNames.count && event.name == stepNames[depth] {
+            depth += 1
+        }
+        return depth
+    }
+}

--- a/Sources/Scout/UI/Funnel/FunnelBuilder.swift
+++ b/Sources/Scout/UI/Funnel/FunnelBuilder.swift
@@ -1,0 +1,126 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct FunnelBuilder: View {
+    @Binding var stepNames: [String]
+    @Binding var key: Funnel.CorrelationKey
+    let suggestions: [String]
+
+    @State private var showCustomStep = false
+    @State private var customStep = ""
+
+    var body: some View {
+        Header(title: "Steps")
+
+        ForEach(Array(stepNames.enumerated()), id: \.element) { index, name in
+            HStack(spacing: 10) {
+                FunnelStepIndex(index: index)
+                Text(verbatim: name)
+                    .font(.footnote)
+                    .monospaced()
+            }
+        }
+        .onDelete { stepNames.remove(atOffsets: $0) }
+        .onMove { stepNames.move(fromOffsets: $0, toOffset: $1) }
+
+        if stepNames.count < Funnel.stepLimit.upperBound {
+            addStepMenu
+        }
+
+        Header(title: "Correlate by")
+
+        Picker(selection: $key) {
+            ForEach(Funnel.CorrelationKey.allCases) { key in
+                Text(verbatim: key.title)
+            }
+        } label: {
+            Text(verbatim: "Correlate by")
+        }
+        .pickerStyle(.segmented)
+        .listRowSeparator(.hidden)
+    }
+
+    private var addStepMenu: some View {
+        Menu {
+            ForEach(availableSuggestions, id: \.self) { name in
+                Button {
+                    stepNames.append(name)
+                } label: {
+                    Text(verbatim: name)
+                }
+            }
+            if availableSuggestions.count > 0 {
+                Divider()
+            }
+            Button {
+                customStep = ""
+                showCustomStep = true
+            } label: {
+                Label {
+                    Text(verbatim: "Custom Event…")
+                } icon: {
+                    Image(systemName: "keyboard")
+                }
+            }
+        } label: {
+            Label {
+                Text(verbatim: "Add Step")
+            } icon: {
+                Image(systemName: "plus.circle.fill")
+            }
+        }
+        .alert(Text(verbatim: "Custom Event"), isPresented: $showCustomStep) {
+            TextField(text: $customStep) {
+                Text(verbatim: "Event name")
+            }
+            .autocorrectionDisabled(true)
+            Button {
+                addCustomStep()
+            } label: {
+                Text(verbatim: "Add")
+            }
+            Button(role: .cancel) {
+            } label: {
+                Text(verbatim: "Cancel")
+            }
+        }
+    }
+
+    private var availableSuggestions: [String] {
+        suggestions.filter { !stepNames.contains($0) }
+    }
+
+    private func addCustomStep() {
+        let name = customStep.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard name.count > 0, !stepNames.contains(name) else { return }
+        stepNames.append(name)
+    }
+}
+
+private struct BuilderPreview: View {
+    @State private var stepNames = ["app_open", "signup_started"]
+    @State private var key = Funnel.CorrelationKey.session
+
+    var body: some View {
+        List {
+            FunnelBuilder(
+                stepNames: $stepNames,
+                key: $key,
+                suggestions: FunnelStep.samples.map(\.name)
+            )
+        }
+        .listStyle(.plain)
+    }
+}
+
+#Preview("Funnel builder") {
+    NavigationStack {
+        BuilderPreview()
+    }
+}

--- a/Sources/Scout/UI/Funnel/FunnelCohortProvider.swift
+++ b/Sources/Scout/UI/Funnel/FunnelCohortProvider.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct FunnelCohortEntry: Identifiable {
+    let groupID: UUID
+    let lastEvent: Event?
+
+    var id: UUID { groupID }
+}
+
+@MainActor
+class FunnelCohortProvider: ObservableObject {
+    @Published var result: Result<[Event], Error>?
+
+    func fetchIfNeeded(ids: [UUID], key: Funnel.CorrelationKey, in database: DatabaseReader) async {
+        guard result == nil, ids.count > 0 else { return }
+
+        do {
+            let filter = RecordQuery.Filter(field: key.field, op: .in, value: .strings(ids.map(\.uuidString)))
+            let query = RecordQuery(recordType: Event.self, filters: [filter])
+            let events: [Event] = try await database.readAll(matching: query, fields: Event.desiredKeys)
+            result = .success(events)
+        } catch {
+            result = .failure(error)
+        }
+    }
+
+    func refresh(ids: [UUID], key: Funnel.CorrelationKey, in database: DatabaseReader) async {
+        result = nil
+        await fetchIfNeeded(ids: ids, key: key, in: database)
+    }
+}
+
+extension Array where Element == Event {
+    func cohortEntries(for groupIDs: [UUID], key: Funnel.CorrelationKey) -> [FunnelCohortEntry] {
+        var groups: [UUID: [Event]] = [:]
+        for event in self {
+            guard let id = key.groupID(of: event) else { continue }
+            groups[id, default: []].append(event)
+        }
+
+        return groupIDs.map { id in
+            let last = groups[id]?.max { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
+            return FunnelCohortEntry(groupID: id, lastEvent: last)
+        }
+    }
+}

--- a/Sources/Scout/UI/Funnel/FunnelLegendRow.swift
+++ b/Sources/Scout/UI/Funnel/FunnelLegendRow.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct FunnelLegendRow: View {
+    let metric: FunnelStepMetrics
+    var color: Color = .blue
+
+    var body: some View {
+        HStack(spacing: 10) {
+            FunnelStepIndex(index: metric.index, color: color)
+            Text(verbatim: metric.step.name)
+                .font(.footnote)
+                .monospaced()
+            Spacer()
+            if let conversion = metric.conversionFromPrevious {
+                Text(verbatim: "→ \(conversion.funnelPercent)")
+                    .font(.caption)
+                    .monospacedDigit()
+                    .foregroundStyle(.red.opacity(0.8))
+            }
+            Text(verbatim: metric.step.count.formatted())
+                .font(.footnote.weight(.semibold))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 56, alignment: .trailing)
+        }
+    }
+}
+
+struct FunnelStepIndex: View {
+    let index: Int
+    var color: Color = .blue
+
+    var body: some View {
+        Text(verbatim: "\(index + 1)")
+            .font(.caption2.weight(.bold))
+            .monospacedDigit()
+            .foregroundStyle(color)
+            .frame(width: 18, height: 18)
+            .background(color.opacity(0.13), in: Circle())
+    }
+}
+
+#Preview("Funnel legend") {
+    List {
+        ForEach(FunnelStep.samples.metrics) { metric in
+            FunnelLegendRow(metric: metric)
+        }
+    }
+    .listStyle(.plain)
+}

--- a/Sources/Scout/UI/Funnel/FunnelPlotView.swift
+++ b/Sources/Scout/UI/Funnel/FunnelPlotView.swift
@@ -1,0 +1,72 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct FunnelPlotView: View {
+    let steps: [FunnelStep]
+    var color: Color = .blue
+
+    private let labelSpace: CGFloat = 24
+
+    var body: some View {
+        GeometryReader { geometry in
+            let metrics = steps.metrics
+            let count = CGFloat(metrics.count)
+            let column = geometry.size.width / (count + 0.618 * (count - 1))
+            let gap = column * 0.618
+            let plotHeight = geometry.size.height - labelSpace
+
+            ZStack(alignment: .topLeading) {
+                connectors(metrics: metrics, column: column, gap: gap, plotHeight: plotHeight)
+
+                ForEach(metrics) { metric in
+                    let height = max(plotHeight * metric.fractionOfFirst, 4)
+                    let x = CGFloat(metric.index) * (column + gap)
+                    let top = labelSpace + plotHeight - height
+
+                    UnevenRoundedRectangle(topLeadingRadius: 5, topTrailingRadius: 5)
+                        .fill(color.gradient)
+                        .frame(width: column, height: height)
+                        .offset(x: x, y: top)
+
+                    Text(verbatim: metric.fractionOfFirst.funnelPercent)
+                        .font(.caption.weight(.semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(metric.index == 0 ? AnyShapeStyle(.secondary) : AnyShapeStyle(color))
+                        .frame(width: column)
+                        .offset(x: x, y: top - labelSpace + 4)
+                }
+            }
+        }
+        .aspectRatio(1.618, contentMode: .fit)
+    }
+
+    private func connectors(metrics: [FunnelStepMetrics], column: CGFloat, gap: CGFloat, plotHeight: CGFloat) -> some View {
+        Path { path in
+            for index in metrics.indices.dropLast() {
+                let from = metrics[index]
+                let to = metrics[index + 1]
+                let leading = CGFloat(index) * (column + gap) + column
+                let trailing = leading + gap
+                let bottom = labelSpace + plotHeight
+
+                path.move(to: CGPoint(x: leading, y: bottom - plotHeight * from.fractionOfFirst))
+                path.addLine(to: CGPoint(x: trailing, y: bottom - plotHeight * to.fractionOfFirst))
+                path.addLine(to: CGPoint(x: trailing, y: bottom))
+                path.addLine(to: CGPoint(x: leading, y: bottom))
+                path.closeSubpath()
+            }
+        }
+        .fill(color.opacity(0.12))
+    }
+}
+
+#Preview("Funnel plot") {
+    FunnelPlotView(steps: FunnelStep.samples)
+        .padding()
+}

--- a/Sources/Scout/UI/Funnel/FunnelProvider.swift
+++ b/Sources/Scout/UI/Funnel/FunnelProvider.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+@MainActor
+class FunnelProvider: ObservableObject {
+    @Published var result: Result<[Event], Error>?
+
+    private struct Request: Hashable {
+        let names: [String]
+        let range: Range<Date>
+    }
+
+    private var request: Request?
+
+    func fetchIfNeeded(names: [String], range: Range<Date>, in database: DatabaseReader) async {
+        let request = Request(names: names, range: range)
+        guard request != self.request else { return }
+
+        self.request = request
+        result = nil
+
+        do {
+            let filters = [RecordQuery.Filter(field: "name", op: .in, value: .strings(names))] + range.dateFilters
+            let query = RecordQuery(recordType: Event.self, filters: filters)
+            let events: [Event] = try await database.readAll(matching: query, fields: Event.desiredKeys)
+            result = .success(events)
+        } catch {
+            result = .failure(error)
+            self.request = nil
+        }
+    }
+
+    func refresh(names: [String], range: Range<Date>, in database: DatabaseReader) async {
+        request = nil
+        await fetchIfNeeded(names: names, range: range, in: database)
+    }
+}
+
+extension FunnelProvider {
+    static func fixture() -> FunnelProvider {
+        let provider = FunnelProvider()
+        provider.result = .success(.funnelSample)
+        provider.request = Request(names: FunnelStep.samples.map(\.name), range: Period.month.initialRange)
+        return provider
+    }
+}
+
+extension Array where Element == Event {
+    static var funnelSample: [Event] {
+        let names = FunnelStep.samples.map(\.name)
+        let counts = [21, 13, 8, 5, 3]
+        let start = Period.month.initialRange.lowerBound
+
+        var events: [Event] = []
+        for session in 0..<counts[0] {
+            let id = UUID()
+            for (index, name) in names.enumerated() where counts[index] > session {
+                events.append(
+                    Event.sample(
+                        name,
+                        at: start.addingTimeInterval(Double(session * 3600 + index * 60)),
+                        sessionID: id
+                    )
+                )
+            }
+        }
+        return events
+    }
+}

--- a/Sources/Scout/UI/Funnel/FunnelStep.swift
+++ b/Sources/Scout/UI/Funnel/FunnelStep.swift
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct FunnelStep: Identifiable {
+    let name: String
+    let count: Int
+
+    var id: String { name }
+}
+
+struct FunnelStepMetrics: Identifiable {
+    let step: FunnelStep
+    let index: Int
+    let fractionOfFirst: Double
+    let conversionFromPrevious: Double?
+    let dropOff: Int
+
+    var id: String { step.id }
+}
+
+extension Array where Element == FunnelStep {
+    var metrics: [FunnelStepMetrics] {
+        guard let first = self.first, first.count > 0 else { return [] }
+        var previous: FunnelStep?
+        return enumerated().map { index, step in
+            let conversion = previous.map { $0.count > 0 ? Double(step.count) / Double($0.count) : 0 }
+            let dropOff = previous.map { $0.count - step.count } ?? 0
+            previous = step
+            return FunnelStepMetrics(
+                step: step,
+                index: index,
+                fractionOfFirst: Double(step.count) / Double(first.count),
+                conversionFromPrevious: conversion,
+                dropOff: dropOff
+            )
+        }
+    }
+}
+
+extension Double {
+    var funnelPercent: String {
+        formatted(.percent.precision(.fractionLength(0)))
+    }
+}
+
+extension FunnelStep {
+    static let samples: [FunnelStep] = [
+        FunnelStep(name: "app_open", count: 12480),
+        FunnelStep(name: "signup_started", count: 7713),
+        FunnelStep(name: "signup_completed", count: 4767),
+        FunnelStep(name: "first_sync", count: 2946),
+        FunnelStep(name: "purchase", count: 1821),
+    ]
+}

--- a/Sources/Scout/UI/Funnel/FunnelStepDetail.swift
+++ b/Sources/Scout/UI/Funnel/FunnelStepDetail.swift
@@ -1,0 +1,142 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct FunnelStepDetail: View {
+    static let displayedDropLimit = 50
+
+    let metric: FunnelStepMetrics
+    let droppedIDs: [UUID]
+    let key: Funnel.CorrelationKey
+
+    @Environment(\.database) var database
+    @StateObject private var cohort: FunnelCohortProvider
+
+    init(metric: FunnelStepMetrics, droppedIDs: [UUID], key: Funnel.CorrelationKey, cohort: FunnelCohortProvider = FunnelCohortProvider()) {
+        self.metric = metric
+        self.droppedIDs = droppedIDs
+        self.key = key
+        self._cohort = StateObject(wrappedValue: cohort)
+    }
+
+    var body: some View {
+        List {
+            summary
+
+            if droppedIDs.count > 0 {
+                dropped
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: metric.step.name)
+        .task {
+            await cohort.fetchIfNeeded(ids: displayedIDs, key: key, in: database)
+        }
+    }
+
+    @ViewBuilder private var summary: some View {
+        row(title: "Reached", value: metric.step.count.formatted(), color: .blue)
+        row(title: "Share of first step", value: metric.fractionOfFirst.funnelPercent, color: .secondary)
+        if let conversion = metric.conversionFromPrevious {
+            row(title: "From previous step", value: conversion.funnelPercent, color: .secondary)
+            row(title: "Dropped", value: metric.dropOff.formatted(), color: .red)
+        }
+    }
+
+    @ViewBuilder private var dropped: some View {
+        Header(title: "Dropped \(key.title)s")
+
+        switch cohort.result {
+        case nil:
+            ProgressView()
+                .frame(maxWidth: .infinity)
+                .listRowSeparator(.hidden)
+                .padding(.vertical, 16)
+        case .failure(let error):
+            Text(verbatim: error.localizedDescription)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .listRowSeparator(.hidden)
+            Button {
+                Task {
+                    await cohort.refresh(ids: displayedIDs, key: key, in: database)
+                }
+            } label: {
+                Text(verbatim: "Retry")
+            }
+            .listRowSeparator(.hidden)
+        case .success(let events):
+            entryRows(from: events)
+        }
+    }
+
+    @ViewBuilder private func entryRows(from events: [Event]) -> some View {
+        ForEach(events.cohortEntries(for: displayedIDs, key: key)) { entry in
+            entryRow(for: entry)
+        }
+
+        if droppedIDs.count > Self.displayedDropLimit {
+            Text(verbatim: "And \(droppedIDs.count - Self.displayedDropLimit) more…")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .listRowSeparator(.hidden)
+        }
+    }
+
+    private func entryRow(for entry: FunnelCohortEntry) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                if let event = entry.lastEvent {
+                    Text(verbatim: "last: \(event.name)")
+                        .font(.footnote)
+                        .monospaced()
+                }
+                Text(verbatim: entry.groupID.uuidString)
+                    .font(.caption2)
+                    .monospaced()
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer()
+            if let date = entry.lastEvent?.date {
+                Text(verbatim: date.relativeString)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func row(title: String, value: String, color: Color) -> some View {
+        HStack {
+            Text(verbatim: title)
+            Spacer()
+            Text(verbatim: value)
+                .monospacedDigit()
+                .foregroundStyle(color)
+        }
+    }
+
+    private var displayedIDs: [UUID] {
+        Array(droppedIDs.prefix(Self.displayedDropLimit))
+    }
+}
+
+#Preview("Funnel step detail") {
+    let metrics = FunnelStep.samples.metrics
+    let ids = (0..<8).map { _ in UUID() }
+
+    let cohort = FunnelCohortProvider()
+    cohort.result = .success(
+        ids.map { id in
+            Event.sample("signup_started", at: Date().addingTimeInterval(-.random(in: 600...86400)), sessionID: id)
+        }
+    )
+
+    return NavigationStack {
+        FunnelStepDetail(metric: metrics[2], droppedIDs: ids, key: .session, cohort: cohort)
+    }
+}

--- a/Sources/Scout/UI/Funnel/FunnelView.swift
+++ b/Sources/Scout/UI/Funnel/FunnelView.swift
@@ -1,0 +1,131 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct FunnelView: View {
+    @Environment(\.database) var database
+
+    @AppStorage("scout_funnel_steps") private var storedSteps = ""
+    @AppStorage("scout_funnel_key") private var key = Funnel.CorrelationKey.session
+    @AppStorage("scout_funnel_period") private var period = Period.month
+
+    @StateObject private var provider: FunnelProvider
+    @StateObject private var suggestions = EventProvider()
+
+    init(steps: [String] = [], provider: FunnelProvider = FunnelProvider()) {
+        self._storedSteps = AppStorage(wrappedValue: steps.joined(separator: "\n"), "scout_funnel_steps")
+        self._provider = StateObject(wrappedValue: provider)
+    }
+
+    private struct FetchID: Hashable {
+        let steps: String
+        let period: Period
+    }
+
+    var body: some View {
+        List {
+            FunnelBuilder(stepNames: stepNames, key: $key, suggestions: suggestionNames)
+            results
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: "Funnel")
+        .task {
+            await suggestions.fetchIfNeeded(for: Event.Query(), in: database)
+        }
+        .task(id: FetchID(steps: storedSteps, period: period)) {
+            guard funnel.isRunnable else { return }
+            await provider.fetchIfNeeded(names: funnel.stepNames, range: period.initialRange, in: database)
+        }
+        .refreshable {
+            guard funnel.isRunnable else { return }
+            await provider.refresh(names: funnel.stepNames, range: period.initialRange, in: database)
+        }
+    }
+
+    @ViewBuilder private var results: some View {
+        Header(title: "Funnel") {
+            CompactPeriodPicker(selection: $period)
+        }
+
+        if !funnel.isRunnable {
+            hint("Add \(Funnel.stepLimit.lowerBound) to \(Funnel.stepLimit.upperBound) steps to build the funnel.")
+        } else {
+            switch provider.result {
+            case nil:
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .listRowSeparator(.hidden)
+                    .padding(.vertical, 32)
+            case .failure(let error):
+                hint(error.localizedDescription)
+                Button {
+                    Task {
+                        await provider.refresh(names: funnel.stepNames, range: period.initialRange, in: database)
+                    }
+                } label: {
+                    Text(verbatim: "Retry")
+                }
+                .listRowSeparator(.hidden)
+            case .success(let events):
+                steps(from: events)
+            }
+        }
+    }
+
+    @ViewBuilder private func steps(from events: [Event]) -> some View {
+        let steps = funnel.steps(from: events)
+
+        if steps.metrics.count == 0 {
+            hint("No matching events in this period.")
+        } else {
+            FunnelPlotView(steps: steps)
+                .padding(.vertical, 12)
+                .listRowSeparator(.hidden)
+
+            ForEach(steps.metrics) { metric in
+                Row {
+                    FunnelLegendRow(metric: metric)
+                } destination: {
+                    FunnelStepDetail(
+                        metric: metric,
+                        droppedIDs: funnel.droppedIDs(before: metric.index, from: events),
+                        key: key
+                    )
+                }
+            }
+        }
+    }
+
+    private func hint(_ text: String) -> some View {
+        Text(verbatim: text)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .listRowSeparator(.hidden)
+    }
+
+    private var funnel: Funnel {
+        Funnel(stepNames: stepNames.wrappedValue, key: key)
+    }
+
+    private var stepNames: Binding<[String]> {
+        Binding(
+            get: { storedSteps.count > 0 ? storedSteps.components(separatedBy: "\n") : [] },
+            set: { storedSteps = $0.joined(separator: "\n") }
+        )
+    }
+
+    private var suggestionNames: [String] {
+        suggestions.events?.unique(by: \.name, max: 12) ?? []
+    }
+}
+
+#Preview("Funnel") {
+    NavigationStack {
+        FunnelView(steps: FunnelStep.samples.map(\.name), provider: .fixture())
+    }
+}

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -34,6 +34,15 @@ struct HomeLogSection: View {
             count: spans.map { $0.int.series + $0.double.series },
             destination: { MetricsList() }
         )
+        Row {
+            Image(systemName: "line.3.horizontal.decrease")
+                .foregroundColor(.blue)
+                .frame(width: 24)
+            Text(verbatim: "Funnel")
+            Spacer()
+        } destination: {
+            FunnelView()
+        }
         HomeLogRow(
             title: "Crashes",
             image: "exclamationmark.triangle",

--- a/Tests/ScoutTests/UI/Funnel/FunnelCohortProviderTests.swift
+++ b/Tests/ScoutTests/UI/Funnel/FunnelCohortProviderTests.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+struct FunnelCohortProviderTests {
+    @Test("fetchIfNeeded loads only events of the requested sessions")
+    func fetchesRequestedSessions() async throws {
+        let database = DatabaseStub()
+        let dropped = UUID()
+        database.add(
+            Record.eventStub(name: "open", sessionID: dropped, date: Date()),
+            Record.eventStub(name: "open", sessionID: UUID(), date: Date())
+        )
+
+        let provider = FunnelCohortProvider()
+        await provider.fetchIfNeeded(ids: [dropped], key: .session, in: database)
+
+        let events = try provider.result?.get()
+        #expect(events?.count == 1)
+        #expect(events?.first?.sessionID == dropped)
+    }
+
+    @Test("fetchIfNeeded skips repeated calls and empty cohorts")
+    func skipsRepeatsAndEmptyCohorts() async {
+        let database = DatabaseStub()
+
+        let provider = FunnelCohortProvider()
+        await provider.fetchIfNeeded(ids: [], key: .session, in: database)
+        #expect(database.readCount(of: EventObject.recordType) == 0)
+
+        await provider.fetchIfNeeded(ids: [UUID()], key: .session, in: database)
+        await provider.fetchIfNeeded(ids: [UUID()], key: .session, in: database)
+        #expect(database.readCount(of: EventObject.recordType) == 1)
+    }
+
+    @Test("cohortEntries picks each group's latest event and keeps input order")
+    func cohortEntriesPickLatestEvent() {
+        let first = UUID()
+        let second = UUID()
+        let missing = UUID()
+        let events = [
+            Event.sample("open", at: Date(timeIntervalSinceReferenceDate: 0), sessionID: first),
+            Event.sample("signup", at: Date(timeIntervalSinceReferenceDate: 10), sessionID: first),
+            Event.sample("open", at: Date(timeIntervalSinceReferenceDate: 5), sessionID: second),
+        ]
+
+        let entries = events.cohortEntries(for: [second, first, missing], key: .session)
+
+        #expect(entries.map(\.groupID) == [second, first, missing])
+        #expect(entries.map(\.lastEvent?.name) == ["open", "signup", nil])
+    }
+}

--- a/Tests/ScoutTests/UI/Funnel/FunnelProviderTests.swift
+++ b/Tests/ScoutTests/UI/Funnel/FunnelProviderTests.swift
@@ -1,0 +1,69 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+struct FunnelProviderTests {
+    @Test("fetchIfNeeded loads only events matching the step names and range")
+    func fetchesMatchingEvents() async throws {
+        let database = DatabaseStub()
+        let range = Date(timeIntervalSinceReferenceDate: 0)..<Date(timeIntervalSinceReferenceDate: 100)
+        database.add(
+            Record.eventStub(name: "open", sessionID: UUID(), date: Date(timeIntervalSinceReferenceDate: 10)),
+            Record.eventStub(name: "signup", sessionID: UUID(), date: Date(timeIntervalSinceReferenceDate: 20)),
+            Record.eventStub(name: "other", sessionID: UUID(), date: Date(timeIntervalSinceReferenceDate: 30)),
+            Record.eventStub(name: "open", sessionID: UUID(), date: Date(timeIntervalSinceReferenceDate: 200))
+        )
+
+        let provider = FunnelProvider()
+        await provider.fetchIfNeeded(names: ["open", "signup"], range: range, in: database)
+
+        let events = try provider.result?.get()
+        #expect(events?.count == 2)
+        #expect(events?.allSatisfy { ["open", "signup"].contains($0.name) } == true)
+    }
+
+    @Test("fetchIfNeeded skips repeated requests with the same parameters")
+    func skipsRepeatedRequests() async {
+        let database = DatabaseStub()
+        let range = Date(timeIntervalSinceReferenceDate: 0)..<Date(timeIntervalSinceReferenceDate: 100)
+
+        let provider = FunnelProvider()
+        await provider.fetchIfNeeded(names: ["open", "signup"], range: range, in: database)
+        await provider.fetchIfNeeded(names: ["open", "signup"], range: range, in: database)
+
+        #expect(database.readCount(of: EventObject.recordType) == 1)
+    }
+
+    @Test("fetchIfNeeded refetches when the step names change")
+    func refetchesOnChange() async {
+        let database = DatabaseStub()
+        let range = Date(timeIntervalSinceReferenceDate: 0)..<Date(timeIntervalSinceReferenceDate: 100)
+
+        let provider = FunnelProvider()
+        await provider.fetchIfNeeded(names: ["open", "signup"], range: range, in: database)
+        await provider.fetchIfNeeded(names: ["open", "purchase"], range: range, in: database)
+
+        #expect(database.readCount(of: EventObject.recordType) == 2)
+    }
+
+    @Test("refresh refetches with unchanged parameters")
+    func refreshRefetches() async {
+        let database = DatabaseStub()
+        let range = Date(timeIntervalSinceReferenceDate: 0)..<Date(timeIntervalSinceReferenceDate: 100)
+
+        let provider = FunnelProvider()
+        await provider.fetchIfNeeded(names: ["open", "signup"], range: range, in: database)
+        await provider.refresh(names: ["open", "signup"], range: range, in: database)
+
+        #expect(database.readCount(of: EventObject.recordType) == 2)
+    }
+}

--- a/Tests/ScoutTests/UI/Funnel/FunnelStepTests.swift
+++ b/Tests/ScoutTests/UI/Funnel/FunnelStepTests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct FunnelStepTests {
+    @Test("Metrics derive fractions, conversions, and drop-offs")
+    func derivesMetrics() {
+        let steps = [
+            FunnelStep(name: "open", count: 100),
+            FunnelStep(name: "signup", count: 40),
+            FunnelStep(name: "purchase", count: 10),
+        ]
+
+        let metrics = steps.metrics
+
+        #expect(metrics.map(\.fractionOfFirst) == [1, 0.4, 0.1])
+        #expect(metrics.map(\.conversionFromPrevious) == [nil, 0.4, 0.25])
+        #expect(metrics.map(\.dropOff) == [0, 60, 30])
+        #expect(metrics.map(\.index) == [0, 1, 2])
+    }
+
+    @Test("Metrics are empty when the first step has no data")
+    func emptyWhenFirstStepIsZero() {
+        let steps = [
+            FunnelStep(name: "open", count: 0),
+            FunnelStep(name: "signup", count: 0),
+        ]
+
+        #expect(steps.metrics.count == 0)
+        #expect([FunnelStep]().metrics.count == 0)
+    }
+}

--- a/Tests/ScoutTests/UI/Funnel/FunnelTests.swift
+++ b/Tests/ScoutTests/UI/Funnel/FunnelTests.swift
@@ -1,0 +1,134 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct FunnelTests {
+    private let funnel = Funnel(stepNames: ["open", "signup", "purchase"])
+
+    @Test("Counts sessions that pass each step in order")
+    func countsOrderedSteps() {
+        let full = UUID()
+        let partial = UUID()
+        let events = [
+            makeEvent("open", session: full, at: 0),
+            makeEvent("signup", session: full, at: 1),
+            makeEvent("purchase", session: full, at: 2),
+            makeEvent("open", session: partial, at: 0),
+            makeEvent("signup", session: partial, at: 1),
+        ]
+
+        let counts = funnel.steps(from: events).map(\.count)
+
+        #expect(counts == [2, 2, 1])
+    }
+
+    @Test("Ignores steps that happen out of order")
+    func ignoresOutOfOrderSteps() {
+        let session = UUID()
+        let events = [
+            makeEvent("signup", session: session, at: 0),
+            makeEvent("open", session: session, at: 1),
+        ]
+
+        let counts = funnel.steps(from: events).map(\.count)
+
+        #expect(counts == [1, 0, 0])
+    }
+
+    @Test("Counts stay monotonic when a later step is frequent on its own")
+    func staysMonotonic() {
+        let entered = UUID()
+        let stray = UUID()
+        let events = [
+            makeEvent("open", session: entered, at: 0),
+            makeEvent("purchase", session: stray, at: 0),
+            makeEvent("purchase", session: UUID(), at: 0),
+        ]
+
+        let counts = funnel.steps(from: events).map(\.count)
+
+        #expect(counts == [1, 0, 0])
+    }
+
+    @Test("Repeated events advance the funnel only once per step")
+    func repeatedEvents() {
+        let session = UUID()
+        let events = [
+            makeEvent("open", session: session, at: 0),
+            makeEvent("open", session: session, at: 1),
+            makeEvent("signup", session: session, at: 2),
+        ]
+
+        let counts = funnel.steps(from: events).map(\.count)
+
+        #expect(counts == [1, 1, 0])
+    }
+
+    @Test("Events without the correlation key are ignored")
+    func ignoresEventsWithoutKey() {
+        let events = [Event.sample("open", at: Date())]
+
+        let counts = funnel.steps(from: events).map(\.count)
+
+        #expect(counts == [0, 0, 0])
+    }
+
+    @Test("Groups by install when the install key is selected")
+    func groupsByInstall() {
+        let install = UUID()
+        var funnel = funnel
+        funnel.key = .install
+        let events = [
+            makeEvent("open", install: install, at: 0),
+            makeEvent("signup", install: install, at: 1),
+        ]
+
+        let counts = funnel.steps(from: events).map(\.count)
+
+        #expect(counts == [1, 1, 0])
+    }
+
+    @Test("droppedIDs returns the cohort stuck at the previous step")
+    func droppedCohort() {
+        let full = UUID()
+        let dropped = UUID()
+        let events = [
+            makeEvent("open", session: full, at: 0),
+            makeEvent("signup", session: full, at: 1),
+            makeEvent("open", session: dropped, at: 0),
+        ]
+
+        #expect(funnel.droppedIDs(before: 1, from: events) == [dropped])
+        #expect(funnel.droppedIDs(before: 0, from: events) == [])
+    }
+
+    @Test("isRunnable requires two to six steps")
+    func runnableRange() {
+        #expect(!Funnel(stepNames: ["a"]).isRunnable)
+        #expect(Funnel(stepNames: ["a", "b"]).isRunnable)
+        #expect(Funnel(stepNames: (0..<6).map(String.init)).isRunnable)
+        #expect(!Funnel(stepNames: (0..<7).map(String.init)).isRunnable)
+    }
+}
+
+private func makeEvent(_ name: String, session: UUID? = nil, install: UUID? = nil, at seconds: TimeInterval) -> Event {
+    Event(
+        name: name,
+        level: nil,
+        date: Date(timeIntervalSinceReferenceDate: seconds),
+        paramCount: nil,
+        uuid: nil,
+        id: UUID().uuidString,
+        installID: install,
+        sessionID: session,
+        deviceID: nil
+    )
+}


### PR DESCRIPTION
Adds a Conversion Funnel screen that answers how many sessions (or installs) that did step A went on to B and C. The funnel is built from 2–6 events picked from suggestions or entered manually, correlated by session or install, and rendered as columns with connector trapezoids plus a tappable legend; tapping a step opens the cohort that dropped off before it, showing each dropped session's last event fetched via the proven `session_id IN [...]` path. Events are fetched with a single `name IN [steps]` query over the selected period, and the ordered, monotonic step matching lives in a unit-tested model. Entry point is a new Funnel row in the Home log section. Funnels by user_id remain out of scope since user_id is never written.