### PR TITLE
Inject provider StateObjects via the synthesized memberwise init

### DIFF
--- a/Sources/Scout/UI/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Crash/CrashListView.swift
@@ -9,11 +9,7 @@ import SwiftUI
 
 struct CrashListView: View {
     @Environment(\.database) var database
-    @StateObject private var provider: CrashProvider
-
-    init(provider: CrashProvider? = nil) {
-        self._provider = StateObject(wrappedValue: provider ?? CrashProvider())
-    }
+    @StateObject var provider = CrashProvider()
 
     var body: some View {
         Group {

--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -10,14 +10,10 @@ import SwiftUI
 struct AnalyticsView: View {
     @State private var filter = Event.Query()
 
-    @StateObject private var provider: EventProvider
-    @StateObject private var search = EventProvider()
+    @StateObject var provider = EventProvider()
+    @StateObject var search = EventProvider()
 
     @Environment(\.database) var database
-
-    init(provider: EventProvider? = nil) {
-        self._provider = StateObject(wrappedValue: provider ?? EventProvider())
-    }
 
     var body: some View {
         Group {

--- a/Sources/Scout/UI/Event/Detail/EventView.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct EventView: View {
     let event: Event
 
-    @StateObject private var param: ParamProvider
-    @StateObject private var stat: StatProvider
+    @StateObject var param: ParamProvider
+    @StateObject var stat: StatProvider
     @State private var isParamPresented = false
 
     init(event: Event, param: ParamProvider? = nil, stat: StatProvider? = nil) {

--- a/Sources/Scout/UI/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Event/Filter/FilterView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct FilterView: View {
     @Environment(\.dismiss) var dismiss
-    @StateObject private var criteria: FilterCriteria<Event.Level>
+    @StateObject var criteria: FilterCriteria<Event.Level>
 
     init(selected: Binding<Set<Event.Level>>) {
         _criteria = StateObject(wrappedValue: FilterCriteria(selected: selected))

--- a/Sources/Scout/UI/Event/List/EventStatList.swift
+++ b/Sources/Scout/UI/Event/List/EventStatList.swift
@@ -11,14 +11,8 @@ struct EventStatList: View {
     let eventName: String
     let range: Range<Date>
 
-    @StateObject private var provider: EventProvider
+    @StateObject var provider = EventProvider()
     @Environment(\.database) var database
-
-    init(eventName: String, range: Range<Date>, provider: EventProvider? = nil) {
-        self.eventName = eventName
-        self.range = range
-        self._provider = StateObject(wrappedValue: provider ?? EventProvider())
-    }
 
     let formatter: DateFormatter = {
         let formatter = DateFormatter()

--- a/Sources/Scout/UI/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkView.swift
@@ -11,11 +11,7 @@ import SwiftUI
 struct NetworkView: View {
     @Environment(\.database) var database
     @State private var showAllEndpoints = false
-    @StateObject private var provider: NetworkProvider
-
-    init(provider: NetworkProvider = NetworkProvider()) {
-        self._provider = StateObject(wrappedValue: provider)
-    }
+    @StateObject var provider = NetworkProvider()
 
     var body: some View {
         ProviderView(provider: provider) { report in

--- a/Sources/Scout/UI/Releases/View/ReleaseHealthView.swift
+++ b/Sources/Scout/UI/Releases/View/ReleaseHealthView.swift
@@ -10,11 +10,7 @@ import SwiftUI
 struct ReleaseHealthView: View {
     @Environment(\.database) var database
 
-    @StateObject private var provider: ReleaseHealthProvider
-
-    init(provider: ReleaseHealthProvider = ReleaseHealthProvider()) {
-        self._provider = StateObject(wrappedValue: provider)
-    }
+    @StateObject var provider = ReleaseHealthProvider()
 
     var body: some View {
         ProviderView(provider: provider) { releases in

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -12,7 +12,7 @@ struct VersionDetailView: View {
     @Environment(\.database) var database
 
     let release: ReleaseHealth
-    @StateObject private var crashProvider: VersionCrashProvider
+    @StateObject var crashProvider: VersionCrashProvider
 
     init(release: ReleaseHealth, crashProvider: VersionCrashProvider? = nil) {
         self.release = release

--- a/Sources/Scout/UI/Settings/SettingsOverviewView.swift
+++ b/Sources/Scout/UI/Settings/SettingsOverviewView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct SettingsOverviewView: View {
     @Binding var activeID: String
-    @StateObject private var provider: BackendHealthProvider
+    @StateObject var provider: BackendHealthProvider
 
     @State private var message: Message?
 

--- a/Sources/Scout/UI/Timeline/View/Timeline.swift
+++ b/Sources/Scout/UI/Timeline/View/Timeline.swift
@@ -12,7 +12,7 @@ struct Timeline: View {
     var event: Event? = nil
 
     @Environment(\.database) var database
-    @StateObject private var provider = TimelineProvider()
+    @StateObject var provider = TimelineProvider()
 
     @State private var scope: TimelineScope = .all
     @State private var showLegend = false


### PR DESCRIPTION
Standardizes provider injection on the HomeList style so no `@StateObject` is `private`. Views whose initializer only wrapped an injected provider now drop that boilerplate and expose the StateObject through the synthesized memberwise initializer with a default value; views that derive their provider from another parameter keep the initializer and just drop `private`, matching the existing MetricsContent/TimerDistributionSection convention. No production call sites or previews change, and both the app and test targets build. Fixture factories are intentionally left for a follow-up.