### PR TITLE
Populate the Home preview with provider fixtures

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -25,3 +25,27 @@ struct ActivityPoint: Decodable {
     let wau: Int
     let mau: Int
 }
+
+extension ActivityProvider {
+    static func fixture() -> ActivityProvider {
+        let provider = ActivityProvider()
+        provider.result = .success(ActivityPoint.samples)
+        return provider
+    }
+}
+
+extension ActivityPoint {
+    static var samples: [ActivityPoint] {
+        let end = Date().startOfDay
+        return (0..<365).compactMap { day in
+            Calendar.utc.date(byAdding: .day, value: -day, to: end).map {
+                ActivityPoint(
+                    date: $0.millisecondsSince1970,
+                    dau: .random(in: 50...200),
+                    wau: .random(in: 300...600),
+                    mau: .random(in: 800...1500)
+                )
+            }
+        }
+    }
+}

--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -77,9 +77,9 @@ extension HomeContent {
 #Preview {
     NavigationStack {
         HomeContent(
-            activity: ActivityProvider(),
-            sessionStat: StatProvider(eventName: "Session", periods: Period.summary),
-            crashStat: StatProvider(eventName: "Crash", periods: Period.summary),
+            activity: .fixture(),
+            sessionStat: .fixture(eventName: "Session"),
+            crashStat: .fixture(eventName: "Crash"),
             releaseProvider: .fixture()
         )
         .navigationTitle("Home")

--- a/Sources/Scout/UI/Stats/StatProvider.swift
+++ b/Sources/Scout/UI/Stats/StatProvider.swift
@@ -25,3 +25,18 @@ class StatProvider: QueryProvider<GridMatrix<Int>> {
         }
     }
 }
+
+extension StatProvider {
+    static func fixture(eventName: String) -> StatProvider {
+        let provider = StatProvider(eventName: eventName, periods: Period.summary)
+        provider.result = .success([sampleMatrix(name: eventName)])
+        return provider
+    }
+
+    private static func sampleMatrix(name: String) -> GridMatrix<Int> {
+        let cells = (1...372).map { day in
+            GridCell(row: day, column: 12, value: Int.random(in: 5...80))
+        }
+        return Matrix(date: Calendar.utc.defaultRange.lowerBound, name: name, cells: cells)
+    }
+}


### PR DESCRIPTION
Adds StatProvider.fixture(eventName:) and ActivityProvider.fixture() preloaded with a year of sample data, matching the existing fixture convention used by ReleaseHealthProvider. The HomeContent preview now builds all four providers from fixtures, so the session, crash, and activity sections render populated instead of empty. Follows up on #785, which made the preview construct these providers explicitly.