### PR TITLE
Populate the Home log section preview with fixture data

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -16,6 +16,7 @@ struct HomeContent: View {
     @StateObject private var sessionStat: StatProvider
     @StateObject private var crashStat: StatProvider
     @StateObject private var releaseProvider: ReleaseHealthProvider
+    @StateObject private var logProvider: HomeLogProvider
     @State private var showReleaseHealth = false
 
     var body: some View {
@@ -33,7 +34,7 @@ struct HomeContent: View {
                 sessionStat: sessionStat,
                 crashStat: crashStat
             )
-            HomeLogSection()
+            HomeLogSection(provider: logProvider)
             HomeReleaseSection(provider: releaseProvider, showReleaseHealth: $showReleaseHealth)
         }
         .navigationDestination(isPresented: $showReleaseHealth) {
@@ -66,11 +67,12 @@ struct HomeContent: View {
 }
 
 extension HomeContent {
-    init(activity: ActivityProvider, sessionStat: StatProvider, crashStat: StatProvider, releaseProvider: ReleaseHealthProvider) {
+    init(activity: ActivityProvider, sessionStat: StatProvider, crashStat: StatProvider, releaseProvider: ReleaseHealthProvider, logProvider: HomeLogProvider) {
         self._activity = StateObject(wrappedValue: activity)
         self._sessionStat = StateObject(wrappedValue: sessionStat)
         self._crashStat = StateObject(wrappedValue: crashStat)
         self._releaseProvider = StateObject(wrappedValue: releaseProvider)
+        self._logProvider = StateObject(wrappedValue: logProvider)
     }
 }
 
@@ -80,8 +82,10 @@ extension HomeContent {
             activity: .fixture(),
             sessionStat: .fixture(eventName: "Session"),
             crashStat: .fixture(eventName: "Crash"),
-            releaseProvider: .fixture()
+            releaseProvider: .fixture(),
+            logProvider: .fixture()
         )
         .navigationTitle("Home")
     }
+    .environmentObject(Tint())
 }

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -51,7 +51,8 @@ struct HomeView: View {
                         activity: ActivityProvider(),
                         sessionStat: StatProvider(eventName: "Session", periods: Period.summary),
                         crashStat: StatProvider(eventName: "Crash", periods: Period.summary),
-                        releaseProvider: ReleaseHealthProvider()
+                        releaseProvider: ReleaseHealthProvider(),
+                        logProvider: HomeLogProvider()
                     )
                     .id(backend.id)
                     .iCloudWarning(backend.accountWarning)

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -11,7 +11,11 @@ import Foundation
 class HomeLogProvider: ObservableObject {
     typealias Output = ([GridMatrix<Int>], [GridMatrix<Double>])
 
-    @Published private var results: [Period: ProviderResult<Output>] = [:]
+    @Published private var results: [Period: ProviderResult<Output>]
+
+    init(results: [Period: ProviderResult<Output>] = [:]) {
+        self.results = results
+    }
 
     func result(for period: Period) -> ProviderResult<Output>? {
         results[period]


### PR DESCRIPTION
Hoists the HomeLogProvider into HomeContent so the Home preview's Log section renders from a fixture instead of an empty provider, and injects a Tint environment object into the preview so navigating out of the section no longer crashes. HomeLogProvider gains an init that accepts preloaded results so the fixture can seed it.