### PR TITLE
Remove segment strip baseline separator

### DIFF
--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -23,24 +23,17 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
     @Namespace private var namespace
 
     var body: some View {
-        strip
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(alignment: .bottom) {
-                Divider()
-            }
-    }
-
-    @ViewBuilder
-    private var strip: some View {
         switch distribution {
         case .compact(let spacing):
             HStack(spacing: spacing) {
                 segments
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         case .justified:
             JustifiedLayout {
                 segments
             }
+            .frame(maxWidth: .infinity)
         }
     }
 


### PR DESCRIPTION
Removes the baseline `Divider` from `SegmentStrip` and inlines the strip container directly into `body`. The full-width frame that used to back the divider is no longer a shared container, so each distribution now carries its own frame: compact keeps `maxWidth: .infinity` with leading alignment to keep labels pinned to the left, while justified only needs `maxWidth: .infinity` so `JustifiedLayout` can spread its segments across the full row. Purely a visual/layout cleanup of the picker — no call sites change.