### PR TITLE
Give the Settings sheet an opaque white background

### DIFF
--- a/Sources/Scout/UI/Home/Connection/ConnectionToolbar.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionToolbar.swift
@@ -35,7 +35,6 @@ private struct ConnectionToolbar: ViewModifier {
             .sheet(isPresented: $isSettingsPresented) {
                 NavigationStack {
                     SettingsOverviewView(backends: backends, activeID: $activeID)
-                        .dismissable()
                 }
             }
     }

--- a/Sources/Scout/UI/Settings/SettingsOverviewView.swift
+++ b/Sources/Scout/UI/Settings/SettingsOverviewView.swift
@@ -55,6 +55,8 @@ struct SettingsOverviewView: View {
         .listStyle(.plain)
         .navigationTitle(en: "Settings")
         .message($message)
+        .dismissable()
+        .opaquePresentationBackground()
         .task {
             await provider.refreshAll()
         }


### PR DESCRIPTION
The Settings sheet had no explicit presentation background, so it picked up the translucent system material by default and rendered gray instead of white. Adds `.opaquePresentationBackground()`, matching the pattern already used by `ConnectionMenu` and `FilterView`.

`.dismissable()` and `.opaquePresentationBackground()` moved from the `ConnectionToolbar` call site into `SettingsOverviewView` itself, since the view is only ever presented from that one sheet — this keeps the view self-contained and its own previews consistent with real usage.