### PR TITLE
Update scout-db to 0.7.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
-        .package(url: "https://github.com/kasianov-mikhail/scout-db.git", from: "0.6.0"),
+        .package(url: "https://github.com/kasianov-mikhail/scout-db.git", from: "0.7.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Bumps the scout-db dependency from 0.6.0 to 0.7.0.

0.7.0 grants the `_icloud` role `CREATE`/`WRITE` on the `Meta` record type — clients publish their entity definitions to `Meta` on first run under their own iCloud account, which the old grants rejected — and adds a backstop timeout so a stalled CloudKit write cancels and frees its request slot instead of starving the pool. No source changes here; only the dependency pin moves.