### PR TITLE
Drop the model identifier chip from DeviceDetailView

### DIFF
--- a/Sources/Scout/UI/Delivery/Devices/View/DeviceDetailView.swift
+++ b/Sources/Scout/UI/Delivery/Devices/View/DeviceDetailView.swift
@@ -22,9 +22,6 @@ struct DeviceDetailView: View {
         List {
             FlowLayout(spacing: 6) {
                 InfoChip(systemImage: device.symbol, text: device.modelName, color: .blue)
-                if device.modelName != device.model {
-                    InfoChip(systemImage: "number", text: device.model, color: .gray, monospaced: true)
-                }
                 InfoChip(systemImage: "gearshape", text: device.osVersion, color: .indigo)
                 InfoChip(systemImage: "clock", text: "seen \(device.lastSeen.relativeString)", color: .teal)
             }


### PR DESCRIPTION
Removes the monospaced model identifier chip (e.g. `# iPhone18,4`) from the device detail header. The device name, OS version, and last-seen chips remain, keeping the row focused on the information users actually recognize.