### PR TITLE
Show a device's recent crashes and hangs in its detail view

### DIFF
--- a/Sources/Scout/UI/Devices/Model/DeviceIncidents.swift
+++ b/Sources/Scout/UI/Devices/Model/DeviceIncidents.swift
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct DeviceIncidents {
+    let crashes: [Crash]
+    let hangs: [Hang]
+}

--- a/Sources/Scout/UI/Devices/View/DeviceDetailView.swift
+++ b/Sources/Scout/UI/Devices/View/DeviceDetailView.swift
@@ -10,6 +10,14 @@ import SwiftUI
 struct DeviceDetailView: View {
     let device: DeviceSummary
 
+    @StateObject private var incidents: DeviceIncidentsProvider
+    @Environment(\.database) var database
+
+    init(device: DeviceSummary, incidents: DeviceIncidentsProvider? = nil) {
+        self.device = device
+        self._incidents = StateObject(wrappedValue: incidents ?? DeviceIncidentsProvider(deviceID: device.id))
+    }
+
     var body: some View {
         List {
             FlowLayout(spacing: 6) {
@@ -25,14 +33,62 @@ struct DeviceDetailView: View {
                 Spacer()
             }
             .listRowSeparator(.hidden)
+
+            if crashes.count > 0 {
+                Header(title: "Recent Crashes")
+                ForEach(crashes) { crash in
+                    Row {
+                        if let date = crash.date {
+                            UTCTimestampText(date: date, size: 14)
+                        }
+                        Spacer()
+                        Text(verbatim: crash.name)
+                            .font(.footnote)
+                            .foregroundStyle(Color.gray)
+                    } destination: {
+                        CrashDetailView(crash: crash)
+                    }
+                }
+            }
+
+            if hangs.count > 0 {
+                Header(title: "Recent Hangs")
+                ForEach(hangs) { hang in
+                    Row {
+                        if let date = hang.date {
+                            UTCTimestampText(date: date, size: 14)
+                        }
+                        Spacer()
+                        Text(verbatim: hang.durationText)
+                            .font(.footnote)
+                            .foregroundStyle(Color.gray)
+                    } destination: {
+                        HangDetailView(hang: hang)
+                    }
+                }
+            }
         }
         .listStyle(.plain)
         .navigationTitle(en: device.model)
+        .task {
+            await incidents.fetchIfNeeded(in: database)
+        }
+    }
+
+    private var crashes: [Crash] {
+        (try? incidents.result?.get().crashes) ?? []
+    }
+
+    private var hangs: [Hang] {
+        (try? incidents.result?.get().hangs) ?? []
     }
 }
 
 #Preview {
-    NavigationStack {
-        DeviceDetailView(device: DeviceSummary.samples[0])
+    let incidents = DeviceIncidentsProvider(deviceID: DeviceSummary.samples[0].id)
+    incidents.result = .success(DeviceIncidents(crashes: Crash.samples, hangs: Hang.samples))
+
+    return NavigationStack {
+        DeviceDetailView(device: DeviceSummary.samples[0], incidents: incidents)
     }
 }

--- a/Sources/Scout/UI/Devices/View/DeviceIncidentsProvider.swift
+++ b/Sources/Scout/UI/Devices/View/DeviceIncidentsProvider.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+@MainActor
+final class DeviceIncidentsProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<DeviceIncidents>?
+
+    private let deviceID: UUID
+
+    init(deviceID: UUID) {
+        self.deviceID = deviceID
+    }
+
+    func fetch(in database: DatabaseReader) async throws -> DeviceIncidents {
+        async let crashes: [Crash] = database.readAll(matching: query(for: Crash.self), fields: Crash.desiredKeys)
+        async let hangs: [Hang] = database.readAll(matching: query(for: Hang.self), fields: Hang.desiredKeys)
+
+        return try await DeviceIncidents(crashes: crashes.sorted(), hangs: hangs.sorted())
+    }
+
+    private func query(for recordType: any RecordDecodable.Type) -> RecordQuery {
+        RecordQuery(
+            recordType: recordType,
+            filters: [RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))],
+            sort: [RecordQuery.Sort(field: "date", ascending: false)]
+        )
+    }
+}

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -166,6 +166,22 @@ extension Record {
         ).record
     }
 
+    static func hangStub(hangID: UUID = UUID(), deviceID: UUID, date: Date, duration: TimeInterval = 1) -> Record {
+        Hang(
+            name: "Stub",
+            fingerprint: "stub",
+            reason: nil,
+            stackTrace: [],
+            duration: duration,
+            date: date,
+            id: hangID.uuidString,
+            deviceID: deviceID,
+            installID: nil,
+            launchID: nil,
+            sessionID: nil
+        ).record
+    }
+
     static func eventStub(name: String, sessionID: UUID, date: Date) -> Record {
         Event.stub(name: name, sessionID: sessionID, date: date).record
     }

--- a/Tests/ScoutTests/UI/Devices/View/DeviceIncidentsProviderTests.swift
+++ b/Tests/ScoutTests/UI/Devices/View/DeviceIncidentsProviderTests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@MainActor
+@Suite("DeviceIncidentsProvider")
+struct DeviceIncidentsProviderTests {
+    @Test("Fetches only the device's crashes and hangs, newest first")
+    func fetchFiltersToDeviceAndSortsNewestFirst() async throws {
+        let device = UUID()
+        let otherDevice = UUID()
+        let oldest = Date(timeIntervalSinceNow: -3600)
+        let newest = Date()
+
+        let database = DatabaseStub()
+        database.add(
+            .crashStub(deviceID: device, date: oldest),
+            .crashStub(deviceID: device, date: newest),
+            .crashStub(deviceID: otherDevice, date: newest),
+            .hangStub(deviceID: device, date: oldest),
+            .hangStub(deviceID: device, date: newest),
+            .hangStub(deviceID: otherDevice, date: newest)
+        )
+
+        let provider = DeviceIncidentsProvider(deviceID: device)
+        await provider.fetchIfNeeded(in: database)
+        let incidents = try #require(provider.result).get()
+
+        #expect(incidents.crashes.map(\.date) == [newest, oldest])
+        #expect(incidents.hangs.map(\.date) == [newest, oldest])
+        #expect(incidents.crashes.allSatisfy { $0.deviceID == device })
+        #expect(incidents.hangs.allSatisfy { $0.deviceID == device })
+    }
+
+    @Test("No crashes or hangs yields empty arrays")
+    func fetchWithNoIncidentsYieldsEmptyArrays() async throws {
+        let database = DatabaseStub()
+
+        let provider = DeviceIncidentsProvider(deviceID: UUID())
+        await provider.fetchIfNeeded(in: database)
+        let incidents = try #require(provider.result).get()
+
+        #expect(incidents.crashes.isEmpty)
+        #expect(incidents.hangs.isEmpty)
+    }
+}


### PR DESCRIPTION
DeviceDetailView only showed a device's aggregate Sessions/Crashes counts, with no way to see what actually happened on that specific device. This adds Recent Crashes and Recent Hangs sections listing that device's individual occurrences, most recent first, with each row navigating to the existing crash/hang detail screen.

Backed by a new DeviceIncidentsProvider that fetches Crash and Hang concurrently, filtered by device_id and sorted newest first, mirroring the query pattern already used by IncidentBreakdownProvider. Stacks on #842 since it builds on DeviceDetailView added there.
