### PR TITLE
Stretch the metrics period strip across the full width

### DIFF
--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -25,8 +25,7 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
     }
 
     var body: some View {
-        SegmentStrip(selection: $extent.period, title: \.shortTitle)
-            .frame(maxWidth: .infinity, alignment: .leading)
+        SegmentStrip(selection: $extent.period, distribution: .justified, title: \.shortTitle)
             .padding(.horizontal)
 
         RangeControl(extent: $extent)


### PR DESCRIPTION
The period strip on the metrics screen (T Y 7 30 365) used SegmentStrip's default `.compact` distribution, so the segments clustered against the leading edge and left the rest of the row empty. Switch it to `.justified`, matching how `PeriodPicker` already lays out its strip, so JustifiedLayout spreads the segments evenly from edge to edge. The redundant outer `maxWidth: .infinity` frame is dropped since the `.justified` branch of SegmentStrip already applies it.