### PR TITLE
Link a crash to its session events and device timeline

### DIFF
--- a/Sources/Scout/UI/Crash/Crash.swift
+++ b/Sources/Scout/UI/Crash/Crash.swift
@@ -65,7 +65,7 @@ extension Crash {
 
 extension Crash {
     static var sample: Crash {
-        Self.sample("NSRangeException", at: Date())
+        sample(.nsRange, minutesAgo: 0)
     }
 
     static func sample(_ name: String, at date: Date, sessionID: UUID? = nil) -> Crash {
@@ -91,88 +91,82 @@ extension Crash {
         let sessionB = UUID()
         let sessionC = UUID()
 
-        return [
-            sampleRecord(
-                name: "NSRangeException",
-                reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
-                minutesAgo: 6,
-                deviceID: deviceX,
-                sessionID: sessionA,
-                stackTrace: rangeStackTrace
-            ),
-            sampleRecord(
-                name: "NSRangeException",
-                reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
-                minutesAgo: 95,
-                deviceID: deviceX,
-                sessionID: sessionB,
-                stackTrace: rangeStackTrace
-            ),
-            sampleRecord(
-                name: "NSRangeException",
-                reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
-                minutesAgo: 340,
-                deviceID: deviceX,
-                sessionID: sessionA,
-                stackTrace: rangeStackTrace
-            ),
-            sampleRecord(
-                name: "Fatal error",
-                reason: "Index out of range",
-                minutesAgo: 42,
-                deviceID: deviceX,
-                sessionID: sessionB,
-                stackTrace: fatalStackTrace
-            ),
-            sampleRecord(
-                name: "Fatal error",
-                reason: "Index out of range",
-                minutesAgo: 220,
-                deviceID: deviceY,
-                sessionID: sessionC,
-                stackTrace: fatalStackTrace
-            ),
-            sampleRecord(
-                name: "SIGSEGV",
-                reason: "Segmentation fault: 11",
-                minutesAgo: 1500,
-                deviceID: deviceY,
-                sessionID: sessionC,
-                stackTrace: segvStackTrace
-            ),
+        let crashes = [
+            sample(.nsRange, minutesAgo: 6, deviceID: deviceX, sessionID: sessionA),
+            sample(.nsRange, minutesAgo: 95, deviceID: deviceX, sessionID: sessionB),
+            sample(.nsRange, minutesAgo: 340, deviceID: deviceX, sessionID: sessionA),
+            sample(.fatal, minutesAgo: 42, deviceID: deviceX, sessionID: sessionB),
+            sample(.fatal, minutesAgo: 220, deviceID: deviceY, sessionID: sessionC),
+            sample(.segv, minutesAgo: 1500, deviceID: deviceY, sessionID: sessionC),
         ]
+
+        return crashes.map(\.record)
     }
 
-    private static func sampleRecord(name: String, reason: String, minutesAgo: Double, deviceID: UUID, sessionID: UUID, stackTrace: [String]) -> Record {
-        var record = Record(recordType: recordType, recordID: UUID().uuidString)
+    private static func sample(_ kind: Kind, minutesAgo: Double, deviceID: UUID = UUID(), sessionID: UUID = UUID()) -> Crash {
+        Crash(
+            name: kind.name,
+            fingerprint: CrashFingerprint(name: kind.name, reason: kind.reason, stackTrace: kind.stackTrace).value,
+            reason: kind.reason,
+            stackTrace: kind.stackTrace,
+            date: Date(timeIntervalSinceNow: -minutesAgo * 60),
+            id: UUID().uuidString,
+            deviceID: deviceID,
+            installID: UUID(),
+            launchID: UUID(),
+            sessionID: sessionID
+        )
+    }
+
+    private var record: Record {
+        var record = Record(recordType: Self.recordType, recordID: id)
         record["name"] = name
+        record["fingerprint"] = fingerprint
         record["reason"] = reason
-        record["date"] = Date(timeIntervalSinceNow: -minutesAgo * 60)
-        record["device_id"] = deviceID.uuidString
-        record["session_id"] = sessionID.uuidString
-        record["install_id"] = UUID().uuidString
-        record["launch_id"] = UUID().uuidString
         record["stack_trace"] = try? JSONEncoder().encode(stackTrace)
+        record["date"] = date
+        record["device_id"] = deviceID?.uuidString
+        record["install_id"] = installID?.uuidString
+        record["launch_id"] = launchID?.uuidString
+        record["session_id"] = sessionID?.uuidString
         return record
     }
 
-    private static let rangeStackTrace = [
-        "0   CoreFoundation        0x0 __exceptionPreprocess + 164",
-        "1   libobjc.A.dylib       0x0 objc_exception_throw + 60",
-        "2   CoreFoundation        0x0 -[__NSArrayM objectAtIndex:] + 1228",
-        "3   Scout                 0x0 FeedViewController.row(at:) + 88",
-    ]
+    private struct Kind {
+        let name: String
+        let reason: String
+        let stackTrace: [String]
 
-    private static let fatalStackTrace = [
-        "0   Scout                 0x0 Scout.Cart.total.getter + 240",
-        "1   Scout                 0x0 Scout.CheckoutView.body.getter + 132",
-        "2   SwiftUI               0x0 closure #1 in ViewBody.render + 96",
-    ]
+        static let nsRange = Kind(
+            name: "NSRangeException",
+            reason: "-[__NSArrayM objectAtIndex:]: index 4 beyond bounds [0 .. 2]",
+            stackTrace: [
+                "0   CoreFoundation        0x0 __exceptionPreprocess + 164",
+                "1   libobjc.A.dylib       0x0 objc_exception_throw + 60",
+                "2   CoreFoundation        0x0 -[__NSArrayM objectAtIndex:] + 1228",
+                "3   Scout                 0x0 FeedViewController.row(at:) + 88",
+            ]
+        )
 
-    private static let segvStackTrace = [
-        "0   Scout                 0x0 ImageLoader.decode(_:) + 512",
-        "1   Scout                 0x0 closure #1 in ImageLoader.load() + 96",
-    ]
+        static let fatal = Kind(
+            name: "Fatal error",
+            reason: "Index out of range",
+            stackTrace: [
+                "0   Scout                 0x0 Scout.Cart.total.getter + 240",
+                "1   Scout                 0x0 Scout.CheckoutView.body.getter + 132",
+                "2   SwiftUI               0x0 closure #1 in ViewBody.render + 96",
+            ]
+        )
+
+        static let segv = Kind(
+            name: "SIGSEGV",
+            reason: "Segmentation fault: 11",
+            stackTrace: [
+                "0   Scout                 0x0 ImageLoader.decode(_:) + 512",
+                "1   Scout                 0x0 closure #1 in ImageLoader.load() + 96",
+            ]
+        )
+    }
 }
 
 extension [Crash] {

--- a/Sources/Scout/UI/Crash/CrashContextSection.swift
+++ b/Sources/Scout/UI/Crash/CrashContextSection.swift
@@ -49,7 +49,6 @@ struct CrashContextSection: View {
     }
 }
 
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Crash/CrashContextSection.swift
+++ b/Sources/Scout/UI/Crash/CrashContextSection.swift
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct CrashContextSection: View {
+    let crash: Crash
+
+    var body: some View {
+        if crash.sessionID != nil || crash.deviceID != nil {
+            Header(title: "Context")
+        }
+
+        if let sessionID = crash.sessionID {
+            Row {
+                Image(systemName: "list.bullet.rectangle.portrait")
+                    .frame(width: 24)
+                    .foregroundStyle(.indigo)
+                Text(verbatim: "Session Events")
+                Spacer()
+                Text(ExportFormat.shortID(sessionID))
+                    .font(.footnote)
+                    .monospaced()
+                    .foregroundStyle(Color.gray)
+            } destination: {
+                SessionEventList(sessionID: sessionID)
+            }
+        }
+
+        if let deviceID = crash.deviceID {
+            Row {
+                Image(systemName: "calendar.day.timeline.left")
+                    .frame(width: 24)
+                    .foregroundStyle(.blue)
+                Text(verbatim: "Timeline")
+                Spacer()
+                Text(ExportFormat.shortID(deviceID))
+                    .font(.footnote)
+                    .monospaced()
+                    .foregroundStyle(Color.gray)
+            } destination: {
+                Timeline(deviceID: deviceID, highlight: .red)
+            }
+        }
+    }
+}
+
+
+#Preview {
+    NavigationStack {
+        List {
+            CrashContextSection(crash: .sample)
+        }
+        .listStyle(.plain)
+    }
+}

--- a/Sources/Scout/UI/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Crash/CrashDetailView.swift
@@ -12,10 +12,30 @@ struct CrashDetailView: View {
 
     var body: some View {
         List {
-            headerSection
+            VStack(alignment: .leading, spacing: 10) {
+                if let date = crash.date {
+                    UTCTimestampText(date: date)
+                }
+
+                if let reason = crash.reason {
+                    (Text(verbatim: "REASON:   ") + Text(reason).foregroundColor(.red))
+                        .lineSpacing(4)
+                        .fontWeight(.bold)
+                }
+            }
+            .padding(.vertical, 4)
+
+            CrashContextSection(crash: crash)
 
             if !crash.stackTrace.isEmpty {
-                stackTraceSection
+                Header(title: "Stack Trace")
+
+                ForEach(Array(crash.stackTrace.enumerated()), id: \.offset) { _, frame in
+                    Text(frame)
+                        .font(.caption)
+                        .monospaced()
+                        .lineLimit(2)
+                }
             }
         }
         .listStyle(.plain)
@@ -29,32 +49,6 @@ struct CrashDetailView: View {
             }
         }
         .navigationTitle(crash.name)
-    }
-
-    private var headerSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            if let date = crash.date {
-                UTCTimestampText(date: date)
-            }
-
-            if let reason = crash.reason {
-                Text(verbatim: "REASON:   ").fontWeight(.bold)
-                    + Text(reason).fontWeight(.bold).foregroundColor(.red)
-            }
-        }
-        .padding(.vertical, 4)
-    }
-
-    @ViewBuilder
-    private var stackTraceSection: some View {
-        Header(title: "Stack Trace")
-
-        ForEach(Array(crash.stackTrace.enumerated()), id: \.offset) { _, frame in
-            Text(frame)
-                .font(.caption)
-                .monospaced()
-                .lineLimit(2)
-        }
     }
 }
 

--- a/Sources/Scout/UI/Event/List/SessionEventList.swift
+++ b/Sources/Scout/UI/Event/List/SessionEventList.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct SessionEventList: View {
+    let sessionID: UUID
+
+    @StateObject var provider = EventProvider()
+    @Environment(\.database) var database
+
+    var body: some View {
+        EventList(provider: provider)
+            .task {
+                await provider.fetchIfNeeded(for: query, in: database)
+            }
+            .navigationTitle(en: "Session Events")
+    }
+
+    private var query: Event.Query {
+        var query = Event.Query()
+        query.sessionID = sessionID
+        return query
+    }
+}
+
+#Preview {
+    let provider = EventProvider()
+    provider.events = .samples
+
+    return NavigationStack {
+        SessionEventList(sessionID: UUID(), provider: provider)
+    }
+}

--- a/Sources/Scout/UI/Event/Provider/Event.Query.swift
+++ b/Sources/Scout/UI/Event/Provider/Event.Query.swift
@@ -14,6 +14,8 @@ extension Event {
         var levels = Query.allLevels
         var text = ""
         var name = ""
+        var sessionID: UUID?
+        var deviceID: UUID?
         var dates: Range<Date>?
 
         func buildFilters() -> [RecordQuery.Filter] {
@@ -27,6 +29,12 @@ extension Event {
             }
             if !name.isEmpty {
                 filters.append(RecordQuery.Filter(field: "name", op: .equals, value: .string(name)))
+            }
+            if let sessionID {
+                filters.append(RecordQuery.Filter(field: "session_id", op: .equals, value: .string(sessionID.uuidString)))
+            }
+            if let deviceID {
+                filters.append(RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString)))
             }
             if let dates {
                 filters.append(contentsOf: dates.dateFilters)

--- a/Sources/Scout/UI/Timeline/View/Timeline.swift
+++ b/Sources/Scout/UI/Timeline/View/Timeline.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct Timeline: View {
     let deviceID: UUID
     var event: Event? = nil
+    var highlight: Color = .accentColor
 
     @Environment(\.database) var database
     @StateObject var provider = TimelineProvider()
@@ -98,6 +99,7 @@ struct Timeline: View {
         return TimelineList(
             items: items,
             highlightedID: event?.id,
+            highlightColor: highlight,
             older: { RailPagination(lane: provider.older, result: $provider.result) },
             newer: { RailPagination(lane: provider.newer, result: $provider.result) }
         )

--- a/Sources/Scout/UI/Timeline/View/TimelineList.swift
+++ b/Sources/Scout/UI/Timeline/View/TimelineList.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct TimelineList<Pagination: View>: View {
     let items: [TimelineItem]
     let highlightedID: String?
+    let highlightColor: Color
 
     @ViewBuilder let older: () -> Pagination
     @ViewBuilder let newer: () -> Pagination
@@ -25,7 +26,8 @@ struct TimelineList<Pagination: View>: View {
                     items: items,
                     index: index,
                     timeline: timeline,
-                    highlighted: row.id == highlightedID
+                    highlighted: row.id == highlightedID,
+                    highlightColor: highlightColor
                 )
             }
 
@@ -42,6 +44,7 @@ struct TimelineList<Pagination: View>: View {
             TimelineList(
                 items: items,
                 highlightedID: items.randomElement()?.id,
+                highlightColor: .accentColor,
                 older: { EmptyView() },
                 newer: { EmptyView() }
             )

--- a/Sources/Scout/UI/Timeline/View/TimelineRow.swift
+++ b/Sources/Scout/UI/Timeline/View/TimelineRow.swift
@@ -14,6 +14,7 @@ struct TimelineRow: View {
     let prev: TimelineItem?
     let next: TimelineItem?
     let showsSeparator: Bool
+    let highlightColor: Color
 
     var body: some View {
         VStack(spacing: 0) {
@@ -36,7 +37,7 @@ struct TimelineRow: View {
             .padding(.horizontal, 16)
             .background {
                 if highlighted {
-                    Color.accentColor.opacity(0.12)
+                    highlightColor.opacity(0.12)
                     GeometryReader { geo in
                         Color.clear.preference(key: AnchorFrameKey.self, value: geo.frame(in: .global))
                     }
@@ -53,13 +54,14 @@ struct TimelineRow: View {
 }
 
 extension TimelineRow {
-    init(items: [TimelineItem], index: Int, timeline: Date, highlighted: Bool) {
+    init(items: [TimelineItem], index: Int, timeline: Date, highlighted: Bool, highlightColor: Color = .accentColor) {
         self.timeline = timeline
         self.highlighted = highlighted
         self.row = items[index]
         self.prev = items[safe: index - 1]
         self.next = items[safe: index + 1]
         self.showsSeparator = index < items.count - 1
+        self.highlightColor = highlightColor
     }
 }
 

--- a/Tests/ScoutTests/UI/Event/Provider/EventQueryTests.swift
+++ b/Tests/ScoutTests/UI/Event/Provider/EventQueryTests.swift
@@ -46,6 +46,30 @@ struct EventQueryTests {
         #expect(filters.contains(RecordQuery.Filter(field: "name", op: .equals, value: .string("Login"))))
     }
 
+    @Test("Filter by session") func session() {
+        let sessionID = UUID()
+
+        var query = Event.Query()
+        query.sessionID = sessionID
+        let filters = query.buildFilters()
+
+        #expect(filters.contains(RecordQuery.Filter(field: "session_id", op: .equals, value: .string(sessionID.uuidString))))
+    }
+
+    @Test("No session produces no session filter") func noSession() {
+        #expect(Event.Query().buildFilters().contains { $0.field == "session_id" } == false)
+    }
+
+    @Test("Filter by device") func device() {
+        let deviceID = UUID()
+
+        var query = Event.Query()
+        query.deviceID = deviceID
+        let filters = query.buildFilters()
+
+        #expect(filters.contains(RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))))
+    }
+
     @Test("Filter by date range") func dates() {
         let start = Date(timeIntervalSinceReferenceDate: 0)
         let end = Date(timeIntervalSinceReferenceDate: 86400)


### PR DESCRIPTION
CrashDetailView used to be a dead end — it showed only the crash time, reason and raw stack trace even though a Crash already carries its session and device ids. This adds a Context section between the header and the stack trace with two navigable rows, Session Events (the event feed filtered by session_id) and Timeline (the existing device timeline), each showing the short id it leads to.

To back that, Event.Query gains session_id/device_id equals filters — a client-only change, since both fields are already in the server's queryable set and used by existing timeline queries — and the new SessionEventList reuses EventList to render the session-filtered feed. The timeline opened from a crash tints its row highlight red rather than the accent blue.

Along the way the Crash sample data is reworked to map records from Crash models through a single Kind bundle, which drops the parallel hand-written Record builder and removes the duplicated reason/stack-trace literals.

Client-only, no wire-format or Core Data changes, so there is no companion scout-server PR. EventQueryTests covers the new filters.