### PR TITLE
Present the dashboard through a scoutHome modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 | 💥 | **Crash Reporting** | Captures uncaught exceptions and signals (SIGABRT, SIGSEGV, etc.) with stack traces. Reports are flushed on the next launch. |
 | ☁️ | **CloudKit Sync** | All data is stored locally with Core Data and synced to a public [CloudKit](https://developer.apple.com/icloud/cloudkit/) database. No custom backend required. |
 | 🌐 | **Multiple Backends** | Sync to CloudKit, to one or more self-hosted [Scout servers](https://github.com/kasianov-mikhail/scout-server), or to any combination of them at once. |
-| 📱 | **SwiftUI Dashboard** | A built-in `HomeView` with charts, event lists, crash details, and activity tracking for debugging in development builds. |
+| 📱 | **SwiftUI Dashboard** | A built-in dashboard with charts, event lists, crash details, and activity tracking for debugging in development builds. |
 
 ## Requirements
 
@@ -53,13 +53,14 @@ For the full walkthrough — backends, logging, and metrics — see the [Usage G
 
 ## Dashboard
 
-Present `HomeView` to browse logs, metrics, crashes, and user activity. Hand it the same backend list you passed to `setup`:
+Attach `scoutHome(isPresented:backends:)` to a view to present the dashboard — logs, metrics, crashes, and user activity — over it. Drive it with a `Bool` binding and hand it the same backend list you passed to `setup`:
 ```swift
-HomeView(backends: [.cloudKit(container)])
+Button("Scout") { isPresented = true }
+    .scoutHome(isPresented: $isPresented, backends: [.cloudKit(container)])
 ```
 Or point it at a Scout server:
 ```swift
-HomeView(backends: [.server(url: serverURL, apiKey: "YOUR_API_KEY")])
+.scoutHome(isPresented: $isPresented, backends: [.server(url: serverURL, apiKey: "YOUR_API_KEY")])
 ```
 > Use this only in debug builds to avoid exposing log data in production.
 

--- a/Sources/Scout/Native/Store/NativeBackend.swift
+++ b/Sources/Scout/Native/Store/NativeBackend.swift
@@ -57,16 +57,8 @@ extension EntityCatalog {
             try? await registry.register(definition)
 
             if published != definition {
-                await publish(definition, in: registry)
+                try? await registry.publish(definition)
             }
-        }
-    }
-
-    private static func publish(_ definition: EntityDefinition, in registry: SchemaRegistry) async {
-        do {
-            try await registry.publish(definition)
-        } catch {
-            await MainActor.run { schemaBootstrapMessage.value = error.localizedDescription }
         }
     }
 }

--- a/Sources/Scout/UI/Home/Connection/ConnectionToolbar.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionToolbar.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension View {
+    func connectionToolbar(backends: [Backend], activeID: Binding<String>) -> some View {
+        modifier(ConnectionToolbar(backends: backends, activeID: activeID))
+    }
+}
+
+private struct ConnectionToolbar: ViewModifier {
+    let backends: [Backend]
+    @Binding var activeID: String
+
+    @State private var isSettingsPresented = false
+
+    func body(content: Content) -> some View {
+        content
+            .toolbar {
+                if !backends.isEmpty {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        ConnectionMenu(
+                            connections: backends.map(Connection.init),
+                            activeID: $activeID,
+                            onSettings: { isSettingsPresented = true }
+                        )
+                    }
+                }
+            }
+            .sheet(isPresented: $isSettingsPresented) {
+                NavigationStack {
+                    SettingsOverviewView(backends: backends, activeID: $activeID)
+                        .dismissable()
+                }
+            }
+    }
+}

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -62,6 +62,7 @@ struct HomeContent: View {
                 .ignoresSafeArea()
         }
         .toolbarBackground(.visible, for: .navigationBar)
+        .onboardingSheet()
     }
 
     private func fetch(_ section: HomeSection) {

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -7,17 +7,30 @@
 
 import SwiftUI
 
-@MainActor let schemaBootstrapMessage = Box<String?>(nil)
+extension View {
+    /// Presents the Scout home screen modally over this view.
+    ///
+    /// The screen is always shown as a full-screen cover, never pushed onto a navigation stack, so
+    /// it keeps its own navigation and environment self-contained.
+    ///
+    /// - Parameters:
+    ///   - isPresented: A binding that controls whether the home screen is shown.
+    ///   - backends: The backends to inspect.
+    ///
+    public func scoutHome(isPresented: Binding<Bool>, backends: [Backend]) -> some View {
+        fullScreenCover(isPresented: isPresented) {
+            HomeView(backends: backends)
+        }
+    }
+}
 
-public struct HomeView: View {
+struct HomeView: View {
     let backends: [Backend]
 
     @AppStorage("scout_active_backend") private var activeID = ""
     @StateObject private var tint = Tint()
-    @ObservedObject private var schema = schemaBootstrapMessage
-    @State private var isSettingsPresented = false
 
-    public init(backends: [Backend]) {
+    init(backends: [Backend]) {
         self.backends = backends
     }
 
@@ -29,18 +42,13 @@ public struct HomeView: View {
         Binding(get: { backend?.id ?? "" }, set: { activeID = $0 })
     }
 
-    public var body: some View {
+    var body: some View {
         NavigationStack {
             Group {
                 if let backend {
-                    if let message = schema.value {
-                        ErrorView(description: Text(verbatim: message), retry: nil)
-                    } else {
-                        HomeContent()
-                            .id(backend.id)
-                            .accountWarning(backend)
-                            .onboardingSheet()
-                    }
+                    HomeContent()
+                        .id(backend.id)
+                        .iCloudWarning(backend.accountWarning)
                 } else {
                     ErrorView(
                         description: Text(verbatim: "Pass at least one backend to inspect Scout data."),
@@ -50,23 +58,7 @@ public struct HomeView: View {
             }
             .navigationTitle(en: "Home")
             .dismissable()
-            .toolbar {
-                if backend != nil {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        ConnectionMenu(
-                            connections: backends.map(Connection.init),
-                            activeID: activeIDBinding,
-                            onSettings: { isSettingsPresented = true }
-                        )
-                    }
-                }
-            }
-            .sheet(isPresented: $isSettingsPresented) {
-                NavigationStack {
-                    SettingsOverviewView(backends: backends, activeID: activeIDBinding)
-                        .dismissable()
-                }
-            }
+            .connectionToolbar(backends: backends, activeID: activeIDBinding)
         }
         .tint(tint.value)
         .environment(\.database, backend?.database ?? DefaultDatabase())

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -16,6 +16,7 @@ extension View {
     /// - Parameters:
     ///   - isPresented: A binding that controls whether the home screen is shown.
     ///   - backends: The backends to inspect.
+    /// - Returns: A view that presents the dashboard over this view while `isPresented` is `true`.
     ///
     public func scoutHome(isPresented: Binding<Bool>, backends: [Backend]) -> some View {
         fullScreenCover(isPresented: isPresented) {

--- a/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
+++ b/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
@@ -8,21 +8,21 @@
 import SwiftUI
 
 extension View {
-    func accountWarning(_ backend: Backend) -> some View {
-        modifier(AccountWarningModifier(backend: backend))
+    func iCloudWarning(_ warning: @escaping @Sendable () async -> Bool) -> some View {
+        modifier(ICloudWarningModifier(warning: warning))
     }
 }
 
-private struct AccountWarningModifier: ViewModifier {
-    let backend: Backend
+private struct ICloudWarningModifier: ViewModifier {
+    let warning: @Sendable () async -> Bool
 
-    @State private var warning = false
+    @State private var isWarning = false
     @State private var isAlertPresented = false
 
     func body(content: Content) -> some View {
         content
             .toolbar {
-                if warning {
+                if isWarning {
                     ToolbarItem(placement: .topBarLeading) {
                         Button {
                             isAlertPresented = true
@@ -50,6 +50,6 @@ private struct AccountWarningModifier: ViewModifier {
     }
 
     private func verify() async {
-        warning = await backend.accountWarning()
+        isWarning = await warning()
     }
 }


### PR DESCRIPTION
Replaces the public `HomeView` with a `scoutHome(isPresented:backends:)` modifier that presents the dashboard as a full-screen cover, and keeps `HomeView` internal so it can no longer be pushed onto a navigation stack — pushing nested its own stack and dropped the `Tint` environment its detail screens rely on. Along the way it extracts the connection menu and settings sheet into a `ConnectionToolbar` modifier, renames the account-warning modifier to `iCloudWarning` and narrows it to just the availability check, moves the onboarding sheet into `HomeContent`, and drops the unused schema-bootstrap error message now that it is no longer surfaced. Companion scout-ip change adopts the new modifier.