### PR TITLE
Reset image scale on the Home navigation stack

### DIFF
--- a/Sources/Scout/UI/Home/HomeContent.swift
+++ b/Sources/Scout/UI/Home/HomeContent.swift
@@ -41,7 +41,6 @@ struct HomeContent: View {
             ReleaseHealthView(provider: releaseProvider)
         }
         .listStyle(.plain)
-        .imageScale(.medium)
         .scrollContentBackground(.hidden)
         .background {
             Rectangle()

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -67,6 +67,7 @@ struct HomeView: View {
             .dismissable()
             .connectionToolbar(backends: backends, activeID: activeIDBinding)
         }
+        .imageScale(.medium)
         .tint(tint.value)
         .environment(\.database, backend?.database ?? DefaultDatabase())
         .environmentObject(tint)


### PR DESCRIPTION
Commit #760 pinned `.imageScale(.medium)` on `HomeContent`'s list so Scout's row icons keep their intended size when the host app presents the dashboard over a toolbar that sets `imageScale(.large)`. That reset only reached the Home list itself — pushed destinations like `EventView` are siblings in the navigation stack, so they still inherited the enlarged scale and rendered oversized calendar and timeline icons. This moves the reset up to the `HomeView` navigation stack, next to the existing `.tint`, so it propagates to every pushed screen and the settings sheet, and drops the now-redundant modifier from `HomeContent`.