### PR TITLE
Use RingIndicator instead of the system spinner in server actions

### DIFF
--- a/Sources/Scout/UI/Home/Settings/BackendDetailView.swift
+++ b/Sources/Scout/UI/Home/Settings/BackendDetailView.swift
@@ -106,7 +106,7 @@ struct BackendDetailView: View {
                         .foregroundStyle(.tint)
                     if isChecking {
                         Spacer()
-                        ProgressView()
+                        RingIndicator(size: 22)
                     }
                 }
             }

--- a/Sources/Scout/UI/Home/Settings/BenchmarkButton.swift
+++ b/Sources/Scout/UI/Home/Settings/BenchmarkButton.swift
@@ -33,7 +33,7 @@ struct BenchmarkButton: View {
                     .foregroundStyle(.tint)
                 if isBenchmarking {
                     Spacer()
-                    ProgressView()
+                    RingIndicator(size: 22)
                 }
             }
         }


### PR DESCRIPTION
Replaces the default system `ProgressView()` with the app's custom `RingIndicator` in the ACTIONS section of the server detail screen — in the "Check Now" row and in the "Run Parallelism Benchmark" button. This makes the loading indicator consistent with the rest of the app, which uses `RingIndicator` everywhere. After this change `ProgressView()` no longer appears anywhere in Sources/Scout.