### PR TITLE
Give ping sparkline bars a fixed width and right-align them

### DIFF
--- a/Sources/Scout/UI/Settings/BackendDetailView.swift
+++ b/Sources/Scout/UI/Settings/BackendDetailView.swift
@@ -143,16 +143,21 @@ struct DetailValueRow: View {
 struct PingSparkline: View {
     let pings: [Int]
 
+    private static let spacing: CGFloat = 3
+
     var body: some View {
         GeometryReader { proxy in
             let peak = Double(pings.max() ?? 1)
-            let step = proxy.size.width / Double(pings.count)
+            let slots = CGFloat(BackendHealth.maxPingHistory)
+            let barWidth = (proxy.size.width - Self.spacing * (slots - 1)) / slots
 
-            HStack(alignment: .bottom, spacing: step * 0.382) {
+            HStack(alignment: .bottom, spacing: Self.spacing) {
+                Spacer(minLength: 0)
+
                 ForEach(Array(pings.enumerated()), id: \.offset) { _, ping in
                     Capsule()
                         .fill(.tint.opacity(0.6))
-                        .frame(height: max(3, proxy.size.height * Double(ping) / peak))
+                        .frame(width: barWidth, height: max(3, proxy.size.height * Double(ping) / peak))
                 }
             }
             .frame(maxHeight: .infinity, alignment: .bottom)

--- a/Sources/Scout/UI/Settings/BackendHealth.swift
+++ b/Sources/Scout/UI/Settings/BackendHealth.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct BackendHealth: Identifiable {
+    static let maxPingHistory = 12
+
     let id: String
     let name: String
     let endpoint: String
@@ -49,7 +51,7 @@ extension BackendHealth {
         health.lastChecked = date
         if let latency {
             health.pings.append(latency)
-            health.pings = Array(health.pings.suffix(12))
+            health.pings = Array(health.pings.suffix(Self.maxPingHistory))
         }
         return health
     }


### PR DESCRIPTION
Recent Pings bars in the backend detail screen were sized by dividing the available width evenly across whatever number of pings had been recorded, so a backend with only a couple of pings showed a couple of stretched, unequal-looking bars instead of a small right-aligned cluster.

Each bar now gets a fixed width sized for the full 12-slot ping history (`BackendHealth.maxPingHistory`), and a leading `Spacer` in the sparkline's `HStack` pushes the bars flush to the trailing edge regardless of how many pings are present.
