### PR TITLE
Reuse RedactedText for the events total in StatView

### DIFF
--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -56,7 +56,7 @@ struct StatView: View {
         Row {
             Text(verbatim: "Events")
             Spacer()
-            Text(count == 0 ? "—" : "\(count)")
+            RedactedText(count: count)
         } destination: {
             EventStatList(eventName: stat.eventName, range: extent.domain)
         }


### PR DESCRIPTION
StatView inlined the zero-to-em-dash idiom that RedactedText(count:) already owns. Reusing it also abbreviates large counts with .compact, matching the rest of the UI.
