### PR TITLE
Show a live device count on the Home Devices row

### DIFF
--- a/Sources/Scout/UI/Devices/Model/DeviceSummary.swift
+++ b/Sources/Scout/UI/Devices/Model/DeviceSummary.swift
@@ -57,7 +57,7 @@ extension DeviceSummary {
     }
 }
 
-extension DeviceSummary {
+extension DeviceSummary: Fixture {
     static let samples: [DeviceSummary] = [
         DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -15 * 60), sessions: 812, crashes: 3),
         DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.3", lastSeen: Date(timeIntervalSinceNow: -3 * 3600), sessions: 540, crashes: 0),

--- a/Sources/Scout/UI/Home/HomeList.swift
+++ b/Sources/Scout/UI/Home/HomeList.swift
@@ -79,7 +79,7 @@ struct HomeList: View {
     let logs = makeLogs()
 
     let devices = DevicesProvider()
-    devices.result = .success(DeviceSummary.samples)
+    devices.result = .success(.samples)
 
     return NavigationStack {
         HomeList(

--- a/Sources/Scout/UI/Home/HomeList.swift
+++ b/Sources/Scout/UI/Home/HomeList.swift
@@ -15,11 +15,12 @@ struct HomeList: View {
     @StateObject var crashes = StatProvider(eventName: "Crash", periods: Period.summary)
     @StateObject var releases = ReleaseHealthProvider()
     @StateObject var logs = HomeLogProvider()
+    @StateObject var devices = DevicesProvider()
 
     @State var showReleaseHealth = false
 
     var body: some View {
-        if let error = HomeErrorView(providers: [sessions, crashes, activities, logs, releases]) {
+        if let error = HomeErrorView(providers: [sessions, crashes, activities, logs, releases, devices]) {
             error
         } else {
             List {
@@ -37,7 +38,7 @@ struct HomeList: View {
                     HomeActivitySection(activity: activities)
                 }
 
-                HomeLogSection(provider: logs)
+                HomeLogSection(log: logs, devices: devices)
                 HomeReleaseSection(provider: releases, showReleaseHealth: $showReleaseHealth)
             }
             .navigationDestination(isPresented: $showReleaseHealth) {
@@ -77,13 +78,17 @@ struct HomeList: View {
 
     let logs = makeLogs()
 
+    let devices = DevicesProvider()
+    devices.result = .success(DeviceSummary.samples)
+
     return NavigationStack {
         HomeList(
             activities: activities,
             sessions: sessions,
             crashes: crashes,
             releases: releases,
-            logs: logs
+            logs: logs,
+            devices: devices
         )
         .navigationTitle(en: "Home")
     }

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -9,14 +9,15 @@ import SwiftUI
 
 struct HomeLogSection: View {
     @Environment(\.database) var database
-    @StateObject var provider = HomeLogProvider()
+    @StateObject var log = HomeLogProvider()
+    @StateObject var devices = DevicesProvider()
 
     var body: some View {
         Header(title: "Log") {
-            CompactPeriodPicker(selection: $provider.period)
+            CompactPeriodPicker(selection: $log.period)
         }
-        .task(id: provider.period) {
-            await provider.fetchIfNeeded(in: database)
+        .task(id: log.period) {
+            await log.fetchIfNeeded(in: database)
         }
 
         let logSpans = logSpans
@@ -45,12 +46,15 @@ struct HomeLogSection: View {
             NetworkView()
         }
 
-        Row {
-            Image(systemName: "iphone").foregroundColor(.blue).frame(width: 24)
-            Text(verbatim: "Devices")
-            Spacer()
-        } destination: {
-            DevicesView()
+        HomeLogRow(
+            title: "Devices",
+            image: "iphone",
+            color: .blue,
+            count: deviceCount,
+            destination: { DevicesView() }
+        )
+        .task {
+            await devices.fetchIfNeeded(in: database)
         }
 
         HomeLogRow(
@@ -71,14 +75,18 @@ struct HomeLogSection: View {
     }
 
     private var logSpans: (int: MatrixSpan<Int>, double: MatrixSpan<Double>)? {
-        guard let result = try? provider.result?.get() else {
+        guard let result = try? log.result?.get() else {
             return nil
         }
 
         return (
-            MatrixSpan(matrices: result.0, range: provider.period.initialRange),
-            MatrixSpan(matrices: result.1, range: provider.period.initialRange)
+            MatrixSpan(matrices: result.0, range: log.period.initialRange),
+            MatrixSpan(matrices: result.1, range: log.period.initialRange)
         )
+    }
+
+    private var deviceCount: Int? {
+        try? devices.result?.get().count
     }
 }
 
@@ -96,9 +104,12 @@ struct HomeLogSection: View {
         return provider
     }
 
+    let devices = DevicesProvider()
+    devices.result = .success(DeviceSummary.samples)
+
     return NavigationStack {
         List {
-            HomeLogSection(provider: makeProvider())
+            HomeLogSection(log: makeProvider(), devices: devices)
         }
         .listStyle(.plain)
     }

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -105,7 +105,7 @@ struct HomeLogSection: View {
     }
 
     let devices = DevicesProvider()
-    devices.result = .success(DeviceSummary.samples)
+    devices.result = .success(.samples)
 
     return NavigationStack {
         List {


### PR DESCRIPTION
The Devices row on Home > Log was a bare Row with no trailing count, unlike every other row in the section. It now uses HomeLogRow with a count backed by DevicesProvider, fetched the same way the other rows fetch theirs. Since HomeLogSection now owns two providers, its existing HomeLogProvider was renamed from provider to log per the multi-provider naming convention, with devices added alongside it; HomeList (the section's sole call site) and its preview were updated to match.

Along the way, DeviceSummary now conforms to Fixture, so its preview/test call sites write `.samples` instead of `DeviceSummary.samples`, matching the convention every other samples-bearing type in the app already follows.
