### PR TITLE
Extract a shared BenchmarkButton view

### DIFF
--- a/Sources/Scout/UI/Settings/BackendDetailView.swift
+++ b/Sources/Scout/UI/Settings/BackendDetailView.swift
@@ -14,7 +14,6 @@ struct BackendDetailView: View {
     @Binding var activeID: String
 
     @State private var isChecking = false
-    @State private var isBenchmarking = false
     @State private var message: Message?
 
     private var backend: BackendHealth? {
@@ -114,29 +113,7 @@ struct BackendDetailView: View {
             .disabled(isChecking)
 
             if let benchmark = backend.runBenchmark {
-                Button {
-                    isBenchmarking = true
-                    Task {
-                        let passed = await benchmark()
-                        isBenchmarking = false
-                        message = Message(
-                            passed
-                                ? "Parallelism limit verified: \(RequestLimiter.requestLimit) in-flight requests hold up."
-                                : "Parallelism check failed — see the console log.",
-                            level: passed ? .success : .warning
-                        )
-                    }
-                } label: {
-                    HStack {
-                        Text(verbatim: "Run Parallelism Benchmark")
-                            .foregroundStyle(.tint)
-                        if isBenchmarking {
-                            Spacer()
-                            ProgressView()
-                        }
-                    }
-                }
-                .disabled(isBenchmarking)
+                BenchmarkButton(benchmark: benchmark, message: $message)
 
                 Text(verbatim: "The benchmark issues test queries to verify the \(RequestLimiter.requestLimit)-request limit.")
                     .font(.caption)

--- a/Sources/Scout/UI/Settings/BenchmarkButton.swift
+++ b/Sources/Scout/UI/Settings/BenchmarkButton.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct BenchmarkButton: View {
+    let benchmark: @Sendable () async -> Bool
+    @Binding var message: Message?
+
+    @State private var isBenchmarking = false
+
+    var body: some View {
+        Button {
+            isBenchmarking = true
+            Task {
+                let passed = await benchmark()
+                isBenchmarking = false
+                message = Message(
+                    passed
+                        ? "Parallelism limit verified: \(RequestLimiter.requestLimit) in-flight requests hold up."
+                        : "Parallelism check failed — see the console log.",
+                    level: passed ? .success : .warning
+                )
+            }
+        } label: {
+            HStack {
+                Text(verbatim: "Run Parallelism Benchmark")
+                    .foregroundStyle(.tint)
+                if isBenchmarking {
+                    Spacer()
+                    ProgressView()
+                }
+            }
+        }
+        .disabled(isBenchmarking)
+    }
+}

--- a/Sources/Scout/UI/Settings/SettingsOverviewView.swift
+++ b/Sources/Scout/UI/Settings/SettingsOverviewView.swift
@@ -12,7 +12,6 @@ struct SettingsOverviewView: View {
     @Binding var activeID: String
     @StateObject private var provider: BackendHealthProvider
 
-    @State private var isBenchmarking = false
     @State private var message: Message?
 
     init(backends: [Backend], activeID: Binding<String>, provider: BackendHealthProvider? = nil) {
@@ -50,29 +49,7 @@ struct SettingsOverviewView: View {
             }
 
             if let benchmark {
-                Button {
-                    isBenchmarking = true
-                    Task {
-                        let passed = await benchmark()
-                        isBenchmarking = false
-                        message = Message(
-                            passed
-                                ? "Parallelism limit verified: \(RequestLimiter.requestLimit) in-flight requests hold up."
-                                : "Parallelism check failed — see the console log.",
-                            level: passed ? .success : .warning
-                        )
-                    }
-                } label: {
-                    HStack {
-                        Text(verbatim: "Run Parallelism Benchmark")
-                            .foregroundStyle(.tint)
-                        if isBenchmarking {
-                            Spacer()
-                            ProgressView()
-                        }
-                    }
-                }
-                .disabled(isBenchmarking)
+                BenchmarkButton(benchmark: benchmark, message: $message)
             }
         }
         .listStyle(.plain)


### PR DESCRIPTION
The parallelism benchmark button was duplicated verbatim in BackendDetailView and SettingsOverviewView, each carrying its own isBenchmarking state and Task. This pulls the button into a single BenchmarkButton view that owns that state and reports back through a Message binding, and both settings screens now use it.