### PR TITLE
[codex] Fix settings menu action

### DIFF
--- a/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
@@ -65,14 +65,14 @@ struct ConnectionMenu: View {
             .task {
                 connections = await connections.refreshingStatuses()
             }
-            .onChange(of: isPresented) { isPresented in
-                guard !isPresented, opensSettingsAfterDismiss else { return }
-
-                opensSettingsAfterDismiss = false
-                onSettings()
-            }
             .popoverDropdown()
             .opaquePresentationBackground()
+        }
+        .onChange(of: isPresented) { isPresented in
+            guard !isPresented, opensSettingsAfterDismiss else { return }
+
+            opensSettingsAfterDismiss = false
+            onSettings()
         }
     }
 }


### PR DESCRIPTION
Moves the settings dismissal observer out of the popover content so it survives the popover being dismissed.

The Settings row still closes the connection menu first, then opens the settings sheet from the parent view. This fixes the case where SwiftUI tears down the popover content before the deferred callback can run.

Validated with `git diff --check`. `swift test` was attempted, but the existing SwiftPM/CoreData resource setup fails before tests can run because `Scout.xcdatamodeld` is not declared as a package resource, so `Bundle.module` is unavailable and the build ends in `fatalError`.