### PR TITLE
[codex] Make preview fixtures deterministic

### DIFF
--- a/Sources/Scout/UI/Activity/ActivityProvider.swift
+++ b/Sources/Scout/UI/Activity/ActivityProvider.swift
@@ -41,9 +41,9 @@ extension ActivityPoint {
             Calendar.utc.date(byAdding: .day, value: -day, to: end).map {
                 ActivityPoint(
                     date: $0.millisecondsSince1970,
-                    dau: .random(in: 50...200),
-                    wau: .random(in: 300...600),
-                    mau: .random(in: 800...1500)
+                    dau: 80 + day % 90 + (day / 7) % 20,
+                    wau: 360 + day % 120 + (day / 5) % 80,
+                    mau: 950 + day % 240 + (day / 11) % 160
                 )
             }
         }

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -44,7 +44,7 @@ struct CrashListView: View {
         .navigationTitle(en: "Crashes")
         .message($provider.message)
         .task {
-            await provider.fetch(in: database)
+            await provider.fetchIfNeeded(in: database)
         }
     }
 

--- a/Sources/Scout/UI/Crash/CrashProvider.swift
+++ b/Sources/Scout/UI/Crash/CrashProvider.swift
@@ -15,6 +15,11 @@ class CrashProvider: ObservableObject {
 
     private var crashes: [Crash] = []
 
+    func fetchIfNeeded(in database: DatabaseReader) async {
+        guard groups == nil else { return }
+        await fetch(in: database)
+    }
+
     func fetch(in database: DatabaseReader) async {
         do {
             let query = RecordQuery(
@@ -55,7 +60,9 @@ class CrashProvider: ObservableObject {
 extension CrashProvider {
     static func fixture() -> CrashProvider {
         let provider = CrashProvider()
-        provider.groups = CrashGroup.groups(from: .samples)
+        let crashes = [Crash].samples
+        provider.crashes = crashes
+        provider.groups = CrashGroup.groups(from: crashes)
         return provider
     }
 }

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -43,6 +43,39 @@ class HomeLogProvider: ObservableObject {
     }
 }
 
+extension HomeLogProvider {
+    static func fixture(periods: [Period] = Period.allCases) -> HomeLogProvider {
+        let provider = HomeLogProvider()
+        for period in periods {
+            provider.results[period] = .success(sampleOutput(for: period))
+        }
+        return provider
+    }
+
+    private static func sampleOutput(for period: Period) -> Output {
+        let date = period.initialRange.lowerBound
+        let intMatrices = [
+            GridMatrix(date: date, name: EventObject.recordType, cells: [GridCell(row: 1, column: 0, value: 48)]),
+            GridMatrix(date: date, name: CrashObject.recordType, cells: [GridCell(row: 1, column: 1, value: 3)]),
+            GridMatrix(
+                date: date,
+                name: "api_calls",
+                category: Telemetry.Export.counter.rawValue,
+                cells: [GridCell(row: 1, column: 2, value: 140)]
+            )
+        ]
+        let doubleMatrices = [
+            GridMatrix(
+                date: date,
+                name: "cache_hit_rate",
+                category: Telemetry.Export.floatingCounter.rawValue,
+                cells: [GridCell(row: 1, column: 3, value: 91.5)]
+            )
+        ]
+        return (intMatrices, doubleMatrices)
+    }
+}
+
 private let lifecycleNames: Set = [
     DeviceObject.recordType,
     InstallObject.recordType,

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -62,7 +62,7 @@ extension HomeLogProvider {
                 name: "api_calls",
                 category: Telemetry.Export.counter.rawValue,
                 cells: [GridCell(row: 1, column: 2, value: 140)]
-            )
+            ),
         ]
         let doubleMatrices = [
             GridMatrix(

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -10,7 +10,11 @@ import SwiftUI
 struct HomeLogSection: View {
     @Environment(\.database) var database
     @AppStorage("scout_home_log_period") private var period: Period = .today
-    @StateObject private var provider = HomeLogProvider()
+    @StateObject private var provider: HomeLogProvider
+
+    init(provider: HomeLogProvider = HomeLogProvider()) {
+        self._provider = StateObject(wrappedValue: provider)
+    }
 
     var body: some View {
         Header(title: "Log") {
@@ -82,7 +86,7 @@ struct HomeLogSection: View {
 #Preview {
     NavigationStack {
         List {
-            HomeLogSection()
+            HomeLogSection(provider: .fixture())
         }
         .listStyle(.plain)
     }

--- a/Sources/Scout/UI/Stats/StatProvider.swift
+++ b/Sources/Scout/UI/Stats/StatProvider.swift
@@ -35,7 +35,7 @@ extension StatProvider {
 
     private static func sampleMatrix(name: String) -> GridMatrix<Int> {
         let cells = (1...372).map { day in
-            GridCell(row: day, column: 12, value: Int.random(in: 5...80))
+            GridCell(row: day, column: 12, value: 12 + day % 40 + (day / 9) % 18)
         }
         return Matrix(date: Calendar.utc.defaultRange.lowerBound, name: name, cells: cells)
     }


### PR DESCRIPTION
This updates preview fixture data so ObservableObject-backed previews keep stable, complete state.

Changes include deterministic activity/stat sample values, a guarded crash provider fetch path so injected fixtures are not overwritten on appear, and a complete crash fixture that keeps the provider's backing cache aligned with published groups.

Home log previews now receive an injectable `HomeLogProvider.fixture()` with preloaded matrix output, matching the existing fixture convention for observable providers.

Validation: `git diff --check` passes. A full `swift test` run was attempted, but the package still fails before completion on existing macOS/package issues: `fullScreenCover` is unavailable on macOS and `Bundle.module` is missing for the Core Data resource.