### PR TITLE
Lower swift-format line length limit to 120

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -3,7 +3,7 @@
   "indentation": {
     "spaces": 4
   },
-  "lineLength": 160,
+  "lineLength": 120,
   "rules": {
     "AlwaysUseLiteralForEmptyCollectionInit": true,
     "BeginDocumentationCommentWithOneLineSummary": true,

--- a/Sources/Scout/Core/Activity/MarkerEntry.Trigger.swift
+++ b/Sources/Scout/Core/Activity/MarkerEntry.Trigger.swift
@@ -13,7 +13,8 @@ extension MarkerEntry {
 
         func execute(in context: NSManagedObjectContext) throws {
             let install = try context.existing(InstallEntry.self, key: "installID", id: installID)
-            try MarkerEntry.mark(name: MarkerEntry.installName, install: install, appVersion: Bundle.main.marketingVersion, in: context)
+            try MarkerEntry.mark(
+                name: MarkerEntry.installName, install: install, appVersion: Bundle.main.marketingVersion, in: context)
 
             if context.hasChanges {
                 try context.save()
@@ -21,7 +22,9 @@ extension MarkerEntry {
         }
     }
 
-    static func mark(name: String, install: InstallEntry?, appVersion: String?, in context: NSManagedObjectContext) throws {
+    static func mark(name: String, install: InstallEntry?, appVersion: String?, in context: NSManagedObjectContext)
+        throws
+    {
         guard let appVersion, let install else { return }
 
         let request = NSFetchRequest<MarkerEntry>(entityName: "MarkerEntry")

--- a/Sources/Scout/Core/Database/Access/DefaultDatabase.swift
+++ b/Sources/Scout/Core/Database/Access/DefaultDatabase.swift
@@ -24,7 +24,9 @@ struct DefaultDatabase: Database {
         []
     }
 
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
         []
     }
 

--- a/Sources/Scout/Core/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Core/Database/Access/RecordSender.swift
@@ -21,10 +21,13 @@ extension RecordSender {
 
 @MainActor
 extension RecordSender {
-    func deliver<T: SyncableEntry & RecordEncodable>(type syncable: T.Type, in context: NSManagedObjectContext) async throws {
+    func deliver<T: SyncableEntry & RecordEncodable>(type syncable: T.Type, in context: NSManagedObjectContext)
+        async throws
+    {
         let request = NSFetchRequest<T>(entityName: String(describing: T.self))
         request.predicate = NSPredicate(
-            format: "SUBQUERY(deliveries, $d, $d.backendID == %@ AND $d.isPending == YES AND $d.attempts < %d).@count > 0",
+            format:
+                "SUBQUERY(deliveries, $d, $d.backendID == %@ AND $d.isPending == YES AND $d.attempts < %d).@count > 0",
             id,
             DeliveryEntry.maxAttempts
         )

--- a/Sources/Scout/Core/Database/Record/RecordValue.swift
+++ b/Sources/Scout/Core/Database/Record/RecordValue.swift
@@ -37,7 +37,8 @@ extension RecordValue: Codable {
         } else if let value = try container.decodeIfPresent([String].self, forKey: .strings) {
             self = .strings(value)
         } else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown field value type"))
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown field value type"))
         }
     }
 

--- a/Sources/Scout/Core/Diagnostics/Crash/CrashArchive.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashArchive.swift
@@ -39,7 +39,8 @@ struct CrashArchive {
     }
 
     func flush(deviceID: UUID) async {
-        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else {
+        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        else {
             return
         }
 
@@ -47,7 +48,8 @@ struct CrashArchive {
         decoder.dateDecodingStrategy = .iso8601
 
         for file in files where file.pathExtension == "crash" {
-            guard let data = try? Data(contentsOf: file), let crash = try? decoder.decode(CrashInfo.self, from: data) else {
+            guard let data = try? Data(contentsOf: file), let crash = try? decoder.decode(CrashInfo.self, from: data)
+            else {
                 try? FileManager.default.removeItem(at: file)
                 continue
             }

--- a/Sources/Scout/Core/Diagnostics/Hang/HangArchive.swift
+++ b/Sources/Scout/Core/Diagnostics/Hang/HangArchive.swift
@@ -46,7 +46,8 @@ struct HangArchive {
     /// into the database for syncing.
     ///
     func flush(deviceID: UUID) async {
-        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else {
+        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        else {
             return
         }
 
@@ -54,7 +55,8 @@ struct HangArchive {
         decoder.dateDecodingStrategy = .iso8601
 
         for file in files where file.pathExtension == "hang" {
-            guard let data = try? Data(contentsOf: file), let hang = try? decoder.decode(HangInfo.self, from: data) else {
+            guard let data = try? Data(contentsOf: file), let hang = try? decoder.decode(HangInfo.self, from: data)
+            else {
                 try? FileManager.default.removeItem(at: file)
                 continue
             }

--- a/Sources/Scout/Core/Diagnostics/Incident/IncidentEntry.swift
+++ b/Sources/Scout/Core/Diagnostics/Incident/IncidentEntry.swift
@@ -21,7 +21,8 @@ extension HasSession where Self: IncidentEntry {
         var record = Record(recordType: type, recordID: id.uuidString)
 
         record["name"] = name
-        record["fingerprint"] = fingerprint ?? CrashFingerprint(name: name ?? "", reason: reason, stackTrace: decodedStackTrace).value
+        record["fingerprint"] =
+            fingerprint ?? CrashFingerprint(name: name ?? "", reason: reason, stackTrace: decodedStackTrace).value
         record["reason"] = reason
         record["stack_trace"] = stackTrace
         record["date"] = date

--- a/Sources/Scout/Core/Diagnostics/Metrics/MetricReader.swift
+++ b/Sources/Scout/Core/Diagnostics/Metrics/MetricReader.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 protocol MetricReader: RecordReader {
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries]
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
 }
 
 struct MetricSeries: Decodable {
@@ -38,7 +39,8 @@ enum MetricValue: Decodable, Equatable {
         } else if let value = try container.decodeIfPresent(Double.self, forKey: .double) {
             self = .double(value)
         } else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown metric value type"))
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown metric value type"))
         }
     }
 }

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -26,8 +26,12 @@ extension CKTelemetryHandler {
         let sessionID = session.current
         persistMetrics { context in
             let date = Date()
-            try saveMetrics(label, date: date, category: Telemetry.Export.timer.rawValue, value: seconds, sessionID: sessionID, context)
-            try saveMetrics(label, date: date, category: LatencyBuckets.category(for: seconds), value: 1, sessionID: sessionID, context)
+            try saveMetrics(
+                label, date: date, category: Telemetry.Export.timer.rawValue, value: seconds, sessionID: sessionID,
+                context)
+            try saveMetrics(
+                label, date: date, category: LatencyBuckets.category(for: seconds), value: 1, sessionID: sessionID,
+                context)
         }
     }
 
@@ -46,7 +50,9 @@ extension CKTelemetryHandler {
     }
 }
 
-func saveMetrics<T: MetricScalar>(_ name: String, date: Date, category: String, value: T, sessionID: UUID, _ context: NSManagedObjectContext) throws {
+func saveMetrics<T: MetricScalar>(
+    _ name: String, date: Date, category: String, value: T, sessionID: UUID, _ context: NSManagedObjectContext
+) throws {
     let metrics = context.insert(T.Object.self)
 
     metrics.value = value

--- a/Sources/Scout/Core/Lifecycle/Base/CurrentHub.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/CurrentHub.swift
@@ -16,7 +16,9 @@ extension NSManagedObjectContext {
         return try fetch(request).first
     }
 
-    func linkedSession(deviceID: UUID, installID: UUID, launchID: UUID, sessionID: UUID, date: Date) throws -> SessionEntry {
+    func linkedSession(deviceID: UUID, installID: UUID, launchID: UUID, sessionID: UUID, date: Date) throws
+        -> SessionEntry
+    {
         let device = try fetchOrCreate(DeviceEntry.self, key: "deviceID", id: deviceID) {
             $0.deviceID = deviceID
             $0.date = date
@@ -38,7 +40,9 @@ extension NSManagedObjectContext {
         }
     }
 
-    private func fetchOrCreate<T: NSManagedObject>(_ type: T.Type, key: String, id: UUID, configure: (T) -> Void) throws -> T {
+    private func fetchOrCreate<T: NSManagedObject>(_ type: T.Type, key: String, id: UUID, configure: (T) -> Void) throws
+        -> T
+    {
         if let object = try existing(type, key: key, id: id) {
             return object
         }

--- a/Sources/Scout/Core/Sync/DateEntry+Cleanup.swift
+++ b/Sources/Scout/Core/Sync/DateEntry+Cleanup.swift
@@ -16,7 +16,8 @@ extension DateEntry {
         let request = NSFetchRequest<DateEntry>(entityName: "DateEntry")
         request.predicate = NSPredicate(format: "datePrimitive < %@", cutoff as NSDate)
 
-        for object in try context.fetch(request) where object.references.count == 0 && !retained.contains(object.objectID) {
+        for object in try context.fetch(request)
+        where object.references.count == 0 && !retained.contains(object.objectID) {
             context.delete(object)
         }
 

--- a/Sources/Scout/Core/Sync/DeliveryEntry.swift
+++ b/Sources/Scout/Core/Sync/DeliveryEntry.swift
@@ -34,7 +34,9 @@ final class DeliveryEntry: NSManagedObject {
         }
     }
 
-    static func retainedIDs(to backendIDs: Set<String>, in context: NSManagedObjectContext) throws -> Set<NSManagedObjectID> {
+    static func retainedIDs(to backendIDs: Set<String>, in context: NSManagedObjectContext) throws -> Set<
+        NSManagedObjectID
+    > {
         let request = NSFetchRequest<DeliveryEntry>(entityName: "DeliveryEntry")
         request.predicate = NSPredicate(
             format: "backendID IN %@ AND isPending == YES AND attempts < %d",

--- a/Sources/Scout/Core/Utilities/Dispatcher/Dispatcher.swift
+++ b/Sources/Scout/Core/Utilities/Dispatcher/Dispatcher.swift
@@ -24,7 +24,8 @@ extension Dispatcher {
         #if os(iOS)
             try await perform { @MainActor in
                 let work = Task(operation: work)
-                let task = UIApplication.shared.beginBackgroundTask(withName: "scout.sync", expirationHandler: work.cancel)
+                let task = UIApplication.shared.beginBackgroundTask(
+                    withName: "scout.sync", expirationHandler: work.cancel)
 
                 defer { UIApplication.shared.endBackgroundTask(task) }
 

--- a/Sources/Scout/Hosted/Access/HostedBackend.swift
+++ b/Sources/Scout/Hosted/Access/HostedBackend.swift
@@ -29,7 +29,9 @@ extension Backend {
             },
             onSetup: {
                 if apiKey != nil, url.scheme?.lowercased() != "https" {
-                    print("[Scout] The API key for '\(url)' will be sent over a non-HTTPS connection in cleartext. Use an https:// URL.")
+                    print(
+                        "[Scout] The API key for '\(url)' will be sent over a non-HTTPS connection in cleartext. Use an https:// URL."
+                    )
                 }
             }
         )

--- a/Sources/Scout/Hosted/Access/HostedMetricReader.swift
+++ b/Sources/Scout/Hosted/Access/HostedMetricReader.swift
@@ -8,12 +8,15 @@
 import Foundation
 
 extension HTTPDatabase: MetricReader {
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
         let from = range.lowerBound.millisecondsSince1970
         let to = range.upperBound.millisecondsSince1970
         let category = category.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? category
 
-        let path = "api/v1/metrics/series?category=\(category)&values=\(T.seriesValues)&bucket=hour&dense=false&from=\(from)&to=\(to)"
+        let path =
+            "api/v1/metrics/series?category=\(category)&values=\(T.seriesValues)&bucket=hour&dense=false&from=\(from)&to=\(to)"
         guard let endpoint = URL(string: path, relativeTo: url) else {
             throw HTTPDatabaseError(status: 0, reason: "Malformed metrics URL")
         }

--- a/Sources/Scout/Native/Request/RequestLimiter.swift
+++ b/Sources/Scout/Native/Request/RequestLimiter.swift
@@ -107,7 +107,9 @@ actor RequestLimiter {
         try await holding({ await acquireAll() }, until: { await releaseAll() }, body: body)
     }
 
-    nonisolated private func holding<R>(_ claim: () async -> Void, until free: () async -> Void, body: () async throws -> R) async rethrows -> R {
+    nonisolated private func holding<R>(
+        _ claim: () async -> Void, until free: () async -> Void, body: () async throws -> R
+    ) async rethrows -> R {
         await claim()
         do {
             let result = try await body()

--- a/Sources/Scout/Native/Store/EntityCatalog.swift
+++ b/Sources/Scout/Native/Store/EntityCatalog.swift
@@ -29,7 +29,8 @@ enum EntityCatalog {
     // Metric series are grouped by a single grid key, so the category and name
     // are packed into one pipe-separated field on write and split on read.
     static func seriesKey(for record: Record) -> ScoutDB.RecordValue? {
-        guard record.recordType == IntMetricsEntry.recordType || record.recordType == DoubleMetricsEntry.recordType else {
+        guard record.recordType == IntMetricsEntry.recordType || record.recordType == DoubleMetricsEntry.recordType
+        else {
             return nil
         }
         let category: String? = record["category"]
@@ -140,10 +141,15 @@ enum EntityCatalog {
 
     private typealias Spec = (String, FieldType)
 
-    private static func definition(entity: String, fields: [Spec], trailing: [Spec] = [], envelopeDate: String = "date", views: [AggregateView]? = nil)
+    private static func definition(
+        entity: String, fields: [Spec], trailing: [Spec] = [], envelopeDate: String = "date",
+        views: [AggregateView]? = nil
+    )
         -> EntityDefinition
     {
-        EntityDefinition(entity: entity, version: 1, fields: slotted(fields + metadata + trailing), envelopeDate: envelopeDate, views: views)
+        EntityDefinition(
+            entity: entity, version: 1, fields: slotted(fields + metadata + trailing), envelopeDate: envelopeDate,
+            views: views)
     }
 
     private static let metadata: [Spec] = [
@@ -163,7 +169,8 @@ enum EntityCatalog {
             let pool = pool(for: type)
             let index = next[pool, default: 0]
             next[pool] = index + 1
-            return FieldDefinition(name: name, type: type, storage: .slot(pool, String(format: "%@_%02d", pool.rawValue, index)))
+            return FieldDefinition(
+                name: name, type: type, storage: .slot(pool, String(format: "%@_%02d", pool.rawValue, index)))
         }
     }
 

--- a/Sources/Scout/Native/Store/MatrixSeries.swift
+++ b/Sources/Scout/Native/Store/MatrixSeries.swift
@@ -28,11 +28,13 @@ struct MatrixSeries {
 
         switch scalar {
         case .double:
-            return try await metricRecords(entity: DoubleMetricsEntry.recordType, from: from, to: to, name: name, store: store)
+            return try await metricRecords(
+                entity: DoubleMetricsEntry.recordType, from: from, to: to, name: name, store: store)
 
         case .int where name == nil:
             async let events = eventRecords(from: from, to: to, name: nil, store: store)
-            async let metrics = metricRecords(entity: IntMetricsEntry.recordType, from: from, to: to, name: nil, store: store)
+            async let metrics = metricRecords(
+                entity: IntMetricsEntry.recordType, from: from, to: to, name: nil, store: store)
             async let crashes = entityRecords(.crashes, from: from, to: to, store: store)
             async let hangs = entityRecords(.hangs, from: from, to: to, store: store)
             async let installs = entityRecords(.versionInstalls, from: from, to: to, store: store)
@@ -53,7 +55,8 @@ struct MatrixSeries {
                 return try await entityRecords(.versionCrashes, from: from, to: to, store: store)
             default:
                 async let events = eventRecords(from: from, to: to, name: name, store: store)
-                async let metrics = metricRecords(entity: IntMetricsEntry.recordType, from: from, to: to, name: name, store: store)
+                async let metrics = metricRecords(
+                    entity: IntMetricsEntry.recordType, from: from, to: to, name: name, store: store)
                 return try await events + metrics
             }
         }
@@ -76,7 +79,8 @@ struct MatrixSeries {
     }
 
     private func eventRecords(from: Date?, to: Date?, name: String?, store: EntityStore) async throws -> [Record] {
-        let points = try await store.series(entity: EventEntry.recordType, view: EntityCatalog.eventCountView, from: from?.startOfDay, to: to)
+        let points = try await store.series(
+            entity: EventEntry.recordType, view: EntityCatalog.eventCountView, from: from?.startOfDay, to: to)
         var buckets: [SeriesBucket: [CellIndex: Double]] = [:]
 
         for point in points where name == nil || point.group == name {
@@ -88,8 +92,11 @@ struct MatrixSeries {
         return assemble(buckets)
     }
 
-    private func metricRecords(entity: String, from: Date?, to: Date?, name: String?, store: EntityStore) async throws -> [Record] {
-        let points = try await store.series(entity: entity, view: EntityCatalog.metricSeriesView, from: from?.startOfDay, to: to)
+    private func metricRecords(entity: String, from: Date?, to: Date?, name: String?, store: EntityStore) async throws
+        -> [Record]
+    {
+        let points = try await store.series(
+            entity: entity, view: EntityCatalog.metricSeriesView, from: from?.startOfDay, to: to)
         var buckets: [SeriesBucket: [CellIndex: Double]] = [:]
 
         for point in points {
@@ -114,13 +121,15 @@ struct MatrixSeries {
         let (entity, dateField, matrixName) = Self.layout(of: source)
         var filters: [EntityStore.Filter] = []
         if let from {
-            filters.append(EntityStore.Filter(field: dateField, op: .greaterThanOrEquals, value: .date(from.startOfDay)))
+            filters.append(
+                EntityStore.Filter(field: dateField, op: .greaterThanOrEquals, value: .date(from.startOfDay)))
         }
         if let to {
             filters.append(EntityStore.Filter(field: dateField, op: .lessThan, value: .date(to)))
         }
 
-        let records = try await store.read(entity: entity, filters: filters, fields: [dateField, "app_version", "install_id"])
+        let records = try await store.read(
+            entity: entity, filters: filters, fields: [dateField, "app_version", "install_id"])
         var visits = records.compactMap { record -> (date: Date, version: String?, install: String?)? in
             guard case .date(let date)? = record.values[dateField] else { return nil }
             let version: String? = record["app_version"]

--- a/Sources/Scout/Native/Store/NativeDatabase.swift
+++ b/Sources/Scout/Native/Store/NativeDatabase.swift
@@ -83,7 +83,9 @@ extension NativeDatabase: RecordLocator {
 }
 
 extension NativeDatabase: MetricReader {
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
         await registration.value
         let entity = T.seriesValues == Int.seriesValues ? IntMetricsEntry.recordType : DoubleMetricsEntry.recordType
         let prefix = category + "|"

--- a/Sources/Scout/UI/Analytics/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Analytics/Activity/ActivityView.swift
@@ -45,7 +45,9 @@ struct ActivityView: View {
                 .scrollDisabled(true)
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
-                        ChartExportButton(title: "Active Users", rangeLabel: extent.domain.label(using: rangeDateFormatter)) {
+                        ChartExportButton(
+                            title: "Active Users", rangeLabel: extent.domain.label(using: rangeDateFormatter)
+                        ) {
                             ChartView(segment: extent.segment(from: data.points(on: extent.period)), timing: extent)
                                 .foregroundStyle(.green)
                         }

--- a/Sources/Scout/UI/Analytics/Event/Param/Value/ParamValue+Text.swift
+++ b/Sources/Scout/UI/Analytics/Event/Param/Value/ParamValue+Text.swift
@@ -20,7 +20,9 @@ extension ParamValue {
             return convertible.text
         case .dictionary, .array:
             let options: JSONSerialization.WritingOptions = [.prettyPrinted, .sortedKeys]
-            guard let data = try? JSONSerialization.data(withJSONObject: jsonObject, options: options), let text = String(data: data, encoding: .utf8) else {
+            guard let data = try? JSONSerialization.data(withJSONObject: jsonObject, options: options),
+                let text = String(data: data, encoding: .utf8)
+            else {
                 return summary
             }
             return text

--- a/Sources/Scout/UI/Delivery/Devices/Export/DevicesExport.swift
+++ b/Sources/Scout/UI/Delivery/Devices/Export/DevicesExport.swift
@@ -32,6 +32,8 @@ extension DevicesExport {
     private func row(for device: DeviceSummary) -> ExportLine {
         let sessions = ExportFormat.counted(device.sessions, .session)
         let crashes = ExportFormat.counted(device.crashes, .crash)
-        return .bullet("\(device.modelName)  (\(device.osVersion), \(sessions), \(crashes), seen \(ExportFormat.timestamp(device.lastSeen)))")
+        return .bullet(
+            "\(device.modelName)  (\(device.osVersion), \(sessions), \(crashes), seen \(ExportFormat.timestamp(device.lastSeen)))"
+        )
     }
 }

--- a/Sources/Scout/UI/Delivery/Devices/Model/DeviceSummary.swift
+++ b/Sources/Scout/UI/Delivery/Devices/Model/DeviceSummary.swift
@@ -27,10 +27,14 @@ struct DeviceSummary: Identifiable, Equatable {
 extension DeviceSummary {
     static func summaries(devices: [Record], sessions: [Record], crashes: [Record]) -> [DeviceSummary] {
         let sessionsByDevice = Dictionary(grouping: sessions.compactMap(SessionFields.init), by: \.deviceID)
-        let crashCounts = Dictionary(crashes.compactMap { (record: Record) -> String? in record["device_id"] }.map { ($0, 1) }, uniquingKeysWith: +)
+        let crashCounts = Dictionary(
+            crashes.compactMap { (record: Record) -> String? in record["device_id"] }.map { ($0, 1) },
+            uniquingKeysWith: +)
 
         return devices.compactMap { device -> DeviceSummary? in
-            guard let deviceID: String = device["device_id"], let uuid = UUID(uuidString: deviceID), let model: String = device["model"] else {
+            guard let deviceID: String = device["device_id"], let uuid = UUID(uuidString: deviceID),
+                let model: String = device["model"]
+            else {
                 return nil
             }
 
@@ -67,14 +71,32 @@ extension DeviceSummary {
 
 extension DeviceSummary: Fixture {
     static let samples: [DeviceSummary] = [
-        DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -15 * 60), sessions: 812, crashes: 3),
-        DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.3", lastSeen: Date(timeIntervalSinceNow: -3 * 3600), sessions: 540, crashes: 0),
-        DeviceSummary(id: UUID(), model: "iPhone14,2", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -6 * 3600), sessions: 391, crashes: 1),
-        DeviceSummary(id: UUID(), model: "iPhone14,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -2 * 86400), sessions: 205, crashes: 0),
-        DeviceSummary(id: UUID(), model: "iPhone13,2", osVersion: "iOS 17.3", lastSeen: Date(timeIntervalSinceNow: -1 * 86400), sessions: 178, crashes: 2),
-        DeviceSummary(id: UUID(), model: "iPhone13,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -9 * 86400), sessions: 96, crashes: 0),
-        DeviceSummary(id: UUID(), model: "iPad13,1", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -4 * 3600), sessions: 143, crashes: 0),
-        DeviceSummary(id: UUID(), model: "iPad14,1", osVersion: "iOS 17.2", lastSeen: Date(timeIntervalSinceNow: -12 * 86400), sessions: 64, crashes: 1),
-        DeviceSummary(id: UUID(), model: "iPhone12,1", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -30 * 86400), sessions: 22, crashes: 0),
+        DeviceSummary(
+            id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -15 * 60),
+            sessions: 812, crashes: 3),
+        DeviceSummary(
+            id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.3", lastSeen: Date(timeIntervalSinceNow: -3 * 3600),
+            sessions: 540, crashes: 0),
+        DeviceSummary(
+            id: UUID(), model: "iPhone14,2", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -6 * 3600),
+            sessions: 391, crashes: 1),
+        DeviceSummary(
+            id: UUID(), model: "iPhone14,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -2 * 86400),
+            sessions: 205, crashes: 0),
+        DeviceSummary(
+            id: UUID(), model: "iPhone13,2", osVersion: "iOS 17.3", lastSeen: Date(timeIntervalSinceNow: -1 * 86400),
+            sessions: 178, crashes: 2),
+        DeviceSummary(
+            id: UUID(), model: "iPhone13,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -9 * 86400),
+            sessions: 96, crashes: 0),
+        DeviceSummary(
+            id: UUID(), model: "iPad13,1", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -4 * 3600),
+            sessions: 143, crashes: 0),
+        DeviceSummary(
+            id: UUID(), model: "iPad14,1", osVersion: "iOS 17.2", lastSeen: Date(timeIntervalSinceNow: -12 * 86400),
+            sessions: 64, crashes: 1),
+        DeviceSummary(
+            id: UUID(), model: "iPhone12,1", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -30 * 86400),
+            sessions: 22, crashes: 0),
     ]
 }

--- a/Sources/Scout/UI/Delivery/Devices/View/DevicesProvider.swift
+++ b/Sources/Scout/UI/Delivery/Devices/View/DevicesProvider.swift
@@ -12,9 +12,12 @@ final class DevicesProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[DeviceSummary]>?
 
     func fetch(in database: DatabaseReader) async throws -> [DeviceSummary] {
-        async let devices: [Record] = database.readAll(matching: RecordQuery(recordType: Device.self), fields: ["device_id", "model"])
-        async let sessions: [Record] = database.readAll(matching: RecordQuery(recordType: Session.self), fields: ["device_id", "os_version", "start_date"])
-        async let crashes: [Record] = database.readAll(matching: RecordQuery(recordType: Crash.self), fields: ["device_id"])
+        async let devices: [Record] = database.readAll(
+            matching: RecordQuery(recordType: Device.self), fields: ["device_id", "model"])
+        async let sessions: [Record] = database.readAll(
+            matching: RecordQuery(recordType: Session.self), fields: ["device_id", "os_version", "start_date"])
+        async let crashes: [Record] = database.readAll(
+            matching: RecordQuery(recordType: Crash.self), fields: ["device_id"])
 
         return try await DeviceSummary.summaries(devices: devices, sessions: sessions, crashes: crashes)
     }

--- a/Sources/Scout/UI/Delivery/Releases/View/DailyCount.swift
+++ b/Sources/Scout/UI/Delivery/Releases/View/DailyCount.swift
@@ -13,7 +13,9 @@ struct DailyCount: Equatable {
 }
 
 extension DailyCount {
-    static func series(from records: [some Incident], days: Int = 14, calendar: Calendar = .current, endingOn today: Date = Date()) -> [DailyCount] {
+    static func series(
+        from records: [some Incident], days: Int = 14, calendar: Calendar = .current, endingOn today: Date = Date()
+    ) -> [DailyCount] {
         let start = calendar.startOfDay(for: today)
 
         var counts: [Date: Int] = [:]

--- a/Sources/Scout/UI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/Scout/UI/Delivery/Releases/View/VersionDetailView.swift
@@ -15,7 +15,10 @@ struct VersionDetailView: View {
     @StateObject var crashes: VersionIncidentProvider<Crash>
     @StateObject var hangs: VersionIncidentProvider<Hang>
 
-    init(release: ReleaseHealth, crashes: VersionIncidentProvider<Crash>? = nil, hangs: VersionIncidentProvider<Hang>? = nil) {
+    init(
+        release: ReleaseHealth, crashes: VersionIncidentProvider<Crash>? = nil,
+        hangs: VersionIncidentProvider<Hang>? = nil
+    ) {
         self.release = release
         self._crashes = StateObject(wrappedValue: crashes ?? VersionIncidentProvider(version: release.id))
         self._hangs = StateObject(wrappedValue: hangs ?? VersionIncidentProvider(version: release.id))
@@ -25,13 +28,17 @@ struct VersionDetailView: View {
         List {
             headerSection
 
-            IncidentTrendSection(title: "Crashes over time", records: crashes.records ?? [], color: release.freeSessions.color)
-            IncidentIssuesSection(title: "Top crash issues", groups: IncidentGroup.groups(from: crashes.records ?? [])) { group in
+            IncidentTrendSection(
+                title: "Crashes over time", records: crashes.records ?? [], color: release.freeSessions.color)
+            IncidentIssuesSection(title: "Top crash issues", groups: IncidentGroup.groups(from: crashes.records ?? []))
+            { group in
                 CrashGroupDetailView(group: group)
             }
 
-            IncidentTrendSection(title: "Hangs over time", records: hangs.records ?? [], color: release.freeSessions.color)
-            IncidentIssuesSection(title: "Top hang issues", groups: IncidentGroup.groups(from: hangs.records ?? [])) { group in
+            IncidentTrendSection(
+                title: "Hangs over time", records: hangs.records ?? [], color: release.freeSessions.color)
+            IncidentIssuesSection(title: "Top hang issues", groups: IncidentGroup.groups(from: hangs.records ?? [])) {
+                group in
                 HangGroupDetailView(group: group)
             }
         }

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -56,7 +56,9 @@ private let lifecycleNames: Set = [
     VersionEntry.recordType,
 ]
 
-private func matrices<T: MetricScalar>(of type: T.Type, in range: Range<Date>, from database: DatabaseReader) async throws -> [GridMatrix<T>] {
+private func matrices<T: MetricScalar>(of type: T.Type, in range: Range<Date>, from database: DatabaseReader)
+    async throws -> [GridMatrix<T>]
+{
     let query = RecordQuery(
         recordType: GridMatrix<T>.self,
         filters: (range.lowerBound.startOfWeek..<range.upperBound).dateFilters

--- a/Sources/Scout/UI/Home/Settings/BackendDetailView.swift
+++ b/Sources/Scout/UI/Home/Settings/BackendDetailView.swift
@@ -115,10 +115,13 @@ struct BackendDetailView: View {
             if let benchmark = backend.runBenchmark {
                 BenchmarkButton(benchmark: benchmark, message: $message)
 
-                Text(verbatim: "The benchmark issues test queries to verify the \(RequestLimiter.requestLimit)-request limit.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .listRowSeparator(.hidden)
+                Text(
+                    verbatim:
+                        "The benchmark issues test queries to verify the \(RequestLimiter.requestLimit)-request limit."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .listRowSeparator(.hidden)
             }
         }
         .listStyle(.plain)

--- a/Sources/Scout/UI/Insights/Chart/Comparison/ChartExtent+Comparison.swift
+++ b/Sources/Scout/UI/Insights/Chart/Comparison/ChartExtent+Comparison.swift
@@ -22,7 +22,9 @@ extension ChartExtent {
     /// months differ in length), the oldest current buckets have no
     /// counterpart and are omitted; the chart draws no reference for them.
     ///
-    func referenceSegment<U: ChartNumeric>(from points: [ChartPoint<U>], alignedTo segment: [ChartPoint<U>]) -> [ChartPoint<U>] {
+    func referenceSegment<U: ChartNumeric>(from points: [ChartPoint<U>], alignedTo segment: [ChartPoint<U>])
+        -> [ChartPoint<U>]
+    {
         zip(segment, previousSegment(from: points)).map { ChartPoint(date: $0.date, count: $1.count) }
     }
 

--- a/Sources/Scout/UI/Insights/Chart/Comparison/ComparisonPair.swift
+++ b/Sources/Scout/UI/Insights/Chart/Comparison/ComparisonPair.swift
@@ -45,7 +45,8 @@ extension Collection {
     /// sitting on the same date; buckets missing from `reference` get a nil
     /// reference and draw no comparison marks.
     ///
-    func paired<T>(with reference: [ChartPoint<T>], unit: Calendar.Component) -> [ComparisonPair<T>] where Element == ChartPoint<T> {
+    func paired<T>(with reference: [ChartPoint<T>], unit: Calendar.Component) -> [ComparisonPair<T>]
+    where Element == ChartPoint<T> {
         let counts = Dictionary(reference.map { ($0.date, $0.count) }, uniquingKeysWith: +)
         return map { point in
             ComparisonPair(

--- a/Sources/Scout/UI/Insights/Chart/Comparison/ReferenceLevel.swift
+++ b/Sources/Scout/UI/Insights/Chart/Comparison/ReferenceLevel.swift
@@ -32,10 +32,12 @@ extension ReferenceLevel {
         guard pair.count != .zero || referenceCount != .zero else {
             return nil
         }
-        guard let barStartX = proxy.position(forX: pair.barStart), let barEndX = proxy.position(forX: pair.barEnd) else {
+        guard let barStartX = proxy.position(forX: pair.barStart), let barEndX = proxy.position(forX: pair.barEnd)
+        else {
             return nil
         }
-        guard let countY = proxy.position(forY: pair.count), let referenceY = proxy.position(forY: referenceCount) else {
+        guard let countY = proxy.position(forY: pair.count), let referenceY = proxy.position(forY: referenceCount)
+        else {
             return nil
         }
 

--- a/Sources/Scout/UI/Insights/Chart/Export/ChartExportRenderer.swift
+++ b/Sources/Scout/UI/Insights/Chart/Export/ChartExportRenderer.swift
@@ -29,7 +29,9 @@ enum ChartExportRenderer {
         #if os(iOS)
             return renderer.uiImage?.pngData()
         #else
-            guard let image = renderer.nsImage, let tiff = image.tiffRepresentation, let bitmap = NSBitmapImageRep(data: tiff) else {
+            guard let image = renderer.nsImage, let tiff = image.tiffRepresentation,
+                let bitmap = NSBitmapImageRep(data: tiff)
+            else {
                 return nil
             }
             return bitmap.representation(using: .png, properties: [:])
@@ -43,7 +45,9 @@ enum ChartExportRenderer {
             let pdf = NSMutableData()
             var box = CGRect(origin: .zero, size: size)
 
-            guard let consumer = CGDataConsumer(data: pdf as CFMutableData), let context = CGContext(consumer: consumer, mediaBox: &box, nil) else {
+            guard let consumer = CGDataConsumer(data: pdf as CFMutableData),
+                let context = CGContext(consumer: consumer, mediaBox: &box, nil)
+            else {
                 return
             }
 

--- a/Sources/Scout/UI/Insights/Chart/View/MiniChart.swift
+++ b/Sources/Scout/UI/Insights/Chart/View/MiniChart.swift
@@ -88,7 +88,9 @@ struct MiniChart: View {
             HStack {
                 Text(verbatim: "Empty")
                 Spacer()
-                MiniChart(series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)), color: .red)
+                MiniChart(
+                    series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)), color: .red
+                )
             }
         }
         .listStyle(.plain)

--- a/Sources/Scout/UI/Insights/Timeline/Export/ExportFormat.swift
+++ b/Sources/Scout/UI/Insights/Timeline/Export/ExportFormat.swift
@@ -74,7 +74,8 @@ extension ExportFormat.Noun {
 extension ExportFormat {
     private static let iso8601 = Date.ISO8601FormatStyle()
     private static let dayStyle = utcStyle("\(year: .padded(4))-\(month: .twoDigits)-\(day: .twoDigits)")
-    private static let timeStyle = utcStyle("\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits)")
+    private static let timeStyle = utcStyle(
+        "\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits)")
 
     private static func utcStyle(_ format: Date.FormatString) -> Date.VerbatimFormatStyle {
         Date.VerbatimFormatStyle(format: format, timeZone: .gmt, calendar: Calendar(identifier: .gregorian))

--- a/Sources/Scout/UI/Insights/Timeline/Pagination/RailLane.swift
+++ b/Sources/Scout/UI/Insights/Timeline/Pagination/RailLane.swift
@@ -113,7 +113,8 @@ final class RailLane: ObservableObject {
 
     private func chunk(in database: DatabaseReader) async throws -> RecordChunk {
         guard let cursor else {
-            return try await Session.fetchChunk(installIDs: pendingInstalls, anchor: anchorDate, ascending: ascending, limit: chunkLimit, in: database)
+            return try await Session.fetchChunk(
+                installIDs: pendingInstalls, anchor: anchorDate, ascending: ascending, limit: chunkLimit, in: database)
         }
         return try await database.readMore(from: cursor, fields: Session.desiredKeys)
     }

--- a/Sources/Scout/UI/Insights/Timeline/Pagination/Session+FetchChunk.swift
+++ b/Sources/Scout/UI/Insights/Timeline/Pagination/Session+FetchChunk.swift
@@ -8,14 +8,17 @@
 import Foundation
 
 extension Session {
-    static func fetchChunk(installIDs: [UUID], anchor: Date?, ascending: Bool, limit: Int, in database: DatabaseReader) async throws -> RecordChunk {
+    static func fetchChunk(installIDs: [UUID], anchor: Date?, ascending: Bool, limit: Int, in database: DatabaseReader)
+        async throws -> RecordChunk
+    {
         var filters = [
             RecordQuery.Filter(field: "install_id", op: .in, value: .strings(installIDs.map(\.uuidString)))
         ]
 
         if let anchor {
             filters.append(
-                RecordQuery.Filter(field: "start_date", op: ascending ? .greaterThan : .lessThanOrEquals, value: .date(anchor))
+                RecordQuery.Filter(
+                    field: "start_date", op: ascending ? .greaterThan : .lessThanOrEquals, value: .date(anchor))
             )
         }
 

--- a/Sources/Scout/UI/Insights/Timeline/Provider/Rail+Init.swift
+++ b/Sources/Scout/UI/Insights/Timeline/Provider/Rail+Init.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 extension Rail {
-    init(device: Device, installs: [Install], launches: [Launch], sessions: [Session] = [], events: [Event] = [], crashes: [Crash] = []) {
+    init(
+        device: Device, installs: [Install], launches: [Launch], sessions: [Session] = [], events: [Event] = [],
+        crashes: [Crash] = []
+    ) {
         let installs = Dictionary(grouping: installs, by: \.deviceID)
         let launches = Dictionary(grouping: launches, by: \.installID)
         let sessions = Dictionary(grouping: sessions, by: \.launchID)

--- a/Sources/Scout/UI/Insights/Timeline/Rail/Launch+Fixture.swift
+++ b/Sources/Scout/UI/Insights/Timeline/Rail/Launch+Fixture.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 extension Launch: Fixture {
-    static func sample(minutesAgo: Double = 0, launchID: UUID = UUID(), installID: UUID = UUID(), ongoing: Bool = false) -> Launch {
+    static func sample(minutesAgo: Double = 0, launchID: UUID = UUID(), installID: UUID = UUID(), ongoing: Bool = false)
+        -> Launch
+    {
         let startDate = Date(timeIntervalSinceNow: -minutesAgo * 60)
         return Launch(
             startDate: startDate,

--- a/Sources/Scout/UI/Insights/Timeline/Rail/Session+Fixture.swift
+++ b/Sources/Scout/UI/Insights/Timeline/Rail/Session+Fixture.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 extension Session: Fixture {
-    static func sample(minutesAgo: Double = 0, sessionID: UUID = UUID(), launchID: UUID = UUID(), installID: UUID = UUID(), ongoing: Bool = false) -> Session {
+    static func sample(
+        minutesAgo: Double = 0, sessionID: UUID = UUID(), launchID: UUID = UUID(), installID: UUID = UUID(),
+        ongoing: Bool = false
+    ) -> Session {
         let startDate = Date(timeIntervalSinceNow: -minutesAgo * 60)
         return Session(
             startDate: startDate,

--- a/Sources/Scout/UI/Insights/Timeline/Rail/Version+Fixture.swift
+++ b/Sources/Scout/UI/Insights/Timeline/Rail/Version+Fixture.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 extension Version: Fixture {
-    static func sample(appVersion: String = "2.4.1", buildNumber: String = "214", minutesAgo: Double = 0, launchID: UUID = UUID()) -> Version {
+    static func sample(
+        appVersion: String = "2.4.1", buildNumber: String = "214", minutesAgo: Double = 0, launchID: UUID = UUID()
+    ) -> Version {
         Version(
             appVersion: appVersion,
             buildNumber: buildNumber,

--- a/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
@@ -37,10 +37,13 @@ extension IncidentBreakdown {
     static var sample: IncidentBreakdown {
         IncidentBreakdown(
             devices: segments(
-                from: Array(repeating: "iPhone15,3", count: 5) + Array(repeating: "iPhone14,2", count: 3) + Array(repeating: "iPhone13,2", count: 2) + [
-                    "iPad13,1"
-                ]),
-            osVersions: segments(from: Array(repeating: "iOS 17.4", count: 6) + Array(repeating: "iOS 17.3", count: 3) + Array(repeating: "iOS 16.7", count: 2))
+                from: Array(repeating: "iPhone15,3", count: 5) + Array(repeating: "iPhone14,2", count: 3)
+                    + Array(repeating: "iPhone13,2", count: 2) + [
+                        "iPad13,1"
+                    ]),
+            osVersions: segments(
+                from: Array(repeating: "iOS 17.4", count: 6) + Array(repeating: "iOS 17.3", count: 3)
+                    + Array(repeating: "iOS 16.7", count: 2))
         )
     }
 }

--- a/Sources/Scout/UI/Monitoring/Incident/Crash/Crash.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Crash/Crash.swift
@@ -57,7 +57,8 @@ extension Crash: RecordDecodable {
         } else {
             stackTrace = []
         }
-        fingerprint = record["fingerprint"] ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value
+        fingerprint =
+            record["fingerprint"] ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value
     }
 }
 

--- a/Sources/Scout/UI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
@@ -15,7 +15,9 @@ struct CrashGroupDetailView: View {
 
     init(group: IncidentGroup<Crash>, breakdown: IncidentBreakdownProvider? = nil) {
         self.group = group
-        self._breakdown = StateObject(wrappedValue: breakdown ?? IncidentBreakdownProvider(deviceIDs: group.deviceIDs, sessionIDs: group.sessionIDs))
+        self._breakdown = StateObject(
+            wrappedValue: breakdown
+                ?? IncidentBreakdownProvider(deviceIDs: group.deviceIDs, sessionIDs: group.sessionIDs))
     }
 
     var body: some View {

--- a/Sources/Scout/UI/Monitoring/Incident/Hang/Hang.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Hang/Hang.swift
@@ -70,7 +70,8 @@ extension Hang: RecordDecodable {
         } else {
             stackTrace = []
         }
-        fingerprint = record["fingerprint"] ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value
+        fingerprint =
+            record["fingerprint"] ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value
     }
 }
 

--- a/Sources/Scout/UI/Monitoring/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Hang/HangGroupDetailView.swift
@@ -15,7 +15,9 @@ struct HangGroupDetailView: View {
 
     init(group: IncidentGroup<Hang>, breakdown: IncidentBreakdownProvider? = nil) {
         self.group = group
-        self._breakdown = StateObject(wrappedValue: breakdown ?? IncidentBreakdownProvider(deviceIDs: group.deviceIDs, sessionIDs: group.sessionIDs))
+        self._breakdown = StateObject(
+            wrappedValue: breakdown
+                ?? IncidentBreakdownProvider(deviceIDs: group.deviceIDs, sessionIDs: group.sessionIDs))
     }
 
     var body: some View {

--- a/Sources/Scout/UI/Monitoring/Metrics/MetricsView.swift
+++ b/Sources/Scout/UI/Monitoring/Metrics/MetricsView.swift
@@ -17,7 +17,10 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
     @State private var isComparing = false
     @ViewBuilder let extra: (ChartExtent<Period>) -> Extra
 
-    init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period, @ViewBuilder extra: @escaping (ChartExtent<Period>) -> Extra) {
+    init(
+        group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period,
+        @ViewBuilder extra: @escaping (ChartExtent<Period>) -> Extra
+    ) {
         self.group = group
         self.formatter = formatter
         self.extra = extra

--- a/Sources/Scout/UI/Monitoring/Network/Export/NetworkReportExport.swift
+++ b/Sources/Scout/UI/Monitoring/Network/Export/NetworkReportExport.swift
@@ -16,7 +16,9 @@ struct NetworkReportExport {
         let endpoints = report.endpoints(in: range)
         guard endpoints.count > 0 else { return nil }
 
-        var lines: [ExportLine] = [.heading(level: 1, title), .text(summary), .blank, .heading(level: 2, "Status codes")]
+        var lines: [ExportLine] = [
+            .heading(level: 1, title), .text(summary), .blank, .heading(level: 2, "Status codes"),
+        ]
         lines.append(contentsOf: statusLines)
 
         lines.append(.blank)

--- a/Sources/Scout/UI/Monitoring/Network/Model/StatusDistribution.swift
+++ b/Sources/Scout/UI/Monitoring/Network/Model/StatusDistribution.swift
@@ -32,7 +32,9 @@ struct StatusDistribution: Equatable {
 }
 
 extension StatusDistribution {
-    static func sample(success: Int, redirect: Int = 0, clientError: Int = 0, serverError: Int = 0) -> StatusDistribution {
+    static func sample(success: Int, redirect: Int = 0, clientError: Int = 0, serverError: Int = 0)
+        -> StatusDistribution
+    {
         let noon = Calendar.current.startOfDay(for: .now).addingTimeInterval(12 * .hour)
         return StatusDistribution(breakdowns: [
             noon: .sample(success: success, redirect: redirect, clientError: clientError, serverError: serverError)

--- a/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointDetailView.swift
+++ b/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointDetailView.swift
@@ -28,7 +28,9 @@ struct NetworkEndpointDetailView: View {
             HStack(spacing: 28) {
                 Metric(title: "Method", value: endpoint.method ?? "—", color: endpoint.methodColor)
                 Metric(title: "Requests", value: endpoint.requests.plain, color: .primary)
-                Metric(title: "Success", value: endpoint.successRate?.formatted ?? "—", color: endpoint.successRate?.color ?? .gray)
+                Metric(
+                    title: "Success", value: endpoint.successRate?.formatted ?? "—",
+                    color: endpoint.successRate?.color ?? .gray)
                 Spacer()
             }
             .listRowSeparator(.hidden)

--- a/Sources/Scout/UI/Primitives/Navigation/View+MonospacedNavigationTitle.swift
+++ b/Sources/Scout/UI/Primitives/Navigation/View+MonospacedNavigationTitle.swift
@@ -71,7 +71,8 @@ extension View {
 
     extension UINavigationBar {
         fileprivate var allAppearances: [UINavigationBarAppearance] {
-            [standardAppearance, compactAppearance, scrollEdgeAppearance, compactScrollEdgeAppearance].compactMap(\.self)
+            [standardAppearance, compactAppearance, scrollEdgeAppearance, compactScrollEdgeAppearance].compactMap(
+                \.self)
         }
     }
 

--- a/Sources/Scout/UI/Primitives/Rows/RowSummary.swift
+++ b/Sources/Scout/UI/Primitives/Rows/RowSummary.swift
@@ -46,7 +46,9 @@ struct RowSummary: View {
             HStack {
                 Text(verbatim: "Empty")
                 Spacer()
-                RowSummary(series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)), count: 0, color: .blue)
+                RowSummary(
+                    series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)), count: 0,
+                    color: .blue)
             }
         }
         .listStyle(.plain)

--- a/Sources/Scout/UI/Primitives/Stats/StatView.swift
+++ b/Sources/Scout/UI/Primitives/Stats/StatView.swift
@@ -27,9 +27,11 @@ struct StatView: View {
                     let points = data.flatMap(\.points)
                     let segment = extent.segment(from: points)
 
-                    ComparableChart(segment: segment, points: points, extent: extent, color: color, isComparing: isComparing)
-                        .listRowSeparator(.hidden, edges: .top)
-                        .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
+                    ComparableChart(
+                        segment: segment, points: points, extent: extent, color: color, isComparing: isComparing
+                    )
+                    .listRowSeparator(.hidden, edges: .top)
+                    .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
 
                     ComparisonToggle(isOn: $isComparing)
                         .disabled(!extent.canCompare(points: points, segment: segment))
@@ -42,7 +44,9 @@ struct StatView: View {
                 .scrollDisabled(true)
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
-                        ChartExportButton(title: stat.eventName, rangeLabel: extent.domain.label(using: rangeDateFormatter)) {
+                        ChartExportButton(
+                            title: stat.eventName, rangeLabel: extent.domain.label(using: rangeDateFormatter)
+                        ) {
                             ChartView(segment: extent.segment(from: data.flatMap(\.points)), timing: extent)
                                 .foregroundStyle(color)
                         }

--- a/Tests/ScoutTests/Core/Activity/ActivityEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Core/Activity/ActivityEntryMonitorTests.swift
@@ -17,7 +17,8 @@ struct ActivityEntryMonitorTests {
     let sessionID = UUID()
 
     @Test("Trigger") func trigger() async throws {
-        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 1)).execute(in: context)
+        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 1)).execute(
+            in: context)
 
         let activities = try context.fetchAll(ActivityEntry.self)
 
@@ -31,8 +32,10 @@ struct ActivityEntryMonitorTests {
     }
 
     @Test("Trigger at next day") func triggerNextDay() async throws {
-        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 1)).execute(in: context)
-        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 2)).execute(in: context)
+        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 1)).execute(
+            in: context)
+        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 2)).execute(
+            in: context)
 
         let activities = try context.fetchAll(ActivityEntry.self)
 
@@ -46,8 +49,10 @@ struct ActivityEntryMonitorTests {
     }
 
     @Test("Trigger skip one day") func triggerSkipDay() async throws {
-        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 1)).execute(in: context)
-        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 3)).execute(in: context)
+        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 1)).execute(
+            in: context)
+        try ActivityEntry.Trigger(session: Protected(sessionID), date: Date(year: 2025, month: 1, day: 3)).execute(
+            in: context)
 
         let activities = try context.fetchAll(ActivityEntry.self)
 

--- a/Tests/ScoutTests/Core/Database/Record/RecordEncodingTests.swift
+++ b/Tests/ScoutTests/Core/Database/Record/RecordEncodingTests.swift
@@ -96,7 +96,8 @@ struct RecordEncodingTests {
 
     @Test("Crash records carry the app version")
     func crashAppVersionRecord() throws {
-        let crash = CrashEntry(entity: NSEntityDescription.entity(forEntityName: "CrashEntry", in: context)!, insertInto: context)
+        let crash = CrashEntry(
+            entity: NSEntityDescription.entity(forEntityName: "CrashEntry", in: context)!, insertInto: context)
         crash.name = "SIGABRT"
         crash.crashID = UUID()
         crash.appVersion = "3.2.0"
@@ -108,7 +109,9 @@ struct RecordEncodingTests {
 }
 
 extension IntMetricsEntry {
-    @discardableResult static func stub(name: String, telemetry: String, value: Int, in context: NSManagedObjectContext) -> IntMetricsEntry {
+    @discardableResult static func stub(name: String, telemetry: String, value: Int, in context: NSManagedObjectContext)
+        -> IntMetricsEntry
+    {
         let entity = NSEntityDescription.entity(forEntityName: "IntMetricsEntry", in: context)!
         let metric = IntMetricsEntry(entity: entity, insertInto: context)
 
@@ -122,7 +125,9 @@ extension IntMetricsEntry {
 }
 
 extension DoubleMetricsEntry {
-    @discardableResult static func stub(name: String, telemetry: String, value: Double, in context: NSManagedObjectContext) -> DoubleMetricsEntry {
+    @discardableResult static func stub(
+        name: String, telemetry: String, value: Double, in context: NSManagedObjectContext
+    ) -> DoubleMetricsEntry {
         let entity = NSEntityDescription.entity(forEntityName: "DoubleMetricsEntry", in: context)!
         let metric = DoubleMetricsEntry(entity: entity, insertInto: context)
 

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/CrashEntryTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/CrashEntryTests.swift
@@ -39,7 +39,9 @@ struct CrashEntryTests {
         object.reason = "Fatal error"
         object.stackTrace = try JSONEncoder().encode(["frame0"])
 
-        #expect(object.record["fingerprint"] == CrashFingerprint(name: "SIGABRT", reason: "Fatal error", stackTrace: ["frame0"]).value)
+        #expect(
+            object.record["fingerprint"]
+                == CrashFingerprint(name: "SIGABRT", reason: "Fatal error", stackTrace: ["frame0"]).value)
     }
 
     private func makeCrashObject(name: String, date: Date, appVersion: String? = nil) -> CrashEntry {

--- a/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Crash/LogCrashTests.swift
@@ -32,7 +32,8 @@ struct LogCrashTests {
         #expect(results.count == 1)
 
         let object = try #require(results.first)
-        let expectedFingerprint = CrashFingerprint(name: crash.name, reason: crash.reason, stackTrace: crash.stackTrace).value
+        let expectedFingerprint = CrashFingerprint(name: crash.name, reason: crash.reason, stackTrace: crash.stackTrace)
+            .value
         #expect(object.name == "SIGABRT")
         #expect(object.fingerprint == expectedFingerprint)
         #expect(object.reason == "Fatal error")

--- a/Tests/ScoutTests/Core/Diagnostics/Hang/HangEntryTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Hang/HangEntryTests.swift
@@ -49,7 +49,9 @@ struct HangEntryTests {
 
         #expect(
             object.record["fingerprint"]
-                == CrashFingerprint(name: "Main Thread Blocked", reason: "Main thread unresponsive for 4.2s", stackTrace: ["frame0"]).value)
+                == CrashFingerprint(
+                    name: "Main Thread Blocked", reason: "Main thread unresponsive for 4.2s", stackTrace: ["frame0"]
+                ).value)
     }
 
     private func makeHangObject(name: String, date: Date, appVersion: String? = nil) -> HangEntry {

--- a/Tests/ScoutTests/Core/Diagnostics/Hang/LogHangTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Hang/LogHangTests.swift
@@ -23,7 +23,9 @@ struct LogHangTests {
 
     @Test("Creates a HangEntry with correct fields")
     func createsHangObject() throws {
-        let hang = makeHangInfo(name: "Main Thread Blocked", reason: "Main thread unresponsive for 4.2s", stackTrace: ["frame0"], duration: 4.2)
+        let hang = makeHangInfo(
+            name: "Main Thread Blocked", reason: "Main thread unresponsive for 4.2s", stackTrace: ["frame0"],
+            duration: 4.2)
 
         try logHang(hang, deviceID: deviceID, context: context)
 
@@ -32,7 +34,8 @@ struct LogHangTests {
         #expect(results.count == 1)
 
         let object = try #require(results.first)
-        let expectedFingerprint = CrashFingerprint(name: hang.name, reason: hang.reason, stackTrace: hang.stackTrace).value
+        let expectedFingerprint = CrashFingerprint(name: hang.name, reason: hang.reason, stackTrace: hang.stackTrace)
+            .value
         #expect(object.name == "Main Thread Blocked")
         #expect(object.fingerprint == expectedFingerprint)
         #expect(object.reason == "Main thread unresponsive for 4.2s")

--- a/Tests/ScoutTests/Native/Store/NativeDatabaseTests.swift
+++ b/Tests/ScoutTests/Native/Store/NativeDatabaseTests.swift
@@ -95,7 +95,8 @@ struct NativeDatabaseTests {
         #expect(Set(series.map(\.name)) == ["checkout", "signup"])
         let checkout = try #require(series.first { $0.name == "checkout" })
         #expect(checkout.points.map(\.value) == [.int(7)])
-        #expect(checkout.points.map(\.date) == [TestDate.reference.addingTimeInterval(10 * .hour).millisecondsSince1970])
+        #expect(
+            checkout.points.map(\.date) == [TestDate.reference.addingTimeInterval(10 * .hour).millisecondsSince1970])
     }
 
     @Test("Session records round-trip their captured environment")
@@ -108,7 +109,8 @@ struct NativeDatabaseTests {
         try await database.write(record: record)
 
         let query = RecordQuery(recordType: Session.self)
-        let chunk = try await database.read(matching: query, fields: ["build_number", "os_version", "locale", "channel"])
+        let chunk = try await database.read(
+            matching: query, fields: ["build_number", "os_version", "locale", "channel"])
         let read = try #require(chunk.records.first)
 
         #expect(read["build_number"] == "412")
@@ -228,7 +230,8 @@ struct SchemaBootstrapTests {
         )
 
         try await database.write(record: makeDeviceRecord(id: "d-1", model: "iPhone16,1"))
-        let chunk = try await database.read(matching: RecordQuery(recordType: Device.self), fields: ["device_id", "model"])
+        let chunk = try await database.read(
+            matching: RecordQuery(recordType: Device.self), fields: ["device_id", "model"])
         #expect(chunk.records.first?["model"] == "iPhone16,1")
     }
 }

--- a/Tests/ScoutTests/Stubs/Entries/SyncableEntry+Stub.swift
+++ b/Tests/ScoutTests/Stubs/Entries/SyncableEntry+Stub.swift
@@ -11,7 +11,9 @@ import CoreData
 
 extension SyncableEntry {
     @discardableResult
-    func seedDelivery(pending: Bool = true, attempts: Int16 = 0, for backendID: String, in context: NSManagedObjectContext) -> DeliveryEntry {
+    func seedDelivery(
+        pending: Bool = true, attempts: Int16 = 0, for backendID: String, in context: NSManagedObjectContext
+    ) -> DeliveryEntry {
         let entity = NSEntityDescription.entity(forEntityName: "DeliveryEntry", in: context)!
         let row = delivery(for: backendID) ?? DeliveryEntry(entity: entity, insertInto: context)
         row.backendID = backendID

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -65,7 +65,9 @@ final class DatabaseStub: DatabaseReader, @unchecked Sendable {
         RecordChunk(records: [], cursor: nil)
     }
 
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
         []
     }
 
@@ -137,7 +139,10 @@ extension Record {
         return record
     }
 
-    static func sessionStub(sessionID: UUID, launchID: UUID, installID: UUID, startDate: Date, osVersion: String? = nil, deviceID: UUID? = nil) -> Record {
+    static func sessionStub(
+        sessionID: UUID, launchID: UUID, installID: UUID, startDate: Date, osVersion: String? = nil,
+        deviceID: UUID? = nil
+    ) -> Record {
         var record = Session(
             startDate: startDate,
             endDate: nil,

--- a/Tests/ScoutTests/Stubs/Records/ServerStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/ServerStub.swift
@@ -25,7 +25,9 @@ final class ServerStub: DatabaseReader, @unchecked Sendable {
         activitySeries
     }
 
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
         metricsSeries
     }
 

--- a/Tests/ScoutTests/Transient/InMemoryContainer.swift
+++ b/Tests/ScoutTests/Transient/InMemoryContainer.swift
@@ -23,7 +23,9 @@ final class InMemoryContainer: NSPersistentContainer, @unchecked Sendable {
         self.persistentStoreDescriptions = [description]
     }
 
-    override func loadPersistentStores(completionHandler block: @escaping (NSPersistentStoreDescription, Error?) -> Void) {
+    override func loadPersistentStores(
+        completionHandler block: @escaping (NSPersistentStoreDescription, Error?) -> Void
+    ) {
         // Call completion with the injected error to simulate a failure.
         let description = persistentStoreDescriptions.first ?? NSPersistentStoreDescription()
         block(description, injectedError)

--- a/Tests/ScoutTests/Transient/InMemoryDatabase.swift
+++ b/Tests/ScoutTests/Transient/InMemoryDatabase.swift
@@ -59,7 +59,9 @@ final class InMemoryDatabase: DatabaseReader, RecordWriter, @unchecked Sendable 
 }
 
 extension InMemoryDatabase {
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
         []
     }
 

--- a/Tests/ScoutTests/UI/Analytics/Event/Param/Value/ParamValueTests.swift
+++ b/Tests/ScoutTests/UI/Analytics/Event/Param/Value/ParamValueTests.swift
@@ -58,7 +58,8 @@ struct ParamValueTests {
     @Test("ISO 8601 dates read as dates")
     func dates() {
         #expect(ParamValue(parsing: "2026-06-11T09:41:00Z") == .stringConvertible(.date("2026-06-11T09:41:00Z")))
-        #expect(ParamValue(parsing: "2026-06-09T18:25:43.511Z") == .stringConvertible(.date("2026-06-09T18:25:43.511Z")))
+        #expect(
+            ParamValue(parsing: "2026-06-09T18:25:43.511Z") == .stringConvertible(.date("2026-06-09T18:25:43.511Z")))
     }
 
     @Test("JSON objects become dictionaries with sorted keys")

--- a/Tests/ScoutTests/UI/Analytics/Event/Provider/EventQueryTests.swift
+++ b/Tests/ScoutTests/UI/Analytics/Event/Provider/EventQueryTests.swift
@@ -41,7 +41,9 @@ struct EventQueryTests {
         let sessionID = UUID()
         let filters = EventQuery(sessionID: sessionID).buildFilters()
 
-        #expect(filters.contains(RecordQuery.Filter(field: "session_id", op: .equals, value: .string(sessionID.uuidString))))
+        #expect(
+            filters.contains(RecordQuery.Filter(field: "session_id", op: .equals, value: .string(sessionID.uuidString)))
+        )
     }
 
     @Test("No session produces no session filter") func noSession() {
@@ -52,7 +54,8 @@ struct EventQueryTests {
         let deviceID = UUID()
         let filters = EventQuery(deviceID: deviceID).buildFilters()
 
-        #expect(filters.contains(RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))))
+        #expect(
+            filters.contains(RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))))
     }
 
     @Test("Filter by date range") func dates() {

--- a/Tests/ScoutTests/UI/Delivery/Devices/Export/DevicesExportTests.swift
+++ b/Tests/ScoutTests/UI/Delivery/Devices/Export/DevicesExportTests.swift
@@ -35,8 +35,12 @@ struct DevicesExportTests {
 
     @Test("Rows follow the newest-lastSeen-first order")
     func testDevicesExportOrdersByLastSeen() throws {
-        let older = DeviceSummary(id: UUID(), model: "iPhone14,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSince1970: 0), sessions: 1, crashes: 0)
-        let newer = DeviceSummary(id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSince1970: 3600), sessions: 1, crashes: 0)
+        let older = DeviceSummary(
+            id: UUID(), model: "iPhone14,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSince1970: 0),
+            sessions: 1, crashes: 0)
+        let newer = DeviceSummary(
+            id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSince1970: 3600),
+            sessions: 1, crashes: 0)
         let text = try #require(DevicesExport(devices: [older, newer]).text)
 
         let newerRange = try #require(text.range(of: "iPhone 14 Pro Max"))

--- a/Tests/ScoutTests/UI/Delivery/Devices/Model/DeviceSummaryTests.swift
+++ b/Tests/ScoutTests/UI/Delivery/Devices/Model/DeviceSummaryTests.swift
@@ -21,8 +21,12 @@ struct DeviceSummaryTests {
         let summaries = DeviceSummary.summaries(
             devices: [.deviceStub(deviceID: deviceID, date: older, model: "iPhone15,3")],
             sessions: [
-                .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: older, osVersion: "iOS 17.3", deviceID: deviceID),
-                .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: newer, osVersion: "iOS 17.4", deviceID: deviceID),
+                .sessionStub(
+                    sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: older, osVersion: "iOS 17.3",
+                    deviceID: deviceID),
+                .sessionStub(
+                    sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: newer, osVersion: "iOS 17.4",
+                    deviceID: deviceID),
             ],
             crashes: [.crashStub(deviceID: deviceID, date: newer)]
         )
@@ -55,7 +59,10 @@ struct DeviceSummaryTests {
 
         let summaries = DeviceSummary.summaries(
             devices: [.deviceStub(deviceID: deviceID, date: Date(), model: nil)],
-            sessions: [.sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: Date(), deviceID: deviceID)],
+            sessions: [
+                .sessionStub(
+                    sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: Date(), deviceID: deviceID)
+            ],
             crashes: []
         )
 
@@ -73,8 +80,10 @@ struct DeviceSummaryTests {
                 .deviceStub(deviceID: deviceB, date: Date(), model: "iPad13,1"),
             ],
             sessions: [
-                .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: Date(), deviceID: deviceA),
-                .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: Date(), deviceID: deviceB),
+                .sessionStub(
+                    sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: Date(), deviceID: deviceA),
+                .sessionStub(
+                    sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: Date(), deviceID: deviceB),
             ],
             crashes: [.crashStub(deviceID: deviceA, date: Date())]
         )

--- a/Tests/ScoutTests/UI/Delivery/Devices/View/DevicesProviderTests.swift
+++ b/Tests/ScoutTests/UI/Delivery/Devices/View/DevicesProviderTests.swift
@@ -23,8 +23,12 @@ struct DevicesProviderTests {
         database.add(
             .deviceStub(deviceID: deviceA, date: date, model: "iPhone15,3"),
             .deviceStub(deviceID: deviceB, date: date, model: "iPad13,1"),
-            .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: date, osVersion: "iOS 17.4", deviceID: deviceA),
-            .sessionStub(sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: date, osVersion: "iOS 17.2", deviceID: deviceB),
+            .sessionStub(
+                sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: date, osVersion: "iOS 17.4",
+                deviceID: deviceA),
+            .sessionStub(
+                sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: date, osVersion: "iOS 17.2",
+                deviceID: deviceB),
             .crashStub(deviceID: deviceA, date: date)
         )
 

--- a/Tests/ScoutTests/UI/Delivery/Releases/Health/ReleaseReportTests.swift
+++ b/Tests/ScoutTests/UI/Delivery/Releases/Health/ReleaseReportTests.swift
@@ -126,7 +126,9 @@ struct ReleaseReportTests {
     @Test("Releases are ordered newest version first, regardless of report order")
     func testSortedByVersion() {
         let releases = ReleaseMatrices(
-            sessions: [sessionMatrix("3.9", count: 1), sessionMatrix("3.10", count: 1), sessionMatrix("4.0", count: 1)],
+            sessions: [
+                sessionMatrix("3.9", count: 1), sessionMatrix("3.10", count: 1), sessionMatrix("4.0", count: 1),
+            ],
             crashes: [],
             hangs: [],
             installs: [],

--- a/Tests/ScoutTests/UI/Home/Section/Log/HomeLogProviderTests.swift
+++ b/Tests/ScoutTests/UI/Home/Section/Log/HomeLogProviderTests.swift
@@ -115,7 +115,9 @@ struct HomeLogProviderTests {
         #expect(provider.result != nil)
     }
 
-    private func makeRecord<T: MetricScalar>(name: String, category: String? = nil, date: Date = Date(), value: T) -> Record {
+    private func makeRecord<T: MetricScalar>(name: String, category: String? = nil, date: Date = Date(), value: T)
+        -> Record
+    {
         Matrix(
             date: date,
             name: name,

--- a/Tests/ScoutTests/UI/Home/Section/Log/MatrixSpanTests.swift
+++ b/Tests/ScoutTests/UI/Home/Section/Log/MatrixSpanTests.swift
@@ -86,7 +86,9 @@ struct MatrixSpanTests {
     }
 
     /// A one-cell matrix whose single point lands exactly on `date`.
-    private func makeMatrix<T: MetricScalar>(name: String, category: String? = nil, date: Date, value: T) -> GridMatrix<T> {
+    private func makeMatrix<T: MetricScalar>(name: String, category: String? = nil, date: Date, value: T) -> GridMatrix<
+        T
+    > {
         Matrix(
             date: date,
             name: name,

--- a/Tests/ScoutTests/UI/Home/Settings/BackendHealthTests.swift
+++ b/Tests/ScoutTests/UI/Home/Settings/BackendHealthTests.swift
@@ -89,6 +89,8 @@ struct BackendHealthTests {
 
 typealias StatusProbe = @Sendable () async -> Backend.Status
 
-func makeHealth(id: String = "backend", status: Backend.Status = .unknown, probe: @escaping StatusProbe = { .unknown }) -> BackendHealth {
+func makeHealth(id: String = "backend", status: Backend.Status = .unknown, probe: @escaping StatusProbe = { .unknown })
+    -> BackendHealth
+{
     BackendHealth(id: id, name: id, endpoint: id, engine: .server, status: status, probe: probe)
 }

--- a/Tests/ScoutTests/UI/Insights/Timeline/Export/ExportFormatTests.swift
+++ b/Tests/ScoutTests/UI/Insights/Timeline/Export/ExportFormatTests.swift
@@ -36,12 +36,15 @@ struct ExportFormatTests {
 
     @Test("Same-day ranges render the end bound as a bare time")
     func testSameDayRange() {
-        #expect(ExportFormat.range(from: TimelineFixture.baseDate, to: TimelineFixture.at(360)) == "2023-11-14 22:13–22:19")
+        #expect(
+            ExportFormat.range(from: TimelineFixture.baseDate, to: TimelineFixture.at(360)) == "2023-11-14 22:13–22:19")
     }
 
     @Test("Multi-day ranges repeat the date in the end bound")
     func testMultiDayRange() {
-        #expect(ExportFormat.range(from: TimelineFixture.baseDate, to: TimelineFixture.at(.day)) == "2023-11-14 22:13–2023-11-15 22:13")
+        #expect(
+            ExportFormat.range(from: TimelineFixture.baseDate, to: TimelineFixture.at(.day))
+                == "2023-11-14 22:13–2023-11-15 22:13")
     }
 
     @Test("Open ranges render as their start")

--- a/Tests/ScoutTests/UI/Insights/Timeline/Export/TimelineExportTests.swift
+++ b/Tests/ScoutTests/UI/Insights/Timeline/Export/TimelineExportTests.swift
@@ -25,7 +25,8 @@ struct TimelineExportTests {
     @Test("Renders the rail as a hierarchical Markdown document")
     func testDocument() throws {
         let session = SessionRoot(
-            session: .stub(sessionID: try uuid("DDDDDDDD"), startDate: TimelineFixture.at(40), endDate: TimelineFixture.at(400)),
+            session: .stub(
+                sessionID: try uuid("DDDDDDDD"), startDate: TimelineFixture.at(40), endDate: TimelineFixture.at(400)),
             events: [
                 .stub(name: "purchase_completed", date: TimelineFixture.at(160)),
                 .stub(name: "app_open", date: TimelineFixture.at(40)),
@@ -114,7 +115,9 @@ struct TimelineExportTests {
     @Test("Session ranges spanning days repeat the date in the end bound")
     func testMultiDayRange() throws {
         let session = SessionRoot(
-            session: .stub(sessionID: try uuid("DDDDDDDD"), startDate: TimelineFixture.at(40), endDate: TimelineFixture.at(40 + .day)),
+            session: .stub(
+                sessionID: try uuid("DDDDDDDD"), startDate: TimelineFixture.at(40),
+                endDate: TimelineFixture.at(40 + .day)),
             events: [],
             crashes: []
         )

--- a/Tests/ScoutTests/UI/Insights/Timeline/Pagination/RailLaneTests.swift
+++ b/Tests/ScoutTests/UI/Insights/Timeline/Pagination/RailLaneTests.swift
@@ -19,7 +19,8 @@ struct RailLaneTests {
     private func makeDatabase() -> DatabaseStub {
         let database = DatabaseStub()
         database.add(
-            .sessionStub(sessionID: sessionID, launchID: launchID, installID: installID, startDate: TimelineFixture.baseDate),
+            .sessionStub(
+                sessionID: sessionID, launchID: launchID, installID: installID, startDate: TimelineFixture.baseDate),
             .eventStub(name: "e", sessionID: sessionID, date: TimelineFixture.baseDate.addingTimeInterval(10))
         )
         return database

--- a/Tests/ScoutTests/UI/Insights/Timeline/Provider/TimelineProviderTests.swift
+++ b/Tests/ScoutTests/UI/Insights/Timeline/Provider/TimelineProviderTests.swift
@@ -22,8 +22,10 @@ struct TimelineProviderTests {
         database.add(
             .deviceStub(deviceID: deviceID, date: TimelineFixture.baseDate),
             .installStub(installID: installID, deviceID: deviceID, date: TimelineFixture.baseDate),
-            .launchStub(launchID: launchID, installID: installID, deviceID: deviceID, startDate: TimelineFixture.at(10)),
-            .sessionStub(sessionID: sessionID, launchID: launchID, installID: installID, startDate: TimelineFixture.at(20)),
+            .launchStub(
+                launchID: launchID, installID: installID, deviceID: deviceID, startDate: TimelineFixture.at(10)),
+            .sessionStub(
+                sessionID: sessionID, launchID: launchID, installID: installID, startDate: TimelineFixture.at(20)),
             .eventStub(name: "e", sessionID: sessionID, date: TimelineFixture.at(30))
         )
         return database

--- a/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentBreakdownProviderTests.swift
+++ b/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentBreakdownProviderTests.swift
@@ -42,9 +42,12 @@ struct IncidentBreakdownProviderTests {
 
         let database = DatabaseStub()
         database.add(
-            .sessionStub(sessionID: sessionA, launchID: UUID(), installID: UUID(), startDate: Date(), osVersion: "iOS 17.4"),
-            .sessionStub(sessionID: sessionB, launchID: UUID(), installID: UUID(), startDate: Date(), osVersion: "iOS 17.4"),
-            .sessionStub(sessionID: other, launchID: UUID(), installID: UUID(), startDate: Date(), osVersion: "iOS 16.7")
+            .sessionStub(
+                sessionID: sessionA, launchID: UUID(), installID: UUID(), startDate: Date(), osVersion: "iOS 17.4"),
+            .sessionStub(
+                sessionID: sessionB, launchID: UUID(), installID: UUID(), startDate: Date(), osVersion: "iOS 17.4"),
+            .sessionStub(
+                sessionID: other, launchID: UUID(), installID: UUID(), startDate: Date(), osVersion: "iOS 16.7")
         )
 
         let provider = IncidentBreakdownProvider(deviceIDs: [], sessionIDs: [sessionA, sessionB])

--- a/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentBreakdownTests.swift
+++ b/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentBreakdownTests.swift
@@ -31,7 +31,8 @@ struct IncidentBreakdownTests {
     @Test("Buckets everything past the top cutoff into Other")
     func bucketsIntoOther() {
         let labels =
-            Array(repeating: "A", count: 5) + Array(repeating: "B", count: 4) + Array(repeating: "C", count: 3) + Array(repeating: "D", count: 2)
+            Array(repeating: "A", count: 5) + Array(repeating: "B", count: 4) + Array(repeating: "C", count: 3)
+            + Array(repeating: "D", count: 2)
             + Array(repeating: "E", count: 1)
         let segments = IncidentBreakdown.segments(from: labels, top: 4)
 

--- a/Tests/ScoutTests/UI/Monitoring/Network/Model/NetworkReportTests.swift
+++ b/Tests/ScoutTests/UI/Monitoring/Network/Model/NetworkReportTests.swift
@@ -141,9 +141,13 @@ struct NetworkReportTests {
     @Test("isEmpty reflects endpoint presence")
     func isEmpty() {
         #expect(NetworkReport(series: []).isEmpty)
-        #expect(NetworkReport(series: [makeSeries(name: "plain_timer", category: "timer_le_1", points: [(base, 1)])]).isEmpty)
-        #expect(!NetworkReport(series: [makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 1)])]).isEmpty)
-        #expect(!NetworkReport(series: [makeSeries(name: "GET /a", category: "timer_le_1", points: [(base, 1)])]).isEmpty)
+        #expect(
+            NetworkReport(series: [makeSeries(name: "plain_timer", category: "timer_le_1", points: [(base, 1)])])
+                .isEmpty)
+        #expect(
+            !NetworkReport(series: [makeSeries(name: "GET /a", category: "status_2xx", points: [(base, 1)])]).isEmpty)
+        #expect(
+            !NetworkReport(series: [makeSeries(name: "GET /a", category: "timer_le_1", points: [(base, 1)])]).isEmpty)
     }
 
     private func makeSeries(name: String, category: String, points: [(Date, Int)]) -> MetricSeries {

--- a/Tests/ScoutTests/UI/Monitoring/Network/View/NetworkProviderTests.swift
+++ b/Tests/ScoutTests/UI/Monitoring/Network/View/NetworkProviderTests.swift
@@ -69,7 +69,9 @@ private final class CategoryDatabaseStub: DatabaseReader, @unchecked Sendable {
         []
     }
 
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
         series.filter { $0.category == category }
     }
 
@@ -89,7 +91,9 @@ private final class ThrowingDatabaseStub: DatabaseReader, @unchecked Sendable {
         throw Failure()
     }
 
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] {
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
         throw Failure()
     }
 

--- a/Tests/ScoutTests/UI/Provider/FeedProviderTests.swift
+++ b/Tests/ScoutTests/UI/Provider/FeedProviderTests.swift
@@ -72,8 +72,12 @@ private struct RefreshFailure: Error {}
 private final class FailingDatabase: DatabaseReader, @unchecked Sendable {
     func lookup(recordName: String, fields: [String]?) async throws -> Record { throw RefreshFailure() }
     func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk { throw RefreshFailure() }
-    func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk { throw RefreshFailure() }
+    func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
+        throw RefreshFailure()
+    }
     func readMore(from cursor: RecordCursor, fields: [String]?) async throws -> RecordChunk { throw RefreshFailure() }
-    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws -> [MetricSeries] { throw RefreshFailure() }
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    { throw RefreshFailure() }
     func activity(in range: Range<Date>) async throws -> [ActivityPoint] { throw RefreshFailure() }
 }


### PR DESCRIPTION
## Summary
- Lowers `lineLength` in `.swift-format` from 160 to 120
- Reformats all Sources/Tests files to comply, via `swift-format format --in-place --recursive`

## Test plan
- [x] `xcrun swift-format lint --recursive --configuration .swift-format Sources Tests` — 0 warnings
- [x] `xcodebuild -scheme Scout build` — BUILD SUCCEEDED
- [x] `xcodebuild -scheme Scout build-for-testing` — TEST BUILD SUCCEEDED