### PR TITLE
Wrap segment selection updates in explicit spring animation

### DIFF
--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -40,9 +40,12 @@ struct SegmentStrip<Value: Hashable>: View {
                         .matchedGeometryEffect(id: "indicator", in: namespace)
                 }
             }
-            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: selection)
             .contentShape(.rect)
-            .onTapGesture { selection = value }
+            .onTapGesture {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    selection = value
+                }
+            }
     }
 }
 


### PR DESCRIPTION
## Summary
- Move the selection change in `SegmentStrip` into `withAnimation` so the spring only applies to the tap-driven state update.
- Remove the broader `.animation(..., value: selection)` modifier to avoid animating unrelated layout changes.

## Testing
- Not run (not requested)