### PR TITLE
Move Tint typealias next to its NavigationTint use site

### DIFF
--- a/Sources/Scout/UI/Primitives/Navigation/View+NavigationTint.swift
+++ b/Sources/Scout/UI/Primitives/Navigation/View+NavigationTint.swift
@@ -7,6 +7,14 @@
 
 import SwiftUI
 
+typealias Tint = Box<Color?>
+
+extension Tint {
+    convenience init() {
+        self.init(nil)
+    }
+}
+
 private struct NavigationTint: ViewModifier {
     let color: Color?
 

--- a/Sources/Scout/UI/Utilities/Box.swift
+++ b/Sources/Scout/UI/Utilities/Box.swift
@@ -15,11 +15,3 @@ class Box<T>: ObservableObject {
         self.value = value
     }
 }
-
-typealias Tint = Box<Color?>
-
-extension Tint {
-    convenience init() {
-        self.init(nil)
-    }
-}


### PR DESCRIPTION
Tint was declared in Box.swift alongside the generic Box class, but it's only used by the navigationTint/resetsTint modifiers. Moves the typealias and its convenience init() into View+NavigationTint.swift, colocating it with its sole use site.
