### PR TITLE
Set viewContext merge policy to dedupe constraint collisions

### DIFF
--- a/Sources/Scout/Core/Persistence/PersistentContainer.swift
+++ b/Sources/Scout/Core/Persistence/PersistentContainer.swift
@@ -47,5 +47,13 @@ extension NSPersistentContainer {
         if let captured {
             throw captured
         }
+
+        // With the default NSErrorMergePolicy a uniqueness-constraint collision
+        // fails the whole save() and leaves the offending insert pending, so on
+        // the long-lived viewContext every later save() throws too. Merging by
+        // property dedupes the colliding row instead — the reason the
+        // constraints exist — and keeps a batched save (e.g. plan inserting many
+        // SyncDelivery rows at once) from being rejected over a single duplicate.
+        viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
     }
 }

--- a/Tests/ScoutTests/Core/Persistence/MergePolicyTests.swift
+++ b/Tests/ScoutTests/Core/Persistence/MergePolicyTests.swift
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@Suite("Merge policy")
+struct MergePolicyTests {
+    /// Uniqueness constraints are only enforced by the SQLite store, so this
+    /// builds a real file-backed store (an in-memory store would silently allow
+    /// the duplicate) to prove the merge policy dedupes a colliding insert
+    /// instead of throwing.
+    ///
+    @Test("A duplicate insert on the same natural key dedupes instead of throwing")
+    func duplicateInsertDedupes() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let container = NSPersistentContainer(named: "Scout")
+        container.persistentStoreDescriptions = [
+            NSPersistentStoreDescription(url: directory.appendingPathComponent("Scout.sqlite"))
+        ]
+        try container.loadStore()
+
+        let context = container.viewContext
+        let eventID = UUID()
+
+        let first = EventObject.stub(name: "first", in: context)
+        first.eventID = eventID
+        try context.save()
+
+        let second = EventObject.stub(name: "second", in: context)
+        second.eventID = eventID
+        try context.save()
+
+        let request = NSFetchRequest<EventObject>(entityName: "EventObject")
+        let events = try context.fetch(request)
+        #expect(events.count == 1)
+    }
+}


### PR DESCRIPTION
## Summary
The uniqueness constraints added in #815 (`crashID`/`eventID`/`userActivityID`/`markerID`) and #818 (`SyncDelivery(object, backendID)`) don't behave as intended under Core Data's default `NSErrorMergePolicy`: a duplicate insert makes `save()` throw *and* leaves the offending change pending on the context. On the long-lived `viewContext` (used by `synchronize`) that poisons every subsequent `save()` until app restart, and a batched save — `SyncableObject.plan` inserting many `SyncDelivery` rows in one go — is rejected wholesale over a single duplicate rather than just dropping the dup.

Setting `viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump` makes a constraint collision **dedupe** the colliding row instead of throwing — which is the behavior the constraints were added to provide (the original ask was "prevent a duplicate row from a retry after a sync failure", i.e. no dup row and no crash). Background contexts are intentionally left on the default: they're short-lived (no poison) and each does a single guarded insert, so a rejected duplicate save there is harmless.

Code-only change — no new model version, no migration.

## Test plan
- [x] `xcodebuild build-for-testing` for the `Scout` scheme
- [x] New `MergePolicyTests` — a duplicate insert on the same natural key resolves to one row without throwing, on a real SQLite store (an in-memory store doesn't enforce uniqueness constraints, so the test builds a file-backed store)
- [x] `ModelMigrationTests`, `DeliverTests`, `SyncableObjectCleanupTests`, `LogCrashTests`, `LogTests`, `PersistenceLoadTests` — no regression
- [x] `swift-format lint --strict`
