### PR TITLE
Extract a shared PercentileRow view

### DIFF
--- a/Sources/Scout/UI/Metrics/Distribution/PercentileRow.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/PercentileRow.swift
@@ -1,0 +1,22 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct PercentileRow: View {
+    let percentiles: LatencyPercentiles
+
+    var body: some View {
+        HStack(spacing: 34) {
+            Metric(title: "P50", value: percentiles.p50.duration, color: .blue)
+            Metric(title: "P90", value: percentiles.p90.duration, color: .teal)
+            Metric(title: "P99", value: percentiles.p99.duration, color: .orange)
+            Spacer()
+        }
+    }
+}

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
@@ -21,7 +21,7 @@ struct TimerDistributionView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 21) {
-            summary
+            PercentileRow(percentiles: percentiles)
 
             Text(verbatim: "P99 TREND")
                 .font(.system(size: 12, weight: .semibold))
@@ -30,15 +30,6 @@ struct TimerDistributionView: View {
             PercentileTrendChart(trend: trend, unit: unit)
         }
         .padding(.vertical)
-    }
-
-    private var summary: some View {
-        HStack(spacing: 34) {
-            Metric(title: "P50", value: percentiles.p50.duration, color: .blue)
-            Metric(title: "P90", value: percentiles.p90.duration, color: .teal)
-            Metric(title: "P99", value: percentiles.p99.duration, color: .orange)
-            Spacer()
-        }
     }
 }
 

--- a/Sources/Scout/UI/Network/View/NetworkEndpointDetailView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkEndpointDetailView.swift
@@ -27,13 +27,8 @@ struct NetworkEndpointDetailView: View {
 
             if let percentiles = distribution?.summary(in: range) {
                 Header(title: "Latency")
-                HStack(spacing: 34) {
-                    Metric(title: "P50", value: percentiles.p50.duration, color: .blue)
-                    Metric(title: "P90", value: percentiles.p90.duration, color: .teal)
-                    Metric(title: "P99", value: percentiles.p99.duration, color: .orange)
-                    Spacer()
-                }
-                .listRowSeparator(.hidden, edges: .bottom)
+                PercentileRow(percentiles: percentiles)
+                    .listRowSeparator(.hidden, edges: .bottom)
             }
 
             if let trend = distribution?.trend(in: range, component: unit), trend.count > 0 {


### PR DESCRIPTION
The P50/P90/P99 Metric row was duplicated verbatim in NetworkEndpointDetailView and TimerDistributionView. This pulls it into a single PercentileRow(percentiles:) that both call.
