### PR TITLE
fix settings on home page

### DIFF
--- a/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
@@ -13,7 +13,6 @@ struct ConnectionMenu: View {
 
     @State private var connections: [Connection]
     @State private var isPresented = false
-    @State private var opensSettingsAfterDismiss = false
 
     init(connections: [Connection], activeID: Binding<Connection.ID>, onSettings: @escaping () -> Void = {}) {
         _activeID = activeID
@@ -44,8 +43,11 @@ struct ConnectionMenu: View {
                 }
 
                 Button {
-                    opensSettingsAfterDismiss = true
                     isPresented = false
+                    Task { @MainActor in
+                        await Task.yield()
+                        onSettings()
+                    }
                 } label: {
                     HStack {
                         Image(systemName: "slider.horizontal.3")
@@ -67,12 +69,6 @@ struct ConnectionMenu: View {
             }
             .popoverDropdown()
             .opaquePresentationBackground()
-        }
-        .onChange(of: isPresented) { isPresented in
-            guard !isPresented, opensSettingsAfterDismiss else { return }
-
-            opensSettingsAfterDismiss = false
-            onSettings()
         }
     }
 }


### PR DESCRIPTION
- Removes the state flag used to track a pending settings transition from `ConnectionMenu`
- Triggers `onSettings()` after dismissing the popover by yielding to the main actor first
- Keeps the settings action from firing while the menu is still visible