### PR TITLE
Stack the hang reason below the BLOCKED ON label

### DIFF
--- a/Sources/Scout/UI/Monitoring/Incident/Hang/HangDetailView.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Hang/HangDetailView.swift
@@ -26,9 +26,12 @@ struct HangDetailView: View {
                 }
 
                 if let reason = hang.reason {
-                    (Text(verbatim: "BLOCKED ON:   ") + Text(reason).foregroundColor(hang.severity.color))
-                        .lineSpacing(4)
-                        .fontWeight(.bold)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(verbatim: "BLOCKED ON:")
+                        Text(reason)
+                            .foregroundColor(hang.severity.color)
+                    }
+                    .fontWeight(.bold)
                 }
             }
             .padding(.vertical, 4)


### PR DESCRIPTION
The hang detail screen concatenated the BLOCKED ON label and its reason into one paragraph, so a long reason wrapped awkwardly against the label. Split them into a VStack so the label sits on its own line with the reason stacked beneath it in the severity color.