### PR TITLE
Replace Dynamic Type text styles with a fixed-size scale

### DIFF
--- a/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
@@ -92,7 +92,7 @@ struct ComparisonChartView<T: ChartNumeric>: View {
     let segment = extent.segment(from: points)
 
     return VStack(alignment: .leading, spacing: 24) {
-        Text(verbatim: "With Data").font(.headline)
+        Text(verbatim: "With Data").font(.fixedHeadline)
         ComparisonChartView(
             segment: segment,
             reference: extent.referenceSegment(from: points, alignedTo: segment),
@@ -100,7 +100,7 @@ struct ComparisonChartView<T: ChartNumeric>: View {
             color: .blue
         )
 
-        Text(verbatim: "Empty State").font(.headline)
+        Text(verbatim: "Empty State").font(.fixedHeadline)
         ComparisonChartView(segment: .empty, reference: .empty, timing: extent, color: .blue)
     }
     .padding()

--- a/Sources/Scout/UI/Chart/Picker/CompactPeriodPicker.swift
+++ b/Sources/Scout/UI/Chart/Picker/CompactPeriodPicker.swift
@@ -29,7 +29,7 @@ struct CompactPeriodPicker: View {
                 Image(systemName: "chevron.up.chevron.down")
                     .font(.system(size: 12, weight: .medium))
                 Text(selection.shortTitle.uppercased())
-                    .font(.callout.weight(.medium))
+                    .font(.fixedCallout.weight(.medium))
             }
             .foregroundStyle(.secondary)
         }

--- a/Sources/Scout/UI/Chart/Range/RangeControl.swift
+++ b/Sources/Scout/UI/Chart/Range/RangeControl.swift
@@ -18,7 +18,7 @@ struct RangeControl<T: ChartTimeScale>: View {
             .disabled(!extent.isLeftEnabled)
 
             Text(extent.domain.label(using: rangeDateFormatter))
-                .font(.callout)
+                .font(.fixedCallout)
                 .monospaced()
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)

--- a/Sources/Scout/UI/Chart/View/ChartView.swift
+++ b/Sources/Scout/UI/Chart/View/ChartView.swift
@@ -39,10 +39,10 @@ struct ChartView<T: ChartNumeric>: View {
 
 #Preview("ChartView – Month") {
     VStack(alignment: .leading, spacing: 24) {
-        Text(verbatim: "With Data").font(.headline)
+        Text(verbatim: "With Data").font(.fixedHeadline)
         ChartView(segment: .sample, timing: ChartExtent(period: Period.month))
 
-        Text(verbatim: "Empty State").font(.headline)
+        Text(verbatim: "Empty State").font(.fixedHeadline)
         ChartView(segment: .empty, timing: ChartExtent(period: Period.month))
     }
     .padding()

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -51,7 +51,7 @@ struct CrashDetailView: View {
 
         ForEach(Array(crash.stackTrace.enumerated()), id: \.offset) { _, frame in
             Text(frame)
-                .font(.caption)
+                .font(.fixedCaption)
                 .monospaced()
                 .lineLimit(2)
         }

--- a/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashGroupDetailView.swift
@@ -66,7 +66,7 @@ struct CrashGroupDetailView: View {
 
                 if let sessionID = crash.sessionID {
                     Text(ExportFormat.shortID(sessionID))
-                        .font(.footnote)
+                        .font(.fixedFootnote)
                         .monospaced()
                         .foregroundStyle(Color.gray)
                 }

--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -51,7 +51,7 @@ struct CrashListView: View {
     private func row(for group: CrashGroup) -> some View {
         Row {
             Text(group.name)
-                .font(.body)
+                .font(.fixedBody)
                 .lineLimit(1)
                 .monospaced()
 
@@ -63,7 +63,7 @@ struct CrashListView: View {
 
             if let date = group.lastDate {
                 Text(verbatim: date.relativeString)
-                    .font(.subheadline)
+                    .font(.fixedSubheadline)
                     .foregroundStyle(Color.gray)
             }
         } destination: {

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.Suggestion.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.Suggestion.swift
@@ -14,7 +14,7 @@ extension AnalyticsView {
         var body: some View {
             HStack {
                 Text(text)
-                    .font(.body)
+                    .font(.fixedBody)
                     .monospaced()
                     .searchCompletion(text)
                     .foregroundStyle(.blue)

--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -24,7 +24,7 @@ struct FilterView: View {
                         .foregroundStyle(level.color ?? .blue)
                         .opacity(criteria.isSelected(level) ? 1 : 0)
                     Text(level.description)
-                        .font(.callout)
+                        .font(.fixedCallout)
                     Spacer()
                 }
                 .contentShape(Rectangle())

--- a/Sources/Scout/UI/Event/List/EventList.swift
+++ b/Sources/Scout/UI/Event/List/EventList.swift
@@ -49,7 +49,7 @@ struct EventList: View {
         Row {
             HStack(spacing: 12) {
                 Text(event.name)
-                    .font(.body)
+                    .font(.fixedBody)
                     .lineLimit(1)
                     .monospaced()
 
@@ -59,7 +59,7 @@ struct EventList: View {
                     TimelineView(.periodic(from: timeline, by: 1)) { _ in
                         Text(verbatim: date.relativeString)
                     }
-                    .font(.subheadline)
+                    .font(.fixedSubheadline)
                     .foregroundStyle(Color.gray)
                 }
             }

--- a/Sources/Scout/UI/Event/List/EventStatList.swift
+++ b/Sources/Scout/UI/Event/List/EventStatList.swift
@@ -34,7 +34,7 @@ struct EventStatList: View {
                     await fetch()
                 }
                 .navigationTitle(range.label(using: formatter))
-                .font(.caption)
+                .font(.fixedCaption)
         }
     }
 

--- a/Sources/Scout/UI/Event/Param/ParamBadge.swift
+++ b/Sources/Scout/UI/Event/Param/ParamBadge.swift
@@ -17,10 +17,10 @@ struct ParamIcon: View {
             switch value.icon {
             case .symbol(let name):
                 Image(systemName: name)
-                    .font(.body)
+                    .font(.fixedBody)
             case .text(let text):
                 Text(text)
-                    .font(.body.weight(.semibold))
+                    .font(.fixedBody.weight(.semibold))
                     .fixedSize()
             }
         }
@@ -35,7 +35,7 @@ struct ParamBadge: View {
 
     var body: some View {
         Label(convertible.label, systemImage: convertible.iconName)
-            .font(.caption.weight(.medium))
+            .font(.fixedCaption.weight(.medium))
             .foregroundStyle(convertible.color)
             .padding(.horizontal, 8)
             .padding(.vertical, 5)

--- a/Sources/Scout/UI/Event/Param/ParamValueRow.swift
+++ b/Sources/Scout/UI/Event/Param/ParamValueRow.swift
@@ -25,7 +25,7 @@ struct ParamValueRow: View {
 
             Text(value.summary)
                 .monospaced()
-                .font(.callout)
+                .font(.fixedCallout)
                 .foregroundStyle(summaryStyle)
                 .lineLimit(1)
         }

--- a/Sources/Scout/UI/Export/ChartSnapshot.swift
+++ b/Sources/Scout/UI/Export/ChartSnapshot.swift
@@ -52,12 +52,12 @@ struct ChartSnapshot<ChartContent: View>: View {
     }
 
     private var titleText: some View {
-        Text(verbatim: title).font(.headline)
+        Text(verbatim: title).font(.fixedHeadline)
     }
 
     private var rangeText: some View {
         Text(verbatim: rangeLabel)
-            .font(.caption)
+            .font(.fixedCaption)
             .foregroundStyle(.secondary)
     }
 }

--- a/Sources/Scout/UI/Home/Connection/ConnectionRow.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionRow.swift
@@ -22,7 +22,7 @@ struct ConnectionRow: View {
                     .accessibilityLabel(Text(verbatim: connection.status.label))
                 VStack(spacing: 0) {
                     HStack {
-                        Text(verbatim: connection.name).font(.callout)
+                        Text(verbatim: connection.name).font(.fixedCallout)
                         Spacer(minLength: 0)
                     }
                     .padding(.vertical, 12)

--- a/Sources/Scout/UI/Home/Connection/ConnectionSettingsRow.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionSettingsRow.swift
@@ -17,7 +17,7 @@ struct ConnectionSettingsRow: View {
                     .imageScale(.medium)
                     .foregroundStyle(.secondary)
                 Text(verbatim: "Settings")
-                    .font(.callout)
+                    .font(.fixedCallout)
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, 16)

--- a/Sources/Scout/UI/Home/Onboarding/OnboardingPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/OnboardingPage.swift
@@ -20,7 +20,7 @@ struct OnboardingPage<Accessory: View, Content: View>: View {
             accessory
 
             Text(verbatim: title)
-                .font(.title)
+                .font(.fixedTitle)
                 .bold()
 
             content

--- a/Sources/Scout/UI/Home/Onboarding/ReadyPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/ReadyPage.swift
@@ -17,7 +17,7 @@ struct ReadyPage: View {
                 .foregroundStyle(.green)
         } content: {
             Text(verbatim: "Run your app and come back here to see your data.")
-                .font(.body)
+                .font(.fixedBody)
                 .kerning(0.3)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -55,7 +55,7 @@ struct SetupPage: View {
                         .frame(width: 22, height: 22)
                         .background(Circle().fill(.blue))
                     Text(label)
-                        .font(.subheadline)
+                        .font(.fixedSubheadline)
                         .fontWeight(.medium)
                 }
                 Text(code.swiftSyntax)

--- a/Sources/Scout/UI/Home/Onboarding/WelcomePage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/WelcomePage.swift
@@ -42,9 +42,9 @@ struct WelcomePage: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.headline)
+                    .font(.fixedHeadline)
                 Text(description)
-                    .font(.subheadline)
+                    .font(.fixedSubheadline)
                     .kerning(0.3)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
@@ -20,7 +20,7 @@ struct HomeReleaseSection: View {
             } label: {
                 if let releases = provider.releases, releases.count > 0 {
                     Text(verbatim: "All".uppercased())
-                        .font(.callout.weight(.medium))
+                        .font(.fixedCallout.weight(.medium))
                         .foregroundStyle(.blue)
                 }
             }

--- a/Sources/Scout/UI/Message/MessageView.swift
+++ b/Sources/Scout/UI/Message/MessageView.swift
@@ -13,7 +13,7 @@ struct MessageView: View {
 
     var body: some View {
         Text(text)
-            .font(.callout)
+            .font(.fixedCallout)
             .multilineTextAlignment(.center)
             .lineSpacing(4)
             .padding(.horizontal)

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
@@ -24,7 +24,7 @@ struct TimerDistributionView: View {
             PercentileRow(percentiles: percentiles)
 
             Text(verbatim: "P99 TREND")
-                .font(.caption.weight(.semibold))
+                .font(.fixedCaption.weight(.semibold))
                 .foregroundStyle(Color.gray)
 
             PercentileTrendChart(trend: trend, unit: unit)

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -71,7 +71,7 @@ struct MetricsContent<T: ChartNumeric>: View {
         }
         .monospaced()
         .italic()
-        .font(.body)
+        .font(.fixedBody)
         .lineLimit(1)
     }
 }

--- a/Sources/Scout/UI/Network/View/NetworkEndpointRow.swift
+++ b/Sources/Scout/UI/Network/View/NetworkEndpointRow.swift
@@ -39,9 +39,9 @@ struct NetworkEndpointRow: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 Text(verbatim: endpoint.name)
-                    .font(.subheadline.weight(.medium))
+                    .font(.fixedSubheadline.weight(.medium))
                 Text(verbatim: endpoint.requests.plain + " req · " + (endpoint.successRate?.formatted ?? "—"))
-                    .font(.caption)
+                    .font(.fixedCaption)
                     .foregroundStyle(.gray)
             }
 
@@ -49,10 +49,10 @@ struct NetworkEndpointRow: View {
 
             VStack(alignment: .trailing, spacing: 8) {
                 Text(verbatim: endpoint.p99?.duration ?? "—")
-                    .font(.subheadline.weight(.semibold))
+                    .font(.fixedSubheadline.weight(.semibold))
                     .monospacedDigit()
                 Text(verbatim: "P99")
-                    .font(.caption2.weight(.semibold))
+                    .font(.fixedCaption2.weight(.semibold))
                     .foregroundStyle(.gray)
             }
         }

--- a/Sources/Scout/UI/Network/View/StatusBar.swift
+++ b/Sources/Scout/UI/Network/View/StatusBar.swift
@@ -31,7 +31,7 @@ struct StatusBar: View {
                     HStack(spacing: 5) {
                         Circle().fill(segment.color).frame(width: 7, height: 7)
                         Text(verbatim: segment.label + " " + segment.count.plain)
-                            .font(.caption)
+                            .font(.fixedCaption)
                             .foregroundStyle(.gray)
                     }
                 }

--- a/Sources/Scout/UI/Primitives/Rows/Header.swift
+++ b/Sources/Scout/UI/Primitives/Rows/Header.swift
@@ -19,7 +19,7 @@ struct Header<Trailing: View>: View {
 
     var body: some View {
         HStack {
-            Text(title.uppercased()).font(.callout.weight(.bold))
+            Text(title.uppercased()).font(.fixedCallout.weight(.bold))
 
             Spacer()
 

--- a/Sources/Scout/UI/Primitives/States/ErrorView.swift
+++ b/Sources/Scout/UI/Primitives/States/ErrorView.swift
@@ -20,11 +20,11 @@ struct ErrorView: View {
                 .foregroundColor(.yellow)
 
             Text(verbatim: "An error occurred")
-                .font(.title2)
+                .font(.fixedTitle2)
                 .bold()
 
             description
-                .font(.body)
+                .font(.fixedBody)
                 .multilineTextAlignment(.center)
 
             if let retry {

--- a/Sources/Scout/UI/Primitives/States/Placeholder.swift
+++ b/Sources/Scout/UI/Primitives/States/Placeholder.swift
@@ -26,7 +26,7 @@ struct Placeholder: View {
 
             if let description {
                 Text(description)
-                    .font(.body)
+                    .font(.fixedBody)
                     .kerning(0.3)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)

--- a/Sources/Scout/UI/Primitives/Styles/Font+Styles.swift
+++ b/Sources/Scout/UI/Primitives/Styles/Font+Styles.swift
@@ -12,3 +12,18 @@ extension Font {
     static let codeChip = Font.system(size: 14, design: .monospaced)
     static let stepBadge = Font.system(size: 13, weight: .semibold)
 }
+
+// A fixed-size mirror of the built-in Dynamic Type scale: each style matches its
+// semantic counterpart's size at the default content size but does not scale.
+extension Font {
+    static let fixedTitle = Font.system(size: 28)
+    static let fixedTitle2 = Font.system(size: 22)
+    static let fixedTitle3 = Font.system(size: 20)
+    static let fixedHeadline = Font.system(size: 17, weight: .semibold)
+    static let fixedBody = Font.system(size: 17)
+    static let fixedCallout = Font.system(size: 16)
+    static let fixedSubheadline = Font.system(size: 15)
+    static let fixedFootnote = Font.system(size: 13)
+    static let fixedCaption = Font.system(size: 12)
+    static let fixedCaption2 = Font.system(size: 11)
+}

--- a/Sources/Scout/UI/Primitives/Values/CountBadge.swift
+++ b/Sources/Scout/UI/Primitives/Values/CountBadge.swift
@@ -14,7 +14,7 @@ struct CountBadge: View {
 
     var body: some View {
         Text(verbatim: "\(prefix)\(count)")
-            .font(.caption.weight(.semibold))
+            .font(.fixedCaption.weight(.semibold))
             .monospacedDigit()
             .foregroundStyle(color)
             .padding(.horizontal, 7)

--- a/Sources/Scout/UI/Primitives/Values/Metric.swift
+++ b/Sources/Scout/UI/Primitives/Values/Metric.swift
@@ -15,11 +15,11 @@ struct Metric: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(verbatim: value)
-                .font(.title2.weight(.bold))
+                .font(.fixedTitle2.weight(.bold))
                 .monospacedDigit()
                 .foregroundStyle(color)
             Text(verbatim: title.uppercased())
-                .font(.caption.weight(.semibold))
+                .font(.fixedCaption.weight(.semibold))
                 .foregroundStyle(Color.gray)
         }
     }

--- a/Sources/Scout/UI/Releases/View/ReleaseRow.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseRow.swift
@@ -15,7 +15,7 @@ struct ReleaseRow: View {
             CompactRing(release: release)
 
             Text(verbatim: release.id)
-                .font(.body)
+                .font(.fixedBody)
                 .monospacedDigit()
 
             Spacer()
@@ -62,7 +62,7 @@ struct ReleaseRowPlaceholder: View {
             CompactRing(adoption: 1.0, color: .gray)
 
             Text(verbatim: "3.2.1")
-                .font(.body)
+                .font(.fixedBody)
                 .monospacedDigit()
 
             Spacer()
@@ -81,7 +81,7 @@ private struct ReleasePercent: View {
 
     var body: some View {
         Text(verbatim: text)
-            .font(.subheadline)
+            .font(.fixedSubheadline)
             .monospacedDigit()
             .foregroundStyle(.primary)
             .frame(minWidth: 80, alignment: .trailing)

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -109,7 +109,7 @@ struct VersionDetailView: View {
             ForEach(issues) { group in
                 Row {
                     Text(verbatim: group.name)
-                        .font(.callout)
+                        .font(.fixedCallout)
                         .monospaced()
                         .lineLimit(1)
 

--- a/Sources/Scout/UI/Settings/BackendDetailView.swift
+++ b/Sources/Scout/UI/Settings/BackendDetailView.swift
@@ -38,14 +38,14 @@ struct BackendDetailView: View {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 10) {
                     Image(systemName: backend.status.healthIcon)
-                        .font(.title2)
+                        .font(.fixedTitle2)
                         .foregroundStyle(backend.status.healthColor)
 
                     VStack(alignment: .leading, spacing: 1) {
                         Text(verbatim: backend.status.healthLabel)
-                            .font(.headline)
+                            .font(.fixedHeadline)
                         Text(verbatim: backend.engine.label)
-                            .font(.caption)
+                            .font(.fixedCaption)
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -116,7 +116,7 @@ struct BackendDetailView: View {
                 BenchmarkButton(benchmark: benchmark, message: $message)
 
                 Text(verbatim: "The benchmark issues test queries to verify the \(RequestLimiter.requestLimit)-request limit.")
-                    .font(.caption)
+                    .font(.fixedCaption)
                     .foregroundStyle(.secondary)
                     .listRowSeparator(.hidden)
             }
@@ -134,7 +134,7 @@ struct DetailValueRow: View {
             Text(verbatim: title)
             Spacer()
             Text(verbatim: value)
-                .font(.body.monospacedDigit())
+                .font(.fixedBody.monospacedDigit())
                 .foregroundStyle(.secondary)
         }
     }

--- a/Sources/Scout/UI/Settings/GlanceHero.swift
+++ b/Sources/Scout/UI/Settings/GlanceHero.swift
@@ -46,11 +46,11 @@ struct GlanceHero: View {
                 .foregroundStyle(summary.color)
 
             Text(verbatim: summary.title)
-                .font(.title3.weight(.semibold))
+                .font(.fixedTitle3.weight(.semibold))
                 .multilineTextAlignment(.center)
 
             Text(verbatim: summary.detail)
-                .font(.footnote)
+                .font(.fixedFootnote)
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)

--- a/Sources/Scout/UI/Settings/SettingsOverviewView.swift
+++ b/Sources/Scout/UI/Settings/SettingsOverviewView.swift
@@ -74,7 +74,7 @@ private struct BackendRow: View {
 
         if isActive {
             Text(verbatim: "Active")
-                .font(.caption2.weight(.semibold))
+                .font(.fixedCaption2.weight(.semibold))
                 .padding(.horizontal, 6)
                 .padding(.vertical, 2)
                 .background(Capsule().fill(.tint.opacity(0.15)))
@@ -84,7 +84,7 @@ private struct BackendRow: View {
         Spacer()
 
         Text(verbatim: backend.latencyLabel)
-            .font(.body.monospacedDigit())
+            .font(.fixedBody.monospacedDigit())
             .foregroundStyle(.secondary)
     }
 }

--- a/Sources/Scout/UI/Timeline/View/Anchor/AnchoredScroll.swift
+++ b/Sources/Scout/UI/Timeline/View/Anchor/AnchoredScroll.swift
@@ -120,7 +120,7 @@ extension EnvironmentValues {
                     Text("Row \(row)").monospaced()
                     Spacer()
                     if row == anchor {
-                        Text("anchor").foregroundStyle(.tint).font(.caption)
+                        Text("anchor").foregroundStyle(.tint).font(.fixedCaption)
                     }
                 }
                 .padding()

--- a/Sources/Scout/UI/Timeline/View/Legend/Legend.swift
+++ b/Sources/Scout/UI/Timeline/View/Legend/Legend.swift
@@ -26,7 +26,7 @@ struct Legend: View {
                                     .fill(kind.color)
                                     .frame(width: 8, height: 8)
                                 Text(kind.label)
-                                    .font(.footnote)
+                                    .font(.fixedFootnote)
                                     .foregroundStyle(.primary)
                             }
                             .padding(.horizontal, 10)
@@ -44,7 +44,7 @@ struct Legend: View {
 
             if let expanded {
                 Text(expanded.legendDescription)
-                    .font(.footnote)
+                    .font(.fixedFootnote)
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal)

--- a/Sources/Scout/UI/Timeline/View/TimelineRow.swift
+++ b/Sources/Scout/UI/Timeline/View/TimelineRow.swift
@@ -23,7 +23,7 @@ struct TimelineRow: View {
                 }
 
                 Text(row.name)
-                    .font(.body)
+                    .font(.fixedBody)
                     .lineLimit(1)
                     .monospaced()
                     .padding(.leading, 8)
@@ -33,7 +33,7 @@ struct TimelineRow: View {
                 TimelineView(.periodic(from: timeline, by: 1)) { _ in
                     Text(row.date.relativeString)
                 }
-                .font(.subheadline)
+                .font(.fixedSubheadline)
                 .foregroundStyle(.gray)
             }
             .frame(height: 43)


### PR DESCRIPTION
Introduces a fixed-size mirror of the built-in text-style scale on `Font` — fixedTitle through fixedCaption2, each matching its semantic counterpart's size at the default content size but built on `.system(size:)` so it no longer scales with Dynamic Type — and moves every `.font(.body)`, `.font(.callout)`, and the rest of the semantic usages across the UI onto it, preserving the existing weight and monospacedDigit modifiers. The result is one named typographic vocabulary with fixed sizing instead of Dynamic Type. Follows on from #795 and #797.