### PR TITLE
Scroll the Home section picker with the list rows

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -31,31 +31,29 @@ struct HomeContent: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        List {
             HomeSectionPicker(selection: $section)
-                .padding(.horizontal)
                 .padding(.top, 8)
                 .padding(.bottom, 4)
+                .listRowSeparator(.hidden)
                 .onAppear { fetch(section) }
                 .onChange(of: section) { fetch($0) }
 
-            List {
-                HomeStatSection(
-                    section: section,
-                    activity: activity,
-                    sessionStat: sessionStat,
-                    crashStat: crashStat
-                )
-                HomeLogSection()
-                HomeReleaseSection(provider: releaseProvider, showReleaseHealth: $showReleaseHealth)
-            }
-            .navigationDestination(isPresented: $showReleaseHealth) {
-                ReleaseHealthView(provider: releaseProvider)
-            }
-            .listStyle(.plain)
-            .imageScale(.medium)
-            .scrollContentBackground(.hidden)
+            HomeStatSection(
+                section: section,
+                activity: activity,
+                sessionStat: sessionStat,
+                crashStat: crashStat
+            )
+            HomeLogSection()
+            HomeReleaseSection(provider: releaseProvider, showReleaseHealth: $showReleaseHealth)
         }
+        .navigationDestination(isPresented: $showReleaseHealth) {
+            ReleaseHealthView(provider: releaseProvider)
+        }
+        .listStyle(.plain)
+        .imageScale(.medium)
+        .scrollContentBackground(.hidden)
         .background {
             Rectangle()
                 .fill(.background)

--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -25,9 +25,12 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
     var body: some View {
         switch distribution {
         case .compact(let spacing):
-            HStack(spacing: spacing) {
-                segments
+            ScrollView(.horizontal) {
+                HStack(spacing: spacing) {
+                    segments
+                }
             }
+            .scrollIndicators(.hidden)
             .frame(maxWidth: .infinity, alignment: .leading)
         case .justified:
             JustifiedLayout {

--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -25,12 +25,9 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
     var body: some View {
         switch distribution {
         case .compact(let spacing):
-            ScrollView(.horizontal) {
-                HStack(spacing: spacing) {
-                    segments
-                }
+            HStack(spacing: spacing) {
+                segments
             }
-            .scrollIndicators(.hidden)
             .frame(maxWidth: .infinity, alignment: .leading)
         case .justified:
             JustifiedLayout {


### PR DESCRIPTION
Moves the Home section picker (Users/Sessions/Crashes) from a fixed header above the list into the list itself as its first row, so it scrolls away vertically together with the stat rows and sections below instead of staying pinned. Horizontal insets now come from the plain list row so the strip aligns with the section headers.