### PR TITLE
Extract connection popover rows into their own views

### DIFF
--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -37,9 +37,27 @@ public struct Backend: Sendable {
 extension Backend {
     static var samples: [Backend] {
         [
-            Backend(id: "https://api.scout.app", database: DefaultDatabase(), checkAvailability: { true }, displayName: "Production", probeStatus: { .reachable }),
-            Backend(id: "https://staging.scout.app", database: DefaultDatabase(), checkAvailability: { true }, displayName: "Staging", probeStatus: { .unknown }),
-            Backend(id: "http://localhost:8080", database: DefaultDatabase(), checkAvailability: { false }, displayName: "Local", probeStatus: { .unreachable }),
+            Backend(
+                id: "https://api.scout.app",
+                database: DefaultDatabase(),
+                checkAvailability: { true },
+                displayName: "Production",
+                probeStatus: { .reachable }
+            ),
+            Backend(
+                id: "https://staging.scout.app",
+                database: DefaultDatabase(),
+                checkAvailability: { true },
+                displayName: "Staging",
+                probeStatus: { .unknown }
+            ),
+            Backend(
+                id: "http://localhost:8080",
+                database: DefaultDatabase(),
+                checkAvailability: { false },
+                displayName: "Local",
+                probeStatus: { .unreachable }
+            ),
         ]
     }
 }

--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -33,3 +33,13 @@ public struct Backend: Sendable {
         let isSecure: Bool
     }
 }
+
+extension Backend {
+    static var samples: [Backend] {
+        [
+            Backend(id: "https://api.scout.app", database: DefaultDatabase(), checkAvailability: { true }, displayName: "Production", probeStatus: { .reachable }),
+            Backend(id: "https://staging.scout.app", database: DefaultDatabase(), checkAvailability: { true }, displayName: "Staging", probeStatus: { .unknown }),
+            Backend(id: "http://localhost:8080", database: DefaultDatabase(), checkAvailability: { false }, displayName: "Local", probeStatus: { .unreachable }),
+        ]
+    }
+}

--- a/Sources/Scout/UI/Database/DefaultDatabase.swift
+++ b/Sources/Scout/UI/Database/DefaultDatabase.swift
@@ -11,7 +11,7 @@ extension EnvironmentValues {
     @Entry var database: DatabaseReader = DefaultDatabase()
 }
 
-struct DefaultDatabase: DatabaseReader {
+struct DefaultDatabase: Database {
     func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
         RecordChunk(records: query.recordType.sampleRecords, cursor: nil)
     }
@@ -27,4 +27,7 @@ struct DefaultDatabase: DatabaseReader {
     func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
         []
     }
+
+    func write(record: Record) async throws {}
+    func write(records: [Record]) async throws {}
 }

--- a/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
@@ -29,40 +29,27 @@ struct ConnectionMenu: View {
         .popover(isPresented: $isPresented) {
             VStack(spacing: 0) {
                 ForEach(connections) { connection in
-                    Button {
+                    ConnectionRow(
+                        connection: connection,
+                        isActive: connection.id == activeID,
+                        showsSeparator: connection.id != connections.last?.id
+                    ) {
                         activeID = connection.id
                         isPresented = false
-                    } label: {
-                        ConnectionRow(
-                            connection: connection,
-                            isActive: connection.id == activeID,
-                            showsSeparator: true
-                        )
                     }
-                    .buttonStyle(.plain)
                 }
 
-                Button {
+                Divider()
+
+                ConnectionSettingsRow {
                     isPresented = false
                     Task { @MainActor in
                         await Task.yield()
                         onSettings()
                     }
-                } label: {
-                    HStack {
-                        Image(systemName: "slider.horizontal.3")
-                            .imageScale(.medium)
-                            .foregroundStyle(.secondary)
-                        Text(verbatim: "Settings")
-                            .font(.system(size: 16))
-                        Spacer(minLength: 0)
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 12)
-                    .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
             }
+            .padding(.vertical, 8)
             .frame(minWidth: 240)
             .task {
                 connections = await connections.refreshingStatuses()

--- a/Sources/Scout/UI/Home/Connection/ConnectionRow.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionRow.swift
@@ -11,35 +11,47 @@ struct ConnectionRow: View {
     let connection: Connection
     let isActive: Bool
     let showsSeparator: Bool
+    let action: () -> Void
 
     var body: some View {
-        HStack {
-            Image(systemName: "circle.fill")
-                .imageScale(.medium)
-                .foregroundStyle(connection.status.color)
-                .accessibilityLabel(Text(verbatim: connection.status.label))
-            VStack(spacing: 0) {
-                HStack {
-                    Text(verbatim: connection.name).font(.system(size: 16))
-                    Spacer(minLength: 0)
-                }
-                .padding(.vertical, 12)
+        Button(action: action) {
+            HStack {
+                Image(systemName: "circle.fill")
+                    .imageScale(.medium)
+                    .foregroundStyle(connection.status.color)
+                    .accessibilityLabel(Text(verbatim: connection.status.label))
+                VStack(spacing: 0) {
+                    HStack {
+                        Text(verbatim: connection.name).font(.system(size: 16))
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.vertical, 12)
 
-                if showsSeparator {
-                    Divider()
+                    if showsSeparator {
+                        Divider()
+                    }
+                }
+                .padding(.trailing, 16)
+            }
+            .padding(.leading, 16)
+            .background {
+                if isActive {
+                    Rectangle().fill(.tint.opacity(0.12))
                 }
             }
-            .padding(.trailing, 16)
+            .contentShape(Rectangle())
         }
-        .padding(.leading, 16)
-        .background {
-            if isActive {
-                Rectangle().fill(.tint.opacity(0.12))
-            }
-        }
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
         .accessibilityAddTraits(isActive ? [.isSelected] : [])
     }
+}
+
+#Preview {
+    VStack(spacing: 0) {
+        ConnectionRow(connection: Connection.samples[0], isActive: true, showsSeparator: true, action: {})
+        ConnectionRow(connection: Connection.samples[1], isActive: false, showsSeparator: false, action: {})
+    }
+    .frame(minWidth: 240)
 }
 
 extension Backend.Status {

--- a/Sources/Scout/UI/Home/Connection/ConnectionSettingsRow.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionSettingsRow.swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct ConnectionSettingsRow: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Image(systemName: "slider.horizontal.3")
+                    .imageScale(.medium)
+                    .foregroundStyle(.secondary)
+                Text(verbatim: "Settings")
+                    .font(.system(size: 16))
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .padding(.top, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    ConnectionSettingsRow(action: {})
+        .frame(minWidth: 240)
+}

--- a/Sources/Scout/UI/Home/Connection/ConnectionToolbar.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionToolbar.swift
@@ -40,3 +40,13 @@ private struct ConnectionToolbar: ViewModifier {
             }
     }
 }
+
+@available(iOS 17.0, macOS 14.0, *)
+#Preview {
+    @Previewable @State var activeID = Backend.samples[0].id
+    NavigationStack {
+        Text(verbatim: "Content")
+            .navigationTitle(en: "Home")
+            .connectionToolbar(backends: Backend.samples, activeID: $activeID)
+    }
+}


### PR DESCRIPTION
Splits the connection popover's content into dedicated row views. The tappable connection row now lives inside ConnectionRow itself (folding in the surrounding Button), and the settings entry moves to a new ConnectionSettingsRow, so ConnectionMenu just composes the two. Adds SwiftUI previews for the toolbar and both rows, backed by a reusable Backend.samples that reuses DefaultDatabase as its store.