### PR TITLE
Extract a shared SummaryRow for activity and stat rows

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityRow.swift
+++ b/Sources/Scout/UI/Activity/ActivityRow.swift
@@ -17,22 +17,13 @@ struct ActivityRow: View {
     var body: some View {
         let days = days
 
-        Row {
-            if let systemImage {
-                Image(systemName: systemImage)
-                    .foregroundColor(color)
-                    .frame(width: 24)
-            }
-            Text(period.title)
-                .foregroundColor(.primary)
-            Spacer()
-
-            RowSummary(
-                series: days.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .latest) },
-                count: days?.max()?.count,
-                color: color
-            )
-        } destination: {
+        SummaryRow(
+            title: period.title,
+            color: color,
+            systemImage: systemImage,
+            series: days.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .latest) },
+            count: days?.max()?.count
+        ) {
             ActivityView(activity: activity, period: period)
         }
     }

--- a/Sources/Scout/UI/Primitives/Rows/SummaryRow.swift
+++ b/Sources/Scout/UI/Primitives/Rows/SummaryRow.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct SummaryRow<Destination: View>: View {
+    let title: String
+    let color: Color
+    var titleColor: Color = .primary
+    var systemImage: String? = nil
+    let series: MiniChartSeries?
+    let count: Int?
+    @ViewBuilder let destination: () -> Destination
+
+    var body: some View {
+        Row {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .foregroundColor(color)
+                    .frame(width: 24)
+            }
+            Text(title)
+                .foregroundColor(titleColor)
+            Spacer()
+
+            RowSummary(series: series, count: count, color: color)
+        } destination: {
+            destination()
+        }
+    }
+}

--- a/Sources/Scout/UI/Stats/StatRow.swift
+++ b/Sources/Scout/UI/Stats/StatRow.swift
@@ -18,24 +18,15 @@ struct StatRow<Destination: View>: View {
     var body: some View {
         let points = points
 
-        Row {
-            if let systemImage {
-                Image(systemName: systemImage)
-                    .foregroundColor(color)
-                    .frame(width: 24)
-            }
-            Text(period.title)
-                .foregroundColor(systemImage == nil ? color : .primary)
-            Spacer()
-
-            RowSummary(
-                series: points.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .total) },
-                count: points?.bucket(on: period).total,
-                color: color
-            )
-        } destination: {
-            destination()
-        }
+        SummaryRow(
+            title: period.title,
+            color: color,
+            titleColor: systemImage == nil ? color : .primary,
+            systemImage: systemImage,
+            series: points.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .total) },
+            count: points?.bucket(on: period).total,
+            destination: destination
+        )
     }
 
     /// All fetched points; `nil` while the provider is still loading.


### PR DESCRIPTION
ActivityRow and StatRow repeated the same icon, title, RowSummary, and destination scaffold. This extracts a SummaryRow that both build, keeping each row's own provider, period, and aggregation.
