### PR TITLE
Distinguish read-only and failed backend states from unreachable

### DIFF
--- a/Sources/Scout/Core/Setup/Backend.swift
+++ b/Sources/Scout/Core/Setup/Backend.swift
@@ -46,10 +46,7 @@ public struct Backend: Sendable {
 extension Backend.Status: Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
-        case (.reachable, .reachable),
-            (.readOnly, .readOnly),
-            (.unreachable, .unreachable),
-            (.unknown, .unknown):
+        case (.reachable, .reachable), (.readOnly, .readOnly), (.unreachable, .unreachable), (.unknown, .unknown):
             true
         case let (.failed(lhsError), .failed(rhsError)):
             lhsError as NSError == rhsError as NSError

--- a/Sources/Scout/Core/Setup/Backend.swift
+++ b/Sources/Scout/Core/Setup/Backend.swift
@@ -21,12 +21,12 @@ public struct Backend: Sendable {
     var runBenchmark: (@Sendable () async -> Bool)? = nil
     var onSetup: @MainActor @Sendable () -> Void = {}
 
-    enum Status: CaseIterable, Identifiable, Sendable {
+    enum Status: Sendable {
         case reachable
+        case readOnly
         case unreachable
+        case failed(any Error & Sendable)
         case unknown
-
-        var id: Self { self }
     }
 
     enum AccountStatus: Sendable {
@@ -40,6 +40,22 @@ public struct Backend: Sendable {
         let endpoint: String
         let hasAPIKey: Bool
         let isSecure: Bool
+    }
+}
+
+extension Backend.Status: Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.reachable, .reachable),
+             (.readOnly, .readOnly),
+             (.unreachable, .unreachable),
+             (.unknown, .unknown):
+            true
+        case let (.failed(lhsError), .failed(rhsError)):
+            lhsError as NSError == rhsError as NSError
+        default:
+            false
+        }
     }
 }
 

--- a/Sources/Scout/Core/Setup/Backend.swift
+++ b/Sources/Scout/Core/Setup/Backend.swift
@@ -47,9 +47,9 @@ extension Backend.Status: Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case (.reachable, .reachable),
-             (.readOnly, .readOnly),
-             (.unreachable, .unreachable),
-             (.unknown, .unknown):
+            (.readOnly, .readOnly),
+            (.unreachable, .unreachable),
+            (.unknown, .unknown):
             true
         case let (.failed(lhsError), .failed(rhsError)):
             lhsError as NSError == rhsError as NSError

--- a/Sources/Scout/Hosted/Access/HostedBackend.swift
+++ b/Sources/Scout/Hosted/Access/HostedBackend.swift
@@ -24,7 +24,7 @@ extension Backend {
                     try await HTTPDatabase(url: url, apiKey: apiKey).ping()
                     return .reachable
                 } catch {
-                    return .unreachable
+                    return .failed(error)
                 }
             },
             onSetup: {

--- a/Sources/Scout/Native/Store/NativeBackend.swift
+++ b/Sources/Scout/Native/Store/NativeBackend.swift
@@ -28,8 +28,11 @@ extension Backend {
             },
             displayName: "iCloud",
             probeStatus: {
-                let status = try? await container.accountStatus()
-                return status == .available ? .reachable : .unreachable
+                do {
+                    return try await container.accountStatus().backendStatus
+                } catch {
+                    return .failed(error)
+                }
             },
             accountWarning: {
                 switch try await container.accountStatus() {
@@ -53,6 +56,21 @@ extension Backend {
                 }
             }
         )
+    }
+}
+
+extension CKAccountStatus {
+    var backendStatus: Backend.Status {
+        switch self {
+        case .available:
+            .reachable
+        case .noAccount, .restricted, .temporarilyUnavailable:
+            .readOnly
+        case .couldNotDetermine:
+            .unreachable
+        @unknown default:
+            .unreachable
+        }
     }
 }
 

--- a/Sources/Scout/UI/Home/Connection/ConnectionRow.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionRow.swift
@@ -19,7 +19,7 @@ struct ConnectionRow: View {
                 Image(systemName: "circle.fill")
                     .imageScale(.medium)
                     .foregroundStyle(connection.status.healthColor)
-                    .accessibilityLabel(Text(verbatim: connection.status.label))
+                    .accessibilityLabel(Text(verbatim: connection.status.healthLabel))
                 VStack(spacing: 0) {
                     HStack {
                         Text(verbatim: connection.name).font(.callout)
@@ -52,14 +52,4 @@ struct ConnectionRow: View {
         ConnectionRow(connection: [Connection].samples[1], isActive: false, showsSeparator: false, action: {})
     }
     .frame(minWidth: 240)
-}
-
-extension Backend.Status {
-    fileprivate var label: String {
-        switch self {
-        case .reachable: "Reachable"
-        case .unreachable: "Unreachable"
-        case .unknown: "Unknown"
-        }
-    }
 }

--- a/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
+++ b/Sources/Scout/UI/Home/Modifier/ICloudWarning.swift
@@ -66,7 +66,7 @@ extension Backend.AccountStatus {
     fileprivate var title: String {
         switch self {
         case .noAccount:
-            "iCloud Unavailable"
+            "Not Signed In to iCloud"
         case .restricted:
             "iCloud Restricted"
         case .temporarilyUnavailable:

--- a/Sources/Scout/UI/Home/Settings/BackendHealth.swift
+++ b/Sources/Scout/UI/Home/Settings/BackendHealth.swift
@@ -77,7 +77,8 @@ extension Backend.Status {
     var healthLabel: String {
         switch self {
         case .reachable: "Operational"
-        case .unreachable: "Unreachable"
+        case .readOnly: "Read-Only"
+        case .unreachable, .failed: "Unreachable"
         case .unknown: "Checking"
         }
     }
@@ -85,7 +86,8 @@ extension Backend.Status {
     var healthColor: Color {
         switch self {
         case .reachable: .green
-        case .unreachable: .red
+        case .readOnly: .orange
+        case .unreachable, .failed: .red
         case .unknown: .gray
         }
     }
@@ -93,7 +95,8 @@ extension Backend.Status {
     var healthIcon: String {
         switch self {
         case .reachable: "checkmark.circle.fill"
-        case .unreachable: "xmark.octagon.fill"
+        case .readOnly: "exclamationmark.triangle.fill"
+        case .unreachable, .failed: "xmark.octagon.fill"
         case .unknown: "questionmark.circle.fill"
         }
     }


### PR DESCRIPTION
When iCloud has no signed-in account the app still reads the public CloudKit database, so showing the backend as "unavailable" (red, unreachable) was misleading. This splits Backend.Status so that account states which keep reads working — no account, restricted, temporarily unavailable — map to a new degraded read-only state (orange), while a probe that actually throws maps to failed(error), which carries the underlying error. Genuinely dead backends and couldNotDetermine stay unreachable (red). CKAccountStatus now maps through a small backendStatus helper, both the CloudKit and server backends thread the probe error into failed(error), and failed values compare by their bridged NSError so a change in failure cause is not swallowed. The health label/color/icon switches fold .readOnly and .failed in, the connection dot reuses healthLabel for its accessibility label, and the no-account alert title now reads "Not Signed In to iCloud". Verified with the full test target on the simulator (540 passing).