### PR TITLE
Route count pluralization through ExportFormat.counted

### DIFF
--- a/Sources/Scout/UI/Event/Param/Value/ParamValue+Display.swift
+++ b/Sources/Scout/UI/Event/Param/Value/ParamValue+Display.swift
@@ -23,9 +23,9 @@ extension ParamValue {
         case .stringConvertible(let convertible):
             convertible.text
         case .dictionary(let entries):
-            entries.count == 1 ? "1 pair" : "\(entries.count) pairs"
+            ExportFormat.counted(entries.count, "pair", "pairs")
         case .array(let values):
-            values.count == 1 ? "1 item" : "\(values.count) items"
+            ExportFormat.counted(values.count, "item", "items")
         }
     }
 

--- a/Sources/Scout/UI/Settings/GlanceHero.swift
+++ b/Sources/Scout/UI/Settings/GlanceHero.swift
@@ -27,7 +27,7 @@ struct GlanceSummary {
     }
 
     var detail: String {
-        let count = total == 1 ? "1 backend" : "\(total) backends"
+        let count = ExportFormat.counted(total, "backend", "backends")
         return averageLatency.map { "\(count) · \($0) ms average latency" } ?? count
     }
 


### PR DESCRIPTION
GlanceHero and ParamValue+Display hand-wrote singular/plural strings that ExportFormat.counted already produces. This routes both through the existing helper.
