### PR TITLE
Rename single-view providers to `provider`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,11 @@
 
 - Use only `.listStyle(.plain)` for `List`s; section titles are `Header(title:)` rows (not `Section` headers/footers), with `.listRowSeparator(.hidden)` on non-row content.
 
+## Provider naming
+
+- A view with a single `@StateObject` provider names it `provider` (e.g. `@StateObject var provider = StatProvider(eventName: "Session", periods: Period.summary)`), regardless of the concrete provider type.
+- A view with more than one `@StateObject` provider gives each a descriptive name reflecting what it represents (e.g. `activities`, `sessions`, `crashes`, `releases`, `logs`).
+
 ## Sample data
 
 - Sample data in app code is named `sample` (a `static var` for fixed instances, a `static func sample(...)` when parameters are needed), placed in an extension at the end of the type's main file (e.g. `Device.swift`), and built directly via the struct initializer.

--- a/Sources/Scout/UI/Metrics/MetricsContent.swift
+++ b/Sources/Scout/UI/Metrics/MetricsContent.swift
@@ -12,18 +12,18 @@ struct MetricsContent<T: ChartNumeric>: View {
     let formatter: KeyPath<T, String>
     let telemetry: Telemetry.Export
 
-    @StateObject var metrics: MetricsProvider<T>
+    @StateObject var provider: MetricsProvider<T>
     @Environment(\.database) var database
 
     init(period: Period, formatter: KeyPath<T, String>, telemetry: Telemetry.Export) {
         self.period = period
         self.formatter = formatter
         self.telemetry = telemetry
-        self._metrics = StateObject(wrappedValue: MetricsProvider(telemetry: telemetry))
+        self._provider = StateObject(wrappedValue: MetricsProvider(telemetry: telemetry))
     }
 
     var body: some View {
-        ProviderView(provider: metrics) { data in
+        ProviderView(provider: provider) { data in
             let groups: [PointGroup<T>] = data.pointGroups()
             let ranked = groups.ranked(on: period)
 
@@ -48,7 +48,7 @@ struct MetricsContent<T: ChartNumeric>: View {
             }
         }
         .task {
-            await metrics.fetchIfNeeded(in: database)
+            await provider.fetchIfNeeded(in: database)
         }
     }
 

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -12,15 +12,15 @@ struct VersionDetailView: View {
     @Environment(\.database) var database
 
     let release: ReleaseHealth
-    @StateObject var crashProvider: VersionCrashProvider
+    @StateObject var provider: VersionCrashProvider
 
-    init(release: ReleaseHealth, crashProvider: VersionCrashProvider? = nil) {
+    init(release: ReleaseHealth, provider: VersionCrashProvider? = nil) {
         self.release = release
-        self._crashProvider = StateObject(wrappedValue: crashProvider ?? VersionCrashProvider(version: release.id))
+        self._provider = StateObject(wrappedValue: provider ?? VersionCrashProvider(version: release.id))
     }
 
     private var crashes: [Crash] {
-        crashProvider.crashes ?? []
+        provider.crashes ?? []
     }
 
     private var issues: [CrashGroup] {
@@ -37,9 +37,9 @@ struct VersionDetailView: View {
         .toolbarBackground(release.freeSessions.color.opacity(0.12), for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .navigationTitle(en: release.id)
-        .message($crashProvider.message)
+        .message($provider.message)
         .task {
-            await crashProvider.fetchIfNeeded(in: database)
+            await provider.fetchIfNeeded(in: database)
         }
     }
 
@@ -128,7 +128,7 @@ struct VersionDetailView: View {
 
 #Preview {
     NavigationStack {
-        VersionDetailView(release: ReleaseHealth.samples[0], crashProvider: .fixture())
+        VersionDetailView(release: ReleaseHealth.samples[0], provider: .fixture())
     }
     .environmentObject(Tint())
 }
@@ -139,7 +139,7 @@ struct VersionDetailView: View {
     return NavigationStack {
         VersionDetailView(
             release: release,
-            crashProvider: VersionCrashProvider(version: release.id, crashes: [])
+            provider: VersionCrashProvider(version: release.id, crashes: [])
         )
     }
     .environmentObject(Tint())


### PR DESCRIPTION
## Summary
- Renames `crashProvider` to `provider` in `VersionDetailView` and `metrics` to `provider` in `MetricsContent`, so both single-`@StateObject`-provider views follow the same naming.
- Documents the convention in CLAUDE.md: single-provider views use `provider`; multi-provider views (e.g. `HomeList`) keep descriptive names per provider.

## Test plan
- [x] `xcodebuild build` for the Scout scheme succeeds with no compile errors from the renames