### PR TITLE
Bucket version crashes per day in a single pass

### DIFF
--- a/Sources/Scout/UI/Releases/View/DailyCrashCount.swift
+++ b/Sources/Scout/UI/Releases/View/DailyCrashCount.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct DailyCrashCount: Equatable {
+    let date: Date
+    let count: Int
+}
+
+extension DailyCrashCount {
+    static func series(from crashes: [Crash], days: Int = 14, calendar: Calendar = .current, endingOn today: Date = Date()) -> [DailyCrashCount] {
+        let start = calendar.startOfDay(for: today)
+
+        var counts: [Date: Int] = [:]
+        for crash in crashes {
+            guard let date = crash.date else { continue }
+            counts[calendar.startOfDay(for: date), default: 0] += 1
+        }
+
+        return (0..<days).reversed().map { offset in
+            let day = calendar.date(byAdding: .day, value: -offset, to: start) ?? start
+            return DailyCrashCount(date: day, count: counts[day] ?? 0)
+        }
+    }
+}

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -62,22 +62,8 @@ struct VersionDetailView: View {
         .listRowSeparator(.hidden)
     }
 
-    private var dailyCrashes: [(date: Date, count: Int)] {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: Date())
-
-        return (0..<14).reversed().compactMap { offset in
-            guard let day = calendar.date(byAdding: .day, value: -offset, to: today) else {
-                return nil
-            }
-            let next = calendar.date(byAdding: .day, value: 1, to: day) ?? day
-            let count = crashes.filter { crash in
-                guard let date = crash.date else { return false }
-                return date >= day && date < next
-            }
-            .count
-            return (day, count)
-        }
+    private var dailyCrashes: [DailyCrashCount] {
+        DailyCrashCount.series(from: crashes)
     }
 
     @ViewBuilder

--- a/Tests/ScoutTests/UI/Releases/View/DailyCrashCountTests.swift
+++ b/Tests/ScoutTests/UI/Releases/View/DailyCrashCountTests.swift
@@ -1,0 +1,49 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct DailyCrashCountTests {
+    private let calendar = Calendar.current
+
+    @Test("Crashes bucket into per-day counts across the window") func testDailyBuckets() {
+        let today = calendar.startOfDay(for: Date())
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+
+        let crashes = [
+            Crash.stub(date: today.addingTimeInterval(3600)),
+            Crash.stub(date: today.addingTimeInterval(7200)),
+            Crash.stub(date: yesterday.addingTimeInterval(60)),
+        ]
+
+        let series = DailyCrashCount.series(from: crashes, days: 14, calendar: calendar, endingOn: today)
+
+        #expect(series.count == 14)
+        #expect(series.last?.date == today)
+        #expect(series.last?.count == 2)
+        #expect(series[12].count == 1)
+        #expect(series.dropLast(2).allSatisfy { $0.count == 0 })
+    }
+
+    @Test("Crashes outside the window and nil dates are ignored") func testOutOfWindow() {
+        let today = calendar.startOfDay(for: Date())
+        let old = calendar.date(byAdding: .day, value: -30, to: today)!
+
+        let series = DailyCrashCount.series(
+            from: [Crash.stub(date: old), Crash.stub(date: nil)],
+            days: 14,
+            calendar: calendar,
+            endingOn: today
+        )
+
+        #expect(series.count == 14)
+        #expect(series.allSatisfy { $0.count == 0 })
+    }
+}


### PR DESCRIPTION
VersionDetailView.dailyCrashes re-filtered the whole crash array once per day, fourteen scans on every body evaluation. This moves the aggregation into a tested DailyCrashCount.series(from:) that buckets by start-of-day in a single pass.
