### PR TITLE
Animate the segment strip indicator without animating the labels

### DIFF
--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -21,8 +21,24 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
     let title: (Value) -> String
 
     @Namespace private var namespace
+    @State private var indicator: Value?
 
     var body: some View {
+        distributed
+            .onAppear {
+                if indicator == nil {
+                    indicator = selection
+                }
+            }
+            .onChange(of: selection) { newValue in
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    indicator = newValue
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var distributed: some View {
         switch distribution {
         case .compact(let spacing):
             HStack(spacing: spacing) {
@@ -37,42 +53,26 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
         }
     }
 
-    @ViewBuilder
     private var segments: some View {
         ForEach(values, id: \.self) { value in
-            if value == selection {
-                selected(value)
-            } else {
-                unselected(value)
-            }
+            Text(title(value).uppercased())
+                .font(.system(size: 14, weight: value == selection ? .bold : .medium))
+                .foregroundStyle(value == selection ? .primary : .secondary)
+                .padding(.horizontal, 8)
+                .padding(.bottom, 6)
+                .overlay(alignment: .bottom) {
+                    if value == indicator {
+                        Capsule()
+                            .fill(tint(value))
+                            .frame(height: 2)
+                            .matchedGeometryEffect(id: "indicator", in: namespace)
+                    }
+                }
+                .contentShape(.rect)
+                .onTapGesture {
+                    selection = value
+                }
         }
-        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: selection)
-    }
-
-    private func selected(_ value: Value) -> some View {
-        Text(title(value).uppercased())
-            .font(.system(size: 14, weight: .bold))
-            .foregroundStyle(.primary)
-            .padding(.horizontal, 8)
-            .padding(.bottom, 6)
-            .overlay(alignment: .bottom) {
-                Capsule()
-                    .fill(tint(value))
-                    .frame(height: 2)
-                    .matchedGeometryEffect(id: "indicator", in: namespace)
-            }
-            .contentShape(.rect)
-    }
-
-    private func unselected(_ value: Value) -> some View {
-        Text(title(value).uppercased())
-            .font(.system(size: 14, weight: .medium))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.bottom, 6)
-            .onTapGesture {
-                selection = value
-            }
     }
 }
 


### PR DESCRIPTION
The Home section picker sits inside the List, where the underline's `matchedGeometryEffect` had stopped sliding — an implicit `.animation(_:value:)` doesn't form a reliable transaction for matched geometry inside a List row, so the indicator jumped between tabs instead of moving. On top of that, driving the whole selected/unselected split off the animated value dragged the label weight and color into the animation too.

This drives the underline from a separate `indicator` state that is updated inside an explicit `withAnimation` on selection change, and seeded on appear so the very first switch animates as well. The label weight and color stay bound to `selection`, so they flip instantly, while only the capsule follows the animated `indicator`. Because the caller's `selection` is still set outside any animation, the period and metrics strips that reuse `SegmentStrip` keep their non-animated content updates. Verified with a simulator build via ScoutIP.