### PR TITLE
Keep Home section stats loading in the background when switching sections

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -28,16 +28,8 @@ struct HomeContent: View {
                 .padding(.horizontal)
                 .padding(.top, 8)
                 .padding(.bottom, 4)
-                .task(id: section) {
-                    switch section {
-                    case .sessions:
-                        await sessionStat.fetchIfNeeded(in: database)
-                    case .crashes:
-                        await crashStat.fetchIfNeeded(in: database)
-                    case .users:
-                        await activity.fetchIfNeeded(in: database)
-                    }
-                }
+                .onAppear { fetch(section) }
+                .onChange(of: section) { fetch($0) }
 
             List {
                 HomeStatSection(
@@ -62,6 +54,19 @@ struct HomeContent: View {
                 .ignoresSafeArea()
         }
         .toolbarBackground(.visible, for: .navigationBar)
+    }
+
+    private func fetch(_ section: HomeSection) {
+        Task {
+            switch section {
+            case .sessions:
+                await sessionStat.fetchIfNeeded(in: database)
+            case .crashes:
+                await crashStat.fetchIfNeeded(in: database)
+            case .users:
+                await activity.fetchIfNeeded(in: database)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The Home section picker used `.task(id: section)`, which cancels the in-flight fetch whenever the selected section changes. Switching away before a section finished loading threw away its progress. This moves the per-section `fetchIfNeeded` into a detached `Task` triggered from `.onAppear`/`.onChange`, so each section keeps loading to completion in the background regardless of what's currently selected. `fetchIfNeeded` is idempotent and caches its result, so dropping cancellation is safe.