### PR TITLE
Replace duplicate fixed font sizes with semantic text styles

### DIFF
--- a/Sources/Scout/UI/Chart/Picker/CompactPeriodPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/CompactPeriodPicker.swift
@@ -29,7 +29,7 @@ struct CompactPeriodPicker: View {
                 Image(systemName: "chevron.up.chevron.down")
                     .font(.system(size: 12, weight: .medium))
                 Text(selection.shortTitle.uppercased())
-                    .font(.system(size: 16, weight: .medium))
+                    .font(.callout.weight(.medium))
             }
             .foregroundStyle(.secondary)
         }

--- a/Sources/Scout/UI/Chart/Range/RangeControl.swift
+++ b/Sources/Scout/UI/Chart/Range/RangeControl.swift
@@ -18,7 +18,7 @@ struct RangeControl<T: ChartTimeScale>: View {
             .disabled(!extent.isLeftEnabled)
 
             Text(extent.domain.label(using: rangeDateFormatter))
-                .font(.system(size: 16))
+                .font(.callout)
                 .monospaced()
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -51,7 +51,7 @@ struct CrashDetailView: View {
 
         ForEach(Array(crash.stackTrace.enumerated()), id: \.offset) { _, frame in
             Text(frame)
-                .font(.system(size: 12))
+                .font(.caption)
                 .monospaced()
                 .lineLimit(2)
         }

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -66,7 +66,7 @@ struct CrashGroupDetailView: View {
 
                 if let sessionID = crash.sessionID {
                     Text(ExportFormat.shortID(sessionID))
-                        .font(.system(size: 13))
+                        .font(.footnote)
                         .monospaced()
                         .foregroundStyle(Color.gray)
                 }

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -51,7 +51,7 @@ struct CrashListView: View {
     private func row(for group: CrashGroup) -> some View {
         Row {
             Text(group.name)
-                .font(.system(size: 17))
+                .font(.body)
                 .lineLimit(1)
                 .monospaced()
 
@@ -63,7 +63,7 @@ struct CrashListView: View {
 
             if let date = group.lastDate {
                 Text(verbatim: date.relativeString)
-                    .font(.system(size: 15))
+                    .font(.subheadline)
                     .foregroundStyle(Color.gray)
             }
         } destination: {

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.Suggestion.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.Suggestion.swift
@@ -14,7 +14,7 @@ extension AnalyticsView {
         var body: some View {
             HStack {
                 Text(text)
-                    .font(.system(size: 17))
+                    .font(.body)
                     .monospaced()
                     .searchCompletion(text)
                     .foregroundStyle(.blue)

--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -24,7 +24,7 @@ struct FilterView: View {
                         .foregroundStyle(level.color ?? .blue)
                         .opacity(criteria.isSelected(level) ? 1 : 0)
                     Text(level.description)
-                        .font(.system(size: 16))
+                        .font(.callout)
                     Spacer()
                 }
                 .contentShape(Rectangle())

--- a/Sources/Scout/UI/Event/List/EventList.swift
+++ b/Sources/Scout/UI/Event/List/EventList.swift
@@ -49,7 +49,7 @@ struct EventList: View {
         Row {
             HStack(spacing: 12) {
                 Text(event.name)
-                    .font(.system(size: 17))
+                    .font(.body)
                     .lineLimit(1)
                     .monospaced()
 
@@ -59,7 +59,7 @@ struct EventList: View {
                     TimelineView(.periodic(from: timeline, by: 1)) { _ in
                         Text(verbatim: date.relativeString)
                     }
-                    .font(.system(size: 15))
+                    .font(.subheadline)
                     .foregroundStyle(Color.gray)
                 }
             }

--- a/Sources/Scout/UI/Event/List/EventStatList.swift
+++ b/Sources/Scout/UI/Event/List/EventStatList.swift
@@ -34,7 +34,7 @@ struct EventStatList: View {
                     await fetch()
                 }
                 .navigationTitle(range.label(using: formatter))
-                .font(.system(size: 12))
+                .font(.caption)
         }
     }
 

--- a/Sources/Scout/UI/Event/Param/ParamValueRow.swift
+++ b/Sources/Scout/UI/Event/Param/ParamValueRow.swift
@@ -25,7 +25,7 @@ struct ParamValueRow: View {
 
             Text(value.summary)
                 .monospaced()
-                .font(.system(size: 16))
+                .font(.callout)
                 .foregroundStyle(summaryStyle)
                 .lineLimit(1)
         }

--- a/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
@@ -54,7 +54,7 @@ struct ConnectionMenu: View {
                             .imageScale(.medium)
                             .foregroundStyle(.secondary)
                         Text(verbatim: "Settings")
-                            .font(.system(size: 16))
+                            .font(.callout)
                         Spacer(minLength: 0)
                     }
                     .padding(.horizontal, 16)

--- a/Sources/Scout/UI/Home/Connection/ConnectionRow.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionRow.swift
@@ -20,7 +20,7 @@ struct ConnectionRow: View {
                 .accessibilityLabel(Text(verbatim: connection.status.label))
             VStack(spacing: 0) {
                 HStack {
-                    Text(verbatim: connection.name).font(.system(size: 16))
+                    Text(verbatim: connection.name).font(.callout)
                     Spacer(minLength: 0)
                 }
                 .padding(.vertical, 12)

--- a/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
@@ -20,7 +20,7 @@ struct HomeReleaseSection: View {
             } label: {
                 if let releases = provider.releases, releases.count > 0 {
                     Text(verbatim: "All".uppercased())
-                        .font(.system(size: 16, weight: .medium))
+                        .font(.callout.weight(.medium))
                         .foregroundStyle(.blue)
                 }
             }

--- a/Sources/Scout/UI/Message/MessageView.swift
+++ b/Sources/Scout/UI/Message/MessageView.swift
@@ -13,7 +13,7 @@ struct MessageView: View {
 
     var body: some View {
         Text(text)
-            .font(.system(size: 16))
+            .font(.callout)
             .multilineTextAlignment(.center)
             .lineSpacing(4)
             .padding(.horizontal)

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
@@ -24,7 +24,7 @@ struct TimerDistributionView: View {
             PercentileRow(percentiles: percentiles)
 
             Text(verbatim: "P99 TREND")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.caption.weight(.semibold))
                 .foregroundStyle(Color.gray)
 
             PercentileTrendChart(trend: trend, unit: unit)

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -71,7 +71,7 @@ struct MetricsContent<T: ChartNumeric>: View {
         }
         .monospaced()
         .italic()
-        .font(.system(size: 17))
+        .font(.body)
         .lineLimit(1)
     }
 }

--- a/Sources/Scout/UI/Network/View/NetworkEndpointRow.swift
+++ b/Sources/Scout/UI/Network/View/NetworkEndpointRow.swift
@@ -39,9 +39,9 @@ struct NetworkEndpointRow: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 Text(verbatim: endpoint.name)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.subheadline.weight(.medium))
                 Text(verbatim: endpoint.requests.plain + " req · " + (endpoint.successRate?.formatted ?? "—"))
-                    .font(.system(size: 12))
+                    .font(.caption)
                     .foregroundStyle(.gray)
             }
 
@@ -49,10 +49,10 @@ struct NetworkEndpointRow: View {
 
             VStack(alignment: .trailing, spacing: 8) {
                 Text(verbatim: endpoint.p99?.duration ?? "—")
-                    .font(.system(size: 15, weight: .semibold))
+                    .font(.subheadline.weight(.semibold))
                     .monospacedDigit()
                 Text(verbatim: "P99")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.caption2.weight(.semibold))
                     .foregroundStyle(.gray)
             }
         }

--- a/Sources/Scout/UI/Network/View/StatusBar.swift
+++ b/Sources/Scout/UI/Network/View/StatusBar.swift
@@ -31,7 +31,7 @@ struct StatusBar: View {
                     HStack(spacing: 5) {
                         Circle().fill(segment.color).frame(width: 7, height: 7)
                         Text(verbatim: segment.label + " " + segment.count.plain)
-                            .font(.system(size: 12))
+                            .font(.caption)
                             .foregroundStyle(.gray)
                     }
                 }

--- a/Sources/Scout/UI/Primitives/Rows/Header.swift
+++ b/Sources/Scout/UI/Primitives/Rows/Header.swift
@@ -19,7 +19,7 @@ struct Header<Trailing: View>: View {
 
     var body: some View {
         HStack {
-            Text(title.uppercased()).font(.system(size: 16, weight: .bold))
+            Text(title.uppercased()).font(.callout.weight(.bold))
 
             Spacer()
 

--- a/Sources/Scout/UI/Primitives/Values/Metric.swift
+++ b/Sources/Scout/UI/Primitives/Values/Metric.swift
@@ -15,11 +15,11 @@ struct Metric: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(verbatim: value)
-                .font(.system(size: 22, weight: .bold))
+                .font(.title2.weight(.bold))
                 .monospacedDigit()
                 .foregroundStyle(color)
             Text(verbatim: title.uppercased())
-                .font(.system(size: 12, weight: .semibold))
+                .font(.caption.weight(.semibold))
                 .foregroundStyle(Color.gray)
         }
     }

--- a/Sources/Scout/UI/Releases/View/ReleaseRow.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseRow.swift
@@ -15,7 +15,7 @@ struct ReleaseRow: View {
             CompactRing(release: release)
 
             Text(verbatim: release.id)
-                .font(.system(size: 17))
+                .font(.body)
                 .monospacedDigit()
 
             Spacer()
@@ -62,7 +62,7 @@ struct ReleaseRowPlaceholder: View {
             CompactRing(adoption: 1.0, color: .gray)
 
             Text(verbatim: "3.2.1")
-                .font(.system(size: 17))
+                .font(.body)
                 .monospacedDigit()
 
             Spacer()
@@ -81,7 +81,7 @@ private struct ReleasePercent: View {
 
     var body: some View {
         Text(verbatim: text)
-            .font(.system(size: 15))
+            .font(.subheadline)
             .monospacedDigit()
             .foregroundStyle(.primary)
             .frame(minWidth: 80, alignment: .trailing)

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -109,7 +109,7 @@ struct VersionDetailView: View {
             ForEach(issues) { group in
                 Row {
                     Text(verbatim: group.name)
-                        .font(.system(size: 16))
+                        .font(.callout)
                         .monospaced()
                         .lineLimit(1)
 

--- a/Sources/Scout/UI/Timeline/View/Legend/Legend.swift
+++ b/Sources/Scout/UI/Timeline/View/Legend/Legend.swift
@@ -26,7 +26,7 @@ struct Legend: View {
                                     .fill(kind.color)
                                     .frame(width: 8, height: 8)
                                 Text(kind.label)
-                                    .font(.system(size: 13))
+                                    .font(.footnote)
                                     .foregroundStyle(.primary)
                             }
                             .padding(.horizontal, 10)
@@ -44,7 +44,7 @@ struct Legend: View {
 
             if let expanded {
                 Text(expanded.legendDescription)
-                    .font(.system(size: 13))
+                    .font(.footnote)
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal)

--- a/Sources/Scout/UI/Timeline/View/TimelineRow.swift
+++ b/Sources/Scout/UI/Timeline/View/TimelineRow.swift
@@ -23,7 +23,7 @@ struct TimelineRow: View {
                 }
 
                 Text(row.name)
-                    .font(.system(size: 17))
+                    .font(.body)
                     .lineLimit(1)
                     .monospaced()
                     .padding(.leading, 8)
@@ -33,7 +33,7 @@ struct TimelineRow: View {
                 TimelineView(.periodic(from: timeline, by: 1)) { _ in
                     Text(row.date.relativeString)
                 }
-                .font(.system(size: 15))
+                .font(.subheadline)
                 .foregroundStyle(.gray)
             }
             .frame(height: 43)


### PR DESCRIPTION
Swaps the fixed `.system(size:)` fonts that merely duplicated the built-in text styles for their semantic equivalents across the UI — size 11 to caption2, 12 to caption, 13 to footnote, 15 to subheadline, 16 to callout, 17 to body, and 22 to title2, preserving any explicit weight and the monospaced chains. Text that was previously pinned to a fixed point size now scales with Dynamic Type. SF Symbol glyphs and the step-number badge in a fixed-size circle keep their explicit sizes since scaling them isn't wanted.