### PR TITLE
Add segment strip separators

### DIFF
--- a/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/PeriodPicker.swift
@@ -13,15 +13,13 @@ struct PeriodPicker<T: PickerCompatible & ChartTimeScale>: View {
     let periods: [T]
 
     var body: some View {
-        JustifiedLayout {
-            SegmentStrip(
-                selection: $extent.period,
-                values: periods,
-                tint: nil,
-                title: title
-            )
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        SegmentStrip(
+            selection: $extent.period,
+            values: periods,
+            distribution: .justified,
+            tint: nil,
+            title: title
+        )
         .padding(.horizontal)
     }
 

--- a/Sources/Scout/UI/Home/Section/Stat/HomeSectionPicker.swift
+++ b/Sources/Scout/UI/Home/Section/Stat/HomeSectionPicker.swift
@@ -44,10 +44,7 @@ struct HomeSectionPicker: View {
     @Binding var selection: HomeSection
 
     var body: some View {
-        HStack(spacing: 20) {
-            SegmentStrip(selection: $selection, tint: { $0.color }) { $0.title }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        SegmentStrip(selection: $selection, tint: { $0.color }) { $0.title }
     }
 }
 

--- a/Sources/Scout/UI/Metrics/MetricsList.swift
+++ b/Sources/Scout/UI/Metrics/MetricsList.swift
@@ -28,14 +28,10 @@ struct MetricsList: View {
     @State private var scope: Scope = .int
 
     var body: some View {
-        JustifiedLayout {
-            SegmentStrip(selection: $period, title: \.shortTitle)
-        }
+        SegmentStrip(selection: $period, distribution: .justified, title: \.shortTitle)
         .padding()
 
-        JustifiedLayout {
-            SegmentStrip(selection: $scope, title: \.rawValue)
-        }
+        SegmentStrip(selection: $scope, distribution: .justified, title: \.rawValue)
         .padding(.horizontal)
 
         switch scope {

--- a/Sources/Scout/UI/Metrics/MetricsList.swift
+++ b/Sources/Scout/UI/Metrics/MetricsList.swift
@@ -29,10 +29,10 @@ struct MetricsList: View {
 
     var body: some View {
         SegmentStrip(selection: $period, distribution: .justified, title: \.shortTitle)
-        .padding()
+            .padding()
 
         SegmentStrip(selection: $scope, distribution: .justified, title: \.rawValue)
-        .padding(.horizontal)
+            .padding(.horizontal)
 
         switch scope {
         case .int:

--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -8,15 +8,58 @@
 import SwiftUI
 
 struct SegmentStrip<Value: Hashable>: View {
+    enum Distribution {
+        case compact(spacing: CGFloat)
+        case justified
+    }
+
     @Binding var selection: Value
 
     let values: [Value]
+    let distribution: Distribution
     let tint: ((Value) -> Color)?
     let title: (Value) -> String
 
     @Namespace private var namespace
 
+    init(
+        selection: Binding<Value>,
+        values: [Value],
+        distribution: Distribution = .compact(spacing: 20),
+        tint: ((Value) -> Color)? = { _ in .primary },
+        title: @escaping (Value) -> String
+    ) {
+        self._selection = selection
+        self.values = values
+        self.distribution = distribution
+        self.tint = tint
+        self.title = title
+    }
+
     var body: some View {
+        strip
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(alignment: .bottom) {
+                Divider()
+            }
+    }
+
+    @ViewBuilder
+    private var strip: some View {
+        switch distribution {
+        case .compact(let spacing):
+            HStack(spacing: spacing) {
+                segments
+            }
+        case .justified:
+            JustifiedLayout {
+                segments
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var segments: some View {
         ForEach(values, id: \.self) { value in
             segment(value)
         }
@@ -50,10 +93,16 @@ struct SegmentStrip<Value: Hashable>: View {
 }
 
 extension SegmentStrip where Value: CaseIterable {
-    init(selection: Binding<Value>, tint: @escaping (Value) -> Color = { _ in .primary }, title: @escaping (Value) -> String) {
+    init(
+        selection: Binding<Value>,
+        distribution: Distribution = .compact(spacing: 20),
+        tint: @escaping (Value) -> Color = { _ in .primary },
+        title: @escaping (Value) -> String
+    ) {
         self.init(
             selection: selection,
             values: Array(Value.allCases),
+            distribution: distribution,
             tint: tint,
             title: title
         )
@@ -66,12 +115,8 @@ extension SegmentStrip where Value: CaseIterable {
 
         var body: some View {
             VStack(spacing: 24) {
-                JustifiedLayout {
-                    SegmentStrip(selection: $selection) { $0.shortTitle }
-                }
-                HStack(spacing: 20) {
-                    SegmentStrip(selection: $selection) { $0.shortTitle }
-                }
+                SegmentStrip(selection: $selection, distribution: .justified) { $0.shortTitle }
+                SegmentStrip(selection: $selection) { $0.shortTitle }
             }
             .padding()
         }


### PR DESCRIPTION
Adds a shared `SegmentStrip` container that owns its width, supports compact and justified distributions, and draws a baseline divider consistently across strip usages.

Updated the home, metrics, and period picker call sites to use the new distribution API while preserving their existing spacing behavior.

Validation: `swift build` compiles the changed SwiftUI files, then stops on the existing SwiftPM/CoreData resource issue at `PersistentContainer.swift:24` where `Bundle.module` is unavailable.