### PR TITLE
Pin the Home section picker above the scrolling stat list

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -8,6 +8,13 @@
 import SwiftUI
 
 struct HomeContent: View {
+    @Environment(\.database) var database
+
+    @AppStorage("scout_home_section") private var section = HomeSection.sessions
+
+    @StateObject private var activity = ActivityProvider()
+    @StateObject private var sessionStat = StatProvider(eventName: "Session", periods: Period.summary)
+    @StateObject private var crashStat = StatProvider(eventName: "Crash", periods: Period.summary)
     @StateObject private var releaseProvider: ReleaseHealthProvider
     @State private var showReleaseHealth = false
 
@@ -16,17 +23,39 @@ struct HomeContent: View {
     }
 
     var body: some View {
-        List {
-            HomeStatSection()
-            HomeLogSection()
-            HomeReleaseSection(provider: releaseProvider, showReleaseHealth: $showReleaseHealth)
+        VStack(spacing: 0) {
+            HomeSectionPicker(selection: $section)
+                .padding(.horizontal)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+                .task(id: section) {
+                    switch section {
+                    case .sessions:
+                        await sessionStat.fetchIfNeeded(in: database)
+                    case .crashes:
+                        await crashStat.fetchIfNeeded(in: database)
+                    case .users:
+                        await activity.fetchIfNeeded(in: database)
+                    }
+                }
+
+            List {
+                HomeStatSection(
+                    section: section,
+                    activity: activity,
+                    sessionStat: sessionStat,
+                    crashStat: crashStat
+                )
+                HomeLogSection()
+                HomeReleaseSection(provider: releaseProvider, showReleaseHealth: $showReleaseHealth)
+            }
+            .navigationDestination(isPresented: $showReleaseHealth) {
+                ReleaseHealthView(provider: releaseProvider)
+            }
+            .listStyle(.plain)
+            .imageScale(.medium)
+            .scrollContentBackground(.hidden)
         }
-        .navigationDestination(isPresented: $showReleaseHealth) {
-            ReleaseHealthView(provider: releaseProvider)
-        }
-        .listStyle(.plain)
-        .imageScale(.medium)
-        .scrollContentBackground(.hidden)
         .background {
             Rectangle()
                 .fill(.background)

--- a/Sources/Scout/UI/Home/Section/Stat/HomeStatSection.swift
+++ b/Sources/Scout/UI/Home/Section/Stat/HomeStatSection.swift
@@ -8,29 +8,15 @@
 import SwiftUI
 
 struct HomeStatSection: View {
+    let section: HomeSection
+
+    @ObservedObject var activity: ActivityProvider
+    @ObservedObject var sessionStat: StatProvider
+    @ObservedObject var crashStat: StatProvider
+
     @Environment(\.database) var database
 
-    @AppStorage("scout_home_section") private var section = HomeSection.sessions
-
-    @StateObject private var activity = ActivityProvider()
-    @StateObject private var sessionStat = StatProvider(eventName: "Session", periods: Period.summary)
-    @StateObject private var crashStat = StatProvider(eventName: "Crash", periods: Period.summary)
-
     var body: some View {
-        HomeSectionPicker(selection: $section)
-            .padding(.bottom, 4)
-            .listRowSeparator(.hidden)
-            .task(id: section) {
-                switch section {
-                case .sessions:
-                    await sessionStat.fetchIfNeeded(in: database)
-                case .crashes:
-                    await crashStat.fetchIfNeeded(in: database)
-                case .users:
-                    await activity.fetchIfNeeded(in: database)
-                }
-            }
-
         sectionRows
     }
 
@@ -53,13 +39,14 @@ struct HomeStatSection: View {
                 await activity.fetchAgain(in: database)
             }
         } else {
-            ForEach(ActivityPeriod.allCases) { period in
+            ForEach(Array(ActivityPeriod.allCases.enumerated()), id: \.element) { index, period in
                 ActivityRow(
                     period: period,
                     color: HomeSection.users.color,
                     systemImage: HomeSection.users.systemImage,
                     activity: activity
                 )
+                .listRowSeparator(index == 0 ? .hidden : .automatic, edges: .top)
             }
         }
     }
@@ -78,7 +65,7 @@ struct HomeStatSection: View {
                 await stat.fetchAgain(in: database)
             }
         } else {
-            ForEach(Period.summary) { period in
+            ForEach(Array(Period.summary.enumerated()), id: \.element) { index, period in
                 StatRow(
                     color: section.color,
                     period: period,
@@ -93,6 +80,7 @@ struct HomeStatSection: View {
                     .environment(\.chartColor, section.color)
                     .navigationTitle(en: section.title)
                 }
+                .listRowSeparator(index == 0 ? .hidden : .automatic, edges: .top)
             }
         }
     }


### PR DESCRIPTION
Lifts the section picker out of the stat list into a fixed header above it, so switching between users, sessions, and crashes stays put while the list scrolls. HomeContent now owns the section state and providers and passes them into HomeStatSection, and the first stat row hides its top separator so no divider sits directly under the picker. Companion to #763.