### PR TITLE
Make mergeDuplicates O(n) via a hashable merge key

### DIFF
--- a/Sources/Scout/Native/Matrix/Cell/GridCell.swift
+++ b/Sources/Scout/Native/Matrix/Cell/GridCell.swift
@@ -43,9 +43,8 @@ extension GridCell: CellProtocol {
 }
 
 extension GridCell: Combining {
-    func isDuplicate(of other: GridCell<T>) -> Bool {
-        row == other.row && column == other.column
-    }
+    // The cell key already encodes (row, column), which is exactly the merge identity.
+    var mergeKey: String { key }
 
     static func + (lhs: Self, rhs: Self) -> Self {
         GridCell(

--- a/Sources/Scout/Native/Matrix/Model/Combining.swift
+++ b/Sources/Scout/Native/Matrix/Model/Combining.swift
@@ -8,11 +8,18 @@
 import Foundation
 
 protocol Combining {
-    func isDuplicate(of other: Self) -> Bool
+    associatedtype MergeKey: Hashable
+
+    /// Identifies values that combine: two values are duplicates iff their keys are equal.
+    var mergeKey: MergeKey { get }
     static func + (lhs: Self, rhs: Self) -> Self
 }
 
 extension Combining {
+    func isDuplicate(of other: Self) -> Bool {
+        mergeKey == other.mergeKey
+    }
+
     static func += (lhs: inout Self, rhs: Self) {
         assert(lhs.isDuplicate(of: rhs), "Cannot combine non-duplicate instances of \(Self.self)")
         lhs = lhs + rhs
@@ -20,15 +27,22 @@ extension Combining {
 }
 
 extension Array where Element: Combining {
+    // Groups by mergeKey in one pass (O(n)) instead of scanning the accumulated
+    // result per element, while preserving each key's first-occurrence order.
     func mergeDuplicates() -> Self {
-        reduce(into: []) { result, value in
-            if let index = result.firstIndex(where: {
-                $0.isDuplicate(of: value)
-            }) {
-                result[index] += value
+        var order: [Element.MergeKey] = []
+        var merged: [Element.MergeKey: Element] = [:]
+
+        for value in self {
+            let key = value.mergeKey
+            if let existing = merged[key] {
+                merged[key] = existing + value
             } else {
-                result.append(value)
+                merged[key] = value
+                order.append(key)
             }
         }
+
+        return order.map { merged[$0]! }
     }
 }

--- a/Sources/Scout/Native/Matrix/Model/Matrix.swift
+++ b/Sources/Scout/Native/Matrix/Model/Matrix.swift
@@ -31,11 +31,15 @@ extension Matrix: RecordDecodable {
 }
 
 extension Matrix: Combining {
-    func isDuplicate(of other: Matrix<T>) -> Bool {
-        date == other.date
-            && name == other.name
-            && category == other.category
-            && version == other.version
+    struct MergeKey: Hashable {
+        let date: Date
+        let name: String
+        let category: String?
+        let version: String?
+    }
+
+    var mergeKey: MergeKey {
+        MergeKey(date: date, name: name, category: category, version: version)
     }
 
     static func + (lhs: Self, rhs: Self) -> Self {


### PR DESCRIPTION
## Summary
`Array<Combining>.mergeDuplicates()` scanned the accumulated result with `firstIndex(where:)` for every element — O(n²) — to combine `Matrix` records and `GridCell`s that share a merge identity. The `Combining` protocol now exposes a `Hashable` `mergeKey`, so merging is a single dictionary pass keyed by it (O(n)), with each key's first-occurrence order preserved.

`isDuplicate(of:)` becomes a default implementation over `mergeKey` equality — still used by `Matrix.==` and the `+=` assert, so nothing else changes. `Matrix` keys on `(date, name, category, version)`; `GridCell` reuses its existing cell `key`, which already encodes `(row, column)`.

Honest scope: `n` is bounded in practice (cells per week ≤ 168, matrices per range), so this is an algorithmic hardening rather than a felt speedup — it only matters on wide date ranges with many distinct metric names, where the old n² grows into the millions of comparisons.

## Test plan
- [x] `xcodebuild build-for-testing` for the `Scout` scheme
- [x] `CombiningTests` (merging, no-duplicates, all-duplicates, empty, and **first-occurrence order preserved**), plus `GridCellTests`, `CellProtocolTests`, `MatrixSeriesTests`, `MatrixRecordTests`, `MatrixSpanTests`, `NativeDatabaseTests` — 26 tests pass
- [x] `swift-format lint --strict`
