### PR TITLE
Type the Home log lifecycle names as a Set

### DIFF
--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -43,7 +43,7 @@ class HomeLogProvider: ObservableObject {
     }
 }
 
-private let lifecycleNames = [
+private let lifecycleNames: Set = [
     DeviceObject.recordType,
     InstallObject.recordType,
     LaunchObject.recordType,


### PR DESCRIPTION
The lifecycleNames constant in HomeLogProvider is only ever used for membership tests, so typing it as a Set instead of an Array makes those lookups constant-time and states the intent directly.