### PR TITLE
Pass key paths to SegmentStrip label arguments

### DIFF
--- a/Sources/Scout/UI/Home/Section/Stat/HomeSectionPicker.swift
+++ b/Sources/Scout/UI/Home/Section/Stat/HomeSectionPicker.swift
@@ -44,7 +44,7 @@ struct HomeSectionPicker: View {
     @Binding var selection: HomeSection
 
     var body: some View {
-        SegmentStrip(selection: $selection, tint: { $0.color }) { $0.title }
+        SegmentStrip(selection: $selection, tint: \.color, title: \.title)
     }
 }
 

--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -83,8 +83,8 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
     @Previewable @State var selection = Period.today
 
     VStack(spacing: 24) {
-        SegmentStrip(selection: $selection, distribution: .justified) { $0.shortTitle }
-        SegmentStrip(selection: $selection) { $0.shortTitle }
+        SegmentStrip(selection: $selection, distribution: .justified, title: \.shortTitle)
+        SegmentStrip(selection: $selection, title: \.shortTitle)
     }
     .padding()
 }


### PR DESCRIPTION
Replaces the `{ $0.shortTitle }`-style projection closures at SegmentStrip call sites with key paths (`\.color`, `\.title`, `\.shortTitle`), matching how the rest of the project already writes simple projections (`.map(\.launch)` and friends). The trailing label closures become the explicit `title:` argument since a key path can't be passed as a trailing closure. No behavior change — key path literals convert to the expected function types, including the optional `tint` parameter. Verified with a simulator build of the Scout scheme. A project-wide sweep found no other projection closures left to convert.