### PR TITLE
Group the fixed text-style fonts into a Font extension

### DIFF
--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -50,7 +50,7 @@ struct SetupPage: View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 10) {
                     Text("\(number)")
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.stepBadge)
                         .foregroundStyle(.white)
                         .frame(width: 22, height: 22)
                         .background(Circle().fill(.blue))

--- a/Sources/Scout/UI/Primitives/Styles/Font+Styles.swift
+++ b/Sources/Scout/UI/Primitives/Styles/Font+Styles.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+extension Font {
+    static let placeholderTitle = Font.system(size: 18, weight: .semibold)
+    static let codeChip = Font.system(size: 14, design: .monospaced)
+    static let stepBadge = Font.system(size: 13, weight: .semibold)
+}

--- a/Sources/Scout/UI/Primitives/Styles/View+CodeChip.swift
+++ b/Sources/Scout/UI/Primitives/Styles/View+CodeChip.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 extension View {
     func codeChipStyle() -> some View {
-        font(.system(size: 14, design: .monospaced))
+        font(.codeChip)
             .foregroundStyle(.primary)
             .padding(.horizontal, 12)
             .padding(.vertical, 10)

--- a/Sources/Scout/UI/Primitives/Styles/View+PlaceholderText.swift
+++ b/Sources/Scout/UI/Primitives/Styles/View+PlaceholderText.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 extension View {
     func placeholderTextStyle() -> some View {
-        font(.system(size: 18, weight: .semibold))
+        font(.placeholderTitle)
             .foregroundStyle(.gray.opacity(0.7))
     }
 }


### PR DESCRIPTION
Collects the three fixed text-style fonts that stayed as literal `.system(size:)` after the semantic-style sweep into a small named vocabulary on `Font` — placeholderTitle (18 semibold), codeChip (14 monospaced), and stepBadge (13 semibold) — and points the code chip and placeholder view helpers plus the setup step badge at those names. Values are unchanged; this is naming and centralization only, following on from #795.