### PR TITLE
Ignore cancellation errors so the Home screen doesn't show a spurious error

### DIFF
--- a/Sources/Scout/UI/Database/Provider.swift
+++ b/Sources/Scout/UI/Database/Provider.swift
@@ -21,19 +21,21 @@ typealias ProviderResult<T> = Result<T, Error>
 extension Provider {
     func fetchAgain(in database: DatabaseReader) async {
         result = nil
-        result = await resolve(in: database)
+        await resolve(in: database)
     }
 
     func fetchIfNeeded(in database: DatabaseReader) async {
         guard result == nil else { return }
-        result = await resolve(in: database)
+        await resolve(in: database)
     }
 
-    private func resolve(in database: DatabaseReader) async -> ProviderResult<Output> {
+    private func resolve(in database: DatabaseReader) async {
         do {
-            return .success(try await fetch(in: database))
+            result = .success(try await fetch(in: database))
+        } catch is CancellationError {
+            // A cancelled task (e.g. the view was recreated) leaves the result untouched so it retries.
         } catch {
-            return .failure(error)
+            result = .failure(error)
         }
     }
 }

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -28,6 +28,8 @@ class HomeLogProvider: ObservableObject {
         }
         do {
             results[period] = .success(try await fetch(for: period, in: database))
+        } catch is CancellationError {
+            // A cancelled task (e.g. the view was recreated) leaves the result untouched so it retries.
         } catch {
             results[period] = .failure(error)
         }


### PR DESCRIPTION
Switching the backend recreates the Home content view via its `.id(backend.id)`, which cancels the in-flight data-loading tasks. The providers caught the resulting `CancellationError` alongside real failures and stored it as a `.failure`, so the user briefly saw an "An error occurred" screen with a `CancellationError` message.

The shared `Provider.resolve` and `HomeLogProvider.fetchIfNeeded` now swallow `CancellationError` and leave the result untouched, mirroring how `TimelineProvider` already handles cancellation. A cancelled fetch keeps the result at `nil` so the view simply retries on its next appearance.