### PR TITLE
Add fetch indexes for the uncovered Core Data queries

### DIFF
--- a/Sources/Scout/Core/Persistence/ScoutModel.xcdatamodeld/ScoutModel.xcdatamodel/contents
+++ b/Sources/Scout/Core/Persistence/ScoutModel.xcdatamodeld/ScoutModel.xcdatamodel/contents
@@ -37,6 +37,8 @@
         <relationship name="object" maxCount="1" deletionRule="Nullify" destinationEntity="SyncableObject" inverseName="deliveries" inverseEntity="SyncableObject"/>
         <fetchIndex name="byBackend">
             <fetchIndexElement property="backendID" type="Binary" order="ascending"/>
+            <fetchIndexElement property="isPending" type="Binary" order="ascending"/>
+            <fetchIndexElement property="attempts" type="Binary" order="ascending"/>
         </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
@@ -119,6 +121,9 @@
             <fetchIndexElement property="install" type="Binary" order="ascending"/>
             <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
         </fetchIndex>
+        <fetchIndex name="byEndDate">
+            <fetchIndexElement property="endDate" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <entity name="MetricsObject" representedClassName="MetricsObject" isAbstract="YES" parentEntity="SyncableObject" syncable="YES" codeGenerationType="none">
         <attribute name="name" attributeType="String"/>
@@ -151,6 +156,9 @@
             <fetchIndexElement property="launch" type="Binary" order="ascending"/>
             <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
         </fetchIndex>
+        <fetchIndex name="byEndDate">
+            <fetchIndexElement property="endDate" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <entity name="SyncableObject" representedClassName="SyncableObject" parentEntity="DateObject" syncable="YES" codeGenerationType="none">
         <relationship name="deliveries" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SyncDelivery" inverseName="object" inverseEntity="SyncDelivery"/>
@@ -175,6 +183,10 @@
             <fetchIndexElement property="session" type="Binary" order="ascending"/>
             <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
         </fetchIndex>
+        <fetchIndex name="byPeriodDay">
+            <fetchIndexElement property="period" type="Binary" order="ascending"/>
+            <fetchIndexElement property="day" type="Binary" order="ascending"/>
+        </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="userActivityID"/>
@@ -186,8 +198,10 @@
         <attribute name="markerID" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
         <relationship name="install" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="InstallObject" inverseName="markers" inverseEntity="InstallObject"/>
-        <fetchIndex name="byInstall">
+        <fetchIndex name="byInstallNameVersion">
             <fetchIndexElement property="install" type="Binary" order="ascending"/>
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+            <fetchIndexElement property="appVersion" type="Binary" order="ascending"/>
         </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>


### PR DESCRIPTION
Audited every Core Data `NSFetchRequest` predicate and sort against the model's existing `fetchIndex` set (the heavy UI queries run through the scout-db `EntityStore`, not Core Data, so those are out of scope here). Most paths were already covered by the id/date/relationship indexes; this fills the gaps.

The clear miss was `UserActivityObject`: the activity provider filters by `period ==` and a `day` range and sorts by `day`, but only a `bySession` index existed, so it scanned a table that grows daily — added a compound `(period, day)`. Session and launch recovery both scan for `endDate == nil` at every launch with no index on `endDate`, so both get one. Widened `VersionMarker.byInstall` to `(install, name, appVersion)` to fully cover its existence check, and `SyncDelivery.byBackend` to `(backendID, isPending, attempts)` to cover the delivery/recordAttempt/cleanup predicates end to end.

Index-only, additive change — lightweight migration recreates the indexes over the existing store.