### PR TITLE
Extract a shared AllButton for section header navigation

### DIFF
--- a/Sources/Scout/UI/Event/Detail/EventView.Sections.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.Sections.swift
@@ -23,7 +23,7 @@ extension EventView {
 
             Header(title: "Params") {
                 if canSeeAll {
-                    SeeAllButton { isParamPresented = true }
+                    AllButton { isParamPresented = true }
                 }
             }
             .task {
@@ -94,16 +94,5 @@ extension EventView {
                 Timeline(deviceID: deviceID, event: event)
             }
         }
-    }
-}
-
-private struct SeeAllButton: View {
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Text(verbatim: "See all").foregroundStyle(.blue)
-        }
-        .buttonStyle(.plain)
     }
 }

--- a/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
@@ -15,16 +15,9 @@ struct HomeReleaseSection: View {
 
     var body: some View {
         Header(title: "Releases") {
-            Button {
-                showReleaseHealth = true
-            } label: {
-                if let releases = provider.releases, releases.count > 0 {
-                    Text(verbatim: "All".uppercased())
-                        .font(.callout.weight(.medium))
-                        .foregroundStyle(.blue)
-                }
+            if let releases = provider.releases, releases.count > 0 {
+                AllButton { showReleaseHealth = true }
             }
-            .buttonStyle(.plain)
         }
         .task {
             await provider.fetchIfNeeded(in: database)

--- a/Sources/Scout/UI/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct NetworkView: View {
     @Environment(\.database) var database
+    @State private var showAllEndpoints = false
     @StateObject private var provider: NetworkProvider
 
     init(provider: NetworkProvider = NetworkProvider()) {
@@ -54,18 +55,16 @@ struct NetworkView: View {
                 .listRowSeparator(.hidden)
 
             Header(title: "Top endpoints") {
-                NavigationLink {
-                    NetworkEndpointsView(report: report, range: range)
-                } label: {
-                    Text(verbatim: "See all").foregroundStyle(.blue)
-                }
-                .buttonStyle(.plain)
+                AllButton { showAllEndpoints = true }
             }
             ForEach(endpoints.prefix(3)) { endpoint in
                 NetworkEndpointLink(endpoint: endpoint, report: report, range: range)
             }
         }
         .listStyle(.plain)
+        .navigationDestination(isPresented: $showAllEndpoints) {
+            NetworkEndpointsView(report: report, range: range)
+        }
     }
 }
 

--- a/Sources/Scout/UI/Primitives/Rows/AllButton.swift
+++ b/Sources/Scout/UI/Primitives/Rows/AllButton.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct AllButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(verbatim: "All".uppercased())
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.blue)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    List {
+        Header(title: "Section Title") {
+            AllButton {}
+        }
+    }
+    .listStyle(.plain)
+}

--- a/Sources/Scout/UI/Primitives/Rows/Header.swift
+++ b/Sources/Scout/UI/Primitives/Rows/Header.swift
@@ -34,11 +34,7 @@ struct Header<Trailing: View>: View {
     List {
         Header(title: "Section Title")
         Header(title: "Section Title") {
-            Button {
-            } label: {
-                Text(verbatim: "See all").foregroundStyle(.blue)
-            }
-            .buttonStyle(.plain)
+            AllButton {}
         }
     }
 }


### PR DESCRIPTION
The Network screen's Top endpoints header used a See all NavigationLink, which made the List draw a trailing disclosure chevron and looked different from the Home dashboard's ALL button. This extracts the dashboard's button into a shared AllButton primitive and reuses it in the Network, Home releases, and event params headers, switching the endpoints navigation to a navigationDestination binding so the chevron is gone.