### PR TITLE
Inject the stat fixture into the event detail preview

### DIFF
--- a/Sources/Scout/UI/Event/Detail/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.Sections.swift
@@ -45,18 +45,9 @@ extension EventView {
 
 extension EventView {
     struct StatSection: View {
-        @StateObject var stat: StatProvider
+        @ObservedObject var stat: StatProvider
 
         @Environment(\.database) var database
-
-        init(eventName: String) {
-            _stat = StateObject(
-                wrappedValue: StatProvider(
-                    eventName: eventName,
-                    periods: Period.allCases
-                )
-            )
-        }
 
         var body: some View {
             Header(title: "Stats").task {

--- a/Sources/Scout/UI/Event/Detail/EventView.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.swift
@@ -11,11 +11,13 @@ struct EventView: View {
     let event: Event
 
     @StateObject private var param: ParamProvider
+    @StateObject private var stat: StatProvider
     @State private var isParamPresented = false
 
-    init(event: Event, param: ParamProvider? = nil) {
+    init(event: Event, param: ParamProvider? = nil, stat: StatProvider? = nil) {
         self.event = event
         _param = StateObject(wrappedValue: param ?? ParamProvider(recordID: event.id))
+        _stat = StateObject(wrappedValue: stat ?? StatProvider(eventName: event.name, periods: Period.allCases))
     }
 
     var body: some View {
@@ -32,7 +34,7 @@ struct EventView: View {
                 )
             }
 
-            StatSection(eventName: event.name)
+            StatSection(stat: stat)
             HistorySection(event: event)
         }
         .listStyle(.plain)
@@ -83,27 +85,11 @@ extension EventView {
     )
 
     NavigationStack {
-        EventView(event: event, param: .fixture(items: params))
+        EventView(
+            event: event,
+            param: .fixture(items: params),
+            stat: .fixture(eventName: event.name)
+        )
     }
-    .environment(\.database, SampleDatabase(eventName: event.name))
     .environmentObject(Tint())
-}
-
-private struct SampleDatabase: Database {
-    let eventName: String
-
-    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
-        RecordChunk(records: [StatProvider.sampleMatrix(name: eventName).record], cursor: nil)
-    }
-
-    func lookup(recordName: String, fields: [String]?) async throws -> Record {
-        throw RecordNotFoundError()
-    }
-
-    func activity(in range: Range<Date>) async throws -> [ActivityPoint] { [] }
-
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] { [] }
-
-    func write(record: Record) async throws {}
-    func write(records: [Record]) async throws {}
 }

--- a/Sources/Scout/UI/Stats/StatProvider.swift
+++ b/Sources/Scout/UI/Stats/StatProvider.swift
@@ -33,7 +33,7 @@ extension StatProvider {
         return provider
     }
 
-    nonisolated static func sampleMatrix(name: String) -> GridMatrix<Int> {
+    private static func sampleMatrix(name: String) -> GridMatrix<Int> {
         let cells = (1...372).map { day in
             GridCell(row: day, column: 12, value: 12 + day % 40 + (day / 9) % 18)
         }


### PR DESCRIPTION
The event detail preview built a bespoke preview-only database to feed the Stats section. It now injects StatProvider.fixture directly, the same way the Params section already takes an injected ParamProvider, so the whole preview relies on the existing provider fixtures and the sample database goes away.

StatSection now receives its provider from EventView rather than constructing one from the event name, matching how ParamSection receives its provider. The private sampleMatrix helper on StatProvider returns to being private since nothing outside it needs the record anymore.