### PR TITLE
Shorten the platform view-modifier names

### DIFF
--- a/Sources/Scout/UI/Analytics/Event/Filter/FilterView.swift
+++ b/Sources/Scout/UI/Analytics/Event/Filter/FilterView.swift
@@ -76,7 +76,7 @@ struct FilterButton: View {
         .sheet(isPresented: $isFilterPresented) {
             FilterView(selected: $levels)
                 .presentationHeight(440)
-                .opaquePresentationBackground()
+                .opaquePresentation()
         }
         .tint(.primary)
     }

--- a/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
@@ -55,7 +55,7 @@ struct ConnectionMenu: View {
                 connections = await connections.refreshingStatuses()
             }
             .popoverDropdown()
-            .opaquePresentationBackground()
+            .opaquePresentation()
         }
     }
 }

--- a/Sources/Scout/UI/Home/Settings/SettingsOverviewView.swift
+++ b/Sources/Scout/UI/Home/Settings/SettingsOverviewView.swift
@@ -56,7 +56,7 @@ struct SettingsOverviewView: View {
         .navigationTitle(en: "Settings")
         .message($message)
         .dismissable()
-        .opaquePresentationBackground()
+        .opaquePresentation()
         .task {
             await provider.refreshAll()
         }

--- a/Sources/Scout/UI/Insights/Chart/Export/ChartExportSheet.swift
+++ b/Sources/Scout/UI/Insights/Chart/Export/ChartExportSheet.swift
@@ -78,7 +78,7 @@ struct ChartExportSheet<ChartContent: View>: View {
             }
         }
         .listStyle(.plain)
-        .disabledScrollBounce()
+        .disabledBounce()
         .scrollContentBackground(.hidden)
         .background(.background)
         .safeAreaInset(edge: .bottom) {

--- a/Sources/Scout/UI/Primitives/Platform/View+DisabledBounce.swift
+++ b/Sources/Scout/UI/Primitives/Platform/View+DisabledBounce.swift
@@ -9,13 +9,14 @@
 import SwiftUI
 
 extension View {
-    /// Gives a sheet an opaque system background, overriding the translucent
-    /// material newer OS versions apply by default.
+    /// Stops a scroll view from bouncing when its content already fits, so a
+    /// non-scrolling list can't be pulled into an empty overscroll area — which
+    /// also blocks any pull-to-refresh inherited from a host view's environment.
     ///
     @ViewBuilder
-    func opaquePresentationBackground() -> some View {
+    func disabledBounce() -> some View {
         if #available(iOS 16.4, macOS 13.3, *) {
-            presentationBackground(.background)
+            scrollBounceBehavior(.basedOnSize)
         } else {
             self
         }

--- a/Sources/Scout/UI/Primitives/Platform/View+OpaquePresentation.swift
+++ b/Sources/Scout/UI/Primitives/Platform/View+OpaquePresentation.swift
@@ -9,14 +9,13 @@
 import SwiftUI
 
 extension View {
-    /// Stops a scroll view from bouncing when its content already fits, so a
-    /// non-scrolling list can't be pulled into an empty overscroll area — which
-    /// also blocks any pull-to-refresh inherited from a host view's environment.
+    /// Gives a sheet an opaque system background, overriding the translucent
+    /// material newer OS versions apply by default.
     ///
     @ViewBuilder
-    func disabledScrollBounce() -> some View {
+    func opaquePresentation() -> some View {
         if #available(iOS 16.4, macOS 13.3, *) {
-            scrollBounceBehavior(.basedOnSize)
+            presentationBackground(.background)
         } else {
             self
         }


### PR DESCRIPTION
Renames the two platform-shim view modifiers to shorter names and renames their files to match: `opaquePresentationBackground()` becomes `opaquePresentation()` and `disabledScrollBounce()` becomes `disabledBounce()`. Updates every call site accordingly. No behavior change.