### PR TITLE
Collapse the schema bootstrap loop to a single register/publish path

### DIFF
--- a/Sources/Scout/Native/Store/ScoutDBBackend.swift
+++ b/Sources/Scout/Native/Store/ScoutDBBackend.swift
@@ -43,20 +43,19 @@ extension Backend {
 }
 
 extension EntityCatalog {
-    // Seeds the registry with the app-embedded definitions and publishes them to
-    // Meta so external readers of the container can decode the records too.
     static func bootstrap(registry: SchemaRegistry) async {
         _ = try? await registry.preload()
         let remote = await registry.definitions()
 
         for definition in definitions {
-            guard let published = remote.first(where: { $0.entity == definition.entity }) else {
-                try? await registry.register(definition)
-                await publish(definition, in: registry)
+            let published = remote.first { $0.entity == definition.entity }
+
+            if let published, published.version > definition.version {
                 continue
             }
-            guard published.version <= definition.version else { continue }
+
             try? await registry.register(definition)
+
             if published != definition {
                 await publish(definition, in: registry)
             }


### PR DESCRIPTION
The bootstrap loop registered and published each definition from two separate branches — one for the unpublished case and one for the up-to-date case. Keeping `published` as an optional lets both branches share a single `register` call and a single `publish` guard: skip only when a newer version is already published, otherwise register, and publish whenever the stored definition differs (which is always true when nothing is published yet).