### PR TITLE
Frame empty comparison and crash charts with baseline gridlines

### DIFF
--- a/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/Scout/UI/Chart/Comparison/ComparisonChartView.swift
@@ -32,10 +32,12 @@ struct ComparisonChartView<T: ChartNumeric>: View {
 
     var body: some View {
         let pairs = segment.paired(with: reference, unit: timing.unit)
+        let isEmpty = segment.total == .zero && reference.total == .zero
 
         Chart(pairs) { pair in
             marks(for: pair)
         }
+        .placeholderAxis(active: isEmpty)
         .chartXScale(domain: pairs.xDomain())
         .chartXAxis {
             AxisMarks(format: timing.unit.chartFormat, values: timing.tickDates(for: segment))
@@ -51,7 +53,7 @@ struct ComparisonChartView<T: ChartNumeric>: View {
             }
         }
         .chartBackground { _ in
-            if segment.total == .zero && reference.total == .zero {
+            if isEmpty {
                 ChartPlaceholder()
             }
         }

--- a/Sources/Scout/UI/Chart/View/ChartView.swift
+++ b/Sources/Scout/UI/Chart/View/ChartView.swift
@@ -15,23 +15,6 @@ struct ChartView<T: ChartNumeric>: View {
     var body: some View {
         let isEmpty = segment.total == .zero
 
-        bars
-            .placeholderAxis(active: isEmpty)
-            .chartXAxis {
-                AxisMarks(format: timing.unit.chartFormat, values: timing.tickDates(for: segment))
-            }
-            .chartBackground { _ in
-                if isEmpty {
-                    ChartPlaceholder()
-                }
-            }
-            .aspectRatio(4 / 3, contentMode: .fit)
-            .padding()
-            .padding(.bottom)
-            .listRowInsets(EdgeInsets())
-    }
-
-    private var bars: some View {
         Chart(segment, id: \.date) { point in
             BarMark(
                 x: .value("X", point.date, unit: timing.unit),
@@ -39,6 +22,19 @@ struct ChartView<T: ChartNumeric>: View {
                 width: .ratio(ChartGeometry.barRatio)
             )
         }
+        .placeholderAxis(active: isEmpty)
+        .chartXAxis {
+            AxisMarks(format: timing.unit.chartFormat, values: timing.tickDates(for: segment))
+        }
+        .chartBackground { _ in
+            if isEmpty {
+                ChartPlaceholder()
+            }
+        }
+        .aspectRatio(4 / 3, contentMode: .fit)
+        .padding()
+        .padding(.bottom)
+        .listRowInsets(EdgeInsets())
     }
 }
 

--- a/Sources/Scout/UI/Chart/View/ChartView.swift
+++ b/Sources/Scout/UI/Chart/View/ChartView.swift
@@ -15,7 +15,8 @@ struct ChartView<T: ChartNumeric>: View {
     var body: some View {
         let isEmpty = segment.total == .zero
 
-        chart(isEmpty: isEmpty)
+        bars
+            .placeholderAxis(active: isEmpty)
             .chartXAxis {
                 AxisMarks(format: timing.unit.chartFormat, values: timing.tickDates(for: segment))
             }
@@ -30,15 +31,6 @@ struct ChartView<T: ChartNumeric>: View {
             .listRowInsets(EdgeInsets())
     }
 
-    @ViewBuilder
-    private func chart(isEmpty: Bool) -> some View {
-        if isEmpty {
-            bars.placeholderAxis
-        } else {
-            bars
-        }
-    }
-
     private var bars: some View {
         Chart(segment, id: \.date) { point in
             BarMark(
@@ -46,16 +38,6 @@ struct ChartView<T: ChartNumeric>: View {
                 y: .value("Y", point.count),
                 width: .ratio(ChartGeometry.barRatio)
             )
-        }
-    }
-}
-
-extension View {
-    fileprivate var placeholderAxis: some View {
-        chartYScale(domain: 0...1).chartYAxis {
-            AxisMarks(values: [0, 1]) { _ in
-                AxisGridLine()
-            }
         }
     }
 }

--- a/Sources/Scout/UI/Chart/View/PlaceholderAxis.swift
+++ b/Sources/Scout/UI/Chart/View/PlaceholderAxis.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Charts
+import SwiftUI
+
+extension View {
+    // Swift Charts drops the Y axis when there is no data, so an empty chart
+    // loses the top and bottom lines that frame it when data is present. Pin a
+    // fixed 0...1 domain and draw gridlines at both bounds to keep that framing.
+    @ViewBuilder
+    func placeholderAxis(active: Bool) -> some View {
+        if active {
+            chartYScale(domain: 0...1).chartYAxis {
+                AxisMarks(values: [0, 1]) { _ in
+                    AxisGridLine()
+                }
+            }
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -69,6 +69,7 @@ struct VersionDetailView: View {
     @ViewBuilder
     private var trendSection: some View {
         let days = dailyCrashes
+        let isEmpty = !days.contains(where: { $0.count > 0 })
 
         Header(title: "Crashes over time")
 
@@ -91,8 +92,9 @@ struct VersionDetailView: View {
         .chartYAxis {
             AxisMarks(position: .leading)
         }
+        .placeholderAxis(active: isEmpty)
         .chartBackground { _ in
-            if !days.contains(where: { $0.count > 0 }) {
+            if isEmpty {
                 ChartPlaceholder().offset(y: -12)
             }
         }


### PR DESCRIPTION
Follows up on #809, which pinned baseline gridlines onto the empty stats chart. The same empty-state framing was missing on two more charts that render a `ChartPlaceholder`: the comparison bar chart and the version detail "Crashes over time" chart. When their data is empty, Swift Charts drops the Y axis and the top and bottom lines that frame the populated chart disappear.

This extracts the empty-state axis from `ChartView` into a shared `placeholderAxis(active:)` modifier and applies it in all three places, so the empty state now keeps its framing gridlines consistently. `MiniChart` and `StatusBar` deliberately hide their axes and are left alone.