### PR TITLE
Add export for the device roster

### DIFF
--- a/Sources/Scout/UI/Devices/Export/DevicesExport.swift
+++ b/Sources/Scout/UI/Devices/Export/DevicesExport.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct DevicesExport {
+    let devices: [DeviceSummary]
+
+    var text: String? {
+        guard devices.count > 0 else { return nil }
+        var lines = [title, summary, ""]
+        lines.append(contentsOf: devices.sorted { $0.lastSeen > $1.lastSeen }.map(row))
+        return lines.joined(separator: "\n")
+    }
+}
+
+extension DevicesExport {
+    private var title: String { "# Scout Devices" }
+    private var summary: String { ExportFormat.counted(devices.count, "device", "devices") }
+    private func row(for device: DeviceSummary) -> String {
+        let sessions = ExportFormat.counted(device.sessions, "session", "sessions")
+        let crashes = ExportFormat.counted(device.crashes, "crash", "crashes")
+        return "- \(device.model)  (\(device.osVersion), \(sessions), \(crashes), seen \(ExportFormat.timestamp(device.lastSeen)))"
+    }
+}

--- a/Sources/Scout/UI/Devices/View/DevicesListView.swift
+++ b/Sources/Scout/UI/Devices/View/DevicesListView.swift
@@ -28,6 +28,15 @@ struct DevicesListView: View {
             }
         }
         .navigationTitle(en: "Devices")
+        .toolbar {
+            if let text = DevicesExport(devices: devices).text {
+                ToolbarItemGroup(placement: .bottomBar) {
+                    ShareLink(item: text)
+                    CopyButton(text: text)
+                    Spacer()
+                }
+            }
+        }
     }
 }
 

--- a/Tests/ScoutTests/UI/Devices/Export/DevicesExportTests.swift
+++ b/Tests/ScoutTests/UI/Devices/Export/DevicesExportTests.swift
@@ -14,7 +14,14 @@ import Testing
 struct DevicesExportTests {
     @Test("Devices render their model, OS, and counts")
     func testDevicesExport() throws {
-        let device = DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSince1970: 1_700_000_000), sessions: 10, crashes: 2)
+        let device = DeviceSummary(
+            id: UUID(),
+            model: "iPhone15,3",
+            osVersion: "iOS 17.4",
+            lastSeen: Date(timeIntervalSince1970: 1_700_000_000),
+            sessions: 10,
+            crashes: 2
+        )
         let text = try #require(DevicesExport(devices: [device]).text)
 
         #expect(text.hasPrefix("# Scout Devices"))

--- a/Tests/ScoutTests/UI/Devices/Export/DevicesExportTests.swift
+++ b/Tests/ScoutTests/UI/Devices/Export/DevicesExportTests.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("DevicesExport")
+struct DevicesExportTests {
+    @Test("Devices render their model, OS, and counts")
+    func testDevicesExport() throws {
+        let device = DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSince1970: 1_700_000_000), sessions: 10, crashes: 2)
+        let text = try #require(DevicesExport(devices: [device]).text)
+
+        #expect(text.hasPrefix("# Scout Devices"))
+        #expect(text.contains("1 device"))
+        #expect(text.contains("iPhone15,3"))
+        #expect(text.contains("iOS 17.4"))
+        #expect(text.contains("10 sessions"))
+        #expect(text.contains("2 crashes"))
+        #expect(text.contains(ExportFormat.timestamp(Date(timeIntervalSince1970: 1_700_000_000))))
+    }
+
+    @Test("Rows follow the newest-lastSeen-first order")
+    func testDevicesExportOrdersByLastSeen() throws {
+        let older = DeviceSummary(id: UUID(), model: "iPhone14,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSince1970: 0), sessions: 1, crashes: 0)
+        let newer = DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSince1970: 3600), sessions: 1, crashes: 0)
+        let text = try #require(DevicesExport(devices: [older, newer]).text)
+
+        let newerRange = try #require(text.range(of: "iPhone15,3"))
+        let olderRange = try #require(text.range(of: "iPhone14,2"))
+        #expect(newerRange.lowerBound < olderRange.lowerBound)
+    }
+
+    @Test("An empty roster exports nothing")
+    func testEmptyDevicesExport() {
+        #expect(DevicesExport(devices: []).text == nil)
+    }
+}


### PR DESCRIPTION
Devices was the last screen without an export action, unlike Chart, Crash, Hang, Timeline, Network, and the Event list. This adds DevicesExport, following the same Markdown-document approach as the existing exports (built with the shared ExportFormat helpers), wired into DevicesListView's toolbar via the standard ShareLink + CopyButton bottom-bar pair.

DevicesExport renders one line per device with its model, OS version, session and crash counts, and last-seen timestamp, sorted newest-first to match the list. It returns nil when the roster is empty, so the toolbar buttons only appear once data is loaded.
