### PR TITLE
Share a Ratio protocol between Adoption and Stability

### DIFF
--- a/Sources/Scout/UI/Releases/Health/Adoption.swift
+++ b/Sources/Scout/UI/Releases/Health/Adoption.swift
@@ -7,14 +7,10 @@
 
 import Foundation
 
-struct Adoption: ExpressibleByFloatLiteral {
+struct Adoption: Ratio {
     let value: Double
 
     init(_ value: Double) {
-        self.value = value
-    }
-
-    init(floatLiteral value: Double) {
         self.value = value
     }
 

--- a/Sources/Scout/UI/Releases/Health/Ratio.swift
+++ b/Sources/Scout/UI/Releases/Health/Ratio.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+protocol Ratio: ExpressibleByFloatLiteral {
+    var value: Double { get }
+    init(_ value: Double)
+}
+
+extension Ratio {
+    init(floatLiteral value: Double) {
+        self.init(value)
+    }
+
+    func percentage(fractionDigits: Int) -> String {
+        String(format: "%.\(fractionDigits)f%%", value * 100)
+    }
+}

--- a/Sources/Scout/UI/Releases/Health/Stability.swift
+++ b/Sources/Scout/UI/Releases/Health/Stability.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Stability {
+struct Stability: Ratio {
     let value: Double
 
     init(_ value: Double) {
@@ -24,13 +24,7 @@ struct Stability {
     }
 
     var formatted: String {
-        String(format: "%.2f%%", value * 100)
-    }
-}
-
-extension Stability: ExpressibleByFloatLiteral {
-    init(floatLiteral value: Double) {
-        self.value = value
+        percentage(fractionDigits: 2)
     }
 }
 


### PR DESCRIPTION
Adoption and Stability duplicated the float-literal ratio-wrapper scaffolding. This adds a Ratio protocol that provides the literal initializer and a percentage formatter; each type keeps its own ratio computation and precision.
