### PR TITLE
Add export for Network reports and the Event list

### DIFF
--- a/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
+++ b/Sources/Scout/UI/Event/Analytics/AnalyticsView.swift
@@ -62,6 +62,13 @@ struct AnalyticsView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     FilterButton(levels: $filter.levels)
                 }
+                if let text = EventListExport(events: provider.events ?? []).text {
+                    ToolbarItemGroup(placement: .bottomBar) {
+                        ShareLink(item: text)
+                        CopyButton(text: text)
+                        Spacer()
+                    }
+                }
             }
             .task {
                 await provider.fetchIfNeeded(for: filter, in: database)

--- a/Sources/Scout/UI/Event/List/Export/EventListExport.swift
+++ b/Sources/Scout/UI/Event/List/Export/EventListExport.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+struct EventListExport {
+    let events: [Event]
+
+    var text: String? {
+        guard events.count > 0 else { return nil }
+
+        var lines = [title, summary, ""]
+        lines.append(contentsOf: events.map(row))
+
+        return lines.joined(separator: "\n")
+    }
+}
+
+extension EventListExport {
+    private var title: String {
+        "# Scout Events"
+    }
+
+    private var summary: String {
+        ExportFormat.counted(events.count, "event", "events")
+    }
+
+    private func row(for event: Event) -> String {
+        var parts: [String] = []
+        if let date = event.date {
+            parts.append(ExportFormat.timestamp(date))
+        }
+        parts.append(event.name)
+        if let level = event.level {
+            parts.append("[\(level.rawValue)]")
+        }
+        return "- \(parts.joined(separator: "  "))"
+    }
+}

--- a/Sources/Scout/UI/Network/Export/NetworkReportExport.swift
+++ b/Sources/Scout/UI/Network/Export/NetworkReportExport.swift
@@ -1,0 +1,70 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+struct NetworkReportExport {
+    let report: NetworkReport
+    let range: Range<Date>
+
+    var text: String? {
+        let endpoints = report.endpoints(in: range)
+        guard endpoints.count > 0 else { return nil }
+
+        var lines = [title, summary]
+
+        lines.append("")
+        lines.append("## Status codes")
+        lines.append(contentsOf: statusLines)
+
+        lines.append("")
+        lines.append("## Endpoints")
+        lines.append(contentsOf: endpoints.map(row))
+
+        return lines.joined(separator: "\n")
+    }
+}
+
+extension NetworkReportExport {
+    private var title: String {
+        "# Scout Network Report"
+    }
+
+    private var summary: String {
+        let breakdown = report.summary(in: range)
+
+        var parts = [
+            ExportFormat.range(from: range.lowerBound, to: range.upperBound),
+            ExportFormat.counted(breakdown.total, "request", "requests"),
+        ]
+        if breakdown.total > 0 {
+            parts.append("success \(breakdown.successRate.formatted)")
+        }
+        if let p99 = report.percentiles(in: range)?.p99 {
+            parts.append("p99 \(p99.duration)")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private var statusLines: [String] {
+        report.summary(in: range).segments.map { segment in
+            "- \(segment.label): \(ExportFormat.counted(segment.count, "request", "requests"))"
+        }
+    }
+
+    private func row(for endpoint: NetworkEndpoint) -> String {
+        var parts = [ExportFormat.counted(endpoint.requests, "request", "requests")]
+        if let successRate = endpoint.successRate {
+            parts.append("success \(successRate.formatted)")
+        }
+        if let p99 = endpoint.p99 {
+            parts.append("p99 \(p99.duration)")
+        }
+        return "- \(endpoint.name)  (\(parts.joined(separator: ", ")))"
+    }
+}

--- a/Sources/Scout/UI/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Network/View/NetworkView.swift
@@ -65,6 +65,15 @@ struct NetworkView: View {
         .navigationDestination(isPresented: $showAllEndpoints) {
             NetworkEndpointsView(report: report, range: range)
         }
+        .toolbar {
+            if let text = NetworkReportExport(report: report, range: range).text {
+                ToolbarItemGroup(placement: .bottomBar) {
+                    ShareLink(item: text)
+                    CopyButton(text: text)
+                    Spacer()
+                }
+            }
+        }
     }
 }
 

--- a/Tests/ScoutTests/UI/Event/List/Export/EventListExportTests.swift
+++ b/Tests/ScoutTests/UI/Event/List/Export/EventListExportTests.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("EventListExport")
+struct EventListExportTests {
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("Events render their timestamp, name, and level")
+    func testEventListExport() throws {
+        let events = [
+            Event(
+                name: "app_launch",
+                level: .info,
+                date: base,
+                paramCount: nil,
+                uuid: nil,
+                id: "1",
+                installID: nil,
+                sessionID: nil,
+                deviceID: nil
+            ),
+            Event(
+                name: "button_tap",
+                level: nil,
+                date: nil,
+                paramCount: nil,
+                uuid: nil,
+                id: "2",
+                installID: nil,
+                sessionID: nil,
+                deviceID: nil
+            ),
+        ]
+        let text = try #require(EventListExport(events: events).text)
+
+        #expect(text.hasPrefix("# Scout Events"))
+        #expect(text.contains("2 events"))
+        #expect(text.contains("- \(ExportFormat.timestamp(base))  app_launch  [info]"))
+        #expect(text.contains("- button_tap"))
+    }
+
+    @Test("An empty list exports nothing")
+    func testEmptyEventListExport() {
+        #expect(EventListExport(events: []).text == nil)
+    }
+}

--- a/Tests/ScoutTests/UI/Network/Export/NetworkReportExportTests.swift
+++ b/Tests/ScoutTests/UI/Network/Export/NetworkReportExportTests.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("NetworkReportExport")
+struct NetworkReportExportTests {
+    let base = Date(year: 2026, month: 6, day: 1)
+
+    var range: Range<Date> {
+        base..<base.adding(.day)
+    }
+
+    @Test("A report with endpoints renders its summary, status codes, and endpoint rows")
+    func testReportExport() throws {
+        let report = NetworkReport(series: [
+            makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 99)]),
+            makeSeries(name: "GET /a", category: "status_5xx", points: [(base, 1)]),
+            makeSeries(name: "GET /a", category: "timer_le_1", points: [(base, 100)]),
+        ])
+        let text = try #require(NetworkReportExport(report: report, range: range).text)
+
+        #expect(text.hasPrefix("# Scout Network Report"))
+        #expect(text.contains("100 requests"))
+        #expect(text.contains("## Status codes"))
+        #expect(text.contains("- 2xx: 99 requests"))
+        #expect(text.contains("- 5xx: 1 request"))
+        #expect(text.contains("## Endpoints"))
+        #expect(text.contains("- GET /a  (100 requests, success"))
+    }
+
+    @Test("A report with no endpoints in range exports nothing")
+    func testEmptyReportExport() {
+        let report = NetworkReport(series: [])
+        #expect(NetworkReportExport(report: report, range: range).text == nil)
+    }
+
+    private func makeSeries(name: String, category: String, points: [(Date, Int)]) -> MetricSeries {
+        MetricSeries(
+            name: name,
+            category: category,
+            points: points.map { date, count in
+                MetricSeriesPoint(date: date.millisecondsSince1970, value: .int(count))
+            }
+        )
+    }
+}


### PR DESCRIPTION
Network and the Event/log list were the only screens without an export action, unlike Chart, Crash, Hang, and Timeline. This adds NetworkReportExport and EventListExport, following the same Markdown-document approach as the existing Crash/Hang/Timeline exports (built with the shared ExportFormat helpers), wired into NetworkView and AnalyticsView's toolbars via the standard ShareLink + CopyButton bottom-bar pair.

NetworkReportExport renders the report's date range, request/success/p99 summary, status-code breakdown, and every endpoint (not just the top three shown on screen). EventListExport renders each event's timestamp, name, and level. Both return nil when there's nothing to export, so the toolbar buttons only appear once data is loaded.