### PR TITLE
Add latency distribution with percentiles for timers

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Telemetry/LatencyBuckets.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/LatencyBuckets.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+enum LatencyBuckets {
+    static let boundsMilliseconds = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000]
+
+    private static let categoryPrefix = "timer_le_"
+    private static let overflowSuffix = "inf"
+
+    static let categories = boundsMilliseconds.map { categoryPrefix + String($0) } + [categoryPrefix + overflowSuffix]
+
+    static func category(for seconds: TimeInterval) -> String {
+        let milliseconds = seconds * 1_000
+        guard let bound = boundsMilliseconds.first(where: { milliseconds <= Double($0) }) else {
+            return categoryPrefix + overflowSuffix
+        }
+        return categoryPrefix + String(bound)
+    }
+
+    static func upperBound(of category: String) -> TimeInterval? {
+        guard category.hasPrefix(categoryPrefix) else { return nil }
+        guard let milliseconds = Int(category.dropFirst(categoryPrefix.count)) else {
+            return nil
+        }
+        return TimeInterval(milliseconds) / 1_000
+    }
+
+    static func index(of category: String) -> Int? {
+        categories.firstIndex(of: category)
+    }
+}

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -4,23 +4,33 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+//
 
 import CoreData
 
 extension CKTelemetryHandler {
     func logMetrics(telemetry: Telemetry.Export, value: some MetricScalar) {
         let label = self.label
+        persistMetrics { context in
+            try saveMetrics(label, date: Date(), category: telemetry.rawValue, value: value, context)
+        }
+    }
+
+    func logTimer(seconds: TimeInterval) {
+        let label = self.label
+        persistMetrics { context in
+            let date = Date()
+            try saveMetrics(label, date: date, category: Telemetry.Export.timer.rawValue, value: seconds, context)
+            try saveMetrics(label, date: date, category: LatencyBuckets.category(for: seconds), value: 1, context)
+        }
+    }
+
+    private func persistMetrics(_ save: @escaping @Sendable (NSManagedObjectContext) throws -> Void) {
         let sync = self.sync
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
-                    try saveMetrics(
-                        label,
-                        date: Date(),
-                        telemetry: telemetry,
-                        value: value,
-                        context
-                    )
+                    try save(context)
                 }
                 try await sync()
             } catch {
@@ -30,19 +40,13 @@ extension CKTelemetryHandler {
     }
 }
 
-func saveMetrics<T: MetricScalar>(
-    _ name: String,
-    date: Date,
-    telemetry: Telemetry.Export,
-    value: T,
-    _ context: NSManagedObjectContext
-) throws {
+func saveMetrics<T: MetricScalar>(_ name: String, date: Date, category: String, value: T, _ context: NSManagedObjectContext) throws {
     let entityName = String(describing: T.Object.self)
     let entity = NSEntityDescription.entity(forEntityName: entityName, in: context)!
     let metrics = T.Object(entity: entity, insertInto: context)
 
     metrics.value = value
-    metrics.telemetry = telemetry.rawValue
+    metrics.telemetry = category
     metrics.date = date
     metrics.name = name
 

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler.swift
@@ -36,6 +36,6 @@ extension CKTelemetryHandler: FloatingPointCounterHandler {
 
 extension CKTelemetryHandler: TimerHandler {
     func recordNanoseconds(_ duration: Int64) {
-        logMetrics(telemetry: .timer, value: Double(duration) / 1_000_000_000)
+        logTimer(seconds: Double(duration) / 1_000_000_000)
     }
 }

--- a/Sources/Scout/UI/Metrics/Distribution/LatencyHistogram.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/LatencyHistogram.swift
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+struct LatencyHistogram: Equatable {
+    private(set) var counts: [Int]
+
+    init() {
+        counts = Array(repeating: 0, count: LatencyBuckets.categories.count)
+    }
+
+    var total: Int {
+        counts.reduce(0, +)
+    }
+
+    mutating func add(count: Int, at index: Int) {
+        guard counts.indices.contains(index) else { return }
+        counts[index] += count
+    }
+
+    static func + (lhs: LatencyHistogram, rhs: LatencyHistogram) -> LatencyHistogram {
+        var sum = LatencyHistogram()
+        sum.counts = zip(lhs.counts, rhs.counts).map(+)
+        return sum
+    }
+
+    func percentile(_ quantile: Double) -> TimeInterval? {
+        guard total > 0 else { return nil }
+
+        let target = Double(total) * quantile
+        var cumulative = 0
+
+        for (index, count) in counts.enumerated() where count > 0 {
+            let previous = cumulative
+            cumulative += count
+
+            if Double(cumulative) >= target {
+                let fraction = (target - Double(previous)) / Double(count)
+                return interpolated(at: index, fraction: fraction)
+            }
+        }
+
+        return Self.bounds.last
+    }
+
+    private static let bounds = LatencyBuckets.boundsMilliseconds.map { TimeInterval($0) / 1_000 }
+
+    private func interpolated(at index: Int, fraction: Double) -> TimeInterval {
+        let bounds = Self.bounds
+        let lower = index == 0 ? 0 : bounds[index - 1]
+        let upper = index < bounds.count ? bounds[index] : bounds[bounds.count - 1]
+        return lower + (upper - lower) * min(max(fraction, 0), 1)
+    }
+}

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistribution.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistribution.swift
@@ -1,0 +1,95 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+struct TimerDistribution: Equatable {
+    let histograms: [Date: LatencyHistogram]
+
+    init(histograms: [Date: LatencyHistogram]) {
+        self.histograms = histograms
+    }
+
+    init(series: [MetricSeries]) {
+        var histograms: [Date: LatencyHistogram] = [:]
+
+        for singleSeries in series {
+            guard let category = singleSeries.category else { continue }
+            guard let index = LatencyBuckets.index(of: category) else { continue }
+
+            for point in singleSeries.points {
+                let date = Date(millisecondsSince1970: point.date)
+                var histogram = histograms[date, default: LatencyHistogram()]
+                histogram.add(count: Int(point.value.doubleValue), at: index)
+                histograms[date] = histogram
+            }
+        }
+
+        self.histograms = histograms
+    }
+
+    var isEmpty: Bool {
+        histograms.values.allSatisfy { $0.total == 0 }
+    }
+
+    func summary(in range: Range<Date>) -> LatencyPercentiles? {
+        let combined = histograms
+            .filter { range.contains($0.key) }
+            .values
+            .reduce(LatencyHistogram(), +)
+
+        guard let p50 = combined.percentile(0.5),
+            let p90 = combined.percentile(0.9),
+            let p99 = combined.percentile(0.99)
+        else {
+            return nil
+        }
+
+        return LatencyPercentiles(p50: p50, p90: p90, p99: p99)
+    }
+
+    func trend(in range: Range<Date>, component: Calendar.Component) -> [PercentileTrendPoint] {
+        var result: [PercentileTrendPoint] = []
+        var date = range.upperBound
+        var steps = 0
+
+        while date > range.lowerBound {
+            steps -= 1
+            let newDate = range.upperBound.adding(component, value: steps)
+            let combined = histograms
+                .filter { newDate..<date ~= $0.key }
+                .values
+                .reduce(LatencyHistogram(), +)
+
+            if let p99 = combined.percentile(0.99) {
+                result.append(PercentileTrendPoint(date: newDate, p99: p99))
+            }
+
+            date = newDate
+        }
+
+        return result.reversed()
+    }
+}
+
+extension TimerDistribution {
+    static var sample: TimerDistribution {
+        let start = Calendar.current.startOfDay(for: .now)
+        var histograms: [Date: LatencyHistogram] = [:]
+
+        for hour in 0..<24 {
+            var histogram = LatencyHistogram()
+            for (offset, weight) in [2, 8, 21, 34, 27, 13, 5, 3, 2, 1].enumerated() {
+                histogram.add(count: weight * (1 + hour % 5), at: offset + 4)
+            }
+            histograms[start.addingTimeInterval(TimeInterval(hour) * .hour)] = histogram
+        }
+
+        return TimerDistribution(histograms: histograms)
+    }
+}

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistribution.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistribution.swift
@@ -38,7 +38,8 @@ struct TimerDistribution: Equatable {
     }
 
     func summary(in range: Range<Date>) -> LatencyPercentiles? {
-        let combined = histograms
+        let combined =
+            histograms
             .filter { range.contains($0.key) }
             .values
             .reduce(LatencyHistogram(), +)
@@ -61,7 +62,8 @@ struct TimerDistribution: Equatable {
         while date > range.lowerBound {
             steps -= 1
             let newDate = range.upperBound.adding(component, value: steps)
-            let combined = histograms
+            let combined =
+                histograms
                 .filter { newDate..<date ~= $0.key }
                 .values
                 .reduce(LatencyHistogram(), +)

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistributionProvider.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistributionProvider.swift
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+class TimerDistributionProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<TimerDistribution>?
+
+    private let name: String
+
+    init(name: String) {
+        self.name = name
+    }
+
+    func fetch(in database: DatabaseReader) async throws -> TimerDistribution {
+        let range = Calendar.utc.defaultRange
+        let name = self.name
+
+        let series = try await withThrowingTaskGroup(of: [MetricSeries].self) { group in
+            for category in LatencyBuckets.categories {
+                group.addTask {
+                    try await database.metricSeries(Int.self, category: category, in: range)
+                }
+            }
+            var series: [MetricSeries] = []
+            for try await chunk in group {
+                series += chunk
+            }
+            return series
+        }
+
+        return TimerDistribution(series: series.filter { $0.name == name })
+    }
+}
+
+extension TimerDistributionProvider {
+    static func fixture() -> TimerDistributionProvider {
+        let provider = TimerDistributionProvider(name: "http_request")
+        provider.result = .success(.sample)
+        return provider
+    }
+}

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistributionSection.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistributionSection.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct TimerDistributionSection: View {
+    let extent: ChartExtent<Period>
+
+    @StateObject var provider: TimerDistributionProvider
+    @Environment(\.database) var database
+
+    init(name: String, extent: ChartExtent<Period>, provider: TimerDistributionProvider? = nil) {
+        self.extent = extent
+        self._provider = StateObject(wrappedValue: provider ?? TimerDistributionProvider(name: name))
+    }
+
+    var body: some View {
+        Group {
+            switch provider.result {
+            case .success(let distribution):
+                if let percentiles = distribution.summary(in: extent.domain) {
+                    TimerDistributionView(
+                        percentiles: percentiles,
+                        trend: distribution.trend(in: extent.domain, component: extent.period.pointComponent),
+                        unit: extent.period.pointComponent
+                    )
+                }
+            default:
+                EmptyView()
+            }
+        }
+        .listRowSeparator(.hidden)
+        .task {
+            await provider.fetchIfNeeded(in: database)
+        }
+    }
+}
+
+#Preview("TimerDistributionSection") {
+    NavigationStack {
+        List {
+            TimerDistributionSection(
+                name: "http_request",
+                extent: ChartExtent(period: .today),
+                provider: .fixture()
+            )
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: "http_request")
+    }
+}

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
@@ -1,0 +1,115 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Charts
+import SwiftUI
+
+struct LatencyPercentiles: Equatable {
+    let p50: TimeInterval
+    let p90: TimeInterval
+    let p99: TimeInterval
+}
+
+struct PercentileTrendPoint: Identifiable, Equatable {
+    let date: Date
+    let p99: TimeInterval
+
+    var id: Date { date }
+}
+
+struct TimerDistributionView: View {
+    let percentiles: LatencyPercentiles
+    let trend: [PercentileTrendPoint]
+    let unit: Calendar.Component
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 21) {
+            summary
+
+            Text(verbatim: "P99 TREND")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.gray)
+
+            chart
+        }
+        .padding(.vertical)
+    }
+
+    private var summary: some View {
+        HStack(spacing: 34) {
+            Metric(title: "P50", value: percentiles.p50.duration, color: .blue)
+            Metric(title: "P90", value: percentiles.p90.duration, color: .teal)
+            Metric(title: "P99", value: percentiles.p99.duration, color: .orange)
+            Spacer()
+        }
+    }
+
+    private var chart: some View {
+        Chart(trend) { point in
+            AreaMark(
+                x: .value("Date", point.date, unit: unit),
+                y: .value("P99", point.p99)
+            )
+            .foregroundStyle(
+                .linearGradient(
+                    colors: [.orange.opacity(0.34), .orange.opacity(0.03)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+
+            LineMark(
+                x: .value("Date", point.date, unit: unit),
+                y: .value("P99", point.p99)
+            )
+            .foregroundStyle(.orange)
+            .lineStyle(StrokeStyle(lineWidth: 2))
+            .interpolationMethod(.monotone)
+        }
+        .chartYAxis {
+            AxisMarks { value in
+                if let seconds = value.as(TimeInterval.self) {
+                    AxisGridLine()
+                    AxisValueLabel(seconds.duration)
+                }
+            }
+        }
+        .aspectRatio(1.618, contentMode: .fit)
+    }
+}
+
+extension LatencyPercentiles {
+    static var sample: LatencyPercentiles {
+        LatencyPercentiles(p50: 0.081, p90: 0.42, p99: 3.8)
+    }
+}
+
+extension Array where Element == PercentileTrendPoint {
+    static var sample: [PercentileTrendPoint] {
+        let p99s = [
+            1.4, 1.2, 1.1, 1.0, 1.1, 1.3, 1.7, 2.4, 2.9, 2.6, 2.2, 2.5,
+            2.8, 2.5, 2.3, 2.7, 3.6, 4.1, 3.0, 2.4, 2.0, 1.8, 1.6, 1.5,
+        ]
+
+        let start = Calendar.current.startOfDay(for: .now)
+
+        return p99s.enumerated().map { hour, p99 in
+            PercentileTrendPoint(date: start.addingTimeInterval(TimeInterval(hour) * .hour), p99: p99)
+        }
+    }
+}
+
+#Preview("TimerDistributionView") {
+    NavigationStack {
+        ScrollView {
+            TimerDistributionView(percentiles: .sample, trend: .sample, unit: .hour)
+                .padding(.horizontal)
+        }
+        .navigationTitle(en: "http_request")
+    }
+}

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MetricsContent<T: ChartNumeric>: View {
     let period: Period
     let formatter: KeyPath<T, String>
+    let telemetry: Telemetry.Export
 
     @StateObject var metrics: MetricsProvider<T>
     @Environment(\.database) var database
@@ -17,6 +18,7 @@ struct MetricsContent<T: ChartNumeric>: View {
     init(period: Period, formatter: KeyPath<T, String>, telemetry: Telemetry.Export) {
         self.period = period
         self.formatter = formatter
+        self.telemetry = telemetry
         self._metrics = StateObject(wrappedValue: MetricsProvider(telemetry: telemetry))
     }
 
@@ -38,11 +40,7 @@ struct MetricsContent<T: ChartNumeric>: View {
                         row(group: group)
                     } destination: {
                         if let named = groups.named(group.name) {
-                            MetricsView(
-                                group: named,
-                                formatter: formatter,
-                                period: period
-                            )
+                            destination(group: named)
                         }
                     }
                 }
@@ -51,6 +49,17 @@ struct MetricsContent<T: ChartNumeric>: View {
         }
         .task {
             await metrics.fetchIfNeeded(in: database)
+        }
+    }
+
+    @ViewBuilder
+    private func destination(group: PointGroup<T>) -> some View {
+        if telemetry == .timer {
+            MetricsView(group: group, formatter: formatter, period: period) { extent in
+                TimerDistributionSection(name: group.name, extent: extent)
+            }
+        } else {
+            MetricsView(group: group, formatter: formatter, period: period)
         }
     }
 

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -4,20 +4,23 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+//
 
 import Charts
 import SwiftUI
 
-struct MetricsView<T: ChartNumeric>: View {
+struct MetricsView<T: ChartNumeric, Extra: View>: View {
     let group: PointGroup<T>
     let formatter: KeyPath<T, String>
 
     @State var extent: ChartExtent<Period>
     @State private var isComparing = false
+    @ViewBuilder let extra: (ChartExtent<Period>) -> Extra
 
-    init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period) {
+    init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period, @ViewBuilder extra: @escaping (ChartExtent<Period>) -> Extra) {
         self.group = group
         self.formatter = formatter
+        self.extra = extra
         self._extent = State(wrappedValue: ChartExtent(period: period))
     }
 
@@ -41,10 +44,12 @@ struct MetricsView<T: ChartNumeric>: View {
 
             ComparisonToggle(isOn: $isComparing)
                 .disabled(!extent.canCompare(points: group.points, segment: segment))
+
+            extra(extent)
         }
         .listStyle(.plain)
         .navigationTitle(group.name)
-        .scrollDisabled(true)
+        .scrollDisabled(Extra.self == EmptyView.self)
     }
 
     private var formattedMarks: some AxisContent {
@@ -54,6 +59,12 @@ struct MetricsView<T: ChartNumeric>: View {
                 AxisValueLabel(value[keyPath: formatter])
             }
         }
+    }
+}
+
+extension MetricsView where Extra == EmptyView {
+    init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period) {
+        self.init(group: group, formatter: formatter, period: period) { _ in EmptyView() }
     }
 }
 

--- a/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
+++ b/Tests/ScoutTests/Core/Backend/ServerContractTests.swift
@@ -160,6 +160,29 @@ struct ServerContractTests {
         #expect(crashes.allSatisfy { $0.name == "SIGSEGV" })
     }
 
+    @Test("Timer bucket increments surface in the metric series by bucket category")
+    func timerBucketSeries() async throws {
+        let database = try makeDatabase()
+        // A unique name isolates this series from any shared server data.
+        let marker = "contract-\(UUID().uuidString)"
+        let category = LatencyBuckets.category(for: 0.1)
+
+        try await database.write(records: [
+            makeMetric(name: marker, category: category),
+            makeMetric(name: marker, category: category),
+        ])
+
+        let series = try await database.metricSeries(
+            Int.self,
+            category: category,
+            in: eventDate.startOfDay..<eventDate.startOfDay.addingDay()
+        )
+        let bucketSeries = try #require(series.first { $0.name == marker })
+
+        #expect(bucketSeries.category == category)
+        #expect(bucketSeries.points.map(\.value.doubleValue).reduce(0, +) == 2)
+    }
+
     @Test("A reachability ping succeeds against a live server")
     func reachabilityPing() async throws {
         let database = try makeDatabase()
@@ -193,6 +216,16 @@ struct ServerContractTests {
         record["session_id"] = UUID().uuidString
         record["install_id"] = installID
         record["start_date"] = startDate
+        return record
+    }
+
+    private func makeMetric(name: String, category: String) -> Record {
+        var record = Record(recordType: "IntMetric", recordID: "contract-\(UUID().uuidString)")
+        record["name"] = name
+        record["category"] = category
+        record["value"] = 1
+        record["date"] = eventDate
+        record["session_id"] = UUID().uuidString
         return record
     }
 

--- a/Tests/ScoutTests/Core/Diagnostics/Metrics/SaveMetricsTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Metrics/SaveMetricsTests.swift
@@ -19,7 +19,7 @@ struct SaveMetricsTests {
 
     @Test("Persists an IntMetricsObject with correct fields")
     func persistsIntMetrics() throws {
-        try saveMetrics("api_calls", date: date, telemetry: .counter, value: 5, context)
+        try saveMetrics("api_calls", date: date, category: "counter", value: 5, context)
 
         let results = try context.fetchAll(IntMetricsObject.self)
 
@@ -34,7 +34,7 @@ struct SaveMetricsTests {
 
     @Test("Persists a DoubleMetricsObject with correct fields")
     func persistsDoubleMetrics() throws {
-        try saveMetrics("response_time", date: date, telemetry: .timer, value: 1.5, context)
+        try saveMetrics("response_time", date: date, category: "timer", value: 1.5, context)
 
         let results = try context.fetchAll(DoubleMetricsObject.self)
 
@@ -48,7 +48,7 @@ struct SaveMetricsTests {
 
     @Test("Saves to the context")
     func savesToContext() throws {
-        try saveMetrics("metric", date: date, telemetry: .counter, value: 1, context)
+        try saveMetrics("metric", date: date, category: "counter", value: 1, context)
 
         #expect(!context.hasChanges)
     }

--- a/Tests/ScoutTests/Core/Diagnostics/Telemetry/LatencyBucketsTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Telemetry/LatencyBucketsTests.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("LatencyBuckets")
+struct LatencyBucketsTests {
+    @Test("Categories cover every bound plus overflow")
+    func categories() {
+        #expect(LatencyBuckets.categories.count == LatencyBuckets.boundsMilliseconds.count + 1)
+        #expect(LatencyBuckets.categories.first == "timer_le_1")
+        #expect(LatencyBuckets.categories.last == "timer_le_inf")
+    }
+
+    @Test("category(for:) picks the first bound at or above the sample")
+    func binning() {
+        #expect(LatencyBuckets.category(for: 0.0005) == "timer_le_1")
+        #expect(LatencyBuckets.category(for: 0.001) == "timer_le_1")
+        #expect(LatencyBuckets.category(for: 0.0011) == "timer_le_2")
+        #expect(LatencyBuckets.category(for: 0.1) == "timer_le_100")
+        #expect(LatencyBuckets.category(for: 3.7) == "timer_le_5000")
+        #expect(LatencyBuckets.category(for: 31) == "timer_le_inf")
+    }
+
+    @Test("upperBound(of:) parses finite bucket categories only")
+    func upperBound() {
+        #expect(LatencyBuckets.upperBound(of: "timer_le_250") == 0.25)
+        #expect(LatencyBuckets.upperBound(of: "timer_le_inf") == nil)
+        #expect(LatencyBuckets.upperBound(of: "counter") == nil)
+    }
+
+    @Test("index(of:) maps categories to histogram slots")
+    func index() {
+        #expect(LatencyBuckets.index(of: "timer_le_1") == 0)
+        #expect(LatencyBuckets.index(of: "timer_le_inf") == LatencyBuckets.boundsMilliseconds.count)
+        #expect(LatencyBuckets.index(of: "timer") == nil)
+    }
+}

--- a/Tests/ScoutTests/Native/Matrix/Batch/MetricsMatrixTests.swift
+++ b/Tests/ScoutTests/Native/Matrix/Batch/MetricsMatrixTests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("Metrics matrix batching")
+struct MetricsMatrixTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let date = Date(year: 2026, month: 6, day: 1)
+
+    @Test("Bucket increments aggregate into a matrix carrying the bucket category")
+    func bucketCategory() throws {
+        let batch = [
+            makeBucketIncrement(category: "timer_le_100", date: date),
+            makeBucketIncrement(category: "timer_le_100", date: date),
+            makeBucketIncrement(category: "timer_le_100", date: date.addingHour()),
+        ]
+
+        let matrix = try IntMetricsObject.matrix(of: batch)
+
+        #expect(type(of: matrix).recordType == "DateIntMatrix")
+        #expect(matrix.category == "timer_le_100")
+        #expect(matrix.name == "http_request")
+        #expect(matrix.date == date.startOfWeek)
+        #expect(matrix.cells.count == 2)
+        #expect(matrix.cells.map(\.value).reduce(0, +) == 3)
+    }
+
+    @Test("Distinct bucket categories stay in separate batches by batch keys")
+    func batchKeys() {
+        #expect(IntMetricsObject.batchKeys.contains(\.telemetry))
+    }
+
+    private func makeBucketIncrement(category: String, date: Date) -> IntMetricsObject {
+        let entity = NSEntityDescription.entity(forEntityName: "IntMetricsObject", in: context)!
+        let metric = IntMetricsObject(entity: entity, insertInto: context)
+
+        metric.name = "http_request"
+        metric.telemetry = category
+        metric.value = 1
+        metric.date = date
+
+        return metric
+    }
+}

--- a/Tests/ScoutTests/UI/Metrics/Distribution/LatencyHistogramTests.swift
+++ b/Tests/ScoutTests/UI/Metrics/Distribution/LatencyHistogramTests.swift
@@ -1,0 +1,73 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("LatencyHistogram")
+struct LatencyHistogramTests {
+    @Test("Empty histogram has no percentiles")
+    func empty() {
+        #expect(LatencyHistogram().percentile(0.99) == nil)
+        #expect(LatencyHistogram().total == 0)
+    }
+
+    @Test("Percentile interpolates within a bucket")
+    func interpolation() {
+        var histogram = LatencyHistogram()
+        histogram.add(count: 100, at: 0)
+
+        #expect(histogram.percentile(0.5) == 0.0005)
+        #expect(histogram.percentile(1) == 0.001)
+    }
+
+    @Test("Percentile walks buckets by cumulative count")
+    func cumulative() throws {
+        var histogram = LatencyHistogram()
+        histogram.add(count: 90, at: 0)
+        histogram.add(count: 10, at: 5)
+
+        let p99 = try #require(histogram.percentile(0.99))
+
+        #expect(abs(p99 - 0.0475) < 0.0001)
+    }
+
+    @Test("Overflow bucket clamps to the last finite bound")
+    func overflow() {
+        var histogram = LatencyHistogram()
+        histogram.add(count: 10, at: LatencyBuckets.boundsMilliseconds.count)
+
+        #expect(histogram.percentile(0.99) == 30)
+    }
+
+    @Test("Adding histograms sums counts per bucket")
+    func addition() {
+        var first = LatencyHistogram()
+        first.add(count: 3, at: 1)
+        var second = LatencyHistogram()
+        second.add(count: 4, at: 1)
+        second.add(count: 5, at: 2)
+
+        let sum = first + second
+
+        #expect(sum.counts[1] == 7)
+        #expect(sum.counts[2] == 5)
+        #expect(sum.total == 12)
+    }
+
+    @Test("Out-of-range indices are ignored")
+    func outOfRange() {
+        var histogram = LatencyHistogram()
+        histogram.add(count: 5, at: -1)
+        histogram.add(count: 5, at: LatencyBuckets.categories.count)
+
+        #expect(histogram.total == 0)
+    }
+}

--- a/Tests/ScoutTests/UI/Metrics/Distribution/TimerDistributionTests.swift
+++ b/Tests/ScoutTests/UI/Metrics/Distribution/TimerDistributionTests.swift
@@ -1,0 +1,103 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("TimerDistribution")
+struct TimerDistributionTests {
+    let base = Date(year: 2026, month: 6, day: 1)
+
+    @Test("Builds histograms from bucket series and ignores foreign categories")
+    func seriesInit() throws {
+        let distribution = TimerDistribution(series: [
+            makeSeries(category: "timer_le_1", points: [(base, 3)]),
+            makeSeries(category: "timer_le_100", points: [(base, 2)]),
+            makeSeries(category: "timer", points: [(base, 9)]),
+        ])
+
+        #expect(distribution.histograms.count == 1)
+
+        let histogram = try #require(distribution.histograms[base])
+        #expect(histogram.total == 5)
+        #expect(histogram.counts[0] == 3)
+        #expect(histogram.counts[6] == 2)
+    }
+
+    @Test("summary combines histograms within the range only")
+    func summaryRange() throws {
+        let inside = base
+        let outside = base.adding(.day, value: 2)
+        let distribution = TimerDistribution(series: [
+            makeSeries(category: "timer_le_1", points: [(inside, 100)]),
+            makeSeries(category: "timer_le_inf", points: [(outside, 100)]),
+        ])
+
+        let summary = try #require(distribution.summary(in: base..<base.adding(.day)))
+
+        #expect(abs(summary.p99 - 0.00099) < 0.000001)
+        #expect(summary.p50 == 0.0005)
+    }
+
+    @Test("summary is nil when the range holds no samples")
+    func summaryEmpty() {
+        let distribution = TimerDistribution(series: [
+            makeSeries(category: "timer_le_1", points: [(base, 5)])
+        ])
+
+        #expect(distribution.summary(in: base.adding(.day)..<base.adding(.day, value: 2)) == nil)
+    }
+
+    @Test("trend reports one chronological p99 point per interval")
+    func trend() throws {
+        let distribution = TimerDistribution(series: [
+            makeSeries(category: "timer_le_1", points: [(base, 100)]),
+            makeSeries(category: "timer_le_inf", points: [(base.adding(.hour), 100)]),
+        ])
+
+        let trend = distribution.trend(in: base..<base.adding(.hour, value: 2), component: .hour)
+
+        #expect(trend.count == 2)
+        #expect(trend.map(\.date) == [base, base.adding(.hour)])
+
+        let first = try #require(trend.first)
+        let last = try #require(trend.last)
+        #expect(first.p99 < 0.001)
+        #expect(last.p99 == 30)
+    }
+
+    @Test("trend skips intervals without samples")
+    func trendGaps() {
+        let distribution = TimerDistribution(series: [
+            makeSeries(category: "timer_le_1", points: [(base, 5)])
+        ])
+
+        let trend = distribution.trend(in: base..<base.adding(.hour, value: 3), component: .hour)
+
+        #expect(trend.count == 1)
+        #expect(trend.first?.date == base)
+    }
+
+    @Test("isEmpty reflects total counts")
+    func isEmpty() {
+        #expect(TimerDistribution(series: []).isEmpty)
+        #expect(!TimerDistribution(series: [makeSeries(category: "timer_le_1", points: [(base, 1)])]).isEmpty)
+    }
+
+    private func makeSeries(category: String, points: [(Date, Int)]) -> MetricSeries {
+        MetricSeries(
+            name: "http_request",
+            category: category,
+            points: points.map { date, count in
+                MetricSeriesPoint(date: date.millisecondsSince1970, value: .int(count))
+            }
+        )
+    }
+}


### PR DESCRIPTION
Timers were only visible as hourly sums, which hides tail latency entirely. Timer samples are now also binned into a fixed ladder of 15 exponential latency buckets (1 ms to 30 s plus overflow), stored as ordinary IntMetricsObject increments whose category encodes the bucket (timer_le_<ms>), so the existing batching, DateIntMatrix aggregation, conflict-aware merge, and metricSeries read path all work unchanged — no new Core Data model version, CloudKit record type, or scout-server changes. The timer detail screen gains a P50/P90/P99 summary and a p99 trend chart computed client-side from the buckets, and falls back to the plain sum chart when no bucket data exists, which is permanently the case for historical data. A new ServerContractTests case pins bucket categories flowing through the series endpoint.