### PR TITLE
Hide the Latency P99 section when there is no latency data

### DIFF
--- a/Sources/Scout/UI/Monitoring/Network/View/NetworkView.swift
+++ b/Sources/Scout/UI/Monitoring/Network/View/NetworkView.swift
@@ -32,6 +32,7 @@ struct NetworkView: View {
         let endpoints = report.endpoints(in: range)
         let breakdown = report.summary(in: range)
         let successRate = breakdown.total > 0 ? breakdown.successRate : nil
+        let trend = report.trend(in: range, component: .hour)
 
         return List {
             HStack(spacing: 28) {
@@ -42,9 +43,11 @@ struct NetworkView: View {
             }
             .listRowSeparator(.hidden)
 
-            Header(title: "Latency P99")
-            PercentileTrendChart(trend: report.trend(in: range, component: .hour), unit: .hour)
-                .listRowSeparator(.hidden)
+            if trend.count > 0 {
+                Header(title: "Latency P99")
+                PercentileTrendChart(trend: trend, unit: .hour)
+                    .listRowSeparator(.hidden)
+            }
 
             Header(title: "Status codes")
             SegmentBar(segments: breakdown.segments)


### PR DESCRIPTION
The Network screen rendered the "Latency P99" header and trend chart unconditionally, so an endpoint that recorded only status codes but no latency timer samples left a large empty chart area between the header and "Status codes". This mirrors the per-endpoint detail screen, which already gates its P99 trend on having data, by only showing the header and `PercentileTrendChart` when `report.trend` returns at least one point.