### PR TITLE
Register the native schema before serving reads, and add missing Device/Session fields

### DIFF
--- a/Sources/Scout/Native/Store/EntityCatalog.swift
+++ b/Sources/Scout/Native/Store/EntityCatalog.swift
@@ -58,6 +58,12 @@ enum EntityCatalog {
             ("session_id", .string),
             ("app_version", .string),
         ],
+        trailing: [
+            ("build_number", .string),
+            ("os_version", .string),
+            ("locale", .string),
+            ("channel", .string),
+        ],
         envelopeDate: "start_date"
     )
 
@@ -77,7 +83,8 @@ enum EntityCatalog {
 
     private static let device = definition(
         entity: DeviceEntry.recordType,
-        fields: [("date", .timestamp)]
+        fields: [("date", .timestamp)],
+        trailing: [("model", .string)]
     )
 
     private static let version = definition(
@@ -131,10 +138,10 @@ enum EntityCatalog {
         )
     }
 
-    private static func definition(entity: String, fields: [(String, FieldType)], envelopeDate: String = "date", views: [AggregateView]? = nil)
+    private static func definition(entity: String, fields: [(String, FieldType)], trailing: [(String, FieldType)] = [], envelopeDate: String = "date", views: [AggregateView]? = nil)
         -> EntityDefinition
     {
-        EntityDefinition(entity: entity, version: 1, fields: slotted(fields + metadata), envelopeDate: envelopeDate, views: views)
+        EntityDefinition(entity: entity, version: 1, fields: slotted(fields + metadata + trailing), envelopeDate: envelopeDate, views: views)
     }
 
     private static let metadata: [(String, FieldType)] = [

--- a/Sources/Scout/Native/Store/EntityCatalog.swift
+++ b/Sources/Scout/Native/Store/EntityCatalog.swift
@@ -138,13 +138,15 @@ enum EntityCatalog {
         )
     }
 
-    private static func definition(entity: String, fields: [(String, FieldType)], trailing: [(String, FieldType)] = [], envelopeDate: String = "date", views: [AggregateView]? = nil)
+    private typealias Spec = (String, FieldType)
+
+    private static func definition(entity: String, fields: [Spec], trailing: [Spec] = [], envelopeDate: String = "date", views: [AggregateView]? = nil)
         -> EntityDefinition
     {
         EntityDefinition(entity: entity, version: 1, fields: slotted(fields + metadata + trailing), envelopeDate: envelopeDate, views: views)
     }
 
-    private static let metadata: [(String, FieldType)] = [
+    private static let metadata: [Spec] = [
         ("hour", .timestamp),
         ("day", .timestamp),
         ("week", .timestamp),
@@ -155,7 +157,7 @@ enum EntityCatalog {
         ("version", .int),
     ]
 
-    private static func slotted(_ specs: [(String, FieldType)]) -> [FieldDefinition] {
+    private static func slotted(_ specs: [Spec]) -> [FieldDefinition] {
         var next: [Pool: Int] = [:]
         return specs.map { name, type in
             let pool = pool(for: type)

--- a/Sources/Scout/Native/Store/NativeBackend.swift
+++ b/Sources/Scout/Native/Store/NativeBackend.swift
@@ -18,10 +18,11 @@ extension Backend {
     public static func cloudKit(container: CKContainer) -> Backend {
         let registry = SchemaRegistry(database: container.publicCloudDatabase)
         let store = EntityStore(database: container.publicCloudDatabase, registry: registry)
+        let registration = Task { await EntityCatalog.register(into: registry) }
 
         return Backend(
             id: container.containerIdentifier ?? "cloudKit",
-            database: NativeDatabase(store: store),
+            database: NativeDatabase(store: store, registration: registration),
             checkAvailability: {
                 (try? await container.accountStatus()) == .available
             },
@@ -48,7 +49,7 @@ extension Backend {
             },
             onSetup: {
                 Task {
-                    await EntityCatalog.bootstrap(registry: registry)
+                    await EntityCatalog.reconcile(registry: registry, database: container.publicCloudDatabase)
                 }
             }
         )
@@ -56,9 +57,18 @@ extension Backend {
 }
 
 extension EntityCatalog {
-    static func bootstrap(registry: SchemaRegistry) async {
-        _ = try? await registry.preload()
-        let remote = await registry.definitions()
+    static func register(into registry: SchemaRegistry) async {
+        for definition in definitions {
+            try? await registry.register(definition)
+        }
+    }
+
+    static func reconcile(registry: SchemaRegistry, database: any CloudDatabase) async {
+        // Read the published schema through a throwaway registry so preload never
+        // overwrites the authoritative local definitions already in `registry`.
+        let mirror = SchemaRegistry(database: database)
+        _ = try? await mirror.preload()
+        let remote = await mirror.definitions()
 
         for definition in definitions {
             let published = remote.first { $0.entity == definition.entity }
@@ -66,9 +76,6 @@ extension EntityCatalog {
             if let published, published.version > definition.version {
                 continue
             }
-
-            try? await registry.register(definition)
-
             if published != definition {
                 try? await registry.publish(definition)
             }

--- a/Sources/Scout/Native/Store/NativeDatabase.swift
+++ b/Sources/Scout/Native/Store/NativeDatabase.swift
@@ -8,19 +8,25 @@
 import Foundation
 import ScoutDB
 
-// Scout's neutral record layer served by a scout-db EntityStore: raw records
-// live in Item slots, while matrix reads are synthesized from GridItem
-// aggregate views and from raw entities.
 struct NativeDatabase: Sendable {
     let store: EntityStore
+
+    let registration: Task<Void, Never>
+
+    init(store: EntityStore, registration: Task<Void, Never> = Task {}) {
+        self.store = store
+        self.registration = registration
+    }
 }
 
 extension NativeDatabase: RecordWriter {
     func write(record: Record) async throws {
+        await registration.value
         try await store.write(Self.values(for: record), entity: record.recordType, uuid: record.recordID)
     }
 
     func write(records: [Record]) async throws {
+        await registration.value
         for (entity, group) in Dictionary(grouping: records, by: \.recordType) {
             let batch = group.map { EntityWrite(values: Self.values(for: $0), uuid: $0.recordID) }
             try await store.write(batch, entity: entity)
@@ -40,6 +46,7 @@ extension NativeDatabase: RecordReader {
     }
 
     func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
+        await registration.value
         let entity = query.recordType.recordType
 
         if let series = MatrixSeries(recordType: entity) {
@@ -67,6 +74,7 @@ extension NativeDatabase: RecordReader {
 
 extension NativeDatabase: RecordLocator {
     func lookup(recordName: String, fields: [String]?) async throws -> Record {
+        await registration.value
         guard let entityRecord = try await store.fetch(uuid: recordName) else {
             throw RecordNotFoundError()
         }
@@ -76,6 +84,7 @@ extension NativeDatabase: RecordLocator {
 
 extension NativeDatabase: MetricReader {
     func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+        await registration.value
         let entity = T.seriesValues == Int.seriesValues ? IntMetricsEntry.recordType : DoubleMetricsEntry.recordType
         let prefix = category + "|"
         let points = try await store.series(
@@ -99,6 +108,7 @@ extension NativeDatabase: MetricReader {
 
 extension NativeDatabase: ActivityReader {
     func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
+        await registration.value
         // WAU/MAU windows reach back before the visible range.
         let lookback = range.lowerBound.addingTimeInterval(-30 * .day).startOfDay
         let sessions = try await store.read(

--- a/Tests/ScoutTests/Native/Store/NativeDatabaseTests.swift
+++ b/Tests/ScoutTests/Native/Store/NativeDatabaseTests.swift
@@ -98,6 +98,37 @@ struct NativeDatabaseTests {
         #expect(checkout.points.map(\.date) == [TestDate.reference.addingTimeInterval(10 * .hour).millisecondsSince1970])
     }
 
+    @Test("Session records round-trip their captured environment")
+    func sessionEnvironmentRoundTrip() async throws {
+        var record = makeSessionRecord(id: "s-1", device: "a", day: 0)
+        record["build_number"] = "412"
+        record["os_version"] = "iOS 17.4"
+        record["locale"] = "en_US"
+        record["channel"] = "TestFlight"
+        try await database.write(record: record)
+
+        let query = RecordQuery(recordType: Session.self)
+        let chunk = try await database.read(matching: query, fields: ["build_number", "os_version", "locale", "channel"])
+        let read = try #require(chunk.records.first)
+
+        #expect(read["build_number"] == "412")
+        #expect(read["os_version"] == "iOS 17.4")
+        #expect(read["locale"] == "en_US")
+        #expect(read["channel"] == "TestFlight")
+    }
+
+    @Test("Device records round-trip the hardware model")
+    func deviceModelRoundTrip() async throws {
+        try await database.write(record: makeDeviceRecord(id: "d-1", model: "iPhone16,1"))
+
+        let query = RecordQuery(recordType: Device.self)
+        let chunk = try await database.read(matching: query, fields: ["device_id", "model"])
+        let record = try #require(chunk.records.first)
+
+        #expect(record["device_id"] == "d-1")
+        #expect(record["model"] == "iPhone16,1")
+    }
+
     @Test("Activity derives DAU, WAU, and MAU from sessions")
     func activity() async throws {
         try await database.write(record: makeSessionRecord(id: "s-1", device: "a", day: 0))
@@ -137,6 +168,76 @@ func makeMetricRecord(id: String, name: String, value: Int64) -> Record {
     record["value"] = value
     record["date"] = TestDate.reference.addingTimeInterval(10 * .hour)
     record["session_id"] = "session-1"
+    return record
+}
+
+@Suite("Schema bootstrap healing")
+struct SchemaBootstrapTests {
+    // Simulates the schema an older app published: Device@1 without `model`.
+    private func publishStaleDeviceSchema(to cloud: ScoutDBTesting.InMemoryDatabase) async throws {
+        let current = try #require(EntityCatalog.definition(for: DeviceEntry.recordType))
+        let stale = EntityDefinition(
+            entity: current.entity,
+            version: current.version,
+            fields: current.fields.filter { $0.name != "model" },
+            envelopeDate: current.envelopeDate,
+            unique: current.unique,
+            views: current.views
+        )
+        try await SchemaRegistry(database: cloud).publish(stale)
+    }
+
+    @Test("A stale published Device schema without model blocks reads until the local schema is registered")
+    func staleSchemaHealing() async throws {
+        let cloud = ScoutDBTesting.InMemoryDatabase()
+        try await publishStaleDeviceSchema(to: cloud)
+
+        // A fresh launch: a new registry over the same CloudKit, before bootstrap.
+        let registry = SchemaRegistry(database: cloud)
+        let database = NativeDatabase(store: EntityStore(database: cloud, registry: registry))
+
+        let query = RecordQuery(recordType: Device.self)
+
+        await #expect(throws: SchemaError.self) {
+            _ = try await database.read(matching: query, fields: ["device_id", "model"])
+        }
+
+        await EntityCatalog.register(into: registry)
+
+        try await database.write(record: makeDeviceRecord(id: "d-1", model: "iPhone16,1"))
+        let chunk = try await database.read(matching: query, fields: ["device_id", "model"])
+        #expect(chunk.records.first?["model"] == "iPhone16,1")
+
+        // Reconcile republishes the local schema so later launches preload it clean.
+        await EntityCatalog.reconcile(registry: SchemaRegistry(database: cloud), database: cloud)
+        let republished = try await SchemaRegistry(database: cloud).definition(for: DeviceEntry.recordType)
+        #expect(republished.fields.contains { $0.name == "model" })
+    }
+
+    @Test("A backend self-registers its schema, so reads work without setup()")
+    func selfRegistration() async throws {
+        let cloud = ScoutDBTesting.InMemoryDatabase()
+        try await publishStaleDeviceSchema(to: cloud)
+
+        // Build the backend the way Backend.cloudKit does — with a registration task —
+        // but never call setup(). The read must still resolve `model`.
+        let registry = SchemaRegistry(database: cloud)
+        let database = NativeDatabase(
+            store: EntityStore(database: cloud, registry: registry),
+            registration: Task { await EntityCatalog.register(into: registry) }
+        )
+
+        try await database.write(record: makeDeviceRecord(id: "d-1", model: "iPhone16,1"))
+        let chunk = try await database.read(matching: RecordQuery(recordType: Device.self), fields: ["device_id", "model"])
+        #expect(chunk.records.first?["model"] == "iPhone16,1")
+    }
+}
+
+func makeDeviceRecord(id: String, model: String) -> Record {
+    var record = Record(recordType: DeviceEntry.recordType, recordID: id)
+    record["date"] = TestDate.reference
+    record["device_id"] = id
+    record["model"] = model
     return record
 }
 


### PR DESCRIPTION
Home was failing with "Unknown field" SchemaErrors because the native CloudKit backend read against the stale published schema before the local definitions were registered, and because several fields written since the session inspector landed (Device `model`; Session `build_number`/`os_version`/`locale`/`channel`) were never declared in EntityCatalog. NativeDatabase now self-registers its local schema through a one-time task awaited before every read/write, so any backend serves reads against the current client schema whether or not `setup()` ran on it. `bootstrap` splits into `register(into:)` and `reconcile(...)`, where reconcile reads the published schema through a throwaway registry so `preload` no longer clobbers the authoritative local cache. The missing fields are appended as trailing slots so existing slot assignments stay put.

The nicer "Unknown field '…'" error text comes from a companion `SchemaError: LocalizedError` change in scout-db, which ships separately.