### PR TITLE
Show a status-specific description for the iCloud warning alert

### DIFF
--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -5,7 +5,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import CloudKit
 import Foundation
+
+typealias AccountWarning = @Sendable () async throws -> CKAccountStatus?
 
 public struct Backend: Sendable {
     let id: String
@@ -15,7 +18,7 @@ public struct Backend: Sendable {
 
     var serverInfo: ServerInfo? = nil
     var probeStatus: @Sendable () async -> Status = { .unknown }
-    var accountWarning: @Sendable () async -> Bool = { false }
+    var accountWarning: AccountWarning = { nil }
     var runBenchmark: (@Sendable () async -> Bool)? = nil
     var onSetup: @MainActor @Sendable () -> Void = {}
 

--- a/Sources/Scout/Core/Backend/Backend.swift
+++ b/Sources/Scout/Core/Backend/Backend.swift
@@ -5,10 +5,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import Foundation
 
-typealias AccountWarning = @Sendable () async throws -> CKAccountStatus?
+typealias AccountWarning = @Sendable () async throws -> Backend.AccountStatus?
 
 public struct Backend: Sendable {
     let id: String
@@ -28,6 +27,13 @@ public struct Backend: Sendable {
         case unknown
 
         var id: Self { self }
+    }
+
+    enum AccountStatus: Sendable {
+        case noAccount
+        case restricted
+        case couldNotDetermine
+        case temporarilyUnavailable
     }
 
     struct ServerInfo: Sendable {

--- a/Sources/Scout/Native/Store/NativeBackend.swift
+++ b/Sources/Scout/Native/Store/NativeBackend.swift
@@ -30,9 +30,7 @@ extension Backend {
                 let status = try? await container.accountStatus()
                 return status == .available ? .reachable : .unreachable
             },
-            accountWarning: {
-                (try? await container.accountStatus()) != .available
-            },
+            accountWarning: container.accountStatus,
             onSetup: {
                 Task {
                     await EntityCatalog.bootstrap(registry: registry)

--- a/Sources/Scout/Native/Store/NativeBackend.swift
+++ b/Sources/Scout/Native/Store/NativeBackend.swift
@@ -30,7 +30,22 @@ extension Backend {
                 let status = try? await container.accountStatus()
                 return status == .available ? .reachable : .unreachable
             },
-            accountWarning: container.accountStatus,
+            accountWarning: {
+                switch try await container.accountStatus() {
+                case .available:
+                    return nil
+                case .noAccount:
+                    return .noAccount
+                case .restricted:
+                    return .restricted
+                case .temporarilyUnavailable:
+                    return .temporarilyUnavailable
+                case .couldNotDetermine:
+                    return .couldNotDetermine
+                @unknown default:
+                    return .couldNotDetermine
+                }
+            },
             onSetup: {
                 Task {
                     await EntityCatalog.bootstrap(registry: registry)

--- a/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
+++ b/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CloudKit
 import SwiftUI
 
 extension View {
@@ -53,8 +52,9 @@ private struct ICloudWarningModifier: ViewModifier {
 
     private func verify() async {
         do {
-            title = try await warning()?.title
-            description = try await warning()?.description
+            let status = try await warning()
+            title = status?.title
+            description = status?.description
         } catch {
             title = "iCloud Error"
             description = error.localizedDescription
@@ -62,8 +62,8 @@ private struct ICloudWarningModifier: ViewModifier {
     }
 }
 
-extension CKAccountStatus {
-    fileprivate var title: String? {
+extension Backend.AccountStatus {
+    fileprivate var title: String {
         switch self {
         case .noAccount:
             "iCloud Unavailable"
@@ -73,14 +73,10 @@ extension CKAccountStatus {
             "iCloud Temporarily Unavailable"
         case .couldNotDetermine:
             "iCloud Status Unknown"
-        case .available:
-            nil
-        @unknown default:
-            "iCloud Status Unknown"
         }
     }
 
-    fileprivate var description: String? {
+    fileprivate var description: String {
         switch self {
         case .noAccount:
             "Sign in to iCloud to sync data."
@@ -89,10 +85,6 @@ extension CKAccountStatus {
         case .temporarilyUnavailable:
             "Your iCloud account is temporarily unavailable. Try again later."
         case .couldNotDetermine:
-            "Couldn't determine your iCloud account status. Check your connection and try again."
-        case .available:
-            nil
-        @unknown default:
             "Couldn't determine your iCloud account status. Check your connection and try again."
         }
     }

--- a/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
+++ b/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
@@ -5,39 +5,41 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import CloudKit
 import SwiftUI
 
 extension View {
-    func iCloudWarning(_ warning: @escaping @Sendable () async -> Bool) -> some View {
+    func iCloudWarning(_ warning: @escaping AccountWarning) -> some View {
         modifier(ICloudWarningModifier(warning: warning))
     }
 }
 
 private struct ICloudWarningModifier: ViewModifier {
-    let warning: @Sendable () async -> Bool
+    let warning: AccountWarning
 
-    @State private var isWarning = false
     @State private var isAlertPresented = false
+    @State private var title: String?
+    @State private var description: String?
 
     func body(content: Content) -> some View {
         content
             .toolbar {
-                if isWarning {
+                if let title, let description {
                     ToolbarItem(placement: .topBarLeading) {
                         Button {
                             isAlertPresented = true
                         } label: {
                             Image(systemName: "icloud.slash").foregroundStyle(.orange)
                         }
+                        .alert(Text(verbatim: title), isPresented: $isAlertPresented) {
+                            Button(role: .cancel, action: {}) {
+                                Text(verbatim: "OK")
+                            }
+                        } message: {
+                            Text(verbatim: description)
+                        }
                     }
                 }
-            }
-            .alert(Text(verbatim: "iCloud Unavailable"), isPresented: $isAlertPresented) {
-                Button(role: .cancel, action: {}) {
-                    Text(verbatim: "OK")
-                }
-            } message: {
-                Text(verbatim: "Sign in to iCloud to sync data.")
             }
             .task {
                 await verify()
@@ -50,6 +52,48 @@ private struct ICloudWarningModifier: ViewModifier {
     }
 
     private func verify() async {
-        isWarning = await warning()
+        do {
+            title = try await warning()?.title
+            description = try await warning()?.description
+        } catch {
+            title = "iCloud Error"
+            description = error.localizedDescription
+        }
+    }
+}
+
+extension CKAccountStatus {
+    fileprivate var title: String? {
+        switch self {
+        case .noAccount:
+            "iCloud Unavailable"
+        case .restricted:
+            "iCloud Restricted"
+        case .temporarilyUnavailable:
+            "iCloud Temporarily Unavailable"
+        case .couldNotDetermine:
+            "iCloud Status Unknown"
+        case .available:
+            nil
+        @unknown default:
+            "iCloud Status Unknown"
+        }
+    }
+
+    fileprivate var description: String? {
+        switch self {
+        case .noAccount:
+            "Sign in to iCloud to sync data."
+        case .restricted:
+            "iCloud access is restricted by parental controls or a device policy."
+        case .temporarilyUnavailable:
+            "Your iCloud account is temporarily unavailable. Try again later."
+        case .couldNotDetermine:
+            "Couldn't determine your iCloud account status. Check your connection and try again."
+        case .available:
+            nil
+        @unknown default:
+            "Couldn't determine your iCloud account status. Check your connection and try again."
+        }
     }
 }


### PR DESCRIPTION
The Home screen's iCloud warning alert always showed the same generic "iCloud Unavailable / Sign in to iCloud to sync data." message, regardless of the actual `CKAccountStatus` (no account, restricted, temporarily unavailable, could not determine).

`Backend.accountWarning` now returns `CKAccountStatus?` (via a `Backend.AccountWarning` typealias) instead of a plain `Bool`, and `ICloudWarningModifier` derives a status-specific title and description for the alert. The closure can now throw; a thrown error falls back to the "could not determine" copy.
