### PR TITLE
Show latency-only endpoints on the Network screen

### DIFF
--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistribution.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistribution.swift
@@ -37,6 +37,13 @@ struct TimerDistribution: Equatable {
         histograms.values.allSatisfy { $0.total == 0 }
     }
 
+    func total(in range: Range<Date>) -> Int {
+        histograms
+            .filter { range.contains($0.key) }
+            .values
+            .reduce(0) { $0 + $1.total }
+    }
+
     func summary(in range: Range<Date>) -> LatencyPercentiles? {
         let combined =
             histograms

--- a/Sources/Scout/UI/Network/Model/NetworkEndpoint.swift
+++ b/Sources/Scout/UI/Network/Model/NetworkEndpoint.swift
@@ -18,9 +18,17 @@ struct NetworkEndpoint: Identifiable {
 
     private static let methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
 
-    var method: String? {
+    static func isEndpointName(_ name: String) -> Bool {
+        method(in: name) != nil
+    }
+
+    private static func method(in name: String) -> String? {
         guard let first = name.split(separator: " ").first.map(String.init) else { return nil }
-        return Self.methods.contains(first) ? first : nil
+        return methods.contains(first) ? first : nil
+    }
+
+    var method: String? {
+        Self.method(in: name)
     }
 
     var path: String {

--- a/Sources/Scout/UI/Network/Model/NetworkReport.swift
+++ b/Sources/Scout/UI/Network/Model/NetworkReport.swift
@@ -44,7 +44,8 @@ struct NetworkReport {
         // Latency-only timers count as endpoints only when their name reads
         // like an HTTP request, so generic app timers stay off the screen.
         self.init(
-            distributions: latency
+            distributions:
+                latency
                 .filter { status.keys.contains($0.key) || NetworkEndpoint.isEndpointName($0.key) }
                 .mapValues(TimerDistribution.init),
             statuses: status.mapValues(StatusDistribution.init)

--- a/Sources/Scout/UI/Network/Model/NetworkReport.swift
+++ b/Sources/Scout/UI/Network/Model/NetworkReport.swift
@@ -41,23 +41,29 @@ struct NetworkReport {
             }
         }
 
+        // Latency-only timers count as endpoints only when their name reads
+        // like an HTTP request, so generic app timers stay off the screen.
         self.init(
-            distributions: latency.filter { status.keys.contains($0.key) }.mapValues(TimerDistribution.init),
+            distributions: latency
+                .filter { status.keys.contains($0.key) || NetworkEndpoint.isEndpointName($0.key) }
+                .mapValues(TimerDistribution.init),
             statuses: status.mapValues(StatusDistribution.init)
         )
     }
 
     var isEmpty: Bool {
-        statuses.values.allSatisfy(\.isEmpty)
+        statuses.values.allSatisfy(\.isEmpty) && distributions.values.allSatisfy(\.isEmpty)
     }
 
     func endpoints(in range: Range<Date>) -> [NetworkEndpoint] {
-        statuses
-            .map { name, distribution in
-                let breakdown = distribution.summary(in: range)
+        Set(statuses.keys)
+            .union(distributions.keys)
+            .map { name in
+                let breakdown = statuses[name]?.summary(in: range) ?? StatusBreakdown()
+                let requests = breakdown.total > 0 ? breakdown.total : distributions[name]?.total(in: range) ?? 0
                 return NetworkEndpoint(
                     name: name,
-                    requests: breakdown.total,
+                    requests: requests,
                     successRate: breakdown.total > 0 ? breakdown.successRate : nil,
                     p99: distributions[name]?.summary(in: range)?.p99
                 )
@@ -82,7 +88,8 @@ struct NetworkReport {
     func requestsPerMinute(in range: Range<Date>, until now: Date = .now) -> Int {
         let end = min(now, range.upperBound)
         let minutes = max(1.0, end.timeIntervalSince(range.lowerBound) / .minute)
-        return Int(Double(summary(in: range).total) / minutes)
+        let total = endpoints(in: range).reduce(0) { $0 + $1.requests }
+        return Int(Double(total) / minutes)
     }
 }
 

--- a/Sources/Scout/UI/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkView.swift
@@ -36,11 +36,12 @@ struct NetworkView: View {
         let range = Period.today.initialRange
         let endpoints = report.endpoints(in: range)
         let breakdown = report.summary(in: range)
+        let successRate = breakdown.total > 0 ? breakdown.successRate : nil
 
         return List {
             HStack(spacing: 28) {
                 Metric(title: "P99", value: report.percentiles(in: range)?.p99.duration ?? "—", color: .orange)
-                Metric(title: "Success", value: breakdown.successRate.formatted, color: breakdown.successRate.color)
+                Metric(title: "Success", value: successRate?.formatted ?? "—", color: successRate?.color ?? .primary)
                 Metric(title: "Req/min", value: report.requestsPerMinute(in: range).plain, color: .primary)
                 Spacer()
             }

--- a/Tests/ScoutTests/UI/Network/Model/NetworkReportTests.swift
+++ b/Tests/ScoutTests/UI/Network/Model/NetworkReportTests.swift
@@ -19,16 +19,31 @@ struct NetworkReportTests {
         base..<base.adding(.day)
     }
 
-    @Test("Only names with status series become endpoints")
-    func endpointRequiresStatuses() {
+    @Test("Names with status series or endpoint-like names become endpoints")
+    func endpointNames() {
         let report = NetworkReport(series: [
             makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 10)]),
             makeSeries(name: "GET /a", category: "timer_le_1", points: [(base, 10)]),
+            makeSeries(name: "GET /b", category: "timer_le_1", points: [(base, 5)]),
             makeSeries(name: "plain_timer", category: "timer_le_1", points: [(base, 10)]),
         ])
 
-        #expect(report.endpoints(in: range).map(\.name) == ["GET /a"])
+        #expect(report.endpoints(in: range).map(\.name) == ["GET /a", "GET /b"])
         #expect(report.distributions.keys.contains("plain_timer") == false)
+    }
+
+    @Test("Latency-only endpoints count requests from the histogram")
+    func latencyOnlyEndpoint() throws {
+        let report = NetworkReport(series: [
+            makeSeries(name: "GET /b", category: "timer_le_1", points: [(base, 5)])
+        ])
+
+        let endpoint = try #require(report.endpoints(in: range).first)
+
+        #expect(endpoint.requests == 5)
+        #expect(endpoint.successRate == nil)
+        #expect(endpoint.p99 != nil)
+        #expect(report.requestsPerMinute(in: range, until: base.adding(.hour)) == 0)
     }
 
     @Test("Endpoints carry requests, success rate, and p99 for the range")
@@ -128,6 +143,7 @@ struct NetworkReportTests {
         #expect(NetworkReport(series: []).isEmpty)
         #expect(NetworkReport(series: [makeSeries(name: "plain_timer", category: "timer_le_1", points: [(base, 1)])]).isEmpty)
         #expect(!NetworkReport(series: [makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 1)])]).isEmpty)
+        #expect(!NetworkReport(series: [makeSeries(name: "GET /a", category: "timer_le_1", points: [(base, 1)])]).isEmpty)
     }
 
     private func makeSeries(name: String, category: String, points: [(Date, Int)]) -> MetricSeries {


### PR DESCRIPTION
The Network screen dropped latency timers that had no paired status series and judged emptiness by statuses alone, so an app that records request timers but no status-dimension counters saw a permanent "No network requests in this period". Latency series whose name reads like an HTTP request now become endpoints on their own: request counts fall back to the histogram totals, the Success metric shows a dash instead of a misleading 100%, and generic app timers stay filtered out as before. Companion PR on the app side records the status counters ScoutIP was missing: kasianov-mikhail/scout-ip#467.