### PR TITLE
Run SyncDelivery.recordAttempt on the main actor

### DIFF
--- a/Sources/Scout/Core/Sync/SyncDelivery+RecordAttempt.swift
+++ b/Sources/Scout/Core/Sync/SyncDelivery+RecordAttempt.swift
@@ -9,8 +9,9 @@ import CoreData
 
 extension SyncDelivery {
     // A single shared increment per cycle, so the per-type delivery passes don't
-    // each spend the budget and abandon the backend early.
-    static func recordAttempt(for backendID: String, in context: NSManagedObjectContext) {
+    // each spend the budget and abandon the backend early. Runs on the main actor
+    // because it mutates the main-queue view context.
+    @MainActor static func recordAttempt(for backendID: String, in context: NSManagedObjectContext) {
         let request = NSFetchRequest<SyncDelivery>(entityName: "SyncDelivery")
         request.predicate = NSPredicate(
             format: "backendID == %@ AND progressPrimitive != 0 AND attempts < %d",

--- a/Sources/Scout/Core/Sync/Synchronize.swift
+++ b/Sources/Scout/Core/Sync/Synchronize.swift
@@ -19,7 +19,7 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
     try await dispatcher.performEnsuringBackground {
         await withTaskGroup(of: Void.self) { group in
             for backend in backends where await backend.checkAvailability() {
-                SyncDelivery.recordAttempt(for: backend.id, in: context)
+                await SyncDelivery.recordAttempt(for: backend.id, in: context)
 
                 let recordSender = RecordSender(backend: backend)
 


### PR DESCRIPTION
`SyncDelivery.recordAttempt` fetches and saves through the main-queue view context, but `synchronize` calls it from the background task that `performEnsuringBackground` spins up. Once a backend reported available the call ran off the main thread and tripped Core Data's multithreading guard, crashing with `EXC_BREAKPOINT`. This isolates `recordAttempt` to the main actor — matching `RecordSender.deliver`, which already touches the same context on the main actor — and awaits it at the call site.