### PR TITLE
Reuse shared helpers and avoid redundant recomputation in views

### DIFF
--- a/Sources/Scout/Native/Matrix/Model/Matrix.swift
+++ b/Sources/Scout/Native/Matrix/Model/Matrix.swift
@@ -52,10 +52,6 @@ extension Matrix: Combining {
 
 extension Matrix: Equatable {
     static func == (lhs: Matrix<T>, rhs: Matrix<T>) -> Bool {
-        lhs.date == rhs.date
-            && lhs.name == rhs.name
-            && lhs.category == rhs.category
-            && lhs.version == rhs.version
-            && lhs.cells == rhs.cells
+        lhs.isDuplicate(of: rhs) && lhs.cells == rhs.cells
     }
 }

--- a/Sources/Scout/UI/Activity/ActivityRow.swift
+++ b/Sources/Scout/UI/Activity/ActivityRow.swift
@@ -15,6 +15,8 @@ struct ActivityRow: View {
     @ObservedObject var activity: ActivityProvider
 
     var body: some View {
+        let days = days
+
         Row {
             if let systemImage {
                 Image(systemName: systemImage)
@@ -25,7 +27,11 @@ struct ActivityRow: View {
                 .foregroundColor(.primary)
             Spacer()
 
-            RowSummary(series: series, count: count, color: color)
+            RowSummary(
+                series: days.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .latest) },
+                count: days?.max()?.count,
+                color: color
+            )
         } destination: {
             ActivityView(activity: activity, period: period)
         }
@@ -36,14 +42,6 @@ struct ActivityRow: View {
         try? activity.result?.get()
             .points(on: period)
             .bucket(on: period)
-    }
-
-    private var series: MiniChartSeries? {
-        days.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .latest) }
-    }
-
-    private var count: Int? {
-        days?.max()?.count
     }
 }
 

--- a/Sources/Scout/UI/Event/Detail/EventView.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.swift
@@ -61,10 +61,8 @@ extension EventView {
                 Spacer().frame(height: 10)
 
                 if let level = event.level {
-                    Group {
-                        Text(verbatim: "LEVEL:   ") + level.descriptionText
-                    }
-                    .fontWeight(.bold)
+                    (Text(verbatim: "LEVEL:   ") + level.descriptionText)
+                        .fontWeight(.bold)
                 }
             }
             .padding(.vertical, 4)

--- a/Sources/Scout/UI/Event/Param/ParamView.swift
+++ b/Sources/Scout/UI/Event/Param/ParamView.swift
@@ -30,15 +30,10 @@ struct ParamView: View {
         Group {
             if value.isContainer {
                 List(value.nodes) { node in
-                    ZStack {
+                    Row {
                         ParamValueRow(node: node)
-
-                        NavigationLink {
-                            ParamView(node: node)
-                        } label: {
-                            EmptyView()
-                        }
-                        .opacity(0)
+                    } destination: {
+                        ParamView(node: node)
                     }
                 }
                 .listStyle(.plain)

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -25,11 +25,9 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
     }
 
     var body: some View {
-        HStack(spacing: 20) {
-            SegmentStrip(selection: $extent.period, title: \.shortTitle)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal)
+        SegmentStrip(selection: $extent.period, title: \.shortTitle)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal)
 
         RangeControl(extent: $extent)
 

--- a/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
+++ b/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
@@ -34,25 +34,17 @@ extension Double {
     /// - Important: The output is intentionally non-localized to ensure consistent decimal and grouping separators.
     ///
     var decimal: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.decimalSeparator = "."
-        formatter.groupingSeparator = " "
-
+        let formatter: NumberFormatter
         switch self {
         case 0:
             return "0.0"
         case ..<0.01:
-            formatter.minimumFractionDigits = 3
-            formatter.maximumFractionDigits = 3
+            formatter = smallDecimalFormatter
         case ..<1_000:
-            formatter.minimumFractionDigits = 1
-            formatter.maximumFractionDigits = 2
+            formatter = midDecimalFormatter
         default:
-            formatter.minimumFractionDigits = 1
-            formatter.maximumFractionDigits = 1
+            formatter = largeDecimalFormatter
         }
-
         return formatter.string(from: NSNumber(value: self))!
     }
 }
@@ -93,3 +85,17 @@ extension TimeInterval {
         }
     }
 }
+
+private func decimalFormatter(minimumFractionDigits: Int, maximumFractionDigits: Int) -> NumberFormatter {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.decimalSeparator = "."
+    formatter.groupingSeparator = " "
+    formatter.minimumFractionDigits = minimumFractionDigits
+    formatter.maximumFractionDigits = maximumFractionDigits
+    return formatter
+}
+
+nonisolated(unsafe) private let smallDecimalFormatter = decimalFormatter(minimumFractionDigits: 3, maximumFractionDigits: 3)
+nonisolated(unsafe) private let midDecimalFormatter = decimalFormatter(minimumFractionDigits: 1, maximumFractionDigits: 2)
+nonisolated(unsafe) private let largeDecimalFormatter = decimalFormatter(minimumFractionDigits: 1, maximumFractionDigits: 1)

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -82,9 +82,11 @@ struct VersionDetailView: View {
 
     @ViewBuilder
     private var trendSection: some View {
+        let days = dailyCrashes
+
         Header(title: "Crashes over time")
 
-        Chart(dailyCrashes, id: \.date) { day in
+        Chart(days, id: \.date) { day in
             BarMark(
                 x: .value("Day", day.date, unit: .day),
                 y: .value("Crashes", day.count),
@@ -104,7 +106,7 @@ struct VersionDetailView: View {
             AxisMarks(position: .leading)
         }
         .chartBackground { _ in
-            if !dailyCrashes.contains(where: { $0.count > 0 }) {
+            if !days.contains(where: { $0.count > 0 }) {
                 ChartPlaceholder().offset(y: -12)
             }
         }

--- a/Sources/Scout/UI/Settings/BackendHealth.swift
+++ b/Sources/Scout/UI/Settings/BackendHealth.swift
@@ -107,22 +107,13 @@ extension BackendHealth {
     }
 
     var lastCheckedLabel: String {
-        lastChecked?.agoLabel ?? "Never"
+        lastChecked?.relativeString ?? "Never"
     }
 
     var pingSpreadLabel: String? {
-        guard let low = pings.min(), let high = pings.max(), pings.count > 0 else { return nil }
+        guard let low = pings.min(), let high = pings.max() else { return nil }
         let average = pings.reduce(0, +) / pings.count
         return "\(low) / \(average) / \(high) ms"
-    }
-}
-
-extension Date {
-    var agoLabel: String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: self, relativeTo: Date())
     }
 }
 

--- a/Sources/Scout/UI/Stats/StatRow.swift
+++ b/Sources/Scout/UI/Stats/StatRow.swift
@@ -16,6 +16,8 @@ struct StatRow<Destination: View>: View {
     @ViewBuilder let destination: () -> Destination
 
     var body: some View {
+        let points = points
+
         Row {
             if let systemImage {
                 Image(systemName: systemImage)
@@ -26,7 +28,11 @@ struct StatRow<Destination: View>: View {
                 .foregroundColor(systemImage == nil ? color : .primary)
             Spacer()
 
-            RowSummary(series: series, count: count, color: color)
+            RowSummary(
+                series: points.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .total) },
+                count: points?.bucket(on: period).total,
+                color: color
+            )
         } destination: {
             destination()
         }
@@ -35,14 +41,6 @@ struct StatRow<Destination: View>: View {
     /// All fetched points; `nil` while the provider is still loading.
     private var points: [ChartPoint<Int>]? {
         try? stat.result?.get().flatMap(\.points)
-    }
-
-    private var series: MiniChartSeries? {
-        points.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .total) }
-    }
-
-    private var count: Int? {
-        points?.bucket(on: period).total
     }
 }
 


### PR DESCRIPTION
A batch of quality-only cleanups from a whole-project simplify pass. Caches the decimal NumberFormatter instead of allocating one per call, reuses the shared Date.relativeString and Row primitives in place of hand-rolled equivalents, computes per-row and per-chart derived values once rather than twice, delegates Matrix equality to isDuplicate(of:), and removes a dead guard clause and redundant view wrappers. Behavior is preserved aside from two deliberate consistency touches: backend "last checked" now reads "recently" under a minute like elsewhere in the app, and nested parameter rows pick up the standard trailing separator. Build and the full test suite are green.