### PR TITLE
Add a generic Core Data fetch helper for lifecycle relations

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Base/NSManagedObjectContext+Fetch.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/NSManagedObjectContext+Fetch.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension NSManagedObjectContext {
+    func objects<T: NSManagedObject>(_ type: T.Type, where format: String, _ args: Any..., dateAscending: Bool? = nil, limit: Int? = nil) throws -> [T] {
+        let request = NSFetchRequest<T>(entityName: String(describing: type))
+        request.predicate = NSPredicate(format: format, argumentArray: args)
+
+        if let dateAscending {
+            request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: dateAscending)]
+        }
+        if let limit {
+            request.fetchLimit = limit
+        }
+
+        return try fetch(request)
+    }
+}

--- a/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
@@ -17,10 +17,6 @@ class TrackedObject: SyncableObject {
     }
 
     func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
-        let request = NSFetchRequest<TrackedObject>(entityName: "TrackedObject")
-        request.predicate = NSPredicate(format: "sessionID == %@", sessionID as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
-        request.fetchLimit = 1
-        return try context.fetch(request).first?.date
+        try context.objects(TrackedObject.self, where: "sessionID == %@", sessionID, dateAscending: false, limit: 1).first?.date
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
@@ -12,10 +12,7 @@ final class DeviceObject: SyncableObject {
     static let recordType = "Device"
 
     func installs(in context: NSManagedObjectContext) throws -> [InstallObject] {
-        let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
-        request.predicate = NSPredicate(format: "deviceID == %@", deviceID as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
-        return try context.fetch(request)
+        try context.objects(InstallObject.self, where: "deviceID == %@", deviceID, dateAscending: true)
     }
 }
 

--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
@@ -12,10 +12,7 @@ final class InstallObject: SyncableObject {
     static let recordType = "Install"
 
     func versions(in context: NSManagedObjectContext) throws -> [VersionObject] {
-        let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        request.predicate = NSPredicate(format: "installID == %@", installID as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
-        return try context.fetch(request)
+        try context.objects(VersionObject.self, where: "installID == %@", installID, dateAscending: true)
     }
 }
 

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
@@ -14,17 +14,11 @@ final class LaunchObject: SyncableObject {
     @NSManaged var endDate: Date?
 
     func sessions(in context: NSManagedObjectContext) throws -> [SessionObject] {
-        let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
-        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
-        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
-        return try context.fetch(request)
+        try context.objects(SessionObject.self, where: "launchID == %@", launchID, dateAscending: true)
     }
 
     func version(in context: NSManagedObjectContext) throws -> VersionObject? {
-        let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
-        request.fetchLimit = 1
-        return try context.fetch(request).first
+        try context.objects(VersionObject.self, where: "launchID == %@", launchID, limit: 1).first
     }
 }
 

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
@@ -15,10 +15,7 @@ final class SessionObject: TrackedObject {
     @NSManaged var endDate: Date?
 
     func launch(in context: NSManagedObjectContext) throws -> LaunchObject? {
-        let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
-        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
-        request.fetchLimit = 1
-        return try context.fetch(request).first
+        try context.objects(LaunchObject.self, where: "launchID == %@", launchID, limit: 1).first
     }
 }
 

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
@@ -15,22 +15,14 @@ final class VersionObject: SyncableObject {
     @NSManaged var buildNumber: String?
 
     func install(in context: NSManagedObjectContext) throws -> InstallObject? {
-        let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
-        request.predicate = NSPredicate(format: "installID == %@", installID as CVarArg)
-        request.fetchLimit = 1
-        return try context.fetch(request).first
+        try context.objects(InstallObject.self, where: "installID == %@", installID, limit: 1).first
     }
 
     func launches(in context: NSManagedObjectContext) throws -> [LaunchObject] {
-        let versionRequest = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        versionRequest.predicate = NSPredicate(format: "appVersion == %@", appVersion!)
-        let versions = try context.fetch(versionRequest)
+        let versions = try context.objects(VersionObject.self, where: "appVersion == %@", appVersion!)
         let launchIDs = versions.compactMap(\.launchID)
 
-        let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
-        request.predicate = NSPredicate(format: "launchID IN %@", launchIDs)
-        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
-        return try context.fetch(request)
+        return try context.objects(LaunchObject.self, where: "launchID IN %@", launchIDs, dateAscending: true)
     }
 }
 


### PR DESCRIPTION
Each lifecycle object hand-built an NSFetchRequest with a predicate, an optional date sort, and an optional limit. This adds context.objects(_:where:dateAscending:limit:) and routes the relation lookups through it, which also folds away the repeated date sort descriptor.
