### PR TITLE
Scope the period strip's selection animation to the strip itself

### DIFF
--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -42,6 +42,7 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
         ForEach(values, id: \.self) { value in
             segment(value)
         }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: selection)
     }
 
     @ViewBuilder
@@ -64,9 +65,7 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
             }
             .contentShape(.rect)
             .onTapGesture {
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                    selection = value
-                }
+                selection = value
             }
     }
 }


### PR DESCRIPTION
The D/W/M period strip wrapped its selection change in a global withAnimation transaction, which was only meant to slide the strip's underline indicator. Because the selection is bound to the chart extent's period, that same transaction also drove the chart's data update, so the bars animated alongside the strip. Replacing the global withAnimation with a scoped .animation(_:value:) on the segments keeps the indicator animating while the chart bars update without animation. This also fixes the same coupling on the other screens that reuse SegmentStrip.