### PR TITLE
Stop the chart export sheet from pull-to-refreshing and give it a primary background

### DIFF
--- a/Sources/Scout/UI/Chart/Export/ChartExportSheet.swift
+++ b/Sources/Scout/UI/Chart/Export/ChartExportSheet.swift
@@ -78,6 +78,9 @@ struct ChartExportSheet<ChartContent: View>: View {
             }
         }
         .listStyle(.plain)
+        .disabledScrollBounce()
+        .scrollContentBackground(.hidden)
+        .background(.background)
         .safeAreaInset(edge: .bottom) {
             shareButton.padding()
         }

--- a/Sources/Scout/UI/Primitives/Platform/View+DisabledScrollBounce.swift
+++ b/Sources/Scout/UI/Primitives/Platform/View+DisabledScrollBounce.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+extension View {
+    /// Stops a scroll view from bouncing when its content already fits, so a
+    /// non-scrolling list can't be pulled into an empty overscroll area — which
+    /// also blocks any pull-to-refresh inherited from a host view's environment.
+    ///
+    @ViewBuilder
+    func disabledScrollBounce() -> some View {
+        if #available(iOS 16.4, macOS 13.3, *) {
+            scrollBounceBehavior(.basedOnSize)
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
The Export Image sheet showed a pull-to-refresh spinner and exposed a grey overscroll area at the top. The sheet's List has no `.refreshable` of its own — the refresh action leaks in through the environment from a host view that presents Scout's screens, since a sheet inherits its presenter's environment and `.refreshable` is stored under the read-only `\.refresh` key (which can't be cleared via `.environment`).

Since the sheet's content fits on screen, `.scrollBounceBehavior(.basedOnSize)` disables the top overscroll, so the list can't be pulled and the inherited pull-to-refresh can no longer trigger. It's wrapped in a `disabledScrollBounce()` shim gated to iOS 16.4 / macOS 13.3 (the deployment target is 16.0 / 13.0), mirroring the existing `opaquePresentationBackground` shim. The list's default background is hidden in favour of the adaptive primary `.background` style so the sheet matches the chart instead of showing grey. Builds clean on both iOS and macOS.