### PR TITLE
Fix monospaced navigation title leaking onto pushed screens

### DIFF
--- a/Sources/Scout/UI/Monitoring/Network/View/MonospacedNavigationTitle.swift
+++ b/Sources/Scout/UI/Monitoring/Network/View/MonospacedNavigationTitle.swift
@@ -29,33 +29,43 @@ extension View {
         func updateUIViewController(_ controller: Controller, context: Context) {}
 
         final class Controller: UIViewController {
-            private var restore: ((UINavigationBar) -> Void)?
+            private var originals: [TitleFonts] = []
 
             override func viewWillAppear(_ animated: Bool) {
                 super.viewWillAppear(animated)
 
-                if let bar = navigationController?.navigationBar {
-                    restore = { bar in
-                        for appearance in bar.allAppearances {
-                            appearance.largeTitleTextAttributes = bar.standardAppearance.largeTitleTextAttributes
-                            appearance.titleTextAttributes = bar.standardAppearance.titleTextAttributes
-                        }
-                    }
+                guard let bar = navigationController?.navigationBar else { return }
 
-                    for appearance in bar.allAppearances {
-                        appearance.largeTitleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 24, weight: .bold)
-                        appearance.titleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 17, weight: .semibold)
-                    }
+                originals = bar.allAppearances.map(TitleFonts.init)
+
+                for appearance in bar.allAppearances {
+                    appearance.largeTitleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 24, weight: .bold)
+                    appearance.titleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 17, weight: .semibold)
                 }
             }
 
             override func viewWillDisappear(_ animated: Bool) {
                 super.viewWillDisappear(animated)
-
-                if let bar = navigationController?.navigationBar {
-                    restore?(bar)
-                }
+                originals.forEach { $0.restore() }
             }
+        }
+    }
+
+    @MainActor
+    private struct TitleFonts {
+        let appearance: UINavigationBarAppearance
+        let largeTitle: UIFont?
+        let title: UIFont?
+
+        init(_ appearance: UINavigationBarAppearance) {
+            self.appearance = appearance
+            self.largeTitle = appearance.largeTitleTextAttributes[.font] as? UIFont
+            self.title = appearance.titleTextAttributes[.font] as? UIFont
+        }
+
+        func restore() {
+            appearance.largeTitleTextAttributes[.font] = largeTitle
+            appearance.titleTextAttributes[.font] = title
         }
     }
 


### PR DESCRIPTION
The monospaced navigation title customization mutated the shared UINavigationBar appearance objects for the whole stack, and its restore logic copied attributes back from standardAppearance — which had itself already been overwritten with the monospaced font. As a result the original system font was never truly restored, so pushed screens like Stats inherited the monospaced large title even though they set a plain navigationTitle.

Now the controller snapshots each appearance's original title fonts before mutating them and restores exactly those on viewWillDisappear, so the monospaced styling stays scoped to the screen that requested it. The snapshot lives in a small TitleFonts type instead of a tuple, marked @MainActor since the appearance attributes are main-actor isolated under Swift 6.