### PR TITLE
Use @Previewable in picker previews

### DIFF
--- a/Sources/Scout/UI/Chart/Picker/CompactPeriodPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/CompactPeriodPicker.swift
@@ -37,20 +37,16 @@ struct CompactPeriodPicker: View {
     }
 }
 
+@available(iOS 17.0, macOS 14.0, *)
 #Preview {
-    struct Preview: View {
-        @State private var selection = Period.today
+    @Previewable @State var selection = Period.today
 
-        var body: some View {
-            List {
-                HStack {
-                    Text(verbatim: "Period")
-                    Spacer()
-                    CompactPeriodPicker(selection: $selection)
-                }
-            }
-            .listStyle(.plain)
+    List {
+        HStack {
+            Text(verbatim: "Period")
+            Spacer()
+            CompactPeriodPicker(selection: $selection)
         }
     }
-    return Preview()
+    .listStyle(.plain)
 }

--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -109,17 +109,13 @@ extension SegmentStrip where Value: CaseIterable {
     }
 }
 
+@available(iOS 17.0, macOS 14.0, *)
 #Preview {
-    struct Preview: View {
-        @State private var selection = Period.today
+    @Previewable @State var selection = Period.today
 
-        var body: some View {
-            VStack(spacing: 24) {
-                SegmentStrip(selection: $selection, distribution: .justified) { $0.shortTitle }
-                SegmentStrip(selection: $selection) { $0.shortTitle }
-            }
-            .padding()
-        }
+    VStack(spacing: 24) {
+        SegmentStrip(selection: $selection, distribution: .justified) { $0.shortTitle }
+        SegmentStrip(selection: $selection) { $0.shortTitle }
     }
-    return Preview()
+    .padding()
 }


### PR DESCRIPTION
Replaces the wrapper `Preview` struct pattern in the CompactPeriodPicker and SegmentStrip previews with the `@Previewable @State` macro, gated behind an iOS 17 / macOS 14 availability check. This flattens the preview bodies and drops the boilerplate state-hosting view.