### PR TITLE
Re-enable the Core Data model-version guard

### DIFF
--- a/.github/workflows/coredata.yml
+++ b/.github/workflows/coredata.yml
@@ -15,40 +15,33 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      # Temporarily disabled while the schema settles after the ScoutModel
-      # rework: the next few PRs are expected to reshape the fresh model
-      # freely, before its versions become immutable. Re-enable the guarded
-      # step below (and drop this pass-through) once the model stabilizes.
-      - name: Check model version rules
-        run: echo "model-versions check temporarily disabled during the ScoutModel rework"
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
-      # - uses: actions/checkout@v7
-      #   with:
-      #     fetch-depth: 0
-      #
-      # - name: Check model version rules
-      #   run: |
-      #     git diff --name-status --no-renames \
-      #       "origin/${{ github.base_ref }}"...HEAD \
-      #       -- Sources/Scout/Core/Persistence/ScoutModel.xcdatamodeld > /tmp/model-changes
-      #     cat /tmp/model-changes
-      #
-      #     touched=$(awk -F'\t' '$1 != "A" && $2 !~ /\.xccurrentversion$/' /tmp/model-changes)
-      #     if [ -n "$touched" ]; then
-      #       echo
-      #       echo "Model versions in ScoutModel.xcdatamodeld are immutable once they are on ${{ github.base_ref }}:"
-      #       echo "a store created by a shipped version can only be opened by migrating to a newer one."
-      #       echo "Add a new model version (Xcode: Editor > Add Model Version) instead of editing or deleting these:"
-      #       echo "$touched"
-      #       exit 1
-      #     fi
-      #
-      #     added=$(awk -F'\t' '$1 == "A" && $2 ~ /\.xcdatamodel\//' /tmp/model-changes)
-      #     current=$(awk -F'\t' '$2 ~ /\.xccurrentversion$/' /tmp/model-changes)
-      #     if [ -n "$added" ] && [ -z "$current" ]; then
-      #       echo
-      #       echo "A new model version was added, but .xccurrentversion was not updated,"
-      #       echo "so the app would still build against the previous version."
-      #       echo "Mark the new version as current (Xcode: File Inspector > Model Version > Current)."
-      #       exit 1
-      #     fi
+      - name: Check model version rules
+        run: |
+          git diff --name-status --no-renames \
+            "origin/${{ github.base_ref }}"...HEAD \
+            -- Sources/Scout/Core/Persistence/ScoutModel.xcdatamodeld > /tmp/model-changes
+          cat /tmp/model-changes
+
+          touched=$(awk -F'\t' '$1 != "A" && $2 !~ /\.xccurrentversion$/' /tmp/model-changes)
+          if [ -n "$touched" ]; then
+            echo
+            echo "Model versions in ScoutModel.xcdatamodeld are immutable once they are on ${{ github.base_ref }}:"
+            echo "a store created by a shipped version can only be opened by migrating to a newer one."
+            echo "Add a new model version (Xcode: Editor > Add Model Version) instead of editing or deleting these:"
+            echo "$touched"
+            exit 1
+          fi
+
+          added=$(awk -F'\t' '$1 == "A" && $2 ~ /\.xcdatamodel\//' /tmp/model-changes)
+          current=$(awk -F'\t' '$2 ~ /\.xccurrentversion$/' /tmp/model-changes)
+          if [ -n "$added" ] && [ -z "$current" ]; then
+            echo
+            echo "A new model version was added, but .xccurrentversion was not updated,"
+            echo "so the app would still build against the previous version."
+            echo "Mark the new version as current (Xcode: File Inspector > Model Version > Current)."
+            exit 1
+          fi


### PR DESCRIPTION
The Core Data required check has been echoing a pass-through since the ScoutModel rework, when the fresh model was expected to be reshaped freely across a few PRs. This restores the real guard: it again fails a PR that edits or deletes an existing model version instead of adding a new one, and one that adds a version without marking it current.

Heads-up on interaction with in-flight work: once this lands, any open PR that edits ScoutModel.xcdatamodeld in place — including #858 — will need to ship its schema change as a new model version with a lightweight migration to pass this check.