### PR TITLE
Bind the Home log spans once per render

### DIFF
--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -32,6 +32,8 @@ struct HomeLogSection: View {
 
     @ViewBuilder
     private var logRows: some View {
+        let spans = logSpans
+
         HomeLogRow(
             title: "Events",
             image: "list.bullet",
@@ -64,7 +66,7 @@ struct HomeLogSection: View {
         )
     }
 
-    private var spans: (int: MatrixSpan<Int>, double: MatrixSpan<Double>)? {
+    private var logSpans: (int: MatrixSpan<Int>, double: MatrixSpan<Double>)? {
         guard let result = try? provider.result(for: period)?.get() else {
             return nil
         }


### PR DESCRIPTION
logRows read the spans property three to four times per render, rebuilding both MatrixSpans each time on the hot Home path. This binds it once to a local let.
