### PR TITLE
Drop redundant lifecycle-hub writes and an inert protocol conformance

### DIFF
--- a/Sources/Scout/Core/Activity/UserActivityObject.swift
+++ b/Sources/Scout/Core/Activity/UserActivityObject.swift
@@ -8,7 +8,7 @@
 import CoreData
 
 @objc(UserActivityObject)
-final class UserActivityObject: SyncableObject, HasSession {
+final class UserActivityObject: SyncableObject {
     override class var isLocalOnly: Bool { true }
 
     @NSManaged var session: SessionObject?

--- a/Sources/Scout/Core/Lifecycle/Base/CurrentHub.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/CurrentHub.swift
@@ -18,7 +18,6 @@ extension NSManagedObjectContext {
 
     func linkedSession(installID: UUID, launchID: UUID, sessionID: UUID, date: Date) throws -> SessionObject {
         let device = try fetchOrCreate(DeviceObject.self, key: "deviceID", id: IDs.device) {
-            $0.deviceID = IDs.device
             $0.date = date
         }
         let install = try fetchOrCreate(InstallObject.self, key: "installID", id: installID) {

--- a/Sources/Scout/Native/Store/EntityCatalog.swift
+++ b/Sources/Scout/Native/Store/EntityCatalog.swift
@@ -137,8 +137,6 @@ enum EntityCatalog {
         EntityDefinition(entity: entity, version: 1, fields: slotted(fields + metadata), envelopeDate: envelopeDate, views: views)
     }
 
-    // The date components and app-context IDs every record carries — see
-    // `DateObject.metadata`.
     private static let metadata: [(String, FieldType)] = [
         ("hour", .timestamp),
         ("day", .timestamp),


### PR DESCRIPTION
linkedSession re-set deviceID to the same IDs.device that DeviceObject.awakeFromInsert already applies on every insert, so the explicit assignment was a no-op; the installID/launchID/sessionID sets stay because those keys arrive as parameters rather than the literal IDs.device. UserActivityObject conformed to HasSession, but its four derived id properties are only ever read through the where Self: IncidentObject extension, which it isn't a member of, so the conformance was inert — the stored session relationship is a plain @NSManaged property and is unaffected. The EntityCatalog metadata comment claimed DateObject.metadata was the source of device_id/install_id/launch_id, which stopped being true once each RecordEncodable began writing those through the Has* chain, so it's removed as stale.

The test target builds clean with build-for-testing.