### PR TITLE
Add a Devices screen with live per-device aggregates

### DIFF
--- a/Sources/Scout/UI/Devices/Model/DeviceSummary.swift
+++ b/Sources/Scout/UI/Devices/Model/DeviceSummary.swift
@@ -1,0 +1,72 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct DeviceSummary: Identifiable, Equatable {
+    let id: UUID
+    let model: String
+    let osVersion: String
+    let lastSeen: Date
+    let sessions: Int
+    let crashes: Int
+}
+
+extension DeviceSummary {
+    static func summaries(devices: [Record], sessions: [Record], crashes: [Record]) -> [DeviceSummary] {
+        let sessionsByDevice = Dictionary(grouping: sessions.compactMap(SessionFields.init), by: \.deviceID)
+        let crashCounts = Dictionary(crashes.compactMap { (record: Record) -> String? in record["device_id"] }.map { ($0, 1) }, uniquingKeysWith: +)
+
+        return devices.compactMap { device -> DeviceSummary? in
+            guard let deviceID: String = device["device_id"], let uuid = UUID(uuidString: deviceID), let model: String = device["model"] else {
+                return nil
+            }
+
+            guard let latest = (sessionsByDevice[deviceID] ?? []).max(by: { $0.startDate < $1.startDate }) else {
+                return nil
+            }
+
+            return DeviceSummary(
+                id: uuid,
+                model: model,
+                osVersion: latest.osVersion,
+                lastSeen: latest.startDate,
+                sessions: sessionsByDevice[deviceID]?.count ?? 0,
+                crashes: crashCounts[deviceID] ?? 0
+            )
+        }
+    }
+
+    private struct SessionFields {
+        let deviceID: String
+        let osVersion: String
+        let startDate: Date
+
+        init?(record: Record) {
+            guard let deviceID: String = record["device_id"], let startDate: Date = record["start_date"] else {
+                return nil
+            }
+            self.deviceID = deviceID
+            osVersion = record["os_version"] ?? "—"
+            self.startDate = startDate
+        }
+    }
+}
+
+extension DeviceSummary {
+    static let samples: [DeviceSummary] = [
+        DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -15 * 60), sessions: 812, crashes: 3),
+        DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.3", lastSeen: Date(timeIntervalSinceNow: -3 * 3600), sessions: 540, crashes: 0),
+        DeviceSummary(id: UUID(), model: "iPhone14,2", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -6 * 3600), sessions: 391, crashes: 1),
+        DeviceSummary(id: UUID(), model: "iPhone14,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -2 * 86400), sessions: 205, crashes: 0),
+        DeviceSummary(id: UUID(), model: "iPhone13,2", osVersion: "iOS 17.3", lastSeen: Date(timeIntervalSinceNow: -1 * 86400), sessions: 178, crashes: 2),
+        DeviceSummary(id: UUID(), model: "iPhone13,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -9 * 86400), sessions: 96, crashes: 0),
+        DeviceSummary(id: UUID(), model: "iPad13,1", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -4 * 3600), sessions: 143, crashes: 0),
+        DeviceSummary(id: UUID(), model: "iPad14,1", osVersion: "iOS 17.2", lastSeen: Date(timeIntervalSinceNow: -12 * 86400), sessions: 64, crashes: 1),
+        DeviceSummary(id: UUID(), model: "iPhone12,1", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -30 * 86400), sessions: 22, crashes: 0),
+    ]
+}

--- a/Sources/Scout/UI/Devices/View/DeviceDetailView.swift
+++ b/Sources/Scout/UI/Devices/View/DeviceDetailView.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct DeviceDetailView: View {
+    let device: DeviceSummary
+
+    var body: some View {
+        List {
+            FlowLayout(spacing: 6) {
+                InfoChip(systemImage: device.model.hasPrefix("iPad") ? "ipad" : "iphone", text: device.model, color: .blue, monospaced: true)
+                InfoChip(systemImage: "gearshape", text: device.osVersion, color: .indigo)
+                InfoChip(systemImage: "clock", text: "seen \(device.lastSeen.relativeString)", color: .teal)
+            }
+            .listRowSeparator(.hidden)
+
+            HStack(spacing: 28) {
+                Metric(title: "Sessions", value: device.sessions.plain, color: .primary)
+                Metric(title: "Crashes", value: device.crashes.plain, color: device.crashes > 0 ? .red : .primary)
+                Spacer()
+            }
+            .listRowSeparator(.hidden)
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: device.model)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DeviceDetailView(device: DeviceSummary.samples[0])
+    }
+}

--- a/Sources/Scout/UI/Devices/View/DeviceRow.swift
+++ b/Sources/Scout/UI/Devices/View/DeviceRow.swift
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct DeviceLink: View {
+    let device: DeviceSummary
+
+    var body: some View {
+        Row {
+            DeviceRow(device: device)
+        } destination: {
+            DeviceDetailView(device: device)
+        }
+    }
+}
+
+struct DeviceRow: View {
+    let device: DeviceSummary
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: device.model.hasPrefix("iPad") ? "ipad" : "iphone")
+                .foregroundStyle(.blue)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(verbatim: device.model)
+                    .font(.subheadline.weight(.medium))
+                    .monospaced()
+                Text(verbatim: device.osVersion + " · " + device.sessions.plain + " sessions")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+            }
+
+            Spacer()
+
+            if device.crashes > 0 {
+                CountBadge(count: device.crashes, prefix: "×")
+            }
+
+            Text(verbatim: device.lastSeen.relativeString)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 64, alignment: .trailing)
+        }
+        .frame(height: 44)
+    }
+}
+
+#Preview("DeviceRow") {
+    List(DeviceSummary.samples) { device in
+        DeviceRow(device: device)
+    }
+    .listStyle(.plain)
+}

--- a/Sources/Scout/UI/Devices/View/DevicesListView.swift
+++ b/Sources/Scout/UI/Devices/View/DevicesListView.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct DevicesListView: View {
+    let devices: [DeviceSummary]
+
+    var body: some View {
+        Group {
+            if devices.isEmpty {
+                Placeholder(
+                    text: "No devices",
+                    systemImage: "iphone.gen3",
+                    description: "Devices appear here once your app reports sessions"
+                )
+            } else {
+                List {
+                    ForEach(devices.sorted { $0.lastSeen > $1.lastSeen }) { device in
+                        DeviceLink(device: device)
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .navigationTitle(en: "Devices")
+    }
+}
+
+#Preview("Devices — List") {
+    NavigationStack {
+        DevicesListView(devices: DeviceSummary.samples)
+    }
+}
+
+#Preview("Devices — List Empty") {
+    NavigationStack {
+        DevicesListView(devices: [])
+    }
+}

--- a/Sources/Scout/UI/Devices/View/DevicesProvider.swift
+++ b/Sources/Scout/UI/Devices/View/DevicesProvider.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+@MainActor
+final class DevicesProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<[DeviceSummary]>?
+
+    func fetch(in database: DatabaseReader) async throws -> [DeviceSummary] {
+        async let devices: [Record] = database.readAll(matching: RecordQuery(recordType: Device.self), fields: ["device_id", "model"])
+        async let sessions: [Record] = database.readAll(matching: RecordQuery(recordType: Session.self), fields: ["device_id", "os_version", "start_date"])
+        async let crashes: [Record] = database.readAll(matching: RecordQuery(recordType: Crash.self), fields: ["device_id"])
+
+        return try await DeviceSummary.summaries(devices: devices, sessions: sessions, crashes: crashes)
+    }
+}

--- a/Sources/Scout/UI/Devices/View/DevicesView.swift
+++ b/Sources/Scout/UI/Devices/View/DevicesView.swift
@@ -1,0 +1,86 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct DevicesView: View {
+    @Environment(\.database) var database
+    @StateObject var provider = DevicesProvider()
+    @State private var showAllDevices = false
+
+    var body: some View {
+        ProviderView(provider: provider) { devices in
+            if devices.isEmpty {
+                Placeholder(
+                    text: "No devices",
+                    systemImage: "iphone.gen3",
+                    description: "Devices appear here once your app reports sessions"
+                )
+            } else {
+                content(devices)
+            }
+        }
+        .navigationTitle(en: "Devices")
+        .task {
+            await provider.fetchIfNeeded(in: database)
+        }
+    }
+
+    private func content(_ devices: [DeviceSummary]) -> some View {
+        let sorted = devices.sorted { $0.lastSeen > $1.lastSeen }
+        let activeCutoff = Date(timeIntervalSinceNow: -7 * 86400)
+        let activeCount = devices.filter { $0.lastSeen > activeCutoff }.count
+        let crashingCount = devices.filter { $0.crashes > 0 }.count
+        let modelBreakdown = IncidentBreakdown.segments(from: devices.map(\.model))
+        let osBreakdown = IncidentBreakdown.segments(from: devices.map(\.osVersion))
+
+        return List {
+            HStack(spacing: 28) {
+                Metric(title: "Devices", value: devices.count.plain, color: .primary)
+                Metric(title: "Active 7d", value: activeCount.plain, color: .blue)
+                Metric(title: "With Crashes", value: crashingCount.plain, color: crashingCount > 0 ? .red : .primary)
+                Spacer()
+            }
+            .listRowSeparator(.hidden)
+
+            Header(title: "Top Models")
+            SegmentBar(segments: modelBreakdown).listRowSeparator(.hidden)
+
+            Header(title: "OS Versions")
+            SegmentBar(segments: osBreakdown).listRowSeparator(.hidden)
+
+            Header(title: "Recent Devices") {
+                AllButton { showAllDevices = true }
+            }
+            ForEach(sorted.prefix(3)) { device in
+                DeviceLink(device: device)
+            }
+        }
+        .listStyle(.plain)
+        .navigationDestination(isPresented: $showAllDevices) {
+            DevicesListView(devices: devices)
+        }
+    }
+}
+
+#Preview("Devices") {
+    let provider = DevicesProvider()
+    provider.result = .success(DeviceSummary.samples)
+
+    return NavigationStack {
+        DevicesView(provider: provider)
+    }
+}
+
+#Preview("Devices — Empty") {
+    let provider = DevicesProvider()
+    provider.result = .success([])
+
+    return NavigationStack {
+        DevicesView(provider: provider)
+    }
+}

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -45,6 +45,14 @@ struct HomeLogSection: View {
             NetworkView()
         }
 
+        Row {
+            Image(systemName: "iphone").foregroundColor(.blue).frame(width: 24)
+            Text(verbatim: "Devices")
+            Spacer()
+        } destination: {
+            DevicesView()
+        }
+
         HomeLogRow(
             title: "Crashes",
             image: "exclamationmark.triangle",

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -137,7 +137,7 @@ extension Record {
         return record
     }
 
-    static func sessionStub(sessionID: UUID, launchID: UUID, installID: UUID, startDate: Date, osVersion: String? = nil) -> Record {
+    static func sessionStub(sessionID: UUID, launchID: UUID, installID: UUID, startDate: Date, osVersion: String? = nil, deviceID: UUID? = nil) -> Record {
         var record = Session(
             startDate: startDate,
             endDate: nil,
@@ -147,7 +147,23 @@ extension Record {
             installID: installID
         ).record
         record["os_version"] = osVersion
+        record["device_id"] = deviceID?.uuidString
         return record
+    }
+
+    static func crashStub(crashID: UUID = UUID(), deviceID: UUID, date: Date) -> Record {
+        Crash(
+            name: "Stub",
+            fingerprint: "stub",
+            reason: nil,
+            stackTrace: [],
+            date: date,
+            id: crashID.uuidString,
+            deviceID: deviceID,
+            installID: nil,
+            launchID: nil,
+            sessionID: nil
+        ).record
     }
 
     static func eventStub(name: String, sessionID: UUID, date: Date) -> Record {

--- a/Tests/ScoutTests/UI/Devices/Model/DeviceSummaryTests.swift
+++ b/Tests/ScoutTests/UI/Devices/Model/DeviceSummaryTests.swift
@@ -1,0 +1,86 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("DeviceSummary")
+struct DeviceSummaryTests {
+    @Test("Aggregates sessions and crashes per device, using the latest session for OS version and last seen")
+    func summariesAggregatePerDevice() throws {
+        let deviceID = UUID()
+        let older = Date(timeIntervalSinceNow: -3600)
+        let newer = Date()
+
+        let summaries = DeviceSummary.summaries(
+            devices: [.deviceStub(deviceID: deviceID, date: older, model: "iPhone15,3")],
+            sessions: [
+                .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: older, osVersion: "iOS 17.3", deviceID: deviceID),
+                .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: newer, osVersion: "iOS 17.4", deviceID: deviceID),
+            ],
+            crashes: [.crashStub(deviceID: deviceID, date: newer)]
+        )
+
+        let summary = try #require(summaries.first)
+        #expect(summaries.count == 1)
+        #expect(summary.model == "iPhone15,3")
+        #expect(summary.osVersion == "iOS 17.4")
+        #expect(summary.lastSeen == newer)
+        #expect(summary.sessions == 2)
+        #expect(summary.crashes == 1)
+    }
+
+    @Test("Excludes devices with no recorded sessions")
+    func summariesExcludeSessionlessDevices() {
+        let deviceID = UUID()
+
+        let summaries = DeviceSummary.summaries(
+            devices: [.deviceStub(deviceID: deviceID, date: Date(), model: "iPhone15,3")],
+            sessions: [],
+            crashes: []
+        )
+
+        #expect(summaries.isEmpty)
+    }
+
+    @Test("Excludes devices with no model")
+    func summariesExcludeModellessDevices() {
+        let deviceID = UUID()
+
+        let summaries = DeviceSummary.summaries(
+            devices: [.deviceStub(deviceID: deviceID, date: Date(), model: nil)],
+            sessions: [.sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: Date(), deviceID: deviceID)],
+            crashes: []
+        )
+
+        #expect(summaries.isEmpty)
+    }
+
+    @Test("Keeps devices independent")
+    func summariesKeepDevicesIndependent() {
+        let deviceA = UUID()
+        let deviceB = UUID()
+
+        let summaries = DeviceSummary.summaries(
+            devices: [
+                .deviceStub(deviceID: deviceA, date: Date(), model: "iPhone15,3"),
+                .deviceStub(deviceID: deviceB, date: Date(), model: "iPad13,1"),
+            ],
+            sessions: [
+                .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: Date(), deviceID: deviceA),
+                .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: Date(), deviceID: deviceB),
+            ],
+            crashes: [.crashStub(deviceID: deviceA, date: Date())]
+        )
+
+        let byID = Dictionary(uniqueKeysWithValues: summaries.map { ($0.id, $0) })
+        #expect(byID[deviceA]?.crashes == 1)
+        #expect(byID[deviceB]?.crashes == 0)
+    }
+}

--- a/Tests/ScoutTests/UI/Devices/View/DevicesProviderTests.swift
+++ b/Tests/ScoutTests/UI/Devices/View/DevicesProviderTests.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("DevicesProvider")
+struct DevicesProviderTests {
+    @Test("Fetches every device and aggregates its sessions and crashes")
+    func fetchBuildsSummariesForAllDevices() async throws {
+        let deviceA = UUID()
+        let deviceB = UUID()
+        let date = Date()
+
+        let database = DatabaseStub()
+        database.add(
+            .deviceStub(deviceID: deviceA, date: date, model: "iPhone15,3"),
+            .deviceStub(deviceID: deviceB, date: date, model: "iPad13,1"),
+            .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: date, osVersion: "iOS 17.4", deviceID: deviceA),
+            .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: date, osVersion: "iOS 17.2", deviceID: deviceB),
+            .crashStub(deviceID: deviceA, date: date)
+        )
+
+        let provider = DevicesProvider()
+        await provider.fetchIfNeeded(in: database)
+        let summaries = try #require(provider.result).get()
+
+        #expect(Set(summaries.map(\.model)) == ["iPhone15,3", "iPad13,1"])
+        #expect(summaries.first { $0.model == "iPhone15,3" }?.crashes == 1)
+        #expect(summaries.first { $0.model == "iPad13,1" }?.crashes == 0)
+    }
+
+    @Test("No devices yields no summaries")
+    func fetchEmptyDatabaseYieldsNoSummaries() async throws {
+        let database = DatabaseStub()
+
+        let provider = DevicesProvider()
+        await provider.fetchIfNeeded(in: database)
+        let summaries = try #require(provider.result).get()
+
+        #expect(summaries.isEmpty)
+    }
+}


### PR DESCRIPTION
Adds a Devices screen reachable from Home > Log, next to Network. DevicesView shows headline metrics plus top-model and OS-version breakdowns (reusing the IncidentBreakdown/SegmentBar machinery from #838), with an "All" drill-in to the full roster in DevicesListView. Both are backed by a new DevicesProvider that reads every Device/Session/Crash record and aggregates per device_id — session count, crash count, latest OS version, and last-seen date come from the most recent session per device.

I sketched a few layout directions in Xcode previews first (a dense flat list, a model-grouped view with a family filter strip, and a card grid) before settling on this dashboard-style overview as the best fit with the rest of the app.
