### PR TITLE
Reuse Date.addingDay for the sync cleanup cutoff

### DIFF
--- a/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
@@ -9,9 +9,7 @@ import CoreData
 
 extension SyncableObject {
     static func cleanup(backends: [Backend], in context: NSManagedObjectContext) throws {
-        guard let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: Date()) else {
-            return
-        }
+        let cutoff = Date().addingDay(-7)
 
         let request = NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
         request.predicate = NSPredicate(


### PR DESCRIPTION
SyncableObject.cleanup built its seven-day cutoff with a raw Calendar.current.date(byAdding:) call guarded against an optional. The codebase already exposes Date().addingDay(-7), so this uses it and drops the guard.
