### PR TITLE
Surface data-load errors on the Home screen

### DIFF
--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -17,8 +17,15 @@ class HomeLogProvider: ObservableObject {
         results[period]
     }
 
+    func fetchAgain(for period: Period, in database: DatabaseReader) async {
+        results[period] = nil
+        await fetchIfNeeded(for: period, in: database)
+    }
+
     func fetchIfNeeded(for period: Period, in database: DatabaseReader) async {
-        guard results[period] == nil else { return }
+        guard results[period] == nil else {
+            return
+        }
         do {
             results[period] = .success(try await fetch(for: period, in: database))
         } catch {
@@ -27,9 +34,8 @@ class HomeLogProvider: ObservableObject {
     }
 
     private func fetch(for period: Period, in database: DatabaseReader) async throws -> Output {
-        let range = period.initialRange
-        async let intMatrices = matrices(of: Int.self, in: range, from: database)
-        async let doubleMatrices = matrices(of: Double.self, in: range, from: database)
+        async let intMatrices = matrices(of: Int.self, in: period.initialRange, from: database)
+        async let doubleMatrices = matrices(of: Double.self, in: period.initialRange, from: database)
 
         return try await (intMatrices.filter { !lifecycleNames.contains($0.name) }, doubleMatrices)
     }

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -20,6 +20,18 @@ struct HomeLogSection: View {
             await provider.fetchIfNeeded(for: period, in: database)
         }
 
+        if case .failure(let error) = provider.result(for: period) {
+            ErrorView(description: Text(verbatim: error.localizedDescription)) {
+                Task { await provider.fetchAgain(for: period, in: database) }
+            }
+            .listRowSeparator(.hidden)
+        } else {
+            logRows
+        }
+    }
+
+    @ViewBuilder
+    private var logRows: some View {
         HomeLogRow(
             title: "Events",
             image: "list.bullet",

--- a/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
@@ -30,7 +30,12 @@ struct HomeReleaseSection: View {
             await provider.fetchIfNeeded(in: database)
         }
 
-        if let releases = provider.releases {
+        if case .failure(let error) = provider.result {
+            ErrorView(description: Text(verbatim: error.localizedDescription)) {
+                Task { await provider.fetchAgain(in: database) }
+            }
+            .listRowSeparator(.hidden)
+        } else if let releases = provider.releases {
             if releases.count > 0 {
                 ForEach(releases.prefix(3)) { release in
                     ReleaseRow(release: release)

--- a/Sources/Scout/UI/Home/Section/Stat/HomeStatSection.swift
+++ b/Sources/Scout/UI/Home/Section/Stat/HomeStatSection.swift
@@ -42,6 +42,17 @@ struct HomeStatSection: View {
         case .crashes:
             statRows(for: crashStat, section: .crashes)
         case .users:
+            activityRows
+        }
+    }
+
+    @ViewBuilder
+    private var activityRows: some View {
+        if case .failure(let error) = activity.result {
+            errorRow(error) {
+                await activity.fetchAgain(in: database)
+            }
+        } else {
             ForEach(ActivityPeriod.allCases) { period in
                 ActivityRow(
                     period: period,
@@ -53,21 +64,35 @@ struct HomeStatSection: View {
         }
     }
 
+    private func errorRow(_ error: Error, retry: @escaping () async -> Void) -> some View {
+        ErrorView(description: Text(verbatim: error.localizedDescription)) {
+            Task { await retry() }
+        }
+        .listRowSeparator(.hidden)
+    }
+
+    @ViewBuilder
     private func statRows(for stat: StatProvider, section: HomeSection) -> some View {
-        ForEach(Period.summary) { period in
-            StatRow(
-                color: section.color,
-                period: period,
-                systemImage: section.systemImage,
-                stat: stat
-            ) {
-                StatView(
-                    showList: false,
-                    extent: ChartExtent(period: period),
+        if case .failure(let error) = stat.result {
+            errorRow(error) {
+                await stat.fetchAgain(in: database)
+            }
+        } else {
+            ForEach(Period.summary) { period in
+                StatRow(
+                    color: section.color,
+                    period: period,
+                    systemImage: section.systemImage,
                     stat: stat
-                )
-                .environment(\.chartColor, section.color)
-                .navigationTitle(en: section.title)
+                ) {
+                    StatView(
+                        showList: false,
+                        extent: ChartExtent(period: period),
+                        stat: stat
+                    )
+                    .environment(\.chartColor, section.color)
+                    .navigationTitle(en: section.title)
+                }
             }
         }
     }

--- a/Sources/Scout/UI/Releases/View/ReleaseHealthProvider.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseHealthProvider.swift
@@ -8,46 +8,40 @@
 import SwiftUI
 
 @MainActor
-class ReleaseHealthProvider: ObservableObject {
-    @Published var releases: [ReleaseHealth]?
+class ReleaseHealthProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<[ReleaseHealth]>?
 
     init(releases: [ReleaseHealth]? = nil) {
-        self.releases = releases
+        self.result = releases.map { .success($0) }
     }
 
-    func fetchIfNeeded(in database: DatabaseReader) async {
-        if releases == nil {
-            await fetch(in: database)
-        }
+    var releases: [ReleaseHealth]? {
+        try? result?.get()
     }
 
-    func fetch(in database: DatabaseReader) async {
+    func fetch(in database: DatabaseReader) async throws -> [ReleaseHealth] {
         let range = Calendar.utc.defaultRange
 
-        do {
-            async let sessions: IntMatrices = database.readAll(
-                matching: query(name: SessionObject.recordType, in: range)
-            )
-            async let crashes: IntMatrices = database.readAll(
-                matching: query(name: CrashObject.recordType, in: range)
-            )
-            async let installs: IntMatrices = database.readAll(
-                matching: query(name: VersionMarker.installName, in: range)
-            )
-            async let crashedInstalls: IntMatrices = database.readAll(
-                matching: query(name: VersionMarker.crashName, in: range)
-            )
+        async let sessions: IntMatrices = database.readAll(
+            matching: query(name: SessionObject.recordType, in: range)
+        )
+        async let crashes: IntMatrices = database.readAll(
+            matching: query(name: CrashObject.recordType, in: range)
+        )
+        async let installs: IntMatrices = database.readAll(
+            matching: query(name: VersionMarker.installName, in: range)
+        )
+        async let crashedInstalls: IntMatrices = database.readAll(
+            matching: query(name: VersionMarker.crashName, in: range)
+        )
 
-            releases = try await releaseReport(
-                sessions: sessions,
-                crashes: crashes,
-                installs: installs,
-                crashedInstalls: crashedInstalls,
-                range: range
-            )
-        } catch {
-            releases = []
-        }
+        return try await releaseReport(
+            sessions: sessions,
+            crashes: crashes,
+            installs: installs,
+            crashedInstalls: crashedInstalls,
+            range: range
+        )
     }
 
     private func query(name: String, in range: Range<Date>) -> RecordQuery {

--- a/Sources/Scout/UI/Releases/View/ReleaseHealthView.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseHealthView.swift
@@ -17,24 +17,20 @@ struct ReleaseHealthView: View {
     }
 
     var body: some View {
-        Group {
-            if let releases = provider.releases {
-                if releases.isEmpty {
-                    Placeholder(
-                        text: "No releases",
-                        systemImage: "shippingbox",
-                        description: "Release health appears once your app reports versions"
-                    )
-                } else {
-                    List {
-                        ForEach(releases) { release in
-                            ReleaseRow(release: release)
-                        }
-                    }
-                    .listStyle(.plain)
-                }
+        ProviderView(provider: provider) { releases in
+            if releases.isEmpty {
+                Placeholder(
+                    text: "No releases",
+                    systemImage: "shippingbox",
+                    description: "Release health appears once your app reports versions"
+                )
             } else {
-                RingIndicator().frame(maxHeight: .infinity)
+                List {
+                    ForEach(releases) { release in
+                        ReleaseRow(release: release)
+                    }
+                }
+                .listStyle(.plain)
             }
         }
         .navigationTitle(en: "Releases")


### PR DESCRIPTION
The Home stat, log, and release sections turned a failed scout-db read into an indefinite loading placeholder because the providers swallowed the error into nil. They now expose the failure and render ErrorView with a retry action, and ReleaseHealthProvider keeps the error as a ProviderResult instead of collapsing it into an empty release list.

Pairs with the scout-db recursion fix that was the underlying cause of the reads never returning.