### PR TITLE
Replace device/install/launch/session ID scalars with Core Data relationships

### DIFF
--- a/Sources/Scout/Core/Activity/VersionMarker+Monitor.swift
+++ b/Sources/Scout/Core/Activity/VersionMarker+Monitor.swift
@@ -19,13 +19,14 @@ extension VersionMarker: PartialMonitor {
     static func mark(name: String, installID: UUID, appVersion: String?, in context: NSManagedObjectContext) throws {
         guard let appVersion else { return }
 
+        let install = try InstallObject.first(installID: installID, in: context)
+
         let request = NSFetchRequest<VersionMarker>(entityName: "VersionMarker")
-        request.predicate = NSPredicate(
-            format: "installID == %@ AND name == %@ AND appVersion == %@",
-            installID as CVarArg,
-            name,
-            appVersion
-        )
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            install.map { NSPredicate(format: "install == %@", $0) } ?? NSPredicate(format: "install == nil"),
+            NSPredicate(format: "name == %@", name),
+            NSPredicate(format: "appVersion == %@", appVersion),
+        ])
         request.fetchLimit = 1
 
         guard try context.fetch(request).first == nil else {
@@ -37,6 +38,6 @@ extension VersionMarker: PartialMonitor {
         marker.name = name
         marker.appVersion = appVersion
         marker.date = Date()
-        marker.installID = installID
+        marker.install = install
     }
 }

--- a/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashObject.swift
@@ -30,7 +30,7 @@ extension CrashObject: RecordEncodable {
         record["date"] = date
         record["uuid"] = crashID.uuidString
         record["app_version"] = appVersion
-        record["session_id"] = sessionID.uuidString
+        record["session_id"] = sessionID
 
         record.setValues(metadata)
 

--- a/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
@@ -26,10 +26,11 @@ func logCrash(_ crash: CrashInfo, id: UUID = UUID(), context: NSManagedObjectCon
     object.reason = crash.reason
     object.stackTrace = try? JSONEncoder().encode(crash.stackTrace)
 
-    // Override IDs set by awakeFromInsert with values captured at crash time
-    object.installID = crash.installID
-    object.launchID = crash.launchID
-    object.sessionID = crash.sessionID
+    // Override the relationships set by awakeFromInsert from the current process's
+    // IDs with the ones captured at crash time — nil if that row is already gone.
+    object.install = try InstallObject.first(installID: crash.installID, in: context)
+    object.launch = try LaunchObject.first(launchID: crash.launchID, in: context)
+    object.session = try SessionObject.first(sessionID: crash.sessionID, in: context)
 
     try VersionMarker.mark(
         name: VersionMarker.crashName,

--- a/Sources/Scout/Core/Diagnostics/Hang/HangObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Hang/HangObject.swift
@@ -32,7 +32,7 @@ extension HangObject: RecordEncodable {
         record["date"] = date
         record["uuid"] = hangID.uuidString
         record["app_version"] = appVersion
-        record["session_id"] = sessionID.uuidString
+        record["session_id"] = sessionID
 
         record.setValues(metadata)
 

--- a/Sources/Scout/Core/Diagnostics/Hang/LogHang.swift
+++ b/Sources/Scout/Core/Diagnostics/Hang/LogHang.swift
@@ -27,10 +27,11 @@ func logHang(_ hang: HangInfo, id: UUID = UUID(), context: NSManagedObjectContex
     object.stackTrace = try? JSONEncoder().encode(hang.stackTrace)
     object.duration = hang.duration
 
-    // Override IDs set by awakeFromInsert with values captured at hang time
-    object.installID = hang.installID
-    object.launchID = hang.launchID
-    object.sessionID = hang.sessionID
+    // Override the relationships set by awakeFromInsert from the current process's
+    // IDs with the ones captured at hang time — nil if that row is already gone.
+    object.install = try InstallObject.first(installID: hang.installID, in: context)
+    object.launch = try LaunchObject.first(launchID: hang.launchID, in: context)
+    object.session = try SessionObject.first(sessionID: hang.sessionID, in: context)
 
     try VersionMarker.mark(
         name: VersionMarker.hangName,

--- a/Sources/Scout/Core/Diagnostics/Log/EventObject.swift
+++ b/Sources/Scout/Core/Diagnostics/Log/EventObject.swift
@@ -32,7 +32,7 @@ extension EventObject: RecordEncodable {
         record["param_count"] = paramCount
         record["date"] = date
         record["uuid"] = eventID.uuidString
-        record["session_id"] = sessionID.uuidString
+        record["session_id"] = sessionID
 
         record.setValues(metadata)
 

--- a/Sources/Scout/Core/Diagnostics/Metrics/MetricsObject+RecordEncodable.swift
+++ b/Sources/Scout/Core/Diagnostics/Metrics/MetricsObject+RecordEncodable.swift
@@ -31,7 +31,7 @@ extension MetricsObject {
         record["category"] = telemetry
         record["value"] = value
         record["date"] = date
-        record["session_id"] = sessionID.uuidString
+        record["session_id"] = sessionID
 
         record.setValues(metadata)
 

--- a/Sources/Scout/Core/Lifecycle/Base/IDObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/IDObject.swift
@@ -7,30 +7,32 @@
 
 import CoreData
 
-/// `DateObject` that carries the three app-context IDs
-/// (`deviceID`, `installID`, `launchID`) populated from global `IDs` on insert.
-///
-/// Used to correlate records back to the specific device/install/launch
-/// they were produced in.
-///
 @objc(IDObject)
 class IDObject: DateObject {
-    @NSManaged var deviceID: UUID
-    @NSManaged var installID: UUID
-    @NSManaged var launchID: UUID
+    @NSManaged var device: DeviceObject?
+    @NSManaged var install: InstallObject?
+    @NSManaged var launch: LaunchObject?
 
     override func awakeFromInsert() {
         super.awakeFromInsert()
-        deviceID = IDs.device
-        installID = IDs.install
-        launchID = IDs.launch
+
+        guard let context = managedObjectContext, let coordinator = context.persistentStoreCoordinator else { return }
+        let hub = coordinator.hubObjectIDs
+
+        device = IDs.resolve(hub.device, as: DeviceObject.self, in: context)
+        install = IDs.resolve(hub.install, as: InstallObject.self, in: context)
+        launch = IDs.resolve(hub.launch, as: LaunchObject.self, in: context)
     }
+
+    var deviceIDString: String { device?.deviceID.uuidString ?? "" }
+    var installIDString: String { install?.installID.uuidString ?? "" }
+    var launchIDString: String { launch?.launchID.uuidString ?? "" }
 
     override var metadata: [String: Any] {
         var fields = super.metadata
-        fields["device_id"] = deviceID.uuidString
-        fields["install_id"] = installID.uuidString
-        fields["launch_id"] = launchID.uuidString
+        fields["device_id"] = deviceIDString
+        fields["install_id"] = installIDString
+        fields["launch_id"] = launchIDString
         fields["version"] = 1
         return fields
     }

--- a/Sources/Scout/Core/Lifecycle/Base/IDs.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/IDs.swift
@@ -4,23 +4,17 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+//
 
+import CoreData
 import Foundation
+import ObjectiveC
 
 enum IDs {
     private static let sessionQueue = DispatchQueue(label: "scout.ids.session")
 
-    // Read directly by crash/signal handlers to capture the session ID without
-    // `sessionQueue.sync`, which is async-signal-unsafe and can deadlock — a
-    // fatal signal on a thread already inside the queue re-enters `sync` on
-    // itself. Writes stay private so rotation still runs through `session`.
     nonisolated(unsafe) private(set) static var rawSession = UUID()
 
-    /// Rotates on every `SessionObject.trigger`. `TrackedObject.awakeFromInsert`
-    /// reads it from arbitrary Core Data background contexts, so access is
-    /// serialised through a dispatch queue to avoid torn reads when rotation
-    /// races with concurrent inserts.
-    ///
     static var session: UUID {
         get { sessionQueue.sync { rawSession } }
         set { sessionQueue.sync { rawSession = newValue } }
@@ -31,4 +25,63 @@ enum IDs {
     static let install = UserDefaults.standard.ensure("scout_install_id")
 
     static let device = KeychainStorage.standard.ensure("scout_device_id")
+
+    static func resolve<T: NSManagedObject>(_ id: NSManagedObjectID?, as type: T.Type, in context: NSManagedObjectContext) -> T? {
+        guard let id, let store = id.persistentStore, context.persistentStoreCoordinator?.persistentStores.contains(store) == true else {
+            return nil
+        }
+        return context.object(with: id) as? T
+    }
+}
+
+/// Caches the current device/install/launch/session row's `NSManagedObjectID`,
+/// set by each hub's own `Monitor.trigger` right after it finds or inserts that
+/// row. `IDObject`/`TrackedObject.awakeFromInsert` read these from arbitrary
+/// Core Data background contexts on every insert, resolving the relationship
+/// via `context.object(with:)` instead of a fetch.
+///
+/// Scoped to the persistent store coordinator (not a process-wide global) so
+/// separate containers — e.g. independent in-memory stores across tests —
+/// never resolve a relationship against the wrong store.
+///
+final class HubObjectIDs {
+    private let queue = DispatchQueue(label: "scout.ids.hub")
+
+    nonisolated(unsafe) private var rawDevice: NSManagedObjectID?
+    nonisolated(unsafe) private var rawInstall: NSManagedObjectID?
+    nonisolated(unsafe) private var rawLaunch: NSManagedObjectID?
+    nonisolated(unsafe) private var rawSession: NSManagedObjectID?
+
+    var device: NSManagedObjectID? {
+        get { queue.sync { rawDevice } }
+        set { queue.sync { rawDevice = newValue } }
+    }
+
+    var install: NSManagedObjectID? {
+        get { queue.sync { rawInstall } }
+        set { queue.sync { rawInstall = newValue } }
+    }
+
+    var launch: NSManagedObjectID? {
+        get { queue.sync { rawLaunch } }
+        set { queue.sync { rawLaunch = newValue } }
+    }
+
+    var session: NSManagedObjectID? {
+        get { queue.sync { rawSession } }
+        set { queue.sync { rawSession = newValue } }
+    }
+}
+
+extension NSPersistentStoreCoordinator {
+    nonisolated(unsafe) private static var hubObjectIDsKey: UInt8 = 0
+
+    var hubObjectIDs: HubObjectIDs {
+        if let existing = objc_getAssociatedObject(self, &Self.hubObjectIDsKey) as? HubObjectIDs {
+            return existing
+        }
+        let created = HubObjectIDs()
+        objc_setAssociatedObject(self, &Self.hubObjectIDsKey, created, .OBJC_ASSOCIATION_RETAIN)
+        return created
+    }
 }

--- a/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/TrackedObject.swift
@@ -9,20 +9,27 @@ import CoreData
 
 @objc(TrackedObject)
 class TrackedObject: SyncableObject {
-    @NSManaged var sessionID: UUID
+    @NSManaged var session: SessionObject?
+
+    var sessionID: String { session?.id.uuidString ?? "" }
 
     override func awakeFromInsert() {
         super.awakeFromInsert()
-        sessionID = IDs.session
+
+        if let context = managedObjectContext, let coordinator = context.persistentStoreCoordinator {
+            session = IDs.resolve(coordinator.hubObjectIDs.session, as: SessionObject.self, in: context)
+        }
     }
 
+    // Most recent datePrimitive among TrackedObjects whose session relationship
+    // points at self — called with self as the SessionObject itself.
     func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
         let request = NSFetchRequest<NSDictionary>(entityName: "TrackedObject")
-        request.predicate = NSPredicate(format: "sessionID == %@", sessionID as CVarArg)
+        request.predicate = NSPredicate(format: "session == %@", self)
         request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
         request.resultType = .dictionaryResultType
         request.propertiesToFetch = [DateObject.datePrimitiveKey]
         request.fetchLimit = 1
-        return try context.fetch(request).first?[DateObject.datePrimitiveKey] as? Date
+        return try context.fetch(request).first?[DateObject.datePrimitiveKey] as? Date ?? date
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Device/DeviceObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Device/DeviceObject+Monitor.swift
@@ -9,17 +9,22 @@ import CoreData
 
 extension DeviceObject: PartialMonitor {
     static func trigger(in context: NSManagedObjectContext) throws {
+        let hub = context.persistentStoreCoordinator?.hubObjectIDs
+
         let request = NSFetchRequest<DeviceObject>(entityName: "DeviceObject")
         request.predicate = NSPredicate(format: "deviceID == %@", IDs.device as CVarArg)
         request.fetchLimit = 1
 
-        guard try context.fetch(request).isEmpty else {
+        if let existing = try context.fetch(request).first {
+            hub?.device = existing.objectID
             return
         }
 
         let device = context.insert(DeviceObject.self)
         device.date = Date()
+        device.deviceID = IDs.device
         device.model = SystemInfo.deviceModel
         try context.save()
+        hub?.device = device.objectID
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Device/DeviceObject.swift
@@ -11,11 +11,12 @@ import CoreData
 final class DeviceObject: SyncableObject {
     static let recordType = "Device"
 
+    @NSManaged var deviceID: UUID
     @NSManaged var model: String?
 
     func installs(in context: NSManagedObjectContext) throws -> [InstallObject] {
         let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
-        request.predicate = NSPredicate(format: "deviceID == %@", deviceID as CVarArg)
+        request.predicate = NSPredicate(format: "device == %@", self)
         request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
         return try context.fetch(request)
     }

--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject+Monitor.swift
@@ -9,16 +9,21 @@ import CoreData
 
 extension InstallObject: PartialMonitor {
     static func trigger(in context: NSManagedObjectContext) throws {
+        let hub = context.persistentStoreCoordinator?.hubObjectIDs
+
         let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
         request.predicate = NSPredicate(format: "installID == %@", IDs.install as CVarArg)
         request.fetchLimit = 1
 
-        guard try context.fetch(request).isEmpty else {
+        if let existing = try context.fetch(request).first {
+            hub?.install = existing.objectID
             return
         }
 
         let install = context.insert(InstallObject.self)
         install.date = Date()
+        install.installID = IDs.install
         try context.save()
+        hub?.install = install.objectID
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Install/InstallObject.swift
@@ -11,11 +11,20 @@ import CoreData
 final class InstallObject: SyncableObject {
     static let recordType = "Install"
 
+    @NSManaged var installID: UUID
+
     func versions(in context: NSManagedObjectContext) throws -> [VersionObject] {
         let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        request.predicate = NSPredicate(format: "installID == %@", installID as CVarArg)
+        request.predicate = NSPredicate(format: "install == %@", self)
         request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
         return try context.fetch(request)
+    }
+
+    static func first(installID: UUID, in context: NSManagedObjectContext) throws -> InstallObject? {
+        let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
+        request.predicate = NSPredicate(format: "installID == %@", installID as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
     }
 }
 

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Monitor.swift
@@ -12,12 +12,14 @@ extension LaunchObject: PartialMonitor {
     ///
     /// Created once during `setup()` and finalised only on the next
     /// process start via `completeStale`, which sets `endDate` from the
-    /// latest signal recorded under this `launchID` — the OS provides no
+    /// latest signal recorded against this launch — the OS provides no
     /// reliable hook for "process about to die".
     ///
     static func trigger(in context: NSManagedObjectContext) throws {
         let launch = context.insert(LaunchObject.self)
         launch.date = Date()
+        launch.launchID = IDs.launch
         try context.save()
+        context.persistentStoreCoordinator?.hubObjectIDs.launch = launch.objectID
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Recovery.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject+Recovery.swift
@@ -11,12 +11,11 @@ extension LaunchObject: RecoveryMonitor {
     /// Closes launches from previous app runs that were not properly
     /// completed — typically because the app crashed.
     ///
-    /// `endDate` is set to the most recent timestamp of any IDObject
-    /// sharing the launch's `launchID` (sessions, events, crashes, metrics,
-    /// activity, version, or the launch itself). This approximates the real
-    /// launch length from the last signal emitted before the crash instead
-    /// of collapsing it to zero. Launches with no child records fall back
-    /// to their start date.
+    /// `endDate` is set to the most recent timestamp of any IDObject whose
+    /// `launch` relationship points at this launch (sessions, events, crashes,
+    /// metrics, activity, version). This approximates the real launch length
+    /// from the last signal emitted before the crash instead of collapsing it
+    /// to zero. Launches with no child records fall back to their start date.
     ///
     static func completeStale(in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
@@ -33,12 +32,12 @@ extension LaunchObject: RecoveryMonitor {
 
     private func inferredEndDate(in context: NSManagedObjectContext) throws -> Date? {
         let request = NSFetchRequest<NSDictionary>(entityName: "IDObject")
-        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
+        request.predicate = NSPredicate(format: "launch == %@", self)
         request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
         request.resultType = .dictionaryResultType
         request.propertiesToFetch = [DateObject.datePrimitiveKey]
         request.fetchLimit = 1
 
-        return try context.fetch(request).first?[DateObject.datePrimitiveKey] as? Date
+        return try context.fetch(request).first?[DateObject.datePrimitiveKey] as? Date ?? date
     }
 }

--- a/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Launch/LaunchObject.swift
@@ -12,16 +12,24 @@ final class LaunchObject: SyncableObject {
     static let recordType = "Launch"
 
     @NSManaged var endDate: Date?
+    @NSManaged var launchID: UUID
 
     func sessions(in context: NSManagedObjectContext) throws -> [SessionObject] {
         let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
-        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
+        request.predicate = NSPredicate(format: "launch == %@", self)
         request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
         return try context.fetch(request)
     }
 
     func version(in context: NSManagedObjectContext) throws -> VersionObject? {
         let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
+        request.predicate = NSPredicate(format: "launch == %@", self)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    static func first(launchID: UUID, in context: NSManagedObjectContext) throws -> LaunchObject? {
+        let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
         request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
         request.fetchLimit = 1
         return try context.fetch(request).first

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject+Monitor.swift
@@ -13,18 +13,30 @@ extension SessionObject: Monitor {
 
         let session = context.insert(SessionObject.self)
         session.date = Date()
+        session.id = IDs.session
         session.appVersion = Bundle.main.marketingVersion
         session.buildNumber = Bundle.main.buildNumber
         session.osVersion = SystemInfo.osVersion
         session.locale = SystemInfo.locale
         session.channel = SystemInfo.channel
         try context.save()
+        context.persistentStoreCoordinator?.hubObjectIDs.session = session.objectID
     }
 
     static func complete(in context: NSManagedObjectContext) throws {
+        guard let coordinator = context.persistentStoreCoordinator,
+            let launch = IDs.resolve(
+                coordinator.hubObjectIDs.launch,
+                as: LaunchObject.self,
+                in: context
+            )
+        else {
+            throw MonitorError.notFound
+        }
+
         let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
         request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
-        request.predicate = NSPredicate(format: "launchID == %@", IDs.launch as CVarArg)
+        request.predicate = NSPredicate(format: "launch == %@", launch)
         request.fetchLimit = 1
 
         guard let session = try context.fetch(request).first else {

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject+Recovery.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject+Recovery.swift
@@ -9,8 +9,22 @@ import CoreData
 
 extension SessionObject: RecoveryMonitor {
     static func completeStale(in context: NSManagedObjectContext) throws {
+        let currentLaunch = context.persistentStoreCoordinator.flatMap {
+            IDs.resolve($0.hubObjectIDs.launch, as: LaunchObject.self, in: context)
+        }
+        let notCurrentLaunch =
+            currentLaunch.map {
+                NSCompoundPredicate(orPredicateWithSubpredicates: [
+                    NSPredicate(format: "launch != %@", $0),
+                    NSPredicate(format: "launch == nil"),
+                ])
+            } ?? NSPredicate(value: true)
+
         let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
-        request.predicate = NSPredicate(format: "endDate == nil AND launchID != %@", IDs.launch as CVarArg)
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "endDate == nil"),
+            notCurrentLaunch,
+        ])
 
         for session in try context.fetch(request) {
             session.endDate = try session.inferredEndDate(in: context)

--- a/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Session/SessionObject.swift
@@ -17,10 +17,11 @@ final class SessionObject: TrackedObject {
     @NSManaged var osVersion: String?
     @NSManaged var locale: String?
     @NSManaged var channel: String?
+    @NSManaged var id: UUID
 
-    func launch(in context: NSManagedObjectContext) throws -> LaunchObject? {
-        let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
-        request.predicate = NSPredicate(format: "launchID == %@", launchID as CVarArg)
+    static func first(sessionID: UUID, in context: NSManagedObjectContext) throws -> SessionObject? {
+        let request = NSFetchRequest<SessionObject>(entityName: "SessionObject")
+        request.predicate = NSPredicate(format: "id == %@", sessionID as CVarArg)
         request.fetchLimit = 1
         return try context.fetch(request).first
     }
@@ -28,12 +29,12 @@ final class SessionObject: TrackedObject {
 
 extension SessionObject: RecordEncodable {
     var record: Record {
-        var record = Record(recordType: Self.recordType, recordID: sessionID.uuidString)
+        var record = Record(recordType: Self.recordType, recordID: id.uuidString)
 
         record["start_date"] = date
         record["end_date"] = endDate
-        record["session_id"] = sessionID.uuidString
-        record["launch_id"] = launchID.uuidString
+        record["session_id"] = id.uuidString
+        record["launch_id"] = launchIDString
         record["app_version"] = appVersion
         record["build_number"] = buildNumber
         record["os_version"] = osVersion

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject+Monitor.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject+Monitor.swift
@@ -17,8 +17,12 @@ extension VersionObject: PartialMonitor {
     }
 
     static func trigger(appVersion: String?, buildNumber: String?, in context: NSManagedObjectContext) throws {
+        let install = context.persistentStoreCoordinator.flatMap {
+            IDs.resolve($0.hubObjectIDs.install, as: InstallObject.self, in: context)
+        }
+
         let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
-        request.predicate = NSPredicate(format: "installID == %@", IDs.install as CVarArg)
+        request.predicate = install.map { NSPredicate(format: "install == %@", $0) } ?? NSPredicate(format: "install == nil")
         request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: false)]
         request.fetchLimit = 1
         let latest = try context.fetch(request).first

--- a/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
+++ b/Sources/Scout/Core/Lifecycle/Version/VersionObject.swift
@@ -14,39 +14,25 @@ final class VersionObject: SyncableObject {
     @NSManaged var appVersion: String?
     @NSManaged var buildNumber: String?
 
-    func install(in context: NSManagedObjectContext) throws -> InstallObject? {
-        let request = NSFetchRequest<InstallObject>(entityName: "InstallObject")
-        request.predicate = NSPredicate(format: "installID == %@", installID as CVarArg)
-        request.fetchLimit = 1
-        return try context.fetch(request).first
-    }
-
     func launches(in context: NSManagedObjectContext) throws -> [LaunchObject] {
         guard let appVersion else { return [] }
 
-        let versionRequest = NSFetchRequest<NSDictionary>(entityName: "VersionObject")
-        versionRequest.predicate = NSPredicate(format: "appVersion == %@", appVersion)
-        versionRequest.resultType = .dictionaryResultType
-        versionRequest.propertiesToFetch = ["launchID"]
-        versionRequest.returnsDistinctResults = true
-        let launchIDs = try context.fetch(versionRequest).compactMap { $0["launchID"] as? UUID }
-
-        let request = NSFetchRequest<LaunchObject>(entityName: "LaunchObject")
-        request.predicate = NSPredicate(format: "launchID IN %@", launchIDs)
-        request.sortDescriptors = [NSSortDescriptor(key: DateObject.datePrimitiveKey, ascending: true)]
-        return try context.fetch(request)
+        let request = NSFetchRequest<VersionObject>(entityName: "VersionObject")
+        request.predicate = NSPredicate(format: "appVersion == %@", appVersion)
+        request.sortDescriptors = [NSSortDescriptor(key: "launch.\(DateObject.datePrimitiveKey)", ascending: true)]
+        return try context.fetch(request).compactMap(\.launch)
     }
 }
 
 extension VersionObject: RecordEncodable {
     var record: Record {
-        let recordName = "\(installID.uuidString)-\(appVersion ?? "")-\(buildNumber ?? "")"
+        let recordName = "\(installIDString)-\(appVersion ?? "")-\(buildNumber ?? "")"
         var record = Record(recordType: Self.recordType, recordID: recordName)
 
         record["date"] = date
         record["app_version"] = appVersion
         record["build_number"] = buildNumber
-        record["launch_id"] = launchID.uuidString
+        record["launch_id"] = launchIDString
 
         record.setValues(metadata)
 

--- a/Sources/Scout/Core/Persistence/Migration/RelationshipBackfillMigrationPolicy.swift
+++ b/Sources/Scout/Core/Persistence/Migration/RelationshipBackfillMigrationPolicy.swift
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import CoreData
+
+/// Backfills the `device`/`install`/`launch`/`session` relationships introduced in Scout 14.
+///
+/// Looks up the hub row with a matching new local primary key from the raw UUID scalars
+/// (`deviceID`/`installID`/`launchID`/`sessionID`) every entity carried before. Runs as
+/// the second migration pass (`createRelationships`), which Core Data guarantees fires
+/// only after every entity's destination instances already exist, so the hub lookups
+/// below always find their target regardless of entity processing order.
+///
+@objc(RelationshipBackfillMigrationPolicy)
+final class RelationshipBackfillMigrationPolicy: NSEntityMigrationPolicy {
+    // `sourceKey` is the scalar attribute Scout 13 carried (inherited from IDObject/
+    // TrackedObject); `destinationKey` is the hub's own local primary key in Scout 14 —
+    // these differ for session, since SessionObject's own PK was renamed to `id`.
+    private static let hubs: [(relationship: String, entityName: String, sourceKey: String, destinationKey: String)] = [
+        ("device", "DeviceObject", "deviceID", "deviceID"),
+        ("install", "InstallObject", "installID", "installID"),
+        ("launch", "LaunchObject", "launchID", "launchID"),
+        ("session", "SessionObject", "sessionID", "id"),
+    ]
+
+    override func createRelationships(
+        forDestination dInstance: NSManagedObject,
+        in mapping: NSEntityMapping,
+        manager: NSMigrationManager
+    ) throws {
+        try super.createRelationships(forDestination: dInstance, in: mapping, manager: manager)
+
+        guard let sInstance = manager.sourceInstances(forEntityMappingName: mapping.name, destinationInstances: [dInstance]).first else {
+            return
+        }
+
+        for hub in Self.hubs {
+            guard dInstance.entity.relationshipsByName[hub.relationship] != nil,
+                sInstance.entity.attributesByName[hub.sourceKey] != nil,
+                let id = sInstance.value(forKey: hub.sourceKey) as? UUID
+            else {
+                continue
+            }
+
+            dInstance.setValue(
+                try findHub(entityName: hub.entityName, key: hub.destinationKey, id: id, in: manager.destinationContext),
+                forKey: hub.relationship
+            )
+        }
+    }
+
+    private func findHub(entityName: String, key: String, id: UUID, in context: NSManagedObjectContext) throws -> NSManagedObject? {
+        let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
+        request.predicate = NSPredicate(format: "%K == %@", key, id as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+}

--- a/Sources/Scout/Core/Persistence/Migration/StoreMigrator.swift
+++ b/Sources/Scout/Core/Persistence/Migration/StoreMigrator.swift
@@ -1,0 +1,119 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import CoreData
+
+enum StoreMigratorError: Error {
+    case missingModel
+}
+
+/// Migrates a store sitting at an arbitrary older model version up to the current one.
+///
+/// Runs in two stages so both hops stay lightweight enough to run on every OS version
+/// Scout supports (no `NSStagedMigrationManager`, iOS 17+ only):
+///
+/// 1. Whatever version the store is at → Scout 13, via Core Data's inferred
+///    mapping — every prior model bump has been mutually lightweight-compatible,
+///    so this covers stores that are many versions behind in a single hop.
+/// 2. Scout 13 → the current model, via `RelationshipBackfillMigrationPolicy`,
+///    since turning the old `deviceID`/`installID`/`launchID`/`sessionID`
+///    scalars into relationships isn't something inference can do.
+///
+/// A store already on the current model, or with no file on disk yet (first
+/// launch, or an in-memory store used by tests), is left untouched.
+///
+struct StoreMigrator {
+    let url: URL
+    let type: String
+    let bundle: Bundle
+
+    func migrateIfNeeded(currentModel: NSManagedObjectModel) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+
+        let metadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: type, at: url, options: nil)
+
+        guard !currentModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata) else {
+            return
+        }
+        guard NSManagedObjectModel.mergedModel(from: [bundle], forStoreMetadata: metadata) != nil else {
+            return
+        }
+        guard let momdURL = bundle.url(forResource: "Scout", withExtension: "momd") else {
+            return
+        }
+        guard let scout13Model = NSManagedObjectModel(contentsOf: momdURL.appendingPathComponent("Scout 13.mom")) else {
+            throw StoreMigratorError.missingModel
+        }
+
+        var workingURL = url
+
+        if !scout13Model.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata) {
+            workingURL = try migrate(storeAt: workingURL, to: scout13Model) { source, destination in
+                try NSMappingModel.inferredMappingModel(forSourceModel: source, destinationModel: destination)
+            }
+        }
+
+        workingURL = try migrate(storeAt: workingURL, to: currentModel, mapping: backfillMapping)
+
+        try replace(storeAt: url, withStoreAt: workingURL, model: currentModel)
+    }
+
+    private func backfillMapping(from sourceModel: NSManagedObjectModel, to destinationModel: NSManagedObjectModel) throws -> NSMappingModel {
+        let mapping = try NSMappingModel.inferredMappingModel(forSourceModel: sourceModel, destinationModel: destinationModel)
+        let policyClassName = NSStringFromClass(RelationshipBackfillMigrationPolicy.self)
+
+        for entityMapping in mapping.entityMappings {
+            entityMapping.entityMigrationPolicyClassName = policyClassName
+        }
+
+        return mapping
+    }
+
+    private func migrate(
+        storeAt sourceURL: URL,
+        to destinationModel: NSManagedObjectModel,
+        mapping mappingBuilder: (NSManagedObjectModel, NSManagedObjectModel) throws -> NSMappingModel
+    ) throws -> URL {
+        let sourceMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: type, at: sourceURL, options: nil)
+
+        guard let sourceModel = NSManagedObjectModel.mergedModel(from: [bundle], forStoreMetadata: sourceMetadata) else {
+            throw StoreMigratorError.missingModel
+        }
+
+        let mapping = try mappingBuilder(sourceModel, destinationModel)
+        let manager = NSMigrationManager(sourceModel: sourceModel, destinationModel: destinationModel)
+        let destinationURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).sqlite")
+
+        try manager.migrateStore(
+            from: sourceURL,
+            sourceType: type,
+            options: nil,
+            with: mapping,
+            toDestinationURL: destinationURL,
+            destinationType: type,
+            destinationOptions: nil
+        )
+
+        return destinationURL
+    }
+
+    private func replace(storeAt url: URL, withStoreAt migratedURL: URL, model: NSManagedObjectModel) throws {
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+
+        try coordinator.replacePersistentStore(
+            at: url,
+            destinationOptions: nil,
+            withPersistentStoreFrom: migratedURL,
+            sourceOptions: nil,
+            ofType: type
+        )
+        try coordinator.destroyPersistentStore(at: migratedURL, ofType: type, options: nil)
+    }
+}

--- a/Sources/Scout/Core/Persistence/PersistentContainer.swift
+++ b/Sources/Scout/Core/Persistence/PersistentContainer.swift
@@ -36,6 +36,11 @@ extension NSPersistentContainer {
 extension NSPersistentContainer {
     func loadStore() throws {
         for description in persistentStoreDescriptions {
+            if description.type == NSSQLiteStoreType, let url = description.url {
+                let migrator = StoreMigrator(url: url, type: description.type, bundle: .module)
+                try migrator.migrateIfNeeded(currentModel: managedObjectModel)
+            }
+
             description.shouldMigrateStoreAutomatically = true
             description.shouldInferMappingModelAutomatically = true
         }

--- a/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/.xccurrentversion
+++ b/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Scout 13.xcdatamodel</string>
+	<string>Scout 14.xcdatamodel</string>
 </dict>
 </plist>

--- a/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/Scout 14.xcdatamodel/contents
+++ b/Sources/Scout/Core/Persistence/Scout.xcdatamodeld/Scout 14.xcdatamodel/contents
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24902" systemVersion="25F80" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CrashObject" representedClassName="CrashObject" parentEntity="TrackedObject" syncable="YES">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="crashID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="fingerprint" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="stackTrace" optional="YES" attributeType="Binary"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="crashID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="DateObject" representedClassName="DateObject" isAbstract="YES" syncable="YES">
+        <attribute name="datePrimitive" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="day" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="hour" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="month" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="week" attributeType="Date" usesScalarValueType="NO"/>
+        <fetchIndex name="byDatePrimitive">
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="DeviceObject" representedClassName="DeviceObject" parentEntity="SyncableObject" syncable="YES">
+        <attribute name="deviceID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="model" optional="YES" attributeType="String"/>
+        <relationship name="records" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="IDObject" inverseName="device" inverseEntity="IDObject"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="deviceID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="DoubleMetricsObject" representedClassName="DoubleMetricsObject" parentEntity="MetricsObject" syncable="YES">
+        <attribute name="value" attributeType="Double" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="EventObject" representedClassName="EventObject" parentEntity="NamedObject" syncable="YES">
+        <attribute name="eventID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="level" attributeType="String"/>
+        <attribute name="paramCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="params" optional="YES" attributeType="Binary"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="eventID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="HangObject" representedClassName="HangObject" parentEntity="TrackedObject" syncable="YES">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="duration" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="fingerprint" optional="YES" attributeType="String"/>
+        <attribute name="hangID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="stackTrace" optional="YES" attributeType="Binary"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="hangID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="IDObject" representedClassName="IDObject" isAbstract="YES" parentEntity="DateObject" syncable="YES">
+        <relationship name="device" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DeviceObject" inverseName="records" inverseEntity="DeviceObject"/>
+        <relationship name="install" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="InstallObject" inverseName="records" inverseEntity="InstallObject"/>
+        <relationship name="launch" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LaunchObject" inverseName="records" inverseEntity="LaunchObject"/>
+        <fetchIndex name="byDevice">
+            <fetchIndexElement property="device" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byInstall">
+            <fetchIndexElement property="install" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byLaunch">
+            <fetchIndexElement property="launch" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="InstallObject" representedClassName="InstallObject" parentEntity="SyncableObject" syncable="YES">
+        <attribute name="installID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="records" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="IDObject" inverseName="install" inverseEntity="IDObject"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="installID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="IntMetricsObject" representedClassName="IntMetricsObject" parentEntity="MetricsObject" syncable="YES">
+        <attribute name="value" attributeType="Integer 64" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="LaunchObject" representedClassName="LaunchObject" parentEntity="SyncableObject" syncable="YES">
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="records" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="IDObject" inverseName="launch" inverseEntity="IDObject"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="launchID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="MetricsObject" representedClassName="MetricsObject" isAbstract="YES" parentEntity="TrackedObject" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="telemetry" attributeType="String"/>
+    </entity>
+    <entity name="NamedObject" representedClassName="NamedObject" isAbstract="YES" parentEntity="TrackedObject" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+    </entity>
+    <entity name="SessionObject" representedClassName="SessionObject" parentEntity="TrackedObject" syncable="YES">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="buildNumber" optional="YES" attributeType="String"/>
+        <attribute name="channel" optional="YES" attributeType="String"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="locale" optional="YES" attributeType="String"/>
+        <attribute name="osVersion" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="records" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="TrackedObject" inverseName="session" inverseEntity="TrackedObject"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="IDObject" syncable="YES">
+        <relationship name="deliveries" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SyncDelivery" inverseName="object" inverseEntity="SyncDelivery"/>
+    </entity>
+    <entity name="SyncDelivery" representedClassName="SyncDelivery" syncable="YES">
+        <attribute name="attempts" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="backendID" attributeType="String"/>
+        <attribute name="progressPrimitive" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="object" maxCount="1" deletionRule="Nullify" destinationEntity="SyncableObject" inverseName="deliveries" inverseEntity="SyncableObject"/>
+        <fetchIndex name="byBackend">
+            <fetchIndexElement property="backendID" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="object"/>
+                <constraint value="backendID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="TrackedObject" representedClassName="TrackedObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES">
+        <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionObject" inverseName="records" inverseEntity="SessionObject"/>
+        <fetchIndex name="bySession">
+            <fetchIndexElement property="session" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="UserActivityObject" representedClassName="UserActivityObject" parentEntity="TrackedObject" syncable="YES">
+        <attribute name="dayCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="monthCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="period" attributeType="String"/>
+        <attribute name="userActivityID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="weekCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="userActivityID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="VersionMarker" representedClassName="VersionMarker" parentEntity="SyncableObject" syncable="YES">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="markerID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="markerID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="VersionObject" representedClassName="VersionObject" parentEntity="SyncableObject" syncable="YES">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="buildNumber" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/Sources/Scout/Core/Sync/HubObject.swift
+++ b/Sources/Scout/Core/Sync/HubObject.swift
@@ -19,7 +19,7 @@ extension DeviceObject: HubObject {
     var isReferenced: Bool {
         guard let context = managedObjectContext else { return false }
         let request = NSFetchRequest<NSManagedObject>(entityName: "IDObject")
-        request.predicate = NSPredicate(format: "deviceID == %@ AND SELF != %@", deviceID as CVarArg, self)
+        request.predicate = NSPredicate(format: "device == %@", self)
         request.fetchLimit = 1
         return ((try? context.count(for: request)) ?? 0) > 0
     }
@@ -29,7 +29,7 @@ extension InstallObject: HubObject {
     var isReferenced: Bool {
         guard let context = managedObjectContext else { return false }
         let request = NSFetchRequest<NSManagedObject>(entityName: "IDObject")
-        request.predicate = NSPredicate(format: "installID == %@ AND SELF != %@", installID as CVarArg, self)
+        request.predicate = NSPredicate(format: "install == %@", self)
         request.fetchLimit = 1
         return ((try? context.count(for: request)) ?? 0) > 0
     }
@@ -39,7 +39,7 @@ extension LaunchObject: HubObject {
     var isReferenced: Bool {
         guard let context = managedObjectContext else { return false }
         let request = NSFetchRequest<NSManagedObject>(entityName: "IDObject")
-        request.predicate = NSPredicate(format: "launchID == %@ AND SELF != %@", launchID as CVarArg, self)
+        request.predicate = NSPredicate(format: "launch == %@", self)
         request.fetchLimit = 1
         return ((try? context.count(for: request)) ?? 0) > 0
     }
@@ -49,7 +49,7 @@ extension SessionObject: HubObject {
     var isReferenced: Bool {
         guard let context = managedObjectContext else { return false }
         let request = NSFetchRequest<NSManagedObject>(entityName: "TrackedObject")
-        request.predicate = NSPredicate(format: "sessionID == %@ AND SELF != %@", sessionID as CVarArg, self)
+        request.predicate = NSPredicate(format: "session == %@", self)
         request.fetchLimit = 1
         return ((try? context.count(for: request)) ?? 0) > 0
     }

--- a/Tests/ScoutTests/Core/Activity/VersionMarkerMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Activity/VersionMarkerMonitorTests.swift
@@ -17,25 +17,28 @@ struct VersionMarkerMonitorTests {
 
     @Test("mark records one marker per install, name and version")
     func markIsIdempotent() throws {
-        let install = UUID()
+        let install = InstallObject.stub(date: Date(), in: context)
+        try context.save()
 
-        try VersionMarker.mark(name: VersionMarker.installName, installID: install, appVersion: "2.0", in: context)
-        try VersionMarker.mark(name: VersionMarker.installName, installID: install, appVersion: "2.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.installName, installID: install.installID, appVersion: "2.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.installName, installID: install.installID, appVersion: "2.0", in: context)
 
         let markers = try context.fetchAll(VersionMarker.self)
         #expect(markers.count == 1)
-        #expect(markers.first?.installID == install)
+        #expect(markers.first?.install === install)
         #expect(markers.first?.appVersion == "2.0")
     }
 
     @Test("Different versions, names or installs get their own markers")
     func markDistinguishes() throws {
-        let install = UUID()
+        let install1 = InstallObject.stub(date: Date(), in: context)
+        let install2 = InstallObject.stub(date: Date(), in: context)
+        try context.save()
 
-        try VersionMarker.mark(name: VersionMarker.installName, installID: install, appVersion: "2.0", in: context)
-        try VersionMarker.mark(name: VersionMarker.installName, installID: install, appVersion: "3.0", in: context)
-        try VersionMarker.mark(name: VersionMarker.crashName, installID: install, appVersion: "2.0", in: context)
-        try VersionMarker.mark(name: VersionMarker.installName, installID: UUID(), appVersion: "2.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.installName, installID: install1.installID, appVersion: "2.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.installName, installID: install1.installID, appVersion: "3.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.crashName, installID: install1.installID, appVersion: "2.0", in: context)
+        try VersionMarker.mark(name: VersionMarker.installName, installID: install2.installID, appVersion: "2.0", in: context)
 
         #expect(try context.fetchAll(VersionMarker.self).count == 4)
     }

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/CrashObjectTests.swift
@@ -27,10 +27,10 @@ struct CrashObjectTests {
     @Test("record includes the session ID")
     func testRecordIncludesSessionID() {
         let object = makeCrashObject(name: "SIGABRT", date: date)
-        let sessionID = UUID()
-        object.sessionID = sessionID
+        let session = SessionObject.stub(date: date, in: context)
+        object.session = session
 
-        #expect(object.record["session_id"] == sessionID.uuidString)
+        #expect(object.record["session_id"] == session.id.uuidString)
     }
 
     @Test("record computes a fallback fingerprint for migrated crashes")

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
@@ -24,6 +24,13 @@ struct LogCrashTests {
     func createsCrashObject() throws {
         let crash = makeCrashInfo(name: "SIGABRT", reason: "Fatal error", stackTrace: ["frame0"])
 
+        let install = InstallObject.stub(date: Date(), in: context)
+        install.installID = crash.installID
+        let launch = LaunchObject.stub(date: Date(), in: context)
+        launch.launchID = crash.launchID
+        let session = SessionObject.stub(date: Date(), in: context)
+        session.id = crash.sessionID
+
         try logCrash(crash, context: context)
 
         let results = try context.fetchAll(CrashObject.self)
@@ -36,27 +43,27 @@ struct LogCrashTests {
         #expect(object.fingerprint == expectedFingerprint)
         #expect(object.reason == "Fatal error")
         #expect(object.date == crash.date)
-        #expect(object.installID == crash.installID)
-        #expect(object.launchID == crash.launchID)
-        #expect(object.sessionID == crash.sessionID)
+        #expect(object.install === install)
+        #expect(object.launch === launch)
+        #expect(object.session === session)
         #expect(object.appVersion == crash.appVersion)
     }
 
-    @Test("Preserves sessionID captured at crash time, not the recovery session")
+    @Test("Preserves the session captured at crash time, not the recovery session")
     func preservesCapturedSessionID() throws {
         // The "crashed" process snapshot carries its own sessionID. A fresh
         // UUID can never match the recovery session that `awakeFromInsert`
         // assigns, so the test doesn't need to touch the `IDs.session`
         // global — other suites mutate it concurrently.
-        let crashedSessionID = UUID()
-        let crash = CrashInfo(name: "SIGSEGV", reason: nil, stackTrace: [], sessionID: crashedSessionID)
+        let crashedSession = SessionObject.stub(date: Date(), in: context)
+        let crash = CrashInfo(name: "SIGSEGV", reason: nil, stackTrace: [], sessionID: crashedSession.id)
 
-        #expect(IDs.session != crashedSessionID)
+        #expect(IDs.session != crashedSession.id)
 
         try logCrash(crash, context: context)
 
         let object = try #require(try context.fetchAll(CrashObject.self).first)
-        #expect(object.sessionID == crashedSessionID)
+        #expect(object.session === crashedSession)
     }
 
     @Test("Encodes stack trace as JSON data")

--- a/Tests/ScoutTests/Core/Diagnostics/Hang/HangObjectTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Hang/HangObjectTests.swift
@@ -27,10 +27,10 @@ struct HangObjectTests {
     @Test("record includes the session ID")
     func testRecordIncludesSessionID() {
         let object = makeHangObject(name: "Main Thread Blocked", date: date)
-        let sessionID = UUID()
-        object.sessionID = sessionID
+        let session = SessionObject.stub(date: date, in: context)
+        object.session = session
 
-        #expect(object.record["session_id"] == sessionID.uuidString)
+        #expect(object.record["session_id"] == session.id.uuidString)
     }
 
     @Test("record includes the duration")

--- a/Tests/ScoutTests/Core/Diagnostics/Hang/LogHangTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Hang/LogHangTests.swift
@@ -24,6 +24,13 @@ struct LogHangTests {
     func createsHangObject() throws {
         let hang = makeHangInfo(name: "Main Thread Blocked", reason: "Main thread unresponsive for 4.2s", stackTrace: ["frame0"], duration: 4.2)
 
+        let install = InstallObject.stub(date: Date(), in: context)
+        install.installID = hang.installID
+        let launch = LaunchObject.stub(date: Date(), in: context)
+        launch.launchID = hang.launchID
+        let session = SessionObject.stub(date: Date(), in: context)
+        session.id = hang.sessionID
+
         try logHang(hang, context: context)
 
         let results = try context.fetchAll(HangObject.self)
@@ -37,23 +44,23 @@ struct LogHangTests {
         #expect(object.reason == "Main thread unresponsive for 4.2s")
         #expect(object.duration == 4.2)
         #expect(object.date == hang.date)
-        #expect(object.installID == hang.installID)
-        #expect(object.launchID == hang.launchID)
-        #expect(object.sessionID == hang.sessionID)
+        #expect(object.install === install)
+        #expect(object.launch === launch)
+        #expect(object.session === session)
         #expect(object.appVersion == hang.appVersion)
     }
 
-    @Test("Preserves sessionID captured at hang time, not the recovery session")
+    @Test("Preserves the session captured at hang time, not the recovery session")
     func preservesCapturedSessionID() throws {
-        let hangSessionID = UUID()
-        let hang = HangInfo(name: "Main Thread Blocked", reason: nil, stackTrace: [], duration: 3.5, sessionID: hangSessionID)
+        let hangSession = SessionObject.stub(date: Date(), in: context)
+        let hang = HangInfo(name: "Main Thread Blocked", reason: nil, stackTrace: [], duration: 3.5, sessionID: hangSession.id)
 
-        #expect(IDs.session != hangSessionID)
+        #expect(IDs.session != hangSession.id)
 
         try logHang(hang, context: context)
 
         let object = try #require(try context.fetchAll(HangObject.self).first)
-        #expect(object.sessionID == hangSessionID)
+        #expect(object.session === hangSession)
     }
 
     @Test("Encodes stack trace as JSON data")

--- a/Tests/ScoutTests/Core/Diagnostics/Log/LogTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Log/LogTests.swift
@@ -24,6 +24,10 @@ private func makeEvent(
 @Test("Logging an event") func testLogEvent() throws {
     let context = NSManagedObjectContext.inMemoryContext()
     let date = Date()
+    let install = InstallObject.stub(date: date, in: context)
+    install.installID = IDs.install
+    try context.save()
+    context.persistentStoreCoordinator?.hubObjectIDs.install = install.objectID
 
     try log(
         makeEvent("Test Event", metadata: ["key": .string("value")]),
@@ -41,7 +45,7 @@ private func makeEvent(
     #expect(event.date == date)
     #expect(event.hour == date.startOfHour)
     #expect(event.week == date.startOfWeek)
-    #expect(event.installID == IDs.install)
+    #expect(event.install === install)
     #expect(event.paramCount == 1)
 
     let paramData = try #require(event.params)

--- a/Tests/ScoutTests/Core/Lifecycle/Device/DeviceObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Device/DeviceObjectTests.swift
@@ -16,23 +16,22 @@ struct DeviceObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
     let week = TestDate.reference.startOfWeek
 
-    @Test("installs(in:) returns installs matching deviceID")
+    @Test("installs(in:) returns installs whose device relationship matches")
     func testInstalls() throws {
         let device = DeviceObject.stub(date: week, in: context)
-        let deviceID = device.deviceID
 
         let i1 = InstallObject.stub(date: week, in: context)
-        i1.deviceID = deviceID
+        i1.device = device
 
         let i2 = InstallObject.stub(date: week.addingHour(), in: context)
-        i2.deviceID = deviceID
+        i2.device = device
 
-        InstallObject.stub(date: week, in: context).deviceID = UUID()
+        InstallObject.stub(date: week, in: context).device = DeviceObject.stub(date: week, in: context)
 
         try context.save()
 
         let installs = try device.installs(in: context)
         #expect(installs.count == 2)
-        #expect(installs.allSatisfy { $0.deviceID == deviceID })
+        #expect(installs.allSatisfy { $0.device === device })
     }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Install/InstallObjectTests.swift
@@ -16,18 +16,17 @@ struct InstallObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
     let week = TestDate.reference.startOfWeek
 
-    @Test("versions(in:) returns versions matching installID")
+    @Test("versions(in:) returns versions whose install relationship matches")
     func testVersions() throws {
         let install = InstallObject.stub(date: week, in: context)
-        let installID = install.installID
 
         let v1 = VersionObject.stub(date: week, appVersion: "1.0", in: context)
-        v1.installID = installID
+        v1.install = install
 
         let v2 = VersionObject.stub(date: week.addingHour(), appVersion: "2.0", in: context)
-        v2.installID = installID
+        v2.install = install
 
-        VersionObject.stub(date: week, appVersion: "3.0", in: context).installID = UUID()
+        VersionObject.stub(date: week, appVersion: "3.0", in: context).install = InstallObject.stub(date: week, in: context)
 
         try context.save()
 

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectRecoveryTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectRecoveryTests.swift
@@ -30,6 +30,7 @@ struct LaunchObjectRecoveryTests {
     @Test("Does not close launches from current launch")
     func skipsCurrent() throws {
         let launch = LaunchObject.stub(date: date, in: context)
+        launch.launchID = IDs.launch
 
         try context.save()
         try LaunchObject.completeStale(in: context)
@@ -51,16 +52,15 @@ struct LaunchObjectRecoveryTests {
 
     @Test("Uses latest child timestamp as endDate")
     func endDateFromChild() throws {
-        let staleLaunchID = UUID()
         let launch = LaunchObject.stub(date: date, in: context)
-        launch.launchID = staleLaunchID
+        launch.launchID = UUID()
 
         let session = SessionObject.stub(date: date.addingTimeInterval(10), in: context)
-        session.launchID = staleLaunchID
+        session.launch = launch
 
         let latest = date.addingTimeInterval(300)
         let event = EventObject.stub(name: "x", date: latest, in: context)
-        event.launchID = staleLaunchID
+        event.launch = launch
 
         try context.save()
         try LaunchObject.completeStale(in: context)

--- a/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Launch/LaunchObjectTests.swift
@@ -16,41 +16,39 @@ struct LaunchObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
     let week = TestDate.reference.startOfWeek
 
-    @Test("sessions(in:) returns sessions matching launchID")
+    @Test("sessions(in:) returns sessions whose launch relationship matches")
     func testSessions() throws {
         let launch = LaunchObject.stub(date: week, in: context)
-        let launchID = launch.launchID
 
         let session1 = SessionObject.stub(date: week, in: context)
-        session1.launchID = launchID
+        session1.launch = launch
 
         let session2 = SessionObject.stub(date: week.addingHour(), in: context)
-        session2.launchID = launchID
+        session2.launch = launch
 
-        SessionObject.stub(date: week, in: context).launchID = UUID()
+        SessionObject.stub(date: week, in: context).launch = LaunchObject.stub(date: week, in: context)
 
         try context.save()
 
         let sessions = try launch.sessions(in: context)
         #expect(sessions.count == 2)
-        #expect(sessions[0].launchID == launchID)
-        #expect(sessions[1].launchID == launchID)
+        #expect(sessions[0].launch === launch)
+        #expect(sessions[1].launch === launch)
     }
 
-    @Test("version(in:) returns version matching launchID")
+    @Test("version(in:) returns version whose launch relationship matches")
     func testVersion() throws {
         let launch = LaunchObject.stub(date: week, in: context)
-        let launchID = launch.launchID
 
         let version = VersionObject.stub(date: week, appVersion: "2.0", in: context)
-        version.launchID = launchID
+        version.launch = launch
 
-        VersionObject.stub(date: week, appVersion: "1.0", in: context).launchID = UUID()
+        VersionObject.stub(date: week, appVersion: "1.0", in: context).launch = LaunchObject.stub(date: week, in: context)
 
         try context.save()
 
         let result = try launch.version(in: context)
         #expect(result?.appVersion == "2.0")
-        #expect(result?.launchID == launchID)
+        #expect(result?.launch === launch)
     }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectMonitorTests.swift
@@ -17,6 +17,7 @@ struct SessionObjectMonitorTests {
 
     @Test("complete sets endDate on an open session")
     func completeOpenSession() throws {
+        try LaunchObject.trigger(in: context)
         try SessionObject.trigger(in: context)
 
         try SessionObject.complete(in: context)
@@ -47,6 +48,7 @@ struct SessionObjectMonitorTests {
 
     @Test("complete is a no-op when the session is already closed")
     func completeTwiceIsNoop() throws {
+        try LaunchObject.trigger(in: context)
         try SessionObject.trigger(in: context)
         try SessionObject.complete(in: context)
 
@@ -60,6 +62,8 @@ struct SessionObjectMonitorTests {
 
     @Test("complete throws notFound when no session exists for the current launch")
     func completeWithoutSessionThrows() throws {
+        try LaunchObject.trigger(in: context)
+
         #expect(throws: MonitorError.notFound) {
             try SessionObject.complete(in: context)
         }

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectRecoveryTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectRecoveryTests.swift
@@ -19,7 +19,7 @@ struct SessionObjectRecoveryTests {
     @Test("Closes sessions from previous launches")
     func closesStale() throws {
         let session = SessionObject.stub(date: date, in: context)
-        session.launchID = UUID()
+        session.launch = LaunchObject.stub(date: date, in: context)
 
         try context.save()
         try SessionObject.completeStale(in: context)
@@ -29,7 +29,12 @@ struct SessionObjectRecoveryTests {
 
     @Test("Does not close sessions from current launch")
     func skipsCurrent() throws {
+        let currentLaunch = LaunchObject.stub(date: date, in: context)
+        try context.save()
+        context.persistentStoreCoordinator?.hubObjectIDs.launch = currentLaunch.objectID
+
         let session = SessionObject.stub(date: date, in: context)
+        session.launch = currentLaunch
 
         try context.save()
         try SessionObject.completeStale(in: context)
@@ -41,7 +46,7 @@ struct SessionObjectRecoveryTests {
     func skipsCompleted() throws {
         let endDate = date.addingTimeInterval(60)
         let session = SessionObject.stub(date: date, endDate: endDate, in: context)
-        session.launchID = UUID()
+        session.launch = LaunchObject.stub(date: date, in: context)
 
         try context.save()
         try SessionObject.completeStale(in: context)
@@ -51,14 +56,12 @@ struct SessionObjectRecoveryTests {
 
     @Test("Uses latest child event date as endDate")
     func endDateFromChildEvent() throws {
-        let staleSessionID = UUID()
         let session = SessionObject.stub(date: date, in: context)
-        session.launchID = UUID()
-        session.sessionID = staleSessionID
+        session.launch = LaunchObject.stub(date: date, in: context)
 
         let latest = date.addingTimeInterval(120)
         let event = EventObject.stub(name: "x", date: latest, in: context)
-        event.sessionID = staleSessionID
+        event.session = session
 
         try context.save()
         try SessionObject.completeStale(in: context)

--- a/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Session/SessionObjectTests.swift
@@ -16,19 +16,14 @@ struct SessionObjectTests {
     let context = NSManagedObjectContext.inMemoryContext()
     let week = TestDate.reference.startOfWeek
 
-    @Test("launch(in:) returns launch matching launchID")
+    @Test("session.launch returns the launch it was created during")
     func testLaunch() throws {
-        let session = SessionObject.stub(date: week, in: context)
-        let launchID = session.launchID
-
         let launch = LaunchObject.stub(date: week, in: context)
-        launch.launchID = launchID
-
-        LaunchObject.stub(date: week, in: context).launchID = UUID()
+        let session = SessionObject.stub(date: week, in: context)
+        session.launch = launch
 
         try context.save()
 
-        let result = try session.launch(in: context)
-        #expect(result?.launchID == launchID)
+        #expect(session.launch === launch)
     }
 }

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectMonitorTests.swift
@@ -64,7 +64,7 @@ struct VersionObjectMonitorTests {
     @Test("trigger ignores VersionObjects from other installs")
     func ignoresOtherInstalls() throws {
         let other = VersionObject.stub(date: Date(), appVersion: "1.0", buildNumber: "1", in: context)
-        other.installID = UUID()
+        other.install = InstallObject.stub(date: Date(), in: context)
         try context.save()
 
         try VersionObject.trigger(appVersion: "1.0", buildNumber: "1", in: context)

--- a/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Version/VersionObjectTests.swift
@@ -18,33 +18,24 @@ struct VersionObjectTests {
 
     @Test("launches(in:) returns all launches with same appVersion")
     func testLaunches() throws {
-        let launchID1 = UUID()
-        let launchID2 = UUID()
-        let launchID3 = UUID()
+        let l1 = LaunchObject.stub(date: week, in: context)
+        let l2 = LaunchObject.stub(date: week.addingHour(), in: context)
+        let l3 = LaunchObject.stub(date: week, in: context)
 
         let v1 = VersionObject.stub(date: week, appVersion: "2.0", in: context)
-        v1.launchID = launchID1
+        v1.launch = l1
 
         let v2 = VersionObject.stub(date: week.addingHour(), appVersion: "2.0", in: context)
-        v2.launchID = launchID2
+        v2.launch = l2
 
         let v3 = VersionObject.stub(date: week, appVersion: "1.0", in: context)
-        v3.launchID = launchID3
-
-        let l1 = LaunchObject.stub(date: week, in: context)
-        l1.launchID = launchID1
-
-        let l2 = LaunchObject.stub(date: week.addingHour(), in: context)
-        l2.launchID = launchID2
-
-        let l3 = LaunchObject.stub(date: week, in: context)
-        l3.launchID = launchID3
+        v3.launch = l3
 
         try context.save()
 
         let launches = try v1.launches(in: context)
         #expect(launches.count == 2)
-        #expect(launches.allSatisfy { $0.launchID == launchID1 || $0.launchID == launchID2 })
+        #expect(launches.allSatisfy { $0 === l1 || $0 === l2 })
     }
 
     @Test("launches(in:) returns an empty array when appVersion is nil")
@@ -58,19 +49,14 @@ struct VersionObjectTests {
         #expect(launches.isEmpty)
     }
 
-    @Test("install(in:) returns install matching installID")
+    @Test("install returns the install it belongs to")
     func testInstall() throws {
         let version = VersionObject.stub(date: week, appVersion: "2.0", in: context)
-        let installID = version.installID
-
         let install = InstallObject.stub(date: week, in: context)
-        install.installID = installID
-
-        InstallObject.stub(date: week, in: context).installID = UUID()
+        version.install = install
 
         try context.save()
 
-        let result = try version.install(in: context)
-        #expect(result?.installID == installID)
+        #expect(version.install === install)
     }
 }

--- a/Tests/ScoutTests/Core/Sync/StableRecordIDTests.swift
+++ b/Tests/ScoutTests/Core/Sync/StableRecordIDTests.swift
@@ -41,9 +41,9 @@ struct StableRecordIDTests {
     @Test("SessionObject.record is stable across calls")
     func sessionStable() {
         let session = SessionObject.stub(date: date, in: context)
-        session.sessionID = UUID()
+        session.id = UUID()
         #expect(session.record.recordID == session.record.recordID)
-        #expect(session.record.recordID == session.sessionID.uuidString)
+        #expect(session.record.recordID == session.id.uuidString)
     }
 
     @Test("EventObject.record is stable across calls")
@@ -58,7 +58,8 @@ struct StableRecordIDTests {
     func versionStable() {
         let version = VersionObject.stub(date: date, appVersion: "1.2.3", in: context)
         version.buildNumber = "42"
-        let expected = "\(version.installID.uuidString)-1.2.3-42"
+        version.install = InstallObject.stub(date: date, in: context)
+        let expected = "\(version.install!.installID.uuidString)-1.2.3-42"
         #expect(version.record.recordID == version.record.recordID)
         #expect(version.record.recordID == expected)
     }

--- a/Tests/ScoutTests/Core/Sync/SyncableObjectCleanupTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncableObjectCleanupTests.swift
@@ -51,8 +51,8 @@ struct SyncableObjectCleanupTests {
     @Test("Keeps a synced old launch still referenced by another record")
     func keepsReferencedLaunch() throws {
         let old = Date(timeIntervalSinceNow: -8 * 86400)
-        LaunchObject.stub(date: old, synced: true, in: context)
-        EventObject.stub(name: "child", in: context)
+        let launch = LaunchObject.stub(date: old, synced: true, in: context)
+        EventObject.stub(name: "child", in: context).launch = launch
         try context.save()
 
         try SyncableObject.cleanup(backends: [], in: context)

--- a/Tests/ScoutTests/Stubs/Objects/DeviceObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/DeviceObject+Stub.swift
@@ -18,6 +18,7 @@ extension DeviceObject {
         let device = context.insert(DeviceObject.self)
 
         device.date = date
+        device.deviceID = UUID()
         device.setSynced(synced, in: context)
 
         return device

--- a/Tests/ScoutTests/Stubs/Objects/InstallObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/InstallObject+Stub.swift
@@ -18,6 +18,7 @@ extension InstallObject {
         let install = context.insert(InstallObject.self)
 
         install.date = date
+        install.installID = UUID()
         install.setSynced(synced, in: context)
 
         return install

--- a/Tests/ScoutTests/Stubs/Objects/LaunchObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/LaunchObject+Stub.swift
@@ -19,6 +19,7 @@ extension LaunchObject {
         let launch = context.insert(LaunchObject.self)
 
         launch.date = date
+        launch.launchID = UUID()
         launch.setSynced(synced, in: context)
         launch.endDate = endDate
 

--- a/Tests/ScoutTests/Stubs/Objects/SessionObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/SessionObject+Stub.swift
@@ -20,6 +20,7 @@ extension SessionObject {
         let session = context.insert(SessionObject.self)
 
         session.date = date
+        session.id = UUID()
         session.setSynced(synced, in: context)
         session.endDate = endDate
         session.appVersion = appVersion


### PR DESCRIPTION
Builds on #847 (cleanup relationship-awareness). IDObject/TrackedObject used to stamp deviceID/installID/launchID/sessionID as raw UUID copies on every insert, with every lookup a hand-written NSPredicate matching those scalars. They're now real to-one relationships (device/install/launch/session), resolved from a per-store-coordinator NSManagedObjectID cache (HubObjectIDs) set by each hub's Monitor.trigger, so awakeFromInsert never needs a fetch.

Each hub (Device/Install/Launch/Session) now carries its own local primary key (deviceID/installID/launchID/id) instead of inheriting it, mirroring the existing crashID/hangID/eventID pattern. Crash/Hang capture their install/launch/session by value at crash time and resolve them by value on replay, tolerating a nil relationship if that row is already gone.

Migrating an existing store to the new schema needs a real data backfill lightweight migration can't do (turning a UUID scalar into a relationship), so this adds a two-stage StoreMigrator: infer up to Scout 13 (matching the lightweight compatibility every prior version bump has relied on), then a custom RelationshipBackfillMigrationPolicy for the 13→14 hop that looks up each hub row by its new local key and wires the relationship in Core Data's second migration pass.

Marked draft: the migration currently only has coverage for opening empty fixture stores at each prior version (existing ModelMigrationTests). Still want to add a populated-fixture test asserting the relationship backfill actually works on real data before this merges.

## Test plan
- [x] Full test suite (534 tests) passes on iOS Simulator
- [x] swift-format lint clean
- [ ] Populated-fixture migration test (real data backfill, not just empty-store compatibility)