### PR TITLE
Share metric histogram bucketing between distributions

### DIFF
--- a/Sources/Scout/UI/Metrics/Distribution/LatencyHistogram.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/LatencyHistogram.swift
@@ -58,3 +58,9 @@ struct LatencyHistogram: Equatable {
         return lower + (upper - lower) * min(max(fraction, 0), 1)
     }
 }
+
+extension LatencyHistogram: MetricHistogram {
+    static func bucketIndex(of category: String) -> Int? {
+        LatencyBuckets.index(of: category)
+    }
+}

--- a/Sources/Scout/UI/Metrics/Distribution/MetricHistogram.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/MetricHistogram.swift
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+protocol MetricHistogram {
+    init()
+    mutating func add(count: Int, at index: Int)
+    static func bucketIndex(of category: String) -> Int?
+}
+
+extension MetricHistogram {
+    static func buckets(from series: [MetricSeries]) -> [Date: Self] {
+        var result: [Date: Self] = [:]
+
+        for singleSeries in series {
+            guard let category = singleSeries.category, let index = bucketIndex(of: category) else {
+                continue
+            }
+            for point in singleSeries.points {
+                let date = Date(millisecondsSince1970: point.date)
+                result[date, default: Self()].add(count: Int(point.value.doubleValue), at: index)
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistribution.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistribution.swift
@@ -16,21 +16,7 @@ struct TimerDistribution: Equatable {
     }
 
     init(series: [MetricSeries]) {
-        var histograms: [Date: LatencyHistogram] = [:]
-
-        for singleSeries in series {
-            guard let category = singleSeries.category else { continue }
-            guard let index = LatencyBuckets.index(of: category) else { continue }
-
-            for point in singleSeries.points {
-                let date = Date(millisecondsSince1970: point.date)
-                var histogram = histograms[date, default: LatencyHistogram()]
-                histogram.add(count: Int(point.value.doubleValue), at: index)
-                histograms[date] = histogram
-            }
-        }
-
-        self.histograms = histograms
+        self.init(histograms: LatencyHistogram.buckets(from: series))
     }
 
     var isEmpty: Bool {

--- a/Sources/Scout/UI/Network/Model/StatusBreakdown.swift
+++ b/Sources/Scout/UI/Network/Model/StatusBreakdown.swift
@@ -55,6 +55,12 @@ struct StatusBreakdown: Equatable {
     }
 }
 
+extension StatusBreakdown: MetricHistogram {
+    static func bucketIndex(of category: String) -> Int? {
+        StatusBuckets.index(of: category)
+    }
+}
+
 extension StatusBreakdown {
     static func sample(success: Int, redirect: Int = 0, clientError: Int = 0, serverError: Int = 0) -> StatusBreakdown {
         var breakdown = StatusBreakdown()

--- a/Sources/Scout/UI/Network/Model/StatusDistribution.swift
+++ b/Sources/Scout/UI/Network/Model/StatusDistribution.swift
@@ -16,21 +16,7 @@ struct StatusDistribution: Equatable {
     }
 
     init(series: [MetricSeries]) {
-        var breakdowns: [Date: StatusBreakdown] = [:]
-
-        for singleSeries in series {
-            guard let category = singleSeries.category else { continue }
-            guard let index = StatusBuckets.index(of: category) else { continue }
-
-            for point in singleSeries.points {
-                let date = Date(millisecondsSince1970: point.date)
-                var breakdown = breakdowns[date, default: StatusBreakdown()]
-                breakdown.add(count: Int(point.value.doubleValue), at: index)
-                breakdowns[date] = breakdown
-            }
-        }
-
-        self.breakdowns = breakdowns
+        self.init(breakdowns: StatusBreakdown.buckets(from: series))
     }
 
     var isEmpty: Bool {


### PR DESCRIPTION
TimerDistribution and StatusDistribution had identical [Date: bucket] accumulation loops. This adds a MetricHistogram protocol with a shared buckets(from:) builder that both init(series:) delegate to.
