### PR TITLE
Rename inline navigation title to inline title for clarity

### DIFF
--- a/Sources/Scout/UI/Primitives/Navigation/View+InlineTitle.swift
+++ b/Sources/Scout/UI/Primitives/Navigation/View+InlineTitle.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 extension View {
-    /// Inline navigation title on iOS; no-op on macOS, where titles have no display mode.
     func inlineNavigationTitle() -> some View {
         #if os(iOS)
             navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
This pull request makes a minor update to the navigation-related SwiftUI view extension by renaming the file from `View+InlineNavigationTitle.swift` to `View+InlineTitle.swift`. No functional changes were made to the code itself.Rename View+InlineNavigationTitle to View+InlineTitle for simpler naming. Remove doc comment from internal function per style conventions.