### PR TITLE
Render dynamic-data navigation titles in reduced monospace

### DIFF
--- a/Sources/Scout/UI/Event/Detail/EventView.swift
+++ b/Sources/Scout/UI/Event/Detail/EventView.swift
@@ -39,7 +39,7 @@ struct EventView: View {
         }
         .listStyle(.plain)
         .navigationTint(color)
-        .navigationTitle(event.name)
+        .monospacedNavigationTitle(en: event.name)
         .navigationDestination(isPresented: $isParamPresented) {
             if let items = try? param.result?.get() {
                 ParamList(items: items)

--- a/Sources/Scout/UI/Event/Param/ParamView.swift
+++ b/Sources/Scout/UI/Event/Param/ParamView.swift
@@ -41,7 +41,7 @@ struct ParamView: View {
                 ParamScalarView(raw: raw, value: value)
             }
         }
-        .navigationTitle(key)
+        .monospacedNavigationTitle(en: key)
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
                 ShareLink(item: raw)

--- a/Sources/Scout/UI/Incident/Crash/CrashDetailView.swift
+++ b/Sources/Scout/UI/Incident/Crash/CrashDetailView.swift
@@ -39,7 +39,7 @@ struct CrashDetailView: View {
                 Spacer()
             }
         }
-        .navigationTitle(crash.name)
+        .monospacedNavigationTitle(en: crash.name)
     }
 }
 

--- a/Sources/Scout/UI/Incident/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Incident/Crash/CrashGroupDetailView.swift
@@ -36,7 +36,7 @@ struct CrashGroupDetailView: View {
                 Spacer()
             }
         }
-        .navigationTitle(group.name)
+        .monospacedNavigationTitle(en: group.name)
         .task {
             await breakdown.fetchIfNeeded(in: database)
         }

--- a/Sources/Scout/UI/Incident/Hang/HangDetailView.swift
+++ b/Sources/Scout/UI/Incident/Hang/HangDetailView.swift
@@ -47,7 +47,7 @@ struct HangDetailView: View {
                 Spacer()
             }
         }
-        .navigationTitle(hang.name)
+        .monospacedNavigationTitle(en: hang.name)
     }
 }
 

--- a/Sources/Scout/UI/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/Scout/UI/Incident/Hang/HangGroupDetailView.swift
@@ -36,7 +36,7 @@ struct HangGroupDetailView: View {
                 Spacer()
             }
         }
-        .navigationTitle(group.name)
+        .monospacedNavigationTitle(en: group.name)
         .task {
             await breakdown.fetchIfNeeded(in: database)
         }

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistributionSection.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistributionSection.swift
@@ -54,6 +54,6 @@ struct TimerDistributionSection: View {
             )
         }
         .listStyle(.plain)
-        .navigationTitle(en: "http_request")
+        .monospacedNavigationTitle(en: "http_request")
     }
 }

--- a/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
+++ b/Sources/Scout/UI/Metrics/Distribution/TimerDistributionView.swift
@@ -45,6 +45,6 @@ extension LatencyPercentiles {
             TimerDistributionView(percentiles: .sample, trend: .sample, unit: .hour)
                 .padding(.horizontal)
         }
-        .navigationTitle(en: "http_request")
+        .monospacedNavigationTitle(en: "http_request")
     }
 }

--- a/Sources/Scout/UI/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Metrics/MetricsView.swift
@@ -50,7 +50,7 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
             extra(extent)
         }
         .listStyle(.plain)
-        .navigationTitle(group.name)
+        .monospacedNavigationTitle(en: group.name)
         .scrollDisabled(Extra.self == EmptyView.self)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {

--- a/Sources/Scout/UI/Network/View/MonospacedNavigationTitle.swift
+++ b/Sources/Scout/UI/Network/View/MonospacedNavigationTitle.swift
@@ -43,7 +43,7 @@ extension View {
                     }
 
                     for appearance in bar.allAppearances {
-                        appearance.largeTitleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 34, weight: .bold)
+                        appearance.largeTitleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 24, weight: .bold)
                         appearance.titleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 17, weight: .semibold)
                     }
                 }

--- a/Sources/Scout/UI/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Releases/View/VersionDetailView.swift
@@ -38,7 +38,7 @@ struct VersionDetailView: View {
         .listStyle(.plain)
         .toolbarBackground(release.freeSessions.color.opacity(0.12), for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
-        .navigationTitle(en: release.id)
+        .monospacedNavigationTitle(en: release.id)
         .message($crashes.message)
         .message($hangs.message)
         .task {


### PR DESCRIPTION
Dynamic values shown as navigation titles — event, metric, endpoint, crash and hang names, param keys, and release versions — are raw code-like identifiers, so they now render through monospacedNavigationTitle to set them apart from static section labels like Settings or Devices. The monospaced large title also shrinks from 34pt to 24pt so these data titles read as smaller than standard headings. Device model names and the backend name stay standard, as do all static labels.

The monospacedNavigationTitle modifier already existed for network endpoint paths; this extends it across the app and reduces its size. It still lives under Network/View — a structure-only move to Primitives/Navigation would make sense as a separate follow-up PR.