### PR TITLE
Adopt ProviderView on the Network screen

### DIFF
--- a/Sources/Scout/UI/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkView.swift
@@ -17,31 +17,12 @@ struct NetworkView: View {
     }
 
     var body: some View {
-        Group {
-            switch provider.result {
-            case nil:
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .failure(let error):
-                VStack(spacing: 16) {
-                    Text(verbatim: error.localizedDescription)
-                        .foregroundStyle(.gray)
-                        .multilineTextAlignment(.center)
-                    Button {
-                        Task {
-                            await provider.fetchAgain(in: database)
-                        }
-                    } label: {
-                        Text(verbatim: "Retry")
-                    }
-                }
-                .padding(.horizontal)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .success(let report) where report.isEmpty:
+        ProviderView(provider: provider) { report in
+            if report.isEmpty {
                 Text(verbatim: "No network requests in this period.")
                     .foregroundStyle(.gray)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .success(let report):
+            } else {
                 content(report)
             }
         }


### PR DESCRIPTION
The Network screen still had its own hand-rolled ProgressView and inline error UI instead of the shared ProviderView used by the other screens, so it never picked up the new RingIndicator loading spinner or the standardized ErrorView retry. This swaps the body over to ProviderView, keeping the empty-state message inside the content closure.