### PR TITLE
Restore the Metrics navigation title on the Home Log row

### DIFF
--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -34,7 +34,7 @@ struct HomeLogSection: View {
             image: "chart.bar",
             color: .blue,
             count: logSpans.map { $0.int.series + $0.double.series },
-            destination: { MetricsList() }
+            destination: { MetricsList().navigationTitle(en: "Metrics") }
         )
 
         Row {


### PR DESCRIPTION
The Metrics screen reached from the Home Log section lost its navigation title in #611, which reworked HomeLogSection and dropped the `.navigationTitle(en: "Metrics")` that used to wrap the destination when the Metrics row moved onto the shared HomeLogRow. MetricsList sets the title only in its preview, so the pushed screen rendered with an empty title bar. This restores the title at the destination call site, matching how it was applied before the refactor.