### PR TITLE
Take the report in NetworkEndpointDetailView and own its navigation title

### DIFF
--- a/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointDetailView.swift
+++ b/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointDetailView.swift
@@ -15,6 +15,14 @@ struct NetworkEndpointDetailView: View {
     let range: Range<Date>
     var unit: Calendar.Component = .hour
 
+    init(endpoint: NetworkEndpoint, report: NetworkReport, range: Range<Date>, unit: Calendar.Component = .hour) {
+        self.endpoint = endpoint
+        self.distribution = report.distributions[endpoint.name]
+        self.statuses = report.statuses[endpoint.name]
+        self.range = range
+        self.unit = unit
+    }
+
     var body: some View {
         List {
             HStack(spacing: 28) {
@@ -44,6 +52,7 @@ struct NetworkEndpointDetailView: View {
             }
         }
         .listStyle(.plain)
+        .monospacedNavigationTitle(en: endpoint.path)
     }
 }
 
@@ -53,12 +62,6 @@ struct NetworkEndpointDetailView: View {
     let endpoint = report.endpoints(in: range)[2]
 
     NavigationStack {
-        NetworkEndpointDetailView(
-            endpoint: endpoint,
-            distribution: report.distributions[endpoint.name],
-            statuses: report.statuses[endpoint.name],
-            range: range
-        )
-        .monospacedNavigationTitle(en: endpoint.path)
+        NetworkEndpointDetailView(endpoint: endpoint, report: report, range: range)
     }
 }

--- a/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointRow.swift
+++ b/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointRow.swift
@@ -17,13 +17,7 @@ struct NetworkEndpointLink: View {
         Row {
             NetworkEndpointRow(endpoint: endpoint)
         } destination: {
-            NetworkEndpointDetailView(
-                endpoint: endpoint,
-                distribution: report.distributions[endpoint.name],
-                statuses: report.statuses[endpoint.name],
-                range: range
-            )
-            .monospacedNavigationTitle(en: endpoint.path)
+            NetworkEndpointDetailView(endpoint: endpoint, report: report, range: range)
         }
     }
 }


### PR DESCRIPTION
NetworkEndpointDetailView now takes the whole NetworkReport and derives its own distribution and status slices from the endpoint name, instead of making every call site pull them out by hand. The monospaced navigation title moved inside the view too, so callers just pass endpoint, report and range. This trims the duplicated wiring in NetworkEndpointLink and the preview.