### PR TITLE
Fix crash risk and reduce fetch cost in VersionObject.launches(in:)

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
@@ -22,10 +22,14 @@ final class VersionObject: SyncableObject {
     }
 
     func launches(in context: NSManagedObjectContext) throws -> [LaunchObject] {
-        let versionRequest = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        versionRequest.predicate = NSPredicate(format: "appVersion == %@", appVersion!)
-        let versions = try context.fetch(versionRequest)
-        let launchIDs = versions.compactMap(\.launchID)
+        guard let appVersion else { return [] }
+
+        let versionRequest = NSFetchRequest<NSDictionary>(entityName: "VersionObject")
+        versionRequest.predicate = NSPredicate(format: "appVersion == %@", appVersion)
+        versionRequest.resultType = .dictionaryResultType
+        versionRequest.propertiesToFetch = ["launchID"]
+        versionRequest.returnsDistinctResults = true
+        let launchIDs = try context.fetch(versionRequest).compactMap { $0["launchID"] as? UUID }
 
         let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
         request.predicate = NSPredicate(format: "launchID IN %@", launchIDs)

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
@@ -47,6 +47,17 @@ struct VersionObjectTests {
         #expect(launches.allSatisfy { $0.launchID == launchID1 || $0.launchID == launchID2 })
     }
 
+    @Test("launches(in:) returns an empty array when appVersion is nil")
+    func testLaunchesNilAppVersion() throws {
+        let version = VersionObject.stub(date: week, appVersion: "2.0", in: context)
+        version.appVersion = nil
+
+        try context.save()
+
+        let launches = try version.launches(in: context)
+        #expect(launches.isEmpty)
+    }
+
     @Test("install(in:) returns install matching installID")
     func testInstall() throws {
         let version = VersionObject.stub(date: week, appVersion: "2.0", in: context)


### PR DESCRIPTION
## Summary
`VersionObject.launches(in:)` force-unwrapped the optional `appVersion` when building its first fetch predicate, so a `VersionObject` with a nil `appVersion` would crash instead of returning no launches. The first fetch also faulted full `VersionObject` rows just to read their `launchID`; it now uses a dictionary result type that fetches only `launchID`, avoiding materializing the rest of the object graph for every matching version.

## Test plan
- [x] `xcodebuild build-for-testing` for the `Scout` scheme
- [x] `VersionObjectTests` — existing `launches(in:)` case still passes, plus a new case covering a nil `appVersion`
