### PR TITLE
Hide the stat chart's leaking top row separator

### DIFF
--- a/Sources/Scout/UI/Stats/StatView.swift
+++ b/Sources/Scout/UI/Stats/StatView.swift
@@ -28,6 +28,7 @@ struct StatView: View {
                     let segment = extent.segment(from: points)
 
                     ComparableChart(segment: segment, points: points, extent: extent, color: color, isComparing: isComparing)
+                        .listRowSeparator(.hidden, edges: .top)
                         .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
 
                     ComparisonToggle(isOn: $isComparing)


### PR DESCRIPTION
StatView rendered a divider under the range control on the Crashes screen and every other stat screen. That line was the top separator of the chart's first List row, which only had its bottom edge controlled — the top leaked through. Hiding the top edge removes it, matching MetricsView and ActivityView where the chart row already hides all separators.