### PR TITLE
Match the P99 trend area fill to the line's curve

### DIFF
--- a/Sources/Scout/UI/Metrics/Distribution/PercentileTrendChart.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/PercentileTrendChart.swift
@@ -33,6 +33,7 @@ struct PercentileTrendChart: View {
                     endPoint: .bottom
                 )
             )
+            .interpolationMethod(.monotone)
 
             LineMark(
                 x: .value("Date", point.date, unit: unit),


### PR DESCRIPTION
The P99 trend chart drew its area fill with the default linear interpolation while the line used `.monotone`, so the gradient rose in straight segments to a triangular peak and left a visible gap below the smooth curve. Giving the `AreaMark` the same `.interpolationMethod(.monotone)` makes the fill's top edge follow the line exactly, so the gradient reaches right up to it.