### PR TITLE
Reorganize navigation tint helpers

### DIFF
--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-// The latest scout-db schema bootstrap failure, shown on the home screen.
 @MainActor let schemaBootstrapMessage = Box<String?>(nil)
 
 public struct HomeView: View {

--- a/Sources/Scout/UI/Primitives/Navigation/View+NavigationTint.swift
+++ b/Sources/Scout/UI/Primitives/Navigation/View+NavigationTint.swift
@@ -7,8 +7,9 @@
 
 import SwiftUI
 
-@MainActor
-class Box<T>: ObservableObject {
+typealias Tint = Box<Color?>
+
+@MainActor class Box<T>: ObservableObject {
     @Published var value: T
 
     init(_ value: T) {
@@ -16,11 +17,19 @@ class Box<T>: ObservableObject {
     }
 }
 
-typealias Tint = Box<Color?>
-
-extension Tint {
+extension Box where T: ExpressibleByNilLiteral {
     convenience init() {
         self.init(nil)
+    }
+}
+
+extension View {
+    func navigationTint(_ color: Color?) -> some View {
+        modifier(NavigationTint(color: color))
+    }
+
+    func resetsTint() -> some View {
+        modifier(TintReset())
     }
 }
 
@@ -43,15 +52,5 @@ private struct TintReset: ViewModifier {
 
     func body(content: Content) -> some View {
         content.onAppear { tint.value = nil }
-    }
-}
-
-extension View {
-    func navigationTint(_ color: Color?) -> some View {
-        modifier(NavigationTint(color: color))
-    }
-
-    func resetsTint() -> some View {
-        modifier(TintReset())
     }
 }


### PR DESCRIPTION
Moves the Tint typealias next to Box, generalizes the nil convenience initializer to any Box whose value is ExpressibleByNilLiteral, and lifts the View extension above the private modifiers in View+NavigationTint.swift. Also drops a stale comment in HomeView. No behavior changes. Ships alongside the crash fix in kasianov-mikhail/scout-ip#461.