### PR TITLE
Extract a shared UTCTimestampText view

### DIFF
--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -34,9 +34,7 @@ struct CrashDetailView: View {
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             if let date = crash.date {
-                Text(utcDateFormatter.string(from: date) + " UTC")
-                    .font(.system(size: 16))
-                    .monospaced()
+                UTCTimestampText(date: date)
             }
 
             if let reason = crash.reason {

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -59,9 +59,7 @@ struct CrashGroupDetailView: View {
         ForEach(group.crashes) { crash in
             Row {
                 if let date = crash.date {
-                    Text(utcDateFormatter.string(from: date) + " UTC")
-                        .font(.system(size: 14))
-                        .monospaced()
+                    UTCTimestampText(date: date, size: 14)
                 }
 
                 Spacer()

--- a/Sources/Scout/UI/Event/Detail/EventView.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.swift
@@ -53,9 +53,7 @@ extension EventView {
         var body: some View {
             VStack(alignment: .leading) {
                 if let date = event.date {
-                    Text(utcDateFormatter.string(from: date) + " UTC")
-                        .font(.system(size: 16))
-                        .monospaced()
+                    UTCTimestampText(date: date)
                 }
 
                 Spacer().frame(height: 10)

--- a/Sources/Scout/UI/Utilities/UTCTimestampText.swift
+++ b/Sources/Scout/UI/Utilities/UTCTimestampText.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct UTCTimestampText: View {
+    let date: Date
+    var size: CGFloat = 16
+
+    var body: some View {
+        Text(utcDateFormatter.string(from: date) + " UTC")
+            .font(.system(size: size))
+            .monospaced()
+    }
+}


### PR DESCRIPTION
The 'format the date as UTC, append UTC, and monospace it' line was copy-pasted across the crash and event detail headers. This extracts a UTCTimestampText(date:size:) view next to the shared formatter.
