### PR TITLE
Populate the crash and event previews with provider fixtures

### DIFF
--- a/Sources/Scout/UI/Crash/Crash.swift
+++ b/Sources/Scout/UI/Crash/Crash.swift
@@ -174,3 +174,22 @@ extension Crash {
         "1   Scout                 0x0 closure #1 in ImageLoader.load() + 96",
     ]
 }
+
+extension [Crash] {
+    static var samples: [Crash] {
+        let counts: KeyValuePairs<String, Int> = ["NSRangeException": 8, "Fatal error": 4, "SIGSEGV": 2]
+
+        var crashes: [Crash] = []
+        var index = 0
+
+        for (name, count) in counts {
+            for _ in 0..<count {
+                let date = Date(timeIntervalSinceNow: -Double(index % 13) * 86_400 - Double(index) * 600)
+                crashes.append(.sample(name, at: date, sessionID: UUID()))
+                index += 1
+            }
+        }
+
+        return crashes
+    }
+}

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -9,7 +9,11 @@ import SwiftUI
 
 struct CrashListView: View {
     @Environment(\.database) var database
-    @StateObject private var provider = CrashProvider()
+    @StateObject private var provider: CrashProvider
+
+    init(provider: CrashProvider? = nil) {
+        self._provider = StateObject(wrappedValue: provider ?? CrashProvider())
+    }
 
     var body: some View {
         Group {
@@ -70,7 +74,7 @@ struct CrashListView: View {
 
 #Preview {
     NavigationStack {
-        CrashListView()
+        CrashListView(provider: .fixture())
     }
 }
 

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -51,3 +51,11 @@ class CrashProvider: ObservableObject {
         }
     }
 }
+
+extension CrashProvider {
+    static func fixture() -> CrashProvider {
+        let provider = CrashProvider()
+        provider.groups = CrashGroup.groups(from: .samples)
+        return provider
+    }
+}

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -10,10 +10,14 @@ import SwiftUI
 struct AnalyticsView: View {
     @State private var filter = Event.Query()
 
-    @StateObject private var provider = EventProvider()
+    @StateObject private var provider: EventProvider
     @StateObject private var search = EventProvider()
 
     @Environment(\.database) var database
+
+    init(provider: EventProvider? = nil) {
+        self._provider = StateObject(wrappedValue: provider ?? EventProvider())
+    }
 
     var body: some View {
         Group {
@@ -103,7 +107,7 @@ extension View {
 
 #Preview {
     NavigationStack {
-        AnalyticsView()
+        AnalyticsView(provider: .fixture())
             .environmentObject(Tint())
     }
 }

--- a/Sources/Scout/UI/Event/List/EventStatList.swift
+++ b/Sources/Scout/UI/Event/List/EventStatList.swift
@@ -11,8 +11,14 @@ struct EventStatList: View {
     let eventName: String
     let range: Range<Date>
 
-    @StateObject private var provider = EventProvider()
+    @StateObject private var provider: EventProvider
     @Environment(\.database) var database
+
+    init(eventName: String, range: Range<Date>, provider: EventProvider? = nil) {
+        self.eventName = eventName
+        self.range = range
+        self._provider = StateObject(wrappedValue: provider ?? EventProvider())
+    }
 
     let formatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -42,6 +48,6 @@ struct EventStatList: View {
 
 #Preview {
     NavigationStack {
-        EventStatList(eventName: "Event", range: Period.week.initialRange)
+        EventStatList(eventName: "Event", range: Period.week.initialRange, provider: .fixture())
     }
 }

--- a/Sources/Scout/UI/Event/Model/Event.swift
+++ b/Sources/Scout/UI/Event/Model/Event.swift
@@ -66,3 +66,16 @@ extension Event {
         )
     }
 }
+
+extension [Event] {
+    static var samples: [Event] {
+        let names = ["app_launch", "screen_view", "button_tap", "purchase", "login", "logout"]
+        return (0..<40).map { index in
+            Event.sample(
+                names[index % names.count],
+                at: Date(timeIntervalSinceNow: -Double(index) * 1800),
+                sessionID: UUID()
+            )
+        }
+    }
+}

--- a/Sources/Scout/UI/Event/Provider/EventProvider.swift
+++ b/Sources/Scout/UI/Event/Provider/EventProvider.swift
@@ -53,3 +53,11 @@ class EventProvider: ObservableObject {
         }
     }
 }
+
+extension EventProvider {
+    static func fixture() -> EventProvider {
+        let provider = EventProvider()
+        provider.events = .samples
+        return provider
+    }
+}

--- a/Sources/Scout/UI/Releases/View/VersionCrashProvider.swift
+++ b/Sources/Scout/UI/Releases/View/VersionCrashProvider.swift
@@ -49,22 +49,3 @@ extension VersionCrashProvider {
         VersionCrashProvider(version: "3.2.0", crashes: .samples)
     }
 }
-
-extension [Crash] {
-    fileprivate static var samples: [Crash] {
-        let counts: KeyValuePairs<String, Int> = ["NSRangeException": 8, "Fatal error": 4, "SIGSEGV": 2]
-
-        var crashes: [Crash] = []
-        var index = 0
-
-        for (name, count) in counts {
-            for _ in 0..<count {
-                let date = Date(timeIntervalSinceNow: -Double(index % 13) * 86_400 - Double(index) * 600)
-                crashes.append(.sample(name, at: date, sessionID: UUID()))
-                index += 1
-            }
-        }
-
-        return crashes
-    }
-}


### PR DESCRIPTION
Adds CrashProvider.fixture() and EventProvider.fixture() preloaded with sample data, following the fixture convention used by ReleaseHealthProvider and extended to StatProvider and ActivityProvider in #786. CrashListView, EventStatList, and AnalyticsView gain injectable provider inits so their previews render populated crash and event lists instead of a spinner. The shared [Crash].samples builder moves from VersionCrashProvider into Crash.swift so both crash fixtures reuse it, and a new [Event].samples backs the event fixture.