### PR TITLE
Move the HomeContent init into an extension

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -18,18 +18,6 @@ struct HomeContent: View {
     @StateObject private var releaseProvider: ReleaseHealthProvider
     @State private var showReleaseHealth = false
 
-    init(
-        activity: ActivityProvider = ActivityProvider(),
-        sessionStat: StatProvider = StatProvider(eventName: "Session", periods: Period.summary),
-        crashStat: StatProvider = StatProvider(eventName: "Crash", periods: Period.summary),
-        releaseProvider: ReleaseHealthProvider = ReleaseHealthProvider()
-    ) {
-        self._activity = StateObject(wrappedValue: activity)
-        self._sessionStat = StateObject(wrappedValue: sessionStat)
-        self._crashStat = StateObject(wrappedValue: crashStat)
-        self._releaseProvider = StateObject(wrappedValue: releaseProvider)
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             HomeSectionPicker(selection: $section)
@@ -78,8 +66,23 @@ struct HomeContent: View {
     }
 }
 
+extension HomeContent {
+    init(activity: ActivityProvider, sessionStat: StatProvider, crashStat: StatProvider, releaseProvider: ReleaseHealthProvider) {
+        self._activity = StateObject(wrappedValue: activity)
+        self._sessionStat = StateObject(wrappedValue: sessionStat)
+        self._crashStat = StateObject(wrappedValue: crashStat)
+        self._releaseProvider = StateObject(wrappedValue: releaseProvider)
+    }
+}
+
 #Preview {
     NavigationStack {
-        HomeContent(releaseProvider: .fixture()).navigationTitle("Home")
+        HomeContent(
+            activity: ActivityProvider(),
+            sessionStat: StatProvider(eventName: "Session", periods: Period.summary),
+            crashStat: StatProvider(eventName: "Crash", periods: Period.summary),
+            releaseProvider: .fixture()
+        )
+        .navigationTitle("Home")
     }
 }

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -43,8 +43,8 @@ public struct HomeView: View {
                             releaseProvider: ReleaseHealthProvider()
                         )
                         .id(backend.id)
-                            .accountWarning(backend)
-                            .onboardingSheet()
+                        .accountWarning(backend)
+                        .onboardingSheet()
                     }
                 } else {
                     ErrorView(

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -36,8 +36,13 @@ public struct HomeView: View {
                     if let message = schema.value {
                         ErrorView(description: Text(verbatim: message), retry: nil)
                     } else {
-                        HomeContent()
-                            .id(backend.id)
+                        HomeContent(
+                            activity: ActivityProvider(),
+                            sessionStat: StatProvider(eventName: "Session", periods: Period.summary),
+                            crashStat: StatProvider(eventName: "Crash", periods: Period.summary),
+                            releaseProvider: ReleaseHealthProvider()
+                        )
+                        .id(backend.id)
                             .accountWarning(backend)
                             .onboardingSheet()
                     }


### PR DESCRIPTION
Removes the default parameter values from HomeContent's memberwise-style initializer and relocates the initializer into an extension, keeping the stored properties in the main struct body. HomeView and the preview now pass the previously-defaulted providers explicitly.