### PR TITLE
Wrap the setup snippet so its code renders at full size

### DIFF
--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -17,9 +17,9 @@ struct SetupPage: View {
                     number: 1,
                     label: "Initialize Scout in your app",
                     code: """
-                        try await setup(
-                            backends: [.cloudKit(container: .default())]
-                        )
+                        try await setup(backends: [
+                            .cloudKit(container: .default())
+                        ])
                         """
                 )
                 Step(


### PR DESCRIPTION
The first onboarding step wrapped its snippet across three lines, and the long `.cloudKit(container: .default())` line no longer fit the code chip. That triggered the minimumScaleFactor fallback and shrank the whole block, so the first step's code rendered noticeably smaller than the single-line snippets in the other two steps. Reflowing the array literal onto its own line shortens the longest line enough to fit at full size, so all three steps now share the same code font size.