### PR TITLE
Collapse SyncDelivery progress into a Boolean and trim persistence cruft

### DIFF
--- a/Sources/Scout/Core/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Core/Database/Access/RecordSender.swift
@@ -23,13 +23,17 @@ extension RecordSender {
 extension RecordSender {
     func deliver<T: SyncableObject & RecordEncodable>(type syncable: T.Type, in context: NSManagedObjectContext) async throws {
         let request = NSFetchRequest<T>(entityName: String(describing: T.self))
-        request.predicate = NSPredicate(.raw, to: id)
+        request.predicate = NSPredicate(
+            format: "SUBQUERY(deliveries, $d, $d.backendID == %@ AND $d.isPending == YES AND $d.attempts < %d).@count > 0",
+            id,
+            SyncDelivery.maxAttempts
+        )
 
         var objects: [T] = []
         var deliveries: [SyncDelivery] = []
 
         for object in try context.fetch(request) {
-            if let delivery = object.delivery(for: id), delivery.progress.contains(.raw) {
+            if let delivery = object.delivery(for: id), delivery.isPending {
                 objects.append(object)
                 deliveries.append(delivery)
             }
@@ -37,28 +41,8 @@ extension RecordSender {
 
         if objects.count > 0 {
             try await database.write(records: objects.map(\.record))
-            deliveries.complete(.raw)
+            deliveries.forEach { $0.isPending = false }
             try context.save()
         }
-    }
-}
-
-extension NSPredicate {
-    fileprivate convenience init(_ progress: SyncDelivery.Progress, to backendID: String) {
-        self.init(
-            format: "SUBQUERY(deliveries, $d, $d.backendID == %@ AND $d.progressPrimitive IN %@ AND $d.attempts < %d).@count > 0",
-            backendID,
-            progress.owingStates,
-            SyncDelivery.maxAttempts
-        )
-    }
-}
-
-extension SyncDelivery.Progress {
-    // Matches every persisted state still owing this progress.
-    fileprivate var owingStates: [Int16] {
-        (0...Self.all.rawValue)
-            .filter { Self(rawValue: $0).contains(self) }
-            .map { Int16($0) }
     }
 }

--- a/Sources/Scout/Core/Persistence/Context+Insert.swift
+++ b/Sources/Scout/Core/Persistence/Context+Insert.swift
@@ -8,8 +8,6 @@
 import CoreData
 
 extension NSManagedObjectContext {
-    // Resolves the entity by the class's simple name, which matches the
-    // Core Data entity name for every managed object in the model.
     func insert<T: NSManagedObject>(_ type: T.Type) -> T {
         let entity = NSEntityDescription.entity(forEntityName: String(describing: type), in: self)!
         return T(entity: entity, insertInto: self)

--- a/Sources/Scout/Core/Persistence/PersistentContainer.swift
+++ b/Sources/Scout/Core/Persistence/PersistentContainer.swift
@@ -16,8 +16,6 @@ let persistentContainer: NSPersistentContainer = {
         fatalError("Error loading Core Data store: \(error) | \(error.userInfo)")
     }
 
-    container.removeLegacyStore()
-
     return container
 }()
 
@@ -52,16 +50,5 @@ extension NSPersistentContainer {
         // constraints exist — and keeps a batched save (e.g. plan inserting many
         // SyncDelivery rows at once) from being rejected over a single duplicate.
         viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
-    }
-
-    // The earlier schema shipped a "Scout.sqlite" store this model can't open,
-    // and it is never migrated, so the old file is orphaned — remove it (best
-    // effort) to reclaim its disk space rather than leave it behind forever.
-    func removeLegacyStore() {
-        let directory = NSPersistentContainer.defaultDirectoryURL()
-        for suffix in ["", "-wal", "-shm"] {
-            let url = directory.appendingPathComponent("Scout.sqlite\(suffix)")
-            try? FileManager.default.removeItem(at: url)
-        }
     }
 }

--- a/Sources/Scout/Core/Persistence/ScoutModel.xcdatamodeld/ScoutModel.xcdatamodel/contents
+++ b/Sources/Scout/Core/Persistence/ScoutModel.xcdatamodeld/ScoutModel.xcdatamodel/contents
@@ -33,7 +33,7 @@
     <entity name="SyncDelivery" representedClassName="SyncDelivery" syncable="YES" codeGenerationType="none">
         <attribute name="attempts" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="backendID" attributeType="String"/>
-        <attribute name="progressPrimitive" attributeType="Integer 16" defaultValueString="0" renamingIdentifier="remainingPrimitive" usesScalarValueType="YES"/>
+        <attribute name="isPending" attributeType="Boolean" defaultValueString="NO" renamingIdentifier="progressPrimitive" usesScalarValueType="YES"/>
         <relationship name="object" maxCount="1" deletionRule="Nullify" destinationEntity="SyncableObject" inverseName="deliveries" inverseEntity="SyncableObject"/>
         <fetchIndex name="byBackend">
             <fetchIndexElement property="backendID" type="Binary" order="ascending"/>

--- a/Sources/Scout/Core/Sync/SyncDelivery.swift
+++ b/Sources/Scout/Core/Sync/SyncDelivery.swift
@@ -7,14 +7,19 @@
 
 import CoreData
 
-extension SyncDelivery {
-    // A single shared increment per cycle, so the per-type delivery passes don't
-    // each spend the budget and abandon the backend early. Runs on the main actor
-    // because it mutates the main-queue view context.
+@objc(SyncDelivery)
+final class SyncDelivery: NSManagedObject {
+    static let maxAttempts = 10
+
+    @NSManaged var backendID: String
+    @NSManaged var isPending: Bool
+    @NSManaged var attempts: Int16
+    @NSManaged var object: SyncableObject
+
     @MainActor static func recordAttempt(for backendID: String, in context: NSManagedObjectContext) {
         let request = NSFetchRequest<SyncDelivery>(entityName: "SyncDelivery")
         request.predicate = NSPredicate(
-            format: "backendID == %@ AND progressPrimitive != 0 AND attempts < %d",
+            format: "backendID == %@ AND isPending == YES AND attempts < %d",
             backendID,
             SyncDelivery.maxAttempts
         )

--- a/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Cleanup.swift
@@ -13,7 +13,7 @@ extension SyncableObject {
 
         let request = NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
         request.predicate = NSPredicate(
-            format: "SUBQUERY(deliveries, $d, $d.backendID IN %@ AND $d.progressPrimitive != 0 AND $d.attempts < %d).@count == 0 AND datePrimitive < %@",
+            format: "SUBQUERY(deliveries, $d, $d.backendID IN %@ AND $d.isPending == YES AND $d.attempts < %d).@count == 0 AND datePrimitive < %@",
             backends.map(\.id),
             SyncDelivery.maxAttempts,
             cutoff as NSDate

--- a/Sources/Scout/Core/Sync/SyncableObject+Plan.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject+Plan.swift
@@ -10,27 +10,17 @@ import CoreData
 extension SyncableObject {
     static func plan(backends: [Backend], in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<SyncableObject>(entityName: "SyncableObject")
-        // deliveries.@count == 0: a newly added backend only receives objects
-        // created after it was added; existing history is intentionally not backfilled.
         request.predicate = NSPredicate(format: "deliveries.@count == 0")
 
-        for object in try context.fetch(request) {
+        for object in try context.fetch(request) where !type(of: object).isLocalOnly {
             for backend in backends {
-                backend.planDelivery(for: object, in: context)
+                let row = context.insert(SyncDelivery.self)
+                row.backendID = backend.id
+                row.object = object
+                row.isPending = true
             }
         }
 
         try context.save()
-    }
-}
-
-extension Backend {
-    fileprivate func planDelivery(for object: SyncableObject, in context: NSManagedObjectContext) {
-        guard !type(of: object).isLocalOnly else { return }
-
-        let row = context.insert(SyncDelivery.self)
-        row.backendID = id
-        row.object = object
-        row.progress = .raw
     }
 }

--- a/Sources/Scout/Core/Sync/SyncableObject.swift
+++ b/Sources/Scout/Core/Sync/SyncableObject.swift
@@ -17,32 +17,3 @@ class SyncableObject: DateObject {
         deliveries.first { $0.backendID == backendID }
     }
 }
-
-@objc(SyncDelivery)
-final class SyncDelivery: NSManagedObject {
-    static let maxAttempts = 10
-
-    @NSManaged var backendID: String
-    @NSManaged var progressPrimitive: Int16
-    @NSManaged var attempts: Int16
-    @NSManaged var object: SyncableObject
-
-    var progress: Progress {
-        get { Progress(rawValue: Int(progressPrimitive)) }
-        set { progressPrimitive = Int16(newValue.rawValue) }
-    }
-
-    struct Progress: OptionSet, Sendable {
-        let rawValue: Int
-
-        static let raw = Progress(rawValue: 1 << 0)
-
-        static let all: Progress = [.raw]
-    }
-}
-
-extension [SyncDelivery] {
-    func complete(_ progress: SyncDelivery.Progress) {
-        forEach { $0.progress.remove(progress) }
-    }
-}

--- a/Tests/ScoutTests/Core/Backend/DeliverTests.swift
+++ b/Tests/ScoutTests/Core/Backend/DeliverTests.swift
@@ -77,7 +77,7 @@ struct DeliverTests {
         }
 
         #expect(event.delivery(for: "cloud")?.isDelivered == true)
-        #expect(event.delivery(for: "server")?.progress == [.raw])
+        #expect(event.delivery(for: "server")?.isPending == true)
         #expect(event.delivery(for: "server")?.attempts == 1)
         #expect(cloud.records.count(of: "Event") == 1)
         #expect(server.records.count(of: "Event") == 0)
@@ -95,7 +95,7 @@ struct DeliverTests {
         // The server's row is seeded but untouched — not even an attempt is
         // counted — so it is delivered once its engine runs again.
         #expect(event.delivery(for: "cloud")?.isDelivered == true)
-        #expect(event.delivery(for: "server")?.progress == [.raw])
+        #expect(event.delivery(for: "server")?.isPending == true)
         #expect(event.delivery(for: "server")?.attempts == 0)
         #expect(cloud.records.count(of: "Event") == 1)
         #expect(server.records.count(of: "Event") == 0)
@@ -104,9 +104,9 @@ struct DeliverTests {
     @Test("A backend abandoned after too many attempts is no longer retried")
     func abandonedBackendSettles() async throws {
         let event = EventObject.stub(name: "login", synced: true, in: context)
-        event.seedDelivery([.raw], for: "cloud", in: context)
+        event.seedDelivery(for: "cloud", in: context)
         // The server is already at the attempt ceiling and still owes its raw record.
-        event.seedDelivery([.raw], attempts: Int16(SyncDelivery.maxAttempts), for: "server", in: context)
+        event.seedDelivery(attempts: Int16(SyncDelivery.maxAttempts), for: "server", in: context)
         try context.save()
 
         try await deliver(EventObject.self, to: cloudBackend)

--- a/Tests/ScoutTests/Core/Sync/SyncableObjectCleanupTests.swift
+++ b/Tests/ScoutTests/Core/Sync/SyncableObjectCleanupTests.swift
@@ -67,7 +67,7 @@ struct SyncableObjectCleanupTests {
         // whose configured backends are all settled, never ones still owing work.
         let old = Date(timeIntervalSinceNow: -8 * 86400)
         let event = EventObject.stub(name: "pending", date: old, in: context)
-        event.seedDelivery([.raw], for: "cloud", in: context)
+        event.seedDelivery(for: "cloud", in: context)
         try context.save()
 
         try SyncableObject.cleanup(backends: [makeBackend(id: "cloud")], in: context)

--- a/Tests/ScoutTests/Stubs/Objects/SyncableObject+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Objects/SyncableObject+Stub.swift
@@ -11,12 +11,12 @@ import CoreData
 
 extension SyncableObject {
     @discardableResult
-    func seedDelivery(_ progress: SyncDelivery.Progress, attempts: Int16 = 0, for backendID: String, in context: NSManagedObjectContext) -> SyncDelivery {
+    func seedDelivery(pending: Bool = true, attempts: Int16 = 0, for backendID: String, in context: NSManagedObjectContext) -> SyncDelivery {
         let entity = NSEntityDescription.entity(forEntityName: "SyncDelivery", in: context)!
         let row = delivery(for: backendID) ?? SyncDelivery(entity: entity, insertInto: context)
         row.backendID = backendID
         row.object = self
-        row.progress = progress
+        row.isPending = pending
         row.attempts = attempts
         return row
     }
@@ -29,6 +29,6 @@ extension SyncableObject {
 }
 
 extension SyncDelivery {
-    var isDelivered: Bool { progress.isEmpty }
+    var isDelivered: Bool { !isPending }
     var isAbandoned: Bool { attempts >= Self.maxAttempts }
 }


### PR DESCRIPTION
The delivery progress OptionSet had shrunk to a single `.raw` case, so it no longer earned the abstraction. It's now a stored Boolean `isPending` on `SyncDelivery`: the `Int16 progressPrimitive` attribute, the `owingStates` bit-state expansion, and the array `complete(_:)` helper all go away, and the fetch predicates just check `isPending == YES`. The Core Data attribute is renamed via `renamingIdentifier` so lightweight migration carries existing values across (0 → false, 1 → true) and no in-flight deliveries are lost — worth a reviewer's eye since it's a schema change, still a single in-place model version here as with the earlier `remainingPrimitive` → `progressPrimitive` rename.

Along the way this also inlines `planDelivery` into `plan` and hoists the `isLocalOnly` check into the fetch loop so local-only objects skip the inner loop entirely, drops the `removeLegacyStore` launch cleanup that #851 added for the orphaned pre-migration `Scout.sqlite`, removes a few comments that only restated the code, moves `SyncDelivery` into its own file merged with `recordAttempt`, and renames the context insert helper to `Context+Insert`. Delivery and cleanup tests pass.