### PR TITLE
Extract the repeated relative-time label into RelativeTimeText

### DIFF
--- a/Sources/Scout/UI/Event/List/EventList.swift
+++ b/Sources/Scout/UI/Event/List/EventList.swift
@@ -56,11 +56,7 @@ struct EventList: View {
                 Spacer()
 
                 if let date = event.date {
-                    TimelineView(.periodic(from: timeline, by: 1)) { _ in
-                        Text(verbatim: date.relativeString)
-                    }
-                    .font(.subheadline)
-                    .foregroundStyle(Color.gray)
+                    RelativeTimeText(date: date, timeline: timeline)
                 }
             }
         } destination: {

--- a/Sources/Scout/UI/Timeline/View/TimelineRow.swift
+++ b/Sources/Scout/UI/Timeline/View/TimelineRow.swift
@@ -30,11 +30,7 @@ struct TimelineRow: View {
 
                 Spacer()
 
-                TimelineView(.periodic(from: timeline, by: 1)) { _ in
-                    Text(row.date.relativeString)
-                }
-                .font(.subheadline)
-                .foregroundStyle(.gray)
+                RelativeTimeText(date: row.date, timeline: timeline)
             }
             .frame(height: 43)
             .padding(.horizontal, 16)

--- a/Sources/Scout/UI/Utilities/RelativeTimeText.swift
+++ b/Sources/Scout/UI/Utilities/RelativeTimeText.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+// A gray relative-time label ("2m ago") that refreshes every second, anchored
+// to a shared `timeline` so rows in the same list tick together.
+struct RelativeTimeText: View {
+    let date: Date
+    let timeline: Date
+
+    var body: some View {
+        TimelineView(.periodic(from: timeline, by: 1)) { _ in
+            Text(verbatim: date.relativeString)
+        }
+        .font(.subheadline)
+        .foregroundStyle(.gray)
+    }
+}


### PR DESCRIPTION
## Summary
`TimelineRow` and `EventList` each inlined the same relative-time label —
`TimelineView(.periodic(from: timeline, by: 1)) { Text(date.relativeString) }` with identical `.subheadline`/`.gray` styling. This pulls it into a shared `RelativeTimeText(date:timeline:)` view so the relative-time rendering lives in one place, and switches `TimelineRow`'s label to `Text(verbatim:)` (matching the project's UI-string convention, which its inlined copy didn't follow).

De-duplication / readability only — **not** a performance change. I looked at consolidating the per-row timers into one clock, but the current per-row `TimelineView` is already idiomatic: `List` is lazy so only visible rows instantiate one, they all share the same `timeline` anchor (so the wakeups are phase-aligned and coalesced), `relativeString` uses a shared file-scope formatter, and each `TimelineView` scopes its redraw to just the small label. Hoisting one timer up to the list level would actually widen the redraw to the whole list. So this keeps the existing behavior and just removes the duplication, leaving a single place to revisit the timer strategy if profiling ever calls for it.

## Test plan
- [x] `xcodebuild build-for-testing` for the `Scout` scheme (all call sites resolve; pure view extraction, no logic to unit-test)
- [x] `swift-format lint --strict`
