### PR TITLE
Populate the event detail preview with fixture data

### DIFF
--- a/Sources/Scout/UI/Event/Detail/EventView.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.swift
@@ -13,9 +13,9 @@ struct EventView: View {
     @StateObject private var param: ParamProvider
     @State private var isParamPresented = false
 
-    init(event: Event) {
+    init(event: Event, param: ParamProvider? = nil) {
         self.event = event
-        _param = StateObject(wrappedValue: ParamProvider(recordID: event.id))
+        _param = StateObject(wrappedValue: param ?? ParamProvider(recordID: event.id))
     }
 
     var body: some View {
@@ -69,19 +69,41 @@ extension EventView {
 }
 
 #Preview {
+    let params = ParamProvider.Item.samplePurchase
+    let event = Event(
+        name: "event_name",
+        level: .info,
+        date: Date(),
+        paramCount: params.count,
+        uuid: UUID(),
+        id: UUID().uuidString,
+        installID: UUID(),
+        sessionID: UUID(),
+        deviceID: UUID()
+    )
+
     NavigationStack {
-        let event = Event(
-            name: "event_name",
-            level: .info,
-            date: Date(),
-            paramCount: 3,
-            uuid: UUID(),
-            id: UUID().uuidString,
-            installID: UUID(),
-            sessionID: UUID(),
-            deviceID: UUID()
-        )
-        EventView(event: event)
+        EventView(event: event, param: .fixture(items: params))
     }
+    .environment(\.database, SampleDatabase(eventName: event.name))
     .environmentObject(Tint())
+}
+
+private struct SampleDatabase: Database {
+    let eventName: String
+
+    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
+        RecordChunk(records: [StatProvider.sampleMatrix(name: eventName).record], cursor: nil)
+    }
+
+    func lookup(recordName: String, fields: [String]?) async throws -> Record {
+        throw RecordNotFoundError()
+    }
+
+    func activity(in range: Range<Date>) async throws -> [ActivityPoint] { [] }
+
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] { [] }
+
+    func write(record: Record) async throws {}
+    func write(records: [Record]) async throws {}
 }

--- a/Sources/Scout/UI/Event/Param/ParamProvider.swift
+++ b/Sources/Scout/UI/Event/Param/ParamProvider.swift
@@ -23,3 +23,11 @@ class ParamProvider: ObservableObject, Provider {
             .sorted() ?? []
     }
 }
+
+extension ParamProvider {
+    static func fixture(items: [Item]) -> ParamProvider {
+        let provider = ParamProvider(recordID: UUID().uuidString)
+        provider.result = .success(items.sorted())
+        return provider
+    }
+}

--- a/Sources/Scout/UI/Stats/StatProvider.swift
+++ b/Sources/Scout/UI/Stats/StatProvider.swift
@@ -33,7 +33,7 @@ extension StatProvider {
         return provider
     }
 
-    private static func sampleMatrix(name: String) -> GridMatrix<Int> {
+    nonisolated static func sampleMatrix(name: String) -> GridMatrix<Int> {
         let cells = (1...372).map { day in
             GridCell(row: day, column: 12, value: 12 + day % 40 + (day / 9) % 18)
         }


### PR DESCRIPTION
The event detail preview previously injected no database, so the Params, Stats, and History sections rendered empty placeholders. It now shows realistic content by injecting a fixture ParamProvider and a sample database for the stats query.

ParamProvider gains a fixture(items:) helper that presets its result, so EventView can take an injected provider the same way VersionDetailView takes its crash provider. The preview passes the sample purchase params through it, and a small preview-only database serves the stat matrix so the Today/Yesterday/7/30/365-day rows fill in.