### PR TITLE
Drop the count suffix from segment bar legend labels

### DIFF
--- a/Sources/Scout/UI/Insights/Chart/View/SegmentBar.swift
+++ b/Sources/Scout/UI/Insights/Chart/View/SegmentBar.swift
@@ -38,7 +38,7 @@ struct SegmentBar: View {
                 ForEach(segments) { segment in
                     HStack(spacing: 5) {
                         Circle().fill(segment.color).frame(width: 7, height: 7)
-                        Text(verbatim: segment.label + " " + segment.count.plain)
+                        Text(verbatim: segment.label)
                             .font(.caption)
                             .foregroundStyle(.gray)
                     }


### PR DESCRIPTION
Segment bar legends now show just the model name or OS version, without the trailing occurrence count. Since every screen that uses this legend style funnels through SegmentBar, this cleans up Top Models, OS Versions, crash and hang device/OS breakdowns, and the network status-code distribution in one place.