### PR TITLE
Inject Home stat providers through the constructor

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -18,7 +18,12 @@ struct HomeContent: View {
     @StateObject private var releaseProvider: ReleaseHealthProvider
     @State private var showReleaseHealth = false
 
-    init(activity: ActivityProvider = ActivityProvider(), sessionStat: StatProvider = StatProvider(eventName: "Session", periods: Period.summary), crashStat: StatProvider = StatProvider(eventName: "Crash", periods: Period.summary), releaseProvider: ReleaseHealthProvider = ReleaseHealthProvider()) {
+    init(
+        activity: ActivityProvider = ActivityProvider(),
+        sessionStat: StatProvider = StatProvider(eventName: "Session", periods: Period.summary),
+        crashStat: StatProvider = StatProvider(eventName: "Crash", periods: Period.summary),
+        releaseProvider: ReleaseHealthProvider = ReleaseHealthProvider()
+    ) {
         self._activity = StateObject(wrappedValue: activity)
         self._sessionStat = StateObject(wrappedValue: sessionStat)
         self._crashStat = StateObject(wrappedValue: crashStat)

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -12,13 +12,16 @@ struct HomeContent: View {
 
     @AppStorage("scout_home_section") private var section = HomeSection.sessions
 
-    @StateObject private var activity = ActivityProvider()
-    @StateObject private var sessionStat = StatProvider(eventName: "Session", periods: Period.summary)
-    @StateObject private var crashStat = StatProvider(eventName: "Crash", periods: Period.summary)
+    @StateObject private var activity: ActivityProvider
+    @StateObject private var sessionStat: StatProvider
+    @StateObject private var crashStat: StatProvider
     @StateObject private var releaseProvider: ReleaseHealthProvider
     @State private var showReleaseHealth = false
 
-    init(releaseProvider: ReleaseHealthProvider = ReleaseHealthProvider()) {
+    init(activity: ActivityProvider = ActivityProvider(), sessionStat: StatProvider = StatProvider(eventName: "Session", periods: Period.summary), crashStat: StatProvider = StatProvider(eventName: "Crash", periods: Period.summary), releaseProvider: ReleaseHealthProvider = ReleaseHealthProvider()) {
+        self._activity = StateObject(wrappedValue: activity)
+        self._sessionStat = StateObject(wrappedValue: sessionStat)
+        self._crashStat = StateObject(wrappedValue: crashStat)
         self._releaseProvider = StateObject(wrappedValue: releaseProvider)
     }
 


### PR DESCRIPTION
Extends HomeContent's initializer to accept its activity, session, and crash stat providers as parameters with default values, mirroring how releaseProvider is already injected. This lets previews and tests supply preconfigured providers while leaving the default call sites unchanged.