### PR TITLE
Don't delete a hub record from cleanup while other records still reference it

### DIFF
--- a/Sources/Scout/Core/Sync/HubObject.swift
+++ b/Sources/Scout/Core/Sync/HubObject.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import CoreData
+
+// A SyncableObject that other records identify themselves by (DeviceObject,
+// InstallObject, LaunchObject, SessionObject), so cleanup must not delete
+// it while any such record still exists.
+protocol HubObject {
+    var isReferenced: Bool { get }
+}
+
+extension DeviceObject: HubObject {
+    var isReferenced: Bool {
+        guard let context = managedObjectContext else { return false }
+        let request = NSFetchRequest<NSManagedObject>(entityName: "IDObject")
+        request.predicate = NSPredicate(format: "deviceID == %@ AND SELF != %@", deviceID as CVarArg, self)
+        request.fetchLimit = 1
+        return ((try? context.count(for: request)) ?? 0) > 0
+    }
+}
+
+extension InstallObject: HubObject {
+    var isReferenced: Bool {
+        guard let context = managedObjectContext else { return false }
+        let request = NSFetchRequest<NSManagedObject>(entityName: "IDObject")
+        request.predicate = NSPredicate(format: "installID == %@ AND SELF != %@", installID as CVarArg, self)
+        request.fetchLimit = 1
+        return ((try? context.count(for: request)) ?? 0) > 0
+    }
+}
+
+extension LaunchObject: HubObject {
+    var isReferenced: Bool {
+        guard let context = managedObjectContext else { return false }
+        let request = NSFetchRequest<NSManagedObject>(entityName: "IDObject")
+        request.predicate = NSPredicate(format: "launchID == %@ AND SELF != %@", launchID as CVarArg, self)
+        request.fetchLimit = 1
+        return ((try? context.count(for: request)) ?? 0) > 0
+    }
+}
+
+extension SessionObject: HubObject {
+    var isReferenced: Bool {
+        guard let context = managedObjectContext else { return false }
+        let request = NSFetchRequest<NSManagedObject>(entityName: "TrackedObject")
+        request.predicate = NSPredicate(format: "sessionID == %@ AND SELF != %@", sessionID as CVarArg, self)
+        request.fetchLimit = 1
+        return ((try? context.count(for: request)) ?? 0) > 0
+    }
+}

--- a/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
@@ -20,6 +20,9 @@ extension SyncableObject {
         )
 
         for object in try context.fetch(request) {
+            if let hub = object as? HubObject, hub.isReferenced {
+                continue
+            }
             context.delete(object)
         }
 

--- a/Tests/ScoutTests/Core/Sync/SyncableObjectCleanupTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncableObjectCleanupTests.swift
@@ -48,6 +48,18 @@ struct SyncableObjectCleanupTests {
         #expect(try context.fetchAll(EventObject.self).count == 1)
     }
 
+    @Test("Keeps a synced old launch still referenced by another record")
+    func keepsReferencedLaunch() throws {
+        let old = Date(timeIntervalSinceNow: -8 * 86400)
+        LaunchObject.stub(date: old, synced: true, in: context)
+        EventObject.stub(name: "child", in: context)
+        try context.save()
+
+        try SyncableObject.cleanup(backends: [], in: context)
+
+        #expect(try context.fetchAll(LaunchObject.self).count == 1)
+    }
+
     @Test("Keeps objects with outstanding work regardless of age")
     func keepsUnsynced() throws {
         // Done-ness is derived from delivery rows: cleanup only purges objects


### PR DESCRIPTION
SyncableObject.cleanup() deletes any synced, 7-day-old record regardless of whether other records still identify themselves by it. That's harmless today since Device/Install/Launch/Session are only referenced by copied UUID scalars, but it becomes a real problem once those become Core Data relationships (an upcoming change) — deleting a still-referenced hub row would null out live children's relationships mid-flight, or worse, dangle a cached NSManagedObjectID.

Adds a small HubObject protocol (isReferenced) implemented by DeviceObject/InstallObject/LaunchObject/SessionObject, and cleanup() now skips deleting any candidate that still has other records pointing at it.