### PR TITLE
Reset image scale on Home content so toolbar-presented Scout renders row icons at the intended size

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -25,6 +25,7 @@ struct HomeContent: View {
             ReleaseHealthView(provider: releaseProvider)
         }
         .listStyle(.plain)
+        .imageScale(.medium)
         .scrollContentBackground(.hidden)
         .background {
             Rectangle()


### PR DESCRIPTION
When ScoutIP presents HomeView from a toolbar button via fullScreenCover, the content inherits the toolbar's imageScale(.large) environment, which enlarged every SF Symbol in the Home rows while leaving text unchanged. Pinning the Home list to imageScale(.medium) restores Scout's intended icon size regardless of the host's presentation context.