### PR TITLE
Add icon and description to the Network empty state

### DIFF
--- a/Sources/Scout/UI/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkView.swift
@@ -16,7 +16,11 @@ struct NetworkView: View {
     var body: some View {
         ProviderView(provider: provider) { report in
             if report.isEmpty {
-                Placeholder(text: "No network requests in this period.")
+                Placeholder(
+                    text: "No requests",
+                    systemImage: "network",
+                    description: "No network requests have been recorded in this period"
+                )
             } else {
                 content(report)
             }
@@ -70,5 +74,16 @@ struct NetworkView: View {
 
     return NavigationStack {
         NetworkView(provider: provider)
+    }
+}
+
+#Preview("Empty State") {
+    NavigationStack {
+        Placeholder(
+            text: "No requests",
+            systemImage: "network",
+            description: "No network requests have been recorded in this period"
+        )
+        .navigationTitle(en: "Network")
     }
 }


### PR DESCRIPTION
The Network screen's empty state showed only a single line of gray text, while Hangs and Crashes use the shared Placeholder component with an icon and a second descriptive line. Updated NetworkView to pass systemImage and description to Placeholder, matching the pattern already used across Hangs, Crashes, Releases, Metrics, and Events. Checked the rest of the codebase for similar empty-state call sites — everything else already uses the full Placeholder form; the two remaining single-line uses of placeholderTextStyle (a Home list row and a chart overlay) are compact inline placeholders in a different context and don't need the icon/description treatment.