### PR TITLE
Break down crash and hang groups by device model and OS version

### DIFF
--- a/Sources/Scout/UI/Chart/Model/Segment.swift
+++ b/Sources/Scout/UI/Chart/Model/Segment.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct Segment: Identifiable, Equatable {
+    let label: String
+    let count: Int
+    let color: Color
+
+    var id: String { label }
+}

--- a/Sources/Scout/UI/Chart/View/SegmentBar.swift
+++ b/Sources/Scout/UI/Chart/View/SegmentBar.swift
@@ -9,12 +9,12 @@
 import Charts
 import SwiftUI
 
-struct StatusBar: View {
-    let status: StatusBreakdown
+struct SegmentBar: View {
+    let segments: [Segment]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Chart(status.segments) { segment in
+            Chart(segments) { segment in
                 BarMark(
                     x: .value("Count", segment.count),
                     y: .value("Row", "status")
@@ -27,7 +27,7 @@ struct StatusBar: View {
             .clipShape(Capsule())
 
             HStack(spacing: 16) {
-                ForEach(status.segments) { segment in
+                ForEach(segments) { segment in
                     HStack(spacing: 5) {
                         Circle().fill(segment.color).frame(width: 7, height: 7)
                         Text(verbatim: segment.label + " " + segment.count.plain)
@@ -40,7 +40,14 @@ struct StatusBar: View {
     }
 }
 
-#Preview("StatusBar") {
-    StatusBar(status: .sample(success: 8_140, redirect: 210, clientError: 96, serverError: 18))
-        .padding(.horizontal)
+#Preview("SegmentBar") {
+    SegmentBar(
+        segments: StatusBreakdown.sample(
+            success: 8_140,
+            redirect: 210,
+            clientError: 96,
+            serverError: 18
+        ).segments
+    )
+    .padding(.horizontal)
 }

--- a/Sources/Scout/UI/Incident/Breakdown/IncidentBreakdown.swift
+++ b/Sources/Scout/UI/Incident/Breakdown/IncidentBreakdown.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct IncidentBreakdown: Equatable {
+    let devices: [Segment]
+    let osVersions: [Segment]
+}
+
+extension IncidentBreakdown {
+    static func segments(from labels: [String], top: Int = 4) -> [Segment] {
+        let counts = Dictionary(labels.map { ($0, 1) }, uniquingKeysWith: +)
+        let ranked = counts.sorted { $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key }
+
+        var segments = zip(ranked.prefix(top), colors).map { pair, color in
+            Segment(label: pair.key, count: pair.value, color: color)
+        }
+
+        let other = ranked.count > top ? ranked[top...].reduce(0) { $0 + $1.value } : 0
+        if other > 0 {
+            segments.append(Segment(label: "Other", count: other, color: .gray))
+        }
+
+        return segments
+    }
+
+    private static let colors: [Color] = [.blue, .indigo, .purple, .teal]
+}
+
+extension IncidentBreakdown {
+    static var sample: IncidentBreakdown {
+        IncidentBreakdown(
+            devices: segments(
+                from: Array(repeating: "iPhone15,3", count: 5) + Array(repeating: "iPhone14,2", count: 3) + Array(repeating: "iPhone13,2", count: 2) + [
+                    "iPad13,1"
+                ]),
+            osVersions: segments(from: Array(repeating: "iOS 17.4", count: 6) + Array(repeating: "iOS 17.3", count: 3) + Array(repeating: "iOS 16.7", count: 2))
+        )
+    }
+}

--- a/Sources/Scout/UI/Incident/Breakdown/IncidentBreakdownProvider.swift
+++ b/Sources/Scout/UI/Incident/Breakdown/IncidentBreakdownProvider.swift
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+@MainActor
+final class IncidentBreakdownProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<IncidentBreakdown>?
+
+    private let deviceIDs: [UUID]
+    private let sessionIDs: [UUID]
+
+    init(deviceIDs: [UUID], sessionIDs: [UUID]) {
+        self.deviceIDs = deviceIDs
+        self.sessionIDs = sessionIDs
+    }
+
+    func fetch(in database: DatabaseReader) async throws -> IncidentBreakdown {
+        async let models = deviceModels(in: database)
+        async let versions = osVersions(in: database)
+
+        return IncidentBreakdown(
+            devices: IncidentBreakdown.segments(from: try await models),
+            osVersions: IncidentBreakdown.segments(from: try await versions)
+        )
+    }
+
+    private func deviceModels(in database: DatabaseReader) async throws -> [String] {
+        guard deviceIDs.count > 0 else { return [] }
+
+        let query = RecordQuery(
+            recordType: Device.self,
+            filters: [RecordQuery.Filter(field: "device_id", op: .in, value: .strings(deviceIDs.map(\.uuidString)))]
+        )
+        let records: [Record] = try await database.readAll(matching: query, fields: ["device_id", "model"])
+        return records.compactMap { (record: Record) -> String? in record["model"] }
+    }
+
+    private func osVersions(in database: DatabaseReader) async throws -> [String] {
+        guard sessionIDs.count > 0 else { return [] }
+
+        let query = RecordQuery(
+            recordType: Session.self,
+            filters: [RecordQuery.Filter(field: "session_id", op: .in, value: .strings(sessionIDs.map(\.uuidString)))]
+        )
+        let records: [Record] = try await database.readAll(matching: query, fields: ["session_id", "os_version"])
+        return records.compactMap { (record: Record) -> String? in record["os_version"] }
+    }
+}

--- a/Sources/Scout/UI/Incident/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Incident/Crash/CrashGroupDetailView.swift
@@ -10,9 +10,18 @@ import SwiftUI
 struct CrashGroupDetailView: View {
     let group: IncidentGroup<Crash>
 
+    @StateObject private var breakdown: IncidentBreakdownProvider
+    @Environment(\.database) var database
+
+    init(group: IncidentGroup<Crash>, breakdown: IncidentBreakdownProvider? = nil) {
+        self.group = group
+        self._breakdown = StateObject(wrappedValue: breakdown ?? IncidentBreakdownProvider(deviceIDs: group.deviceIDs, sessionIDs: group.sessionIDs))
+    }
+
     var body: some View {
         List {
             headerSection
+            breakdownSection
             occurrencesSection
         }
         .listStyle(.plain)
@@ -28,6 +37,9 @@ struct CrashGroupDetailView: View {
             }
         }
         .navigationTitle(group.name)
+        .task {
+            await breakdown.fetchIfNeeded(in: database)
+        }
     }
 
     private var headerSection: some View {
@@ -50,6 +62,23 @@ struct CrashGroupDetailView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var breakdownSection: some View {
+        if let value = try? breakdown.result?.get() {
+            if value.devices.count > 0 {
+                Header(title: "Top Devices")
+                SegmentBar(segments: value.devices)
+                    .listRowSeparator(.hidden, edges: .bottom)
+            }
+
+            if value.osVersions.count > 0 {
+                Header(title: "OS Versions")
+                SegmentBar(segments: value.osVersions)
+                    .listRowSeparator(.hidden, edges: .bottom)
+            }
+        }
     }
 
     @ViewBuilder
@@ -78,12 +107,16 @@ struct CrashGroupDetailView: View {
 }
 
 #Preview {
-    NavigationStack {
+    let breakdown = IncidentBreakdownProvider(deviceIDs: [], sessionIDs: [])
+    breakdown.result = .success(.sample)
+
+    return NavigationStack {
         CrashGroupDetailView(
             group: IncidentGroup(records: [
                 .sample("NSRangeException", at: Date()),
                 .sample("NSRangeException", at: Date().addingTimeInterval(-3600)),
-            ])
+            ]),
+            breakdown: breakdown
         )
     }
     .environmentObject(Tint())

--- a/Sources/Scout/UI/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/Scout/UI/Incident/Hang/HangGroupDetailView.swift
@@ -10,9 +10,18 @@ import SwiftUI
 struct HangGroupDetailView: View {
     let group: IncidentGroup<Hang>
 
+    @StateObject private var breakdown: IncidentBreakdownProvider
+    @Environment(\.database) var database
+
+    init(group: IncidentGroup<Hang>, breakdown: IncidentBreakdownProvider? = nil) {
+        self.group = group
+        self._breakdown = StateObject(wrappedValue: breakdown ?? IncidentBreakdownProvider(deviceIDs: group.deviceIDs, sessionIDs: group.sessionIDs))
+    }
+
     var body: some View {
         List {
             headerSection
+            breakdownSection
             occurrencesSection
         }
         .listStyle(.plain)
@@ -28,6 +37,9 @@ struct HangGroupDetailView: View {
             }
         }
         .navigationTitle(group.name)
+        .task {
+            await breakdown.fetchIfNeeded(in: database)
+        }
     }
 
     private var headerSection: some View {
@@ -46,6 +58,23 @@ struct HangGroupDetailView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var breakdownSection: some View {
+        if let value = try? breakdown.result?.get() {
+            if value.devices.count > 0 {
+                Header(title: "Top Devices")
+                SegmentBar(segments: value.devices)
+                    .listRowSeparator(.hidden, edges: .bottom)
+            }
+
+            if value.osVersions.count > 0 {
+                Header(title: "OS Versions")
+                SegmentBar(segments: value.osVersions)
+                    .listRowSeparator(.hidden, edges: .bottom)
+            }
+        }
     }
 
     @ViewBuilder
@@ -72,12 +101,16 @@ struct HangGroupDetailView: View {
 }
 
 #Preview {
-    NavigationStack {
+    let breakdown = IncidentBreakdownProvider(deviceIDs: [], sessionIDs: [])
+    breakdown.result = .success(.sample)
+
+    return NavigationStack {
         HangGroupDetailView(
             group: IncidentGroup(records: [
                 .sample("Image Layout Pass", duration: 9.8, at: Date()),
                 .sample("Image Layout Pass", duration: 4.6, at: Date().addingTimeInterval(-3600)),
-            ])
+            ]),
+            breakdown: breakdown
         )
     }
     .environmentObject(Tint())

--- a/Sources/Scout/UI/Incident/Provider/IncidentGroup.swift
+++ b/Sources/Scout/UI/Incident/Provider/IncidentGroup.swift
@@ -36,12 +36,20 @@ extension IncidentGroup {
         records.count
     }
 
+    var deviceIDs: [UUID] {
+        Array(Set(records.compactMap(\.deviceID)))
+    }
+
+    var sessionIDs: [UUID] {
+        Array(Set(records.compactMap(\.sessionID)))
+    }
+
     var affectedDevices: Int {
-        Set(records.compactMap(\.deviceID)).count
+        deviceIDs.count
     }
 
     var affectedSessions: Int {
-        Set(records.compactMap(\.sessionID)).count
+        sessionIDs.count
     }
 
     var firstDate: Date? {

--- a/Sources/Scout/UI/Network/Model/StatusBreakdown.swift
+++ b/Sources/Scout/UI/Network/Model/StatusBreakdown.swift
@@ -8,14 +8,6 @@
 
 import SwiftUI
 
-struct StatusSegment: Identifiable {
-    let label: String
-    let count: Int
-    let color: Color
-
-    var id: String { label }
-}
-
 struct StatusBreakdown: Equatable {
     private(set) var counts: [Int]
 
@@ -48,9 +40,9 @@ struct StatusBreakdown: Equatable {
 
     private static let colors: [Color] = [.green, .blue, .orange, .red]
 
-    var segments: [StatusSegment] {
+    var segments: [Segment] {
         zip(StatusBuckets.classes, zip(counts, Self.colors)).map { label, pair in
-            StatusSegment(label: label, count: pair.0, color: pair.1)
+            Segment(label: label, count: pair.0, color: pair.1)
         }
     }
 }

--- a/Sources/Scout/UI/Network/View/NetworkEndpointDetailView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkEndpointDetailView.swift
@@ -39,7 +39,7 @@ struct NetworkEndpointDetailView: View {
 
             if let breakdown = statuses?.summary(in: range), breakdown.total > 0 {
                 Header(title: "Status codes")
-                StatusBar(status: breakdown)
+                SegmentBar(segments: breakdown.segments)
                     .listRowSeparator(.hidden, edges: .bottom)
             }
         }

--- a/Sources/Scout/UI/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkView.swift
@@ -51,7 +51,7 @@ struct NetworkView: View {
                 .listRowSeparator(.hidden)
 
             Header(title: "Status codes")
-            StatusBar(status: breakdown)
+            SegmentBar(segments: breakdown.segments)
                 .listRowSeparator(.hidden)
 
             Header(title: "Top endpoints") {

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -106,12 +106,14 @@ final class Gate: @unchecked Sendable {
 }
 
 extension Record {
-    static func deviceStub(deviceID: UUID, date: Date) -> Record {
-        Device(
+    static func deviceStub(deviceID: UUID, date: Date, model: String? = nil) -> Record {
+        var record = Device(
             date: date,
             id: deviceID.uuidString,
             deviceID: deviceID
         ).record
+        record["model"] = model
+        return record
     }
 
     static func installStub(installID: UUID, deviceID: UUID, date: Date) -> Record {
@@ -135,8 +137,8 @@ extension Record {
         return record
     }
 
-    static func sessionStub(sessionID: UUID, launchID: UUID, installID: UUID, startDate: Date) -> Record {
-        Session(
+    static func sessionStub(sessionID: UUID, launchID: UUID, installID: UUID, startDate: Date, osVersion: String? = nil) -> Record {
+        var record = Session(
             startDate: startDate,
             endDate: nil,
             id: sessionID.uuidString,
@@ -144,6 +146,8 @@ extension Record {
             launchID: launchID,
             installID: installID
         ).record
+        record["os_version"] = osVersion
+        return record
     }
 
     static func eventStub(name: String, sessionID: UUID, date: Date) -> Record {

--- a/Tests/ScoutTests/UI/Incident/Breakdown/IncidentBreakdownProviderTests.swift
+++ b/Tests/ScoutTests/UI/Incident/Breakdown/IncidentBreakdownProviderTests.swift
@@ -1,0 +1,69 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("IncidentBreakdownProvider")
+struct IncidentBreakdownProviderTests {
+    @Test("Groups device models for the requested device IDs")
+    func fetchGroupsDeviceModels() async throws {
+        let deviceA = UUID()
+        let deviceB = UUID()
+        let other = UUID()
+
+        let database = DatabaseStub()
+        database.add(
+            .deviceStub(deviceID: deviceA, date: Date(), model: "iPhone15,3"),
+            .deviceStub(deviceID: deviceB, date: Date(), model: "iPhone14,2"),
+            .deviceStub(deviceID: other, date: Date(), model: "iPad13,1")
+        )
+
+        let provider = IncidentBreakdownProvider(deviceIDs: [deviceA, deviceB], sessionIDs: [])
+        await provider.fetchIfNeeded(in: database)
+        let breakdown = try #require(try? provider.result?.get())
+
+        #expect(Set(breakdown.devices.map(\.label)) == ["iPhone15,3", "iPhone14,2"])
+    }
+
+    @Test("Groups OS versions for the requested session IDs")
+    func fetchGroupsOSVersions() async throws {
+        let sessionA = UUID()
+        let sessionB = UUID()
+        let other = UUID()
+
+        let database = DatabaseStub()
+        database.add(
+            .sessionStub(sessionID: sessionA, launchID: UUID(), installID: UUID(), startDate: Date(), osVersion: "iOS 17.4"),
+            .sessionStub(sessionID: sessionB, launchID: UUID(), installID: UUID(), startDate: Date(), osVersion: "iOS 17.4"),
+            .sessionStub(sessionID: other, launchID: UUID(), installID: UUID(), startDate: Date(), osVersion: "iOS 16.7")
+        )
+
+        let provider = IncidentBreakdownProvider(deviceIDs: [], sessionIDs: [sessionA, sessionB])
+        await provider.fetchIfNeeded(in: database)
+        let breakdown = try #require(try? provider.result?.get())
+
+        #expect(breakdown.osVersions.map(\.label) == ["iOS 17.4"])
+        #expect(breakdown.osVersions.first?.count == 2)
+    }
+
+    @Test("Skips fetching when there are no IDs to resolve")
+    func fetchSkipsEmptyIDs() async throws {
+        let database = DatabaseStub()
+
+        let provider = IncidentBreakdownProvider(deviceIDs: [], sessionIDs: [])
+        await provider.fetchIfNeeded(in: database)
+        let breakdown = try #require(try? provider.result?.get())
+
+        #expect(breakdown.devices.isEmpty)
+        #expect(breakdown.osVersions.isEmpty)
+    }
+}

--- a/Tests/ScoutTests/UI/Incident/Breakdown/IncidentBreakdownTests.swift
+++ b/Tests/ScoutTests/UI/Incident/Breakdown/IncidentBreakdownTests.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Testing
+
+@testable import Scout
+
+@Suite("IncidentBreakdown")
+struct IncidentBreakdownTests {
+    @Test("Counts occurrences per label")
+    func countsPerLabel() {
+        let segments = IncidentBreakdown.segments(from: ["A", "A", "B"])
+
+        #expect(Set(segments.map(\.label)) == ["A", "B"])
+        #expect(segments.first { $0.label == "A" }?.count == 2)
+        #expect(segments.first { $0.label == "B" }?.count == 1)
+    }
+
+    @Test("Orders segments by count descending")
+    func ordersByCount() {
+        let segments = IncidentBreakdown.segments(from: ["C", "A", "A", "B", "B", "B"])
+
+        #expect(segments.map(\.label) == ["B", "A", "C"])
+    }
+
+    @Test("Buckets everything past the top cutoff into Other")
+    func bucketsIntoOther() {
+        let labels =
+            Array(repeating: "A", count: 5) + Array(repeating: "B", count: 4) + Array(repeating: "C", count: 3) + Array(repeating: "D", count: 2)
+            + Array(repeating: "E", count: 1)
+        let segments = IncidentBreakdown.segments(from: labels, top: 4)
+
+        #expect(segments.map(\.label) == ["A", "B", "C", "D", "Other"])
+        #expect(segments.last?.count == 1)
+    }
+
+    @Test("Omits Other when everything fits within the top cutoff")
+    func omitsOtherWhenNothingRemains() {
+        let segments = IncidentBreakdown.segments(from: ["A", "B"], top: 4)
+
+        #expect(segments.map(\.label) == ["A", "B"])
+    }
+
+    @Test("Returns no segments for empty input")
+    func emptyInput() {
+        #expect(IncidentBreakdown.segments(from: []).isEmpty)
+    }
+}


### PR DESCRIPTION
Crash and hang group detail views only showed occurrence/device/session counts, with no sense of which hardware or OS versions were actually affected. This adds a Top Devices and OS Versions breakdown (top four plus an Other bucket) to CrashGroupDetailView and HangGroupDetailView, backed by a new IncidentBreakdownProvider that batches device model and session os_version lookups by id instead of fetching them one at a time.

Along the way, StatusSegment/StatusBar (previously Network-only) were generalized into Segment/SegmentBar so the same bar-and-legend rendering is shared between status-code and device/OS breakdowns, and IncidentGroup gained deviceIDs/sessionIDs so affectedDevices/affectedSessions no longer duplicate the same Set logic.