### PR TITLE
Fetch only datePrimitive in inferredEndDate lookups

### DIFF
--- a/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
@@ -17,10 +17,12 @@ class TrackedObject: SyncableObject {
     }
 
     func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
-        let request = NSFetchRequest<TrackedObject>(entityName: "TrackedObject")
+        let request = NSFetchRequest<NSDictionary>(entityName: "TrackedObject")
         request.predicate = NSPredicate(format: "sessionID == %@", sessionID as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
+        request.resultType = .dictionaryResultType
+        request.propertiesToFetch = [DateObject.datePrimitiveKey]
         request.fetchLimit = 1
-        return try context.fetch(request).first?.date
+        return try context.fetch(request).first?[DateObject.datePrimitiveKey] as? Date
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Recovery.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Recovery.swift
@@ -32,11 +32,13 @@ extension LaunchObject: RecoveryMonitor {
     }
 
     private func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
-        let request = NSFetchRequest<IDObject>(entityName: "IDObject")
+        let request = NSFetchRequest<NSDictionary>(entityName: "IDObject")
         request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
+        request.resultType = .dictionaryResultType
+        request.propertiesToFetch = [DateObject.datePrimitiveKey]
         request.fetchLimit = 1
 
-        return try context.fetch(request).first?.date
+        return try context.fetch(request).first?[DateObject.datePrimitiveKey] as? Date
     }
 }


### PR DESCRIPTION
## Summary
`TrackedObject.inferredEndDate(in:)` and `LaunchObject`'s private `inferredEndDate(in:)` each faulted a full managed object (with every inherited `DateObject`/`IDObject` column and the `deliveries` relationship) just to read `.date` off the single most recent match. Both now use a dictionary result type fetching only `datePrimitive`, avoiding the managed object materialization on every launch and session recovery pass. Same pattern as #817's `VersionObject.launches(in:)` fix, applied to the two remaining fetch-just-a-scalar spots found in the codebase.

## Test plan
- [x] `xcodebuild build-for-testing` for the `Scout` scheme
- [x] `LaunchObjectRecoveryTests`, `SessionObjectRecoveryTests` — 8 tests pass, including the cases that assert the inferred end date matches the latest child record
