### PR TITLE
Guard the event stat list fetch so injected fixtures survive

### DIFF
--- a/Sources/Scout/UI/Event/List/EventStatList.swift
+++ b/Sources/Scout/UI/Event/List/EventStatList.swift
@@ -31,18 +31,18 @@ struct EventStatList: View {
         VStack {
             EventList(provider: provider)
                 .task {
-                    await fetch()
+                    await provider.fetchIfNeeded(for: query, in: database)
                 }
                 .navigationTitle(range.label(using: formatter))
                 .font(.caption)
         }
     }
 
-    func fetch() async {
+    var query: Event.Query {
         var query = Event.Query()
         query.dates = range
         query.name = eventName
-        await provider.fetch(for: query, in: database)
+        return query
     }
 }
 


### PR DESCRIPTION
EventStatList's task ran an unconditional fetch that immediately overwrote the injected EventProvider fixture with an empty database result, so the #Preview and any fixture-backed use rendered the "No results" placeholder instead of the sample events. Route the load through provider.fetchIfNeeded so a preloaded fixture is preserved, mirroring how AnalyticsView and CrashListView already guard their fetches, and expose the stat query as a computed property.