### PR TITLE
Fold the endpoint navigation link into NetworkEndpointRow

### DIFF
--- a/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointRow.swift
+++ b/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointRow.swift
@@ -8,55 +8,52 @@
 
 import SwiftUI
 
-struct NetworkEndpointLink: View {
+struct NetworkEndpointRow: View {
     let endpoint: NetworkEndpoint
     let report: NetworkReport
     let range: Range<Date>
 
     var body: some View {
         Row {
-            NetworkEndpointRow(endpoint: endpoint)
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(endpoint.successRate?.color ?? .gray)
+                    .frame(width: 8, height: 8)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(verbatim: endpoint.name)
+                        .font(.subheadline.weight(.medium))
+                    Text(verbatim: endpoint.requests.plain + " req · " + (endpoint.successRate?.formatted ?? "—"))
+                        .font(.caption)
+                        .foregroundStyle(.gray)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 8) {
+                    Text(verbatim: endpoint.p99?.duration ?? "—")
+                        .font(.subheadline.weight(.semibold))
+                        .monospacedDigit()
+                    Text(verbatim: "P99")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.gray)
+                }
+            }
+            .frame(height: 44)
         } destination: {
             NetworkEndpointDetailView(endpoint: endpoint, report: report, range: range)
         }
     }
 }
 
-struct NetworkEndpointRow: View {
-    let endpoint: NetworkEndpoint
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Circle()
-                .fill(endpoint.successRate?.color ?? .gray)
-                .frame(width: 8, height: 8)
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text(verbatim: endpoint.name)
-                    .font(.subheadline.weight(.medium))
-                Text(verbatim: endpoint.requests.plain + " req · " + (endpoint.successRate?.formatted ?? "—"))
-                    .font(.caption)
-                    .foregroundStyle(.gray)
-            }
-
-            Spacer()
-
-            VStack(alignment: .trailing, spacing: 8) {
-                Text(verbatim: endpoint.p99?.duration ?? "—")
-                    .font(.subheadline.weight(.semibold))
-                    .monospacedDigit()
-                Text(verbatim: "P99")
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.gray)
-            }
-        }
-        .frame(height: 44)
-    }
-}
-
 #Preview("NetworkEndpointRow") {
-    List([NetworkEndpoint].samples) { endpoint in
-        NetworkEndpointRow(endpoint: endpoint)
+    let report = NetworkReport.sample
+    let range = Period.today.initialRange
+
+    NavigationStack {
+        List(report.endpoints(in: range)) { endpoint in
+            NetworkEndpointRow(endpoint: endpoint, report: report, range: range)
+        }
+        .listStyle(.plain)
     }
-    .listStyle(.plain)
 }

--- a/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointsView.swift
+++ b/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointsView.swift
@@ -28,7 +28,7 @@ struct NetworkEndpointsView: View {
 
             Header(title: "Endpoints")
             ForEach(endpoints) { endpoint in
-                NetworkEndpointLink(endpoint: endpoint, report: report, range: range)
+                NetworkEndpointRow(endpoint: endpoint, report: report, range: range)
             }
         }
         .listStyle(.plain)

--- a/Sources/Scout/UI/Monitoring/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Monitoring/Network/View/NetworkView.swift
@@ -54,7 +54,7 @@ struct NetworkView: View {
                 AllButton { showAllEndpoints = true }
             }
             ForEach(endpoints.prefix(3)) { endpoint in
-                NetworkEndpointLink(endpoint: endpoint, report: report, range: range)
+                NetworkEndpointRow(endpoint: endpoint, report: report, range: range)
             }
         }
         .listStyle(.plain)


### PR DESCRIPTION
After NetworkEndpointDetailView started taking the whole report, NetworkEndpointLink was left as a pure pass-through that forwarded endpoint, report and range without doing any work. Following the ReleaseRow convention, its Row-and-destination now lives directly in NetworkEndpointRow, so the endpoints lists build the row itself and the separate link wrapper is gone.