### PR TITLE
Group the decimal formatters into a NumberFormatter extension

### DIFF
--- a/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
+++ b/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
@@ -39,11 +39,11 @@ extension Double {
         case 0:
             return "0.0"
         case ..<0.01:
-            formatter = smallDecimalFormatter
+            formatter = .smallDecimal
         case ..<1_000:
-            formatter = midDecimalFormatter
+            formatter = .midDecimal
         default:
-            formatter = largeDecimalFormatter
+            formatter = .largeDecimal
         }
         return formatter.string(from: NSNumber(value: self))!
     }
@@ -86,16 +86,18 @@ extension TimeInterval {
     }
 }
 
-private func decimalFormatter(minimumFractionDigits: Int, maximumFractionDigits: Int) -> NumberFormatter {
-    let formatter = NumberFormatter()
-    formatter.numberStyle = .decimal
-    formatter.decimalSeparator = "."
-    formatter.groupingSeparator = " "
-    formatter.minimumFractionDigits = minimumFractionDigits
-    formatter.maximumFractionDigits = maximumFractionDigits
-    return formatter
-}
+private extension NumberFormatter {
+    static let smallDecimal = decimal(minimumFractionDigits: 3, maximumFractionDigits: 3)
+    static let midDecimal = decimal(minimumFractionDigits: 1, maximumFractionDigits: 2)
+    static let largeDecimal = decimal(minimumFractionDigits: 1, maximumFractionDigits: 1)
 
-nonisolated(unsafe) private let smallDecimalFormatter = decimalFormatter(minimumFractionDigits: 3, maximumFractionDigits: 3)
-nonisolated(unsafe) private let midDecimalFormatter = decimalFormatter(minimumFractionDigits: 1, maximumFractionDigits: 2)
-nonisolated(unsafe) private let largeDecimalFormatter = decimalFormatter(minimumFractionDigits: 1, maximumFractionDigits: 1)
+    static func decimal(minimumFractionDigits: Int, maximumFractionDigits: Int) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.decimalSeparator = "."
+        formatter.groupingSeparator = " "
+        formatter.minimumFractionDigits = minimumFractionDigits
+        formatter.maximumFractionDigits = maximumFractionDigits
+        return formatter
+    }
+}

--- a/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
+++ b/Sources/Scout/UI/Metrics/Series/MetricsFormatters.swift
@@ -86,12 +86,12 @@ extension TimeInterval {
     }
 }
 
-private extension NumberFormatter {
-    static let smallDecimal = decimal(minimumFractionDigits: 3, maximumFractionDigits: 3)
-    static let midDecimal = decimal(minimumFractionDigits: 1, maximumFractionDigits: 2)
-    static let largeDecimal = decimal(minimumFractionDigits: 1, maximumFractionDigits: 1)
+extension NumberFormatter {
+    fileprivate static let smallDecimal = decimal(minimumFractionDigits: 3, maximumFractionDigits: 3)
+    fileprivate static let midDecimal = decimal(minimumFractionDigits: 1, maximumFractionDigits: 2)
+    fileprivate static let largeDecimal = decimal(minimumFractionDigits: 1, maximumFractionDigits: 1)
 
-    static func decimal(minimumFractionDigits: Int, maximumFractionDigits: Int) -> NumberFormatter {
+    fileprivate static func decimal(minimumFractionDigits: Int, maximumFractionDigits: Int) -> NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.decimalSeparator = "."


### PR DESCRIPTION
Removes the now-redundant nonisolated(unsafe) qualifiers from the decimal NumberFormatter constants (NumberFormatter is Sendable) and moves the factory and the three constants into a private extension NumberFormatter, so they are reached through dot notation from Double.decimal.