### PR TITLE
Pin scout-db to released 0.8.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
-        .package(url: "https://github.com/kasianov-mikhail/scout-db.git", branch: "fix-conflict-sendable"),
+        .package(url: "https://github.com/kasianov-mikhail/scout-db.git", from: "0.8.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
PR #880 was merged while its branch still pointed scout-db at the temporary fix-conflict-sendable branch used to verify the Swift 6.0 Sendable fix under Xcode 16.4. That branch has since been merged and deleted in scout-db, and the fix shipped as the 0.8.1 release, so main now references a branch that no longer exists. This pins the dependency to the released 0.8.1 tag.