### PR TITLE
Add a network monitoring domain

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Telemetry/StatusBuckets.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/StatusBuckets.swift
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+enum StatusBuckets {
+    static let classes = ["2xx", "3xx", "4xx", "5xx"]
+
+    static let dimension = "status"
+
+    private static let categoryPrefix = "status_"
+
+    static let categories = classes.map { categoryPrefix + $0 }
+
+    static func category(for code: Int) -> String? {
+        guard (200..<600).contains(code) else { return nil }
+        return categoryPrefix + String(code / 100) + "xx"
+    }
+
+    static func category(in dimensions: [(String, String)]) -> String? {
+        guard let value = dimensions.first(where: { $0.0 == dimension })?.1 else { return nil }
+        guard let code = Int(value) else { return nil }
+        return category(for: code)
+    }
+
+    static func index(of category: String) -> Int? {
+        categories.firstIndex(of: category)
+    }
+}

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -10,9 +10,13 @@ import CoreData
 
 extension CKTelemetryHandler {
     func logMetrics(telemetry: Telemetry.Export, value: some MetricScalar) {
+        logMetrics(category: telemetry.rawValue, value: value)
+    }
+
+    func logMetrics(category: String, value: some MetricScalar) {
         let label = self.label
         persistMetrics { context in
-            try saveMetrics(label, date: Date(), category: telemetry.rawValue, value: value, context)
+            try saveMetrics(label, date: Date(), category: category, value: value, context)
         }
     }
 

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler.swift
@@ -24,7 +24,11 @@ final class CKTelemetryHandler: NSObject {
 
 extension CKTelemetryHandler: CounterHandler {
     func increment(by value: Int64) {
-        logMetrics(telemetry: .counter, value: Int(value))
+        if let category = StatusBuckets.category(in: dimensions) {
+            logMetrics(category: category, value: Int(value))
+        } else {
+            logMetrics(telemetry: .counter, value: Int(value))
+        }
     }
 }
 

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -35,6 +35,15 @@ struct HomeLogSection: View {
             destination: { MetricsList() }
         )
         Row {
+            Image(systemName: "network")
+                .foregroundColor(.blue)
+                .frame(width: 24)
+            Text(verbatim: "Network")
+            Spacer()
+        } destination: {
+            NetworkView()
+        }
+        Row {
             Image(systemName: "line.3.horizontal.decrease")
                 .foregroundColor(.blue)
                 .frame(width: 24)

--- a/Sources/Scout/UI/Metrics/Distribution/PercentileTrendChart.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/PercentileTrendChart.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Charts
+import SwiftUI
+
+struct PercentileTrendPoint: Identifiable, Equatable {
+    let date: Date
+    let p99: TimeInterval
+
+    var id: Date { date }
+}
+
+struct PercentileTrendChart: View {
+    let trend: [PercentileTrendPoint]
+    let unit: Calendar.Component
+
+    var body: some View {
+        Chart(trend) { point in
+            AreaMark(
+                x: .value("Date", point.date, unit: unit),
+                y: .value("P99", point.p99)
+            )
+            .foregroundStyle(
+                .linearGradient(
+                    colors: [.orange.opacity(0.34), .orange.opacity(0.03)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+
+            LineMark(
+                x: .value("Date", point.date, unit: unit),
+                y: .value("P99", point.p99)
+            )
+            .foregroundStyle(.orange)
+            .lineStyle(StrokeStyle(lineWidth: 2))
+            .interpolationMethod(.monotone)
+        }
+        .chartYAxis {
+            AxisMarks { value in
+                if let seconds = value.as(TimeInterval.self) {
+                    AxisGridLine()
+                    AxisValueLabel(seconds.duration)
+                }
+            }
+        }
+        .aspectRatio(1.618, contentMode: .fit)
+    }
+}
+
+extension Array where Element == PercentileTrendPoint {
+    static var sample: [PercentileTrendPoint] {
+        let p99s = [
+            1.4, 1.2, 1.1, 1.0, 1.1, 1.3, 1.7, 2.4, 2.9, 2.6, 2.2, 2.5,
+            2.8, 2.5, 2.3, 2.7, 3.6, 4.1, 3.0, 2.4, 2.0, 1.8, 1.6, 1.5,
+        ]
+
+        let start = Calendar.current.startOfDay(for: .now)
+
+        return p99s.enumerated().map { hour, p99 in
+            PercentileTrendPoint(date: start.addingTimeInterval(TimeInterval(hour) * .hour), p99: p99)
+        }
+    }
+}
+
+#Preview("PercentileTrendChart") {
+    PercentileTrendChart(trend: .sample, unit: .hour)
+        .padding(.horizontal)
+}

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
@@ -6,20 +6,12 @@
 // https://opensource.org/licenses/MIT.
 //
 
-import Charts
 import SwiftUI
 
 struct LatencyPercentiles: Equatable {
     let p50: TimeInterval
     let p90: TimeInterval
     let p99: TimeInterval
-}
-
-struct PercentileTrendPoint: Identifiable, Equatable {
-    let date: Date
-    let p99: TimeInterval
-
-    var id: Date { date }
 }
 
 struct TimerDistributionView: View {
@@ -35,7 +27,7 @@ struct TimerDistributionView: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(Color.gray)
 
-            chart
+            PercentileTrendChart(trend: trend, unit: unit)
         }
         .padding(.vertical)
     }
@@ -48,59 +40,11 @@ struct TimerDistributionView: View {
             Spacer()
         }
     }
-
-    private var chart: some View {
-        Chart(trend) { point in
-            AreaMark(
-                x: .value("Date", point.date, unit: unit),
-                y: .value("P99", point.p99)
-            )
-            .foregroundStyle(
-                .linearGradient(
-                    colors: [.orange.opacity(0.34), .orange.opacity(0.03)],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
-
-            LineMark(
-                x: .value("Date", point.date, unit: unit),
-                y: .value("P99", point.p99)
-            )
-            .foregroundStyle(.orange)
-            .lineStyle(StrokeStyle(lineWidth: 2))
-            .interpolationMethod(.monotone)
-        }
-        .chartYAxis {
-            AxisMarks { value in
-                if let seconds = value.as(TimeInterval.self) {
-                    AxisGridLine()
-                    AxisValueLabel(seconds.duration)
-                }
-            }
-        }
-        .aspectRatio(1.618, contentMode: .fit)
-    }
 }
 
 extension LatencyPercentiles {
     static var sample: LatencyPercentiles {
         LatencyPercentiles(p50: 0.081, p90: 0.42, p99: 3.8)
-    }
-}
-
-extension Array where Element == PercentileTrendPoint {
-    static var sample: [PercentileTrendPoint] {
-        let p99s = [
-            1.4, 1.2, 1.1, 1.0, 1.1, 1.3, 1.7, 2.4, 2.9, 2.6, 2.2, 2.5,
-            2.8, 2.5, 2.3, 2.7, 3.6, 4.1, 3.0, 2.4, 2.0, 1.8, 1.6, 1.5,
-        ]
-
-        let start = Calendar.current.startOfDay(for: .now)
-
-        return p99s.enumerated().map { hour, p99 in
-            PercentileTrendPoint(date: start.addingTimeInterval(TimeInterval(hour) * .hour), p99: p99)
-        }
     }
 }
 

--- a/Sources/Scout/UI/Network/Model/NetworkEndpoint.swift
+++ b/Sources/Scout/UI/Network/Model/NetworkEndpoint.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct NetworkEndpoint: Identifiable {
+    let name: String
+    let requests: Int
+    let successRate: Stability?
+    let p99: TimeInterval?
+
+    var id: String { name }
+
+    private static let methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+
+    var method: String? {
+        guard let first = name.split(separator: " ").first.map(String.init) else { return nil }
+        return Self.methods.contains(first) ? first : nil
+    }
+
+    var path: String {
+        guard let method else { return name }
+        return String(name.dropFirst(method.count)).trimmingCharacters(in: .whitespaces)
+    }
+
+    var methodColor: Color {
+        switch method {
+        case "GET": .green
+        case "POST": .blue
+        case "PUT", "PATCH": .orange
+        case "DELETE": .red
+        default: .gray
+        }
+    }
+}
+
+extension NetworkEndpoint {
+    static let samples = [
+        NetworkEndpoint(name: "GET /v1/events", requests: 8_420, successRate: 0.998, p99: 0.21),
+        NetworkEndpoint(name: "POST /v1/metrics", requests: 5_210, successRate: 0.991, p99: 0.62),
+        NetworkEndpoint(name: "GET /v1/releases", requests: 3_140, successRate: 0.972, p99: 1.9),
+        NetworkEndpoint(name: "POST /v1/crash", requests: 1_180, successRate: 0.883, p99: 4.4),
+        NetworkEndpoint(name: "GET /health", requests: 640, successRate: 1.0, p99: 0.04),
+    ]
+}

--- a/Sources/Scout/UI/Network/Model/NetworkReport.swift
+++ b/Sources/Scout/UI/Network/Model/NetworkReport.swift
@@ -1,0 +1,104 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+struct NetworkReport {
+    let distributions: [String: TimerDistribution]
+    let statuses: [String: StatusDistribution]
+
+    private let combined: TimerDistribution
+
+    init(distributions: [String: TimerDistribution], statuses: [String: StatusDistribution]) {
+        self.distributions = distributions
+        self.statuses = statuses
+
+        var merged: [Date: LatencyHistogram] = [:]
+        for distribution in distributions.values {
+            for (date, histogram) in distribution.histograms {
+                merged[date] = merged[date, default: LatencyHistogram()] + histogram
+            }
+        }
+        combined = TimerDistribution(histograms: merged)
+    }
+
+    init(series: [MetricSeries]) {
+        var latency: [String: [MetricSeries]] = [:]
+        var status: [String: [MetricSeries]] = [:]
+
+        for singleSeries in series {
+            guard let category = singleSeries.category else { continue }
+
+            if LatencyBuckets.index(of: category) != nil {
+                latency[singleSeries.name, default: []].append(singleSeries)
+            } else if StatusBuckets.index(of: category) != nil {
+                status[singleSeries.name, default: []].append(singleSeries)
+            }
+        }
+
+        self.init(
+            distributions: latency.filter { status.keys.contains($0.key) }.mapValues(TimerDistribution.init),
+            statuses: status.mapValues(StatusDistribution.init)
+        )
+    }
+
+    var isEmpty: Bool {
+        statuses.values.allSatisfy(\.isEmpty)
+    }
+
+    func endpoints(in range: Range<Date>) -> [NetworkEndpoint] {
+        statuses
+            .map { name, distribution in
+                let breakdown = distribution.summary(in: range)
+                return NetworkEndpoint(
+                    name: name,
+                    requests: breakdown.total,
+                    successRate: breakdown.total > 0 ? breakdown.successRate : nil,
+                    p99: distributions[name]?.summary(in: range)?.p99
+                )
+            }
+            .sorted { lhs, rhs in
+                lhs.requests == rhs.requests ? lhs.name < rhs.name : lhs.requests > rhs.requests
+            }
+    }
+
+    func summary(in range: Range<Date>) -> StatusBreakdown {
+        statuses.values.reduce(StatusBreakdown()) { $0 + $1.summary(in: range) }
+    }
+
+    func percentiles(in range: Range<Date>) -> LatencyPercentiles? {
+        combined.summary(in: range)
+    }
+
+    func trend(in range: Range<Date>, component: Calendar.Component) -> [PercentileTrendPoint] {
+        combined.trend(in: range, component: component)
+    }
+
+    func requestsPerMinute(in range: Range<Date>, until now: Date = .now) -> Int {
+        let end = min(now, range.upperBound)
+        let minutes = max(1.0, end.timeIntervalSince(range.lowerBound) / .minute)
+        return Int(Double(summary(in: range).total) / minutes)
+    }
+}
+
+extension NetworkReport {
+    static var sample: NetworkReport {
+        let statuses: [String: StatusDistribution] = [
+            "GET /v1/events": .sample(success: 8_140, redirect: 210, clientError: 52, serverError: 18),
+            "POST /v1/metrics": .sample(success: 5_160, clientError: 44, serverError: 6),
+            "GET /v1/releases": .sample(success: 3_050, clientError: 80, serverError: 10),
+            "POST /v1/crash": .sample(success: 1_040, clientError: 120, serverError: 20),
+            "GET /health": .sample(success: 640),
+        ]
+
+        return NetworkReport(
+            distributions: statuses.mapValues { _ in TimerDistribution.sample },
+            statuses: statuses
+        )
+    }
+}

--- a/Sources/Scout/UI/Network/Model/StatusBreakdown.swift
+++ b/Sources/Scout/UI/Network/Model/StatusBreakdown.swift
@@ -1,0 +1,67 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct StatusSegment: Identifiable {
+    let label: String
+    let count: Int
+    let color: Color
+
+    var id: String { label }
+}
+
+struct StatusBreakdown: Equatable {
+    private(set) var counts: [Int]
+
+    init() {
+        counts = Array(repeating: 0, count: StatusBuckets.categories.count)
+    }
+
+    var total: Int {
+        counts.reduce(0, +)
+    }
+
+    var successRate: Stability {
+        Stability(of: errors, in: total)
+    }
+
+    private var errors: Int {
+        counts.suffix(2).reduce(0, +)
+    }
+
+    mutating func add(count: Int, at index: Int) {
+        guard counts.indices.contains(index) else { return }
+        counts[index] += count
+    }
+
+    static func + (lhs: StatusBreakdown, rhs: StatusBreakdown) -> StatusBreakdown {
+        var sum = StatusBreakdown()
+        sum.counts = zip(lhs.counts, rhs.counts).map(+)
+        return sum
+    }
+
+    private static let colors: [Color] = [.green, .blue, .orange, .red]
+
+    var segments: [StatusSegment] {
+        zip(StatusBuckets.classes, zip(counts, Self.colors)).map { label, pair in
+            StatusSegment(label: label, count: pair.0, color: pair.1)
+        }
+    }
+}
+
+extension StatusBreakdown {
+    static func sample(success: Int, redirect: Int = 0, clientError: Int = 0, serverError: Int = 0) -> StatusBreakdown {
+        var breakdown = StatusBreakdown()
+        breakdown.add(count: success, at: 0)
+        breakdown.add(count: redirect, at: 1)
+        breakdown.add(count: clientError, at: 2)
+        breakdown.add(count: serverError, at: 3)
+        return breakdown
+    }
+}

--- a/Sources/Scout/UI/Network/Model/StatusDistribution.swift
+++ b/Sources/Scout/UI/Network/Model/StatusDistribution.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+struct StatusDistribution: Equatable {
+    let breakdowns: [Date: StatusBreakdown]
+
+    init(breakdowns: [Date: StatusBreakdown]) {
+        self.breakdowns = breakdowns
+    }
+
+    init(series: [MetricSeries]) {
+        var breakdowns: [Date: StatusBreakdown] = [:]
+
+        for singleSeries in series {
+            guard let category = singleSeries.category else { continue }
+            guard let index = StatusBuckets.index(of: category) else { continue }
+
+            for point in singleSeries.points {
+                let date = Date(millisecondsSince1970: point.date)
+                var breakdown = breakdowns[date, default: StatusBreakdown()]
+                breakdown.add(count: Int(point.value.doubleValue), at: index)
+                breakdowns[date] = breakdown
+            }
+        }
+
+        self.breakdowns = breakdowns
+    }
+
+    var isEmpty: Bool {
+        breakdowns.values.allSatisfy { $0.total == 0 }
+    }
+
+    func summary(in range: Range<Date>) -> StatusBreakdown {
+        breakdowns
+            .filter { range.contains($0.key) }
+            .values
+            .reduce(StatusBreakdown(), +)
+    }
+}
+
+extension StatusDistribution {
+    static func sample(success: Int, redirect: Int = 0, clientError: Int = 0, serverError: Int = 0) -> StatusDistribution {
+        let noon = Calendar.current.startOfDay(for: .now).addingTimeInterval(12 * .hour)
+        return StatusDistribution(breakdowns: [
+            noon: .sample(success: success, redirect: redirect, clientError: clientError, serverError: serverError)
+        ])
+    }
+}

--- a/Sources/Scout/UI/Network/View/MonospacedNavigationTitle.swift
+++ b/Sources/Scout/UI/Network/View/MonospacedNavigationTitle.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+extension View {
+    func monospacedNavigationTitle(en title: String) -> some View {
+        navigationTitle(en: title)
+            .navigationBarTitleDisplayMode(.large)
+            .background(MonospacedNavigationBar())
+    }
+}
+
+// SwiftUI cannot restyle the system navigation title, so this reaches into the
+// hosting UINavigationBar and swaps its title fonts while the screen is visible.
+private struct MonospacedNavigationBar: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> Controller {
+        Controller()
+    }
+
+    func updateUIViewController(_ controller: Controller, context: Context) {}
+
+    final class Controller: UIViewController {
+        private var restore: ((UINavigationBar) -> Void)?
+
+        override func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+
+            guard let bar = navigationController?.navigationBar else { return }
+
+            let large = bar.standardAppearance.largeTitleTextAttributes
+            let inline = bar.standardAppearance.titleTextAttributes
+            restore = { bar in
+                for appearance in bar.allAppearances {
+                    appearance.largeTitleTextAttributes = large
+                    appearance.titleTextAttributes = inline
+                }
+            }
+
+            for appearance in bar.allAppearances {
+                appearance.largeTitleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 34, weight: .bold)
+                appearance.titleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 17, weight: .semibold)
+            }
+        }
+
+        override func viewWillDisappear(_ animated: Bool) {
+            super.viewWillDisappear(animated)
+
+            if let bar = navigationController?.navigationBar {
+                restore?(bar)
+            }
+        }
+    }
+}
+
+extension UINavigationBar {
+    fileprivate var allAppearances: [UINavigationBarAppearance] {
+        [standardAppearance, compactAppearance, scrollEdgeAppearance, compactScrollEdgeAppearance].compactMap { $0 }
+    }
+}

--- a/Sources/Scout/UI/Network/View/NetworkEndpointDetailView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkEndpointDetailView.swift
@@ -1,0 +1,69 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct NetworkEndpointDetailView: View {
+    let endpoint: NetworkEndpoint
+    let distribution: TimerDistribution?
+    let statuses: StatusDistribution?
+    let range: Range<Date>
+    var unit: Calendar.Component = .hour
+
+    var body: some View {
+        List {
+            HStack(spacing: 28) {
+                Metric(title: "Method", value: endpoint.method ?? "—", color: endpoint.methodColor)
+                Metric(title: "Requests", value: endpoint.requests.plain, color: .primary)
+                Metric(title: "Success", value: endpoint.successRate?.formatted ?? "—", color: endpoint.successRate?.color ?? .gray)
+                Spacer()
+            }
+            .listRowSeparator(.hidden)
+
+            if let percentiles = distribution?.summary(in: range) {
+                Header(title: "Latency")
+                HStack(spacing: 34) {
+                    Metric(title: "P50", value: percentiles.p50.duration, color: .blue)
+                    Metric(title: "P90", value: percentiles.p90.duration, color: .teal)
+                    Metric(title: "P99", value: percentiles.p99.duration, color: .orange)
+                    Spacer()
+                }
+                .listRowSeparator(.hidden, edges: .bottom)
+            }
+
+            if let trend = distribution?.trend(in: range, component: unit), trend.count > 0 {
+                Header(title: "P99 trend")
+                PercentileTrendChart(trend: trend, unit: unit)
+                    .listRowSeparator(.hidden)
+            }
+
+            if let breakdown = statuses?.summary(in: range), breakdown.total > 0 {
+                Header(title: "Status codes")
+                StatusBar(status: breakdown)
+                    .listRowSeparator(.hidden, edges: .bottom)
+            }
+        }
+        .listStyle(.plain)
+    }
+}
+
+#Preview("NetworkEndpointDetailView") {
+    let report = NetworkReport.sample
+    let range = Period.today.initialRange
+    let endpoint = report.endpoints(in: range)[2]
+
+    NavigationStack {
+        NetworkEndpointDetailView(
+            endpoint: endpoint,
+            distribution: report.distributions[endpoint.name],
+            statuses: report.statuses[endpoint.name],
+            range: range
+        )
+        .monospacedNavigationTitle(en: endpoint.path)
+    }
+}

--- a/Sources/Scout/UI/Network/View/NetworkEndpointRow.swift
+++ b/Sources/Scout/UI/Network/View/NetworkEndpointRow.swift
@@ -1,0 +1,68 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct NetworkEndpointLink: View {
+    let endpoint: NetworkEndpoint
+    let report: NetworkReport
+    let range: Range<Date>
+
+    var body: some View {
+        Row {
+            NetworkEndpointRow(endpoint: endpoint)
+        } destination: {
+            NetworkEndpointDetailView(
+                endpoint: endpoint,
+                distribution: report.distributions[endpoint.name],
+                statuses: report.statuses[endpoint.name],
+                range: range
+            )
+            .monospacedNavigationTitle(en: endpoint.path)
+        }
+    }
+}
+
+struct NetworkEndpointRow: View {
+    let endpoint: NetworkEndpoint
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(endpoint.successRate?.color ?? .gray)
+                .frame(width: 8, height: 8)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(verbatim: endpoint.name)
+                    .font(.system(size: 15, weight: .medium))
+                Text(verbatim: endpoint.requests.plain + " req · " + (endpoint.successRate?.formatted ?? "—"))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.gray)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 8) {
+                Text(verbatim: endpoint.p99?.duration ?? "—")
+                    .font(.system(size: 15, weight: .semibold))
+                    .monospacedDigit()
+                Text(verbatim: "P99")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.gray)
+            }
+        }
+        .frame(height: 44)
+    }
+}
+
+#Preview("NetworkEndpointRow") {
+    List(NetworkEndpoint.samples) { endpoint in
+        NetworkEndpointRow(endpoint: endpoint)
+    }
+    .listStyle(.plain)
+}

--- a/Sources/Scout/UI/Network/View/NetworkEndpointsView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkEndpointsView.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct NetworkEndpointsView: View {
+    let report: NetworkReport
+    let range: Range<Date>
+
+    var body: some View {
+        let endpoints = report.endpoints(in: range)
+        let breakdown = report.summary(in: range)
+        let worstP99 = endpoints.compactMap(\.p99).max()
+
+        List {
+            HStack(spacing: 28) {
+                Metric(title: "Requests", value: breakdown.total.plain, color: .primary)
+                Metric(title: "Success", value: breakdown.successRate.formatted, color: breakdown.successRate.color)
+                Metric(title: "Worst P99", value: worstP99?.duration ?? "—", color: .orange)
+                Spacer()
+            }
+            .listRowSeparator(.hidden)
+
+            Header(title: "Endpoints")
+            ForEach(endpoints) { endpoint in
+                NetworkEndpointLink(endpoint: endpoint, report: report, range: range)
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: "Endpoints")
+    }
+}
+
+#Preview("NetworkEndpointsView") {
+    NavigationStack {
+        NetworkEndpointsView(report: .sample, range: Period.today.initialRange)
+    }
+}

--- a/Sources/Scout/UI/Network/View/NetworkProvider.swift
+++ b/Sources/Scout/UI/Network/View/NetworkProvider.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+@MainActor
+class NetworkProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<NetworkReport>?
+
+    func fetch(in database: DatabaseReader) async throws -> NetworkReport {
+        let range = Calendar.utc.defaultRange
+        let categories = LatencyBuckets.categories + StatusBuckets.categories
+
+        let series = try await withThrowingTaskGroup(of: [MetricSeries].self) { group in
+            for category in categories {
+                group.addTask {
+                    try await database.metricSeries(Int.self, category: category, in: range)
+                }
+            }
+
+            var series: [MetricSeries] = []
+            for try await chunk in group {
+                series += chunk
+            }
+            return series
+        }
+
+        return NetworkReport(series: series)
+    }
+}
+
+extension NetworkProvider {
+    static func fixture() -> NetworkProvider {
+        let provider = NetworkProvider()
+        provider.result = .success(.sample)
+        return provider
+    }
+}

--- a/Sources/Scout/UI/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkView.swift
@@ -1,0 +1,96 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct NetworkView: View {
+    @Environment(\.database) var database
+    @StateObject private var provider: NetworkProvider
+
+    init(provider: NetworkProvider = NetworkProvider()) {
+        self._provider = StateObject(wrappedValue: provider)
+    }
+
+    var body: some View {
+        Group {
+            switch provider.result {
+            case nil:
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .failure(let error):
+                VStack(spacing: 16) {
+                    Text(verbatim: error.localizedDescription)
+                        .foregroundStyle(.gray)
+                        .multilineTextAlignment(.center)
+                    Button {
+                        Task {
+                            await provider.fetchAgain(in: database)
+                        }
+                    } label: {
+                        Text(verbatim: "Retry")
+                    }
+                }
+                .padding(.horizontal)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .success(let report) where report.isEmpty:
+                Text(verbatim: "No network requests in this period.")
+                    .foregroundStyle(.gray)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .success(let report):
+                content(report)
+            }
+        }
+        .navigationTitle(en: "Network")
+        .task {
+            await provider.fetchIfNeeded(in: database)
+        }
+    }
+
+    private func content(_ report: NetworkReport) -> some View {
+        let range = Period.today.initialRange
+        let endpoints = report.endpoints(in: range)
+        let breakdown = report.summary(in: range)
+
+        return List {
+            HStack(spacing: 28) {
+                Metric(title: "P99", value: report.percentiles(in: range)?.p99.duration ?? "—", color: .orange)
+                Metric(title: "Success", value: breakdown.successRate.formatted, color: breakdown.successRate.color)
+                Metric(title: "Req/min", value: report.requestsPerMinute(in: range).plain, color: .primary)
+                Spacer()
+            }
+            .listRowSeparator(.hidden)
+
+            Header(title: "Latency P99")
+            PercentileTrendChart(trend: report.trend(in: range, component: .hour), unit: .hour)
+                .listRowSeparator(.hidden)
+
+            Header(title: "Status codes")
+            StatusBar(status: breakdown)
+                .listRowSeparator(.hidden)
+
+            Header(title: "Top endpoints") {
+                NavigationLink {
+                    NetworkEndpointsView(report: report, range: range)
+                } label: {
+                    Text(verbatim: "See all").foregroundStyle(.blue)
+                }
+                .buttonStyle(.plain)
+            }
+            ForEach(endpoints.prefix(3)) { endpoint in
+                NetworkEndpointLink(endpoint: endpoint, report: report, range: range)
+            }
+        }
+        .listStyle(.plain)
+    }
+}
+
+#Preview("NetworkView") {
+    NavigationStack {
+        NetworkView(provider: .fixture())
+    }
+}

--- a/Sources/Scout/UI/Network/View/StatusBar.swift
+++ b/Sources/Scout/UI/Network/View/StatusBar.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Charts
+import SwiftUI
+
+struct StatusBar: View {
+    let status: StatusBreakdown
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Chart(status.segments) { segment in
+                BarMark(
+                    x: .value("Count", segment.count),
+                    y: .value("Row", "status")
+                )
+                .foregroundStyle(segment.color)
+            }
+            .chartXAxis(.hidden)
+            .chartYAxis(.hidden)
+            .frame(height: 18)
+            .clipShape(Capsule())
+
+            HStack(spacing: 16) {
+                ForEach(status.segments) { segment in
+                    HStack(spacing: 5) {
+                        Circle().fill(segment.color).frame(width: 7, height: 7)
+                        Text(verbatim: segment.label + " " + segment.count.plain)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.gray)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview("StatusBar") {
+    StatusBar(status: .sample(success: 8_140, redirect: 210, clientError: 96, serverError: 18))
+        .padding(.horizontal)
+}

--- a/Tests/ScoutTests/Core/Diagnostics/Telemetry/StatusBucketsTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Telemetry/StatusBucketsTests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Testing
+
+@testable import Scout
+
+@Suite("StatusBuckets")
+struct StatusBucketsTests {
+    @Test("category maps codes to their class bucket")
+    func categoryForCode() {
+        #expect(StatusBuckets.category(for: 200) == "status_2xx")
+        #expect(StatusBuckets.category(for: 204) == "status_2xx")
+        #expect(StatusBuckets.category(for: 301) == "status_3xx")
+        #expect(StatusBuckets.category(for: 404) == "status_4xx")
+        #expect(StatusBuckets.category(for: 599) == "status_5xx")
+    }
+
+    @Test("category rejects codes outside 200..<600")
+    func categoryBounds() {
+        #expect(StatusBuckets.category(for: 100) == nil)
+        #expect(StatusBuckets.category(for: 199) == nil)
+        #expect(StatusBuckets.category(for: 600) == nil)
+        #expect(StatusBuckets.category(for: -1) == nil)
+    }
+
+    @Test("category reads the numeric status dimension")
+    func categoryInDimensions() {
+        #expect(StatusBuckets.category(in: [("status", "404")]) == "status_4xx")
+        #expect(StatusBuckets.category(in: [("path", "/v1/events"), ("status", "200")]) == "status_2xx")
+    }
+
+    @Test("category ignores missing or non-numeric status dimensions")
+    func categoryInDimensionsRejects() {
+        #expect(StatusBuckets.category(in: []) == nil)
+        #expect(StatusBuckets.category(in: [("path", "/v1/events")]) == nil)
+        #expect(StatusBuckets.category(in: [("status", "2xx")]) == nil)
+        #expect(StatusBuckets.category(in: [("status", "ok")]) == nil)
+    }
+
+    @Test("index round-trips every category and rejects foreign ones")
+    func index() {
+        for (offset, category) in StatusBuckets.categories.enumerated() {
+            #expect(StatusBuckets.index(of: category) == offset)
+        }
+        #expect(StatusBuckets.index(of: "timer_le_1") == nil)
+        #expect(StatusBuckets.index(of: "counter") == nil)
+    }
+}

--- a/Tests/ScoutTests/UI/Network/Model/NetworkEndpointTests.swift
+++ b/Tests/ScoutTests/UI/Network/Model/NetworkEndpointTests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Testing
+
+@testable import Scout
+
+@Suite("NetworkEndpoint")
+struct NetworkEndpointTests {
+    @Test("Splits a known HTTP verb prefix into method and path")
+    func methodAndPath() {
+        let endpoint = makeEndpoint(name: "GET /v1/events")
+
+        #expect(endpoint.method == "GET")
+        #expect(endpoint.path == "/v1/events")
+    }
+
+    @Test("Keeps the full name as path when no verb prefix is present")
+    func plainName() {
+        let endpoint = makeEndpoint(name: "sync_pipeline")
+
+        #expect(endpoint.method == nil)
+        #expect(endpoint.path == "sync_pipeline")
+    }
+
+    @Test("Rejects unknown and lowercase verbs")
+    func unknownVerbs() {
+        #expect(makeEndpoint(name: "FETCH /x").method == nil)
+        #expect(makeEndpoint(name: "get /x").method == nil)
+    }
+
+    private func makeEndpoint(name: String) -> NetworkEndpoint {
+        NetworkEndpoint(name: name, requests: 0, successRate: nil, p99: nil)
+    }
+}

--- a/Tests/ScoutTests/UI/Network/Model/NetworkReportTests.swift
+++ b/Tests/ScoutTests/UI/Network/Model/NetworkReportTests.swift
@@ -1,0 +1,142 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("NetworkReport")
+struct NetworkReportTests {
+    let base = Date(year: 2026, month: 6, day: 1)
+
+    var range: Range<Date> {
+        base..<base.adding(.day)
+    }
+
+    @Test("Only names with status series become endpoints")
+    func endpointRequiresStatuses() {
+        let report = NetworkReport(series: [
+            makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 10)]),
+            makeSeries(name: "GET /a", category: "timer_le_1", points: [(base, 10)]),
+            makeSeries(name: "plain_timer", category: "timer_le_1", points: [(base, 10)]),
+        ])
+
+        #expect(report.endpoints(in: range).map(\.name) == ["GET /a"])
+        #expect(report.distributions.keys.contains("plain_timer") == false)
+    }
+
+    @Test("Endpoints carry requests, success rate, and p99 for the range")
+    func endpointValues() throws {
+        let report = NetworkReport(series: [
+            makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 99)]),
+            makeSeries(name: "GET /a", category: "status_5xx", points: [(base, 1)]),
+            makeSeries(name: "GET /a", category: "timer_le_inf", points: [(base, 100)]),
+        ])
+
+        let endpoint = try #require(report.endpoints(in: range).first)
+
+        #expect(endpoint.requests == 100)
+        let successRate = try #require(endpoint.successRate?.value)
+        #expect(abs(successRate - 0.99) < 0.000001)
+        #expect(try #require(endpoint.p99) > 10)
+    }
+
+    @Test("Endpoints without latency series have no p99")
+    func endpointWithoutLatency() throws {
+        let report = NetworkReport(series: [
+            makeSeries(name: "POST /b", category: "status_2xx", points: [(base, 5)])
+        ])
+
+        let endpoint = try #require(report.endpoints(in: range).first)
+
+        #expect(endpoint.p99 == nil)
+        #expect(endpoint.requests == 5)
+    }
+
+    @Test("Endpoints with no requests in the range have no success rate")
+    func endpointOutsideRange() throws {
+        let outside = base.adding(.day, value: 2)
+        let report = NetworkReport(series: [
+            makeSeries(name: "GET /a", category: "status_2xx", points: [(outside, 5)])
+        ])
+
+        let endpoint = try #require(report.endpoints(in: range).first)
+
+        #expect(endpoint.requests == 0)
+        #expect(endpoint.successRate == nil)
+    }
+
+    @Test("Endpoints sort by requests, then by name")
+    func endpointSorting() {
+        let report = NetworkReport(series: [
+            makeSeries(name: "GET /small", category: "status_2xx", points: [(base, 1)]),
+            makeSeries(name: "GET /big", category: "status_2xx", points: [(base, 100)]),
+            makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 1)]),
+        ])
+
+        #expect(report.endpoints(in: range).map(\.name) == ["GET /big", "GET /a", "GET /small"])
+    }
+
+    @Test("summary combines statuses across endpoints")
+    func summary() {
+        let report = NetworkReport(series: [
+            makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 10)]),
+            makeSeries(name: "POST /b", category: "status_4xx", points: [(base, 4)]),
+        ])
+
+        let summary = report.summary(in: range)
+
+        #expect(summary.total == 14)
+        #expect(summary.counts == [10, 0, 4, 0])
+    }
+
+    @Test("percentiles and trend combine latency across endpoints")
+    func combinedLatency() throws {
+        let report = NetworkReport(series: [
+            makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 1)]),
+            makeSeries(name: "GET /a", category: "timer_le_1", points: [(base, 100)]),
+            makeSeries(name: "POST /b", category: "status_2xx", points: [(base, 1)]),
+            makeSeries(name: "POST /b", category: "timer_le_inf", points: [(base, 100)]),
+        ])
+
+        let percentiles = try #require(report.percentiles(in: range))
+        #expect(percentiles.p50 <= 0.001)
+        #expect(percentiles.p99 > 10)
+
+        let trend = report.trend(in: base..<base.adding(.hour), component: .hour)
+        #expect(trend.count == 1)
+    }
+
+    @Test("requestsPerMinute divides the range total by elapsed minutes")
+    func requestsPerMinute() {
+        let report = NetworkReport(series: [
+            makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 120)])
+        ])
+
+        #expect(report.requestsPerMinute(in: range, until: base.adding(.hour)) == 2)
+        #expect(report.requestsPerMinute(in: range, until: base) == 120)
+    }
+
+    @Test("isEmpty reflects endpoint presence")
+    func isEmpty() {
+        #expect(NetworkReport(series: []).isEmpty)
+        #expect(NetworkReport(series: [makeSeries(name: "plain_timer", category: "timer_le_1", points: [(base, 1)])]).isEmpty)
+        #expect(!NetworkReport(series: [makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 1)])]).isEmpty)
+    }
+
+    private func makeSeries(name: String, category: String, points: [(Date, Int)]) -> MetricSeries {
+        MetricSeries(
+            name: name,
+            category: category,
+            points: points.map { date, count in
+                MetricSeriesPoint(date: date.millisecondsSince1970, value: .int(count))
+            }
+        )
+    }
+}

--- a/Tests/ScoutTests/UI/Network/Model/StatusBreakdownTests.swift
+++ b/Tests/ScoutTests/UI/Network/Model/StatusBreakdownTests.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Testing
+
+@testable import Scout
+
+@Suite("StatusBreakdown")
+struct StatusBreakdownTests {
+    @Test("add accumulates counts and total")
+    func add() {
+        var breakdown = StatusBreakdown()
+        breakdown.add(count: 3, at: 0)
+        breakdown.add(count: 2, at: 0)
+        breakdown.add(count: 5, at: 3)
+
+        #expect(breakdown.counts == [5, 0, 0, 5])
+        #expect(breakdown.total == 10)
+    }
+
+    @Test("add ignores out-of-bounds indexes")
+    func addOutOfBounds() {
+        var breakdown = StatusBreakdown()
+        breakdown.add(count: 7, at: 4)
+        breakdown.add(count: 7, at: -1)
+
+        #expect(breakdown.total == 0)
+    }
+
+    @Test("+ sums bucket-wise")
+    func plus() {
+        let sum = StatusBreakdown.sample(success: 1, redirect: 2) + .sample(success: 10, serverError: 3)
+
+        #expect(sum.counts == [11, 2, 0, 3])
+    }
+
+    @Test("successRate counts 4xx and 5xx as failures")
+    func successRate() {
+        let breakdown = StatusBreakdown.sample(success: 90, redirect: 6, clientError: 3, serverError: 1)
+
+        #expect(abs(breakdown.successRate.value - 0.96) < 0.000001)
+    }
+
+    @Test("segments pair every class with its count")
+    func segments() {
+        let segments = StatusBreakdown.sample(success: 8, redirect: 4, clientError: 2, serverError: 1).segments
+
+        #expect(segments.map(\.label) == ["2xx", "3xx", "4xx", "5xx"])
+        #expect(segments.map(\.count) == [8, 4, 2, 1])
+    }
+}

--- a/Tests/ScoutTests/UI/Network/Model/StatusDistributionTests.swift
+++ b/Tests/ScoutTests/UI/Network/Model/StatusDistributionTests.swift
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("StatusDistribution")
+struct StatusDistributionTests {
+    let base = Date(year: 2026, month: 6, day: 1)
+
+    @Test("Builds breakdowns from status series and ignores foreign categories")
+    func seriesInit() throws {
+        let distribution = StatusDistribution(series: [
+            makeSeries(category: "status_2xx", points: [(base, 90)]),
+            makeSeries(category: "status_5xx", points: [(base, 10)]),
+            makeSeries(category: "timer_le_1", points: [(base, 9)]),
+            makeSeries(category: "counter", points: [(base, 9)]),
+        ])
+
+        #expect(distribution.breakdowns.count == 1)
+
+        let breakdown = try #require(distribution.breakdowns[base])
+        #expect(breakdown.counts == [90, 0, 0, 10])
+    }
+
+    @Test("summary combines breakdowns within the range only")
+    func summaryRange() {
+        let inside = base
+        let outside = base.adding(.day, value: 2)
+        let distribution = StatusDistribution(series: [
+            makeSeries(category: "status_2xx", points: [(inside, 50), (outside, 100)]),
+            makeSeries(category: "status_4xx", points: [(inside, 5)]),
+        ])
+
+        let summary = distribution.summary(in: base..<base.adding(.day))
+
+        #expect(summary.total == 55)
+        #expect(summary.counts == [50, 0, 5, 0])
+    }
+
+    @Test("isEmpty reflects total counts")
+    func isEmpty() {
+        #expect(StatusDistribution(series: []).isEmpty)
+        #expect(!StatusDistribution(series: [makeSeries(category: "status_2xx", points: [(base, 1)])]).isEmpty)
+    }
+
+    private func makeSeries(category: String, points: [(Date, Int)]) -> MetricSeries {
+        MetricSeries(
+            name: "GET /v1/events",
+            category: category,
+            points: points.map { date, count in
+                MetricSeriesPoint(date: date.millisecondsSince1970, value: .int(count))
+            }
+        )
+    }
+}

--- a/Tests/ScoutTests/UI/Network/View/NetworkProviderTests.swift
+++ b/Tests/ScoutTests/UI/Network/View/NetworkProviderTests.swift
@@ -1,0 +1,103 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("NetworkProvider")
+struct NetworkProviderTests {
+    let base = Calendar.current.startOfDay(for: .now)
+
+    @Test("fetchIfNeeded builds a report from latency and status series")
+    func fetchesReport() async throws {
+        let database = CategoryDatabaseStub(series: [
+            makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 10)]),
+            makeSeries(name: "GET /a", category: "timer_le_1", points: [(base, 10)]),
+            makeSeries(name: "POST /b", category: "status_5xx", points: [(base, 2)]),
+            makeSeries(name: "plain_timer", category: "timer_le_1", points: [(base, 9)]),
+        ])
+
+        let provider = NetworkProvider()
+        await provider.fetchIfNeeded(in: database)
+
+        let report = try #require(try provider.result?.get())
+        let range = base..<base.adding(.day)
+
+        #expect(report.endpoints(in: range).map(\.name) == ["GET /a", "POST /b"])
+        #expect(report.distributions["GET /a"] != nil)
+        #expect(report.distributions["plain_timer"] == nil)
+    }
+
+    @Test("fetchIfNeeded surfaces database errors")
+    func surfacesErrors() async {
+        let provider = NetworkProvider()
+        await provider.fetchIfNeeded(in: ThrowingDatabaseStub())
+
+        guard case .failure = provider.result else {
+            Issue.record("Expected a failure result")
+            return
+        }
+    }
+
+    private func makeSeries(name: String, category: String, points: [(Date, Int)]) -> MetricSeries {
+        MetricSeries(
+            name: name,
+            category: category,
+            points: points.map { date, count in
+                MetricSeriesPoint(date: date.millisecondsSince1970, value: .int(count))
+            }
+        )
+    }
+}
+
+private final class CategoryDatabaseStub: DatabaseReader, @unchecked Sendable {
+    let series: [MetricSeries]
+
+    init(series: [MetricSeries]) {
+        self.series = series
+    }
+
+    func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
+        []
+    }
+
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+        series.filter { $0.category == category }
+    }
+
+    func lookup(recordName: String, fields: [String]?) async throws -> Record {
+        throw RecordNotFoundError()
+    }
+
+    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
+        RecordChunk(records: [], cursor: nil)
+    }
+}
+
+private final class ThrowingDatabaseStub: DatabaseReader, @unchecked Sendable {
+    struct Failure: Error {}
+
+    func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
+        throw Failure()
+    }
+
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+        throw Failure()
+    }
+
+    func lookup(recordName: String, fields: [String]?) async throws -> Record {
+        throw Failure()
+    }
+
+    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
+        throw Failure()
+    }
+}


### PR DESCRIPTION
Adds a Network performance domain reachable from the Home log section: an overview with combined P99, success rate, requests per minute, a P99 trend, and a status-code breakdown; an endpoint list ranked by traffic; and a per-endpoint detail screen with latency percentiles computed from the existing LatencyHistogram buckets. Endpoints are metrics named after the request (e.g. GET /v1/events): timers already feed the latency buckets, and counters carrying a numeric status dimension are now bucketed into status_2xx…status_5xx categories by the telemetry handler. The P99 trend chart is extracted from TimerDistributionView into a shared PercentileTrendChart. No CloudKit schema or scout-server changes are needed since bucket categories are plain field values already covered by the metric series contract.