### PR TITLE
Use justified layout for period picker

### DIFF
--- a/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
@@ -13,7 +13,7 @@ struct PeriodPicker<T: PickerCompatible & ChartTimeScale>: View {
     let periods: [T]
 
     var body: some View {
-        HStack(spacing: 20) {
+        JustifiedLayout {
             SegmentStrip(
                 selection: $extent.period,
                 values: periods,


### PR DESCRIPTION
- Updates `PeriodPicker` to use `JustifiedLayout` instead of a fixed-spaced `HStack`.
- This lets the period segments expand and align more naturally across available width.
- Keeps the picker implementation aligned with other justified chart controls.
- Not run (not requested)