### PR TITLE
Add a Scout vs Firebase vs custom backend comparison to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 
 How Scout compares to a hosted analytics SDK and to rolling your own backend:
 
+✅ strength &nbsp; ⚠️ trade-off &nbsp; ❌ cost or burden
+
 | | **Scout (CloudKit)** | **Firebase** | **Custom backend** |
 |-|-|-|-|
-| **Cost** | Free within [CloudKit's limits](https://developer.apple.com/icloud/cloudkit/) — no servers to pay for, and the quota grows with your app | Free tier, then metered [Blaze](https://firebase.google.com/pricing) billing as reads and traffic grow | Servers, database, and bandwidth billed from day one |
-| **Data privacy** | Data stays in your own CloudKit container on Apple's infrastructure — no third-party analytics vendor, and Apple doesn't mine it for advertising | Data lives on Google's servers and can be linked across its ad and analytics products | You control everything — and carry all the responsibility for securing it |
-| **Infrastructure** | Zero servers — Apple runs the backend | Managed by Google, with vendor lock-in | You deploy and maintain it yourself |
-| **Scaling** | Automatic, within the container quota | Automatic, but the bill scales too | Manual — you provision and pay for capacity |
-| **Setup** | Already included with your Apple Developer account | New project, SDK, and API keys | Build the API, schema, and deployment |
+| **Cost** | ✅ Free within [CloudKit's limits](https://developer.apple.com/icloud/cloudkit/) — no servers to pay for, and the quota grows with your app | ⚠️ Free tier, then metered [Blaze](https://firebase.google.com/pricing) billing as reads and traffic grow | ❌ Servers, database, and bandwidth billed from day one |
+| **Data privacy** | ✅ Data stays in your own CloudKit container on Apple's infrastructure — no third-party analytics vendor, and Apple doesn't mine it for advertising | ❌ Data lives on Google's servers and can be linked across its ad and analytics products | ⚠️ You control everything — and carry all the responsibility for securing it |
+| **Infrastructure** | ✅ Zero servers — Apple runs the backend | ⚠️ Managed by Google, with vendor lock-in | ❌ You deploy and maintain it yourself |
+| **Scaling** | ✅ Automatic, within the container quota | ⚠️ Automatic, but the bill scales too | ❌ Manual — you provision and pay for capacity |
+| **Setup** | ✅ Already included with your Apple Developer account | ⚠️ New project, SDK, and API keys | ❌ Build the API, schema, and deployment |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 
 How Scout compares to a hosted analytics SDK and to rolling your own backend:
 
-✅ strength &nbsp; ⚠️ trade-off &nbsp; ❌ cost or burden
+🟢 strength &nbsp; 🟡 trade-off &nbsp; 🔴 cost or burden
 
 | | **Scout (CloudKit)**<br><img width="255" height="1" src="https://placehold.co/255x1/ffffff00/ffffff00.png"> | **Firebase**<br><img width="255" height="1" src="https://placehold.co/255x1/ffffff00/ffffff00.png"> | **Custom backend**<br><img width="255" height="1" src="https://placehold.co/255x1/ffffff00/ffffff00.png"> |
 |-|-|-|-|
-| **Cost** | ✅ Free within [CloudKit's limits](https://developer.apple.com/icloud/cloudkit/) — no servers to pay for, and the quota grows with your app | ⚠️ Free tier, then metered [Blaze](https://firebase.google.com/pricing) billing as reads and traffic grow | ❌ Servers, database, and bandwidth billed from day one |
-| **Data privacy** | ✅ Data stays in your own CloudKit container on Apple's infrastructure — no third-party analytics vendor, and Apple doesn't mine it for advertising | ❌ Data lives on Google's servers and can be linked across its ad and analytics products | ⚠️ You control everything — and carry all the responsibility for securing it |
-| **Infrastructure** | ✅ Zero servers — Apple runs the backend | ⚠️ Managed by Google, with vendor lock-in | ❌ You deploy and maintain it yourself |
-| **Scaling** | ✅ Automatic, within the container quota | ⚠️ Automatic, but the bill scales too | ❌ Manual — you provision and pay for capacity |
-| **Setup** | ✅ Already included with your Apple Developer account | ⚠️ New project, SDK, and API keys | ❌ Build the API, schema, and deployment |
+| **Cost** | 🟢<br>Free within [CloudKit's limits](https://developer.apple.com/icloud/cloudkit/) — no servers to pay for, and the quota grows with your app | 🟡<br>Free tier, then metered [Blaze](https://firebase.google.com/pricing) billing as reads and traffic grow | 🔴<br>Servers, database, and bandwidth billed from day one |
+| **Data privacy** | 🟢<br>Data stays in your own CloudKit container on Apple's infrastructure — no third-party analytics vendor, and Apple doesn't mine it for advertising | 🔴<br>Data lives on Google's servers and can be linked across its ad and analytics products | 🟡<br>You control everything — and carry all the responsibility for securing it |
+| **Infrastructure** | 🟢<br>Zero servers — Apple runs the backend | 🟡<br>Managed by Google, with vendor lock-in | 🔴<br>You deploy and maintain it yourself |
+| **Scaling** | 🟢<br>Automatic, within the container quota | 🟡<br>Automatic, but the bill scales too | 🔴<br>Manual — you provision and pay for capacity |
+| **Setup** | 🟢<br>Already included with your Apple Developer account | 🟡<br>New project, SDK, and API keys | 🔴<br>Build the API, schema, and deployment |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ How Scout compares to a hosted analytics SDK and to rolling your own backend:
 
 ✅ strength &nbsp; ⚠️ trade-off &nbsp; ❌ cost or burden
 
-| | **Scout (CloudKit)** | **Firebase** | **Custom backend** |
+| | **Scout (CloudKit)**<br><img width="220" height="1" src="https://placehold.co/220x1/ffffff00/ffffff00.png"> | **Firebase**<br><img width="220" height="1" src="https://placehold.co/220x1/ffffff00/ffffff00.png"> | **Custom backend**<br><img width="220" height="1" src="https://placehold.co/220x1/ffffff00/ffffff00.png"> |
 |-|-|-|-|
 | **Cost** | ✅ Free within [CloudKit's limits](https://developer.apple.com/icloud/cloudkit/) — no servers to pay for, and the quota grows with your app | ⚠️ Free tier, then metered [Blaze](https://firebase.google.com/pricing) billing as reads and traffic grow | ❌ Servers, database, and bandwidth billed from day one |
 | **Data privacy** | ✅ Data stays in your own CloudKit container on Apple's infrastructure — no third-party analytics vendor, and Apple doesn't mine it for advertising | ❌ Data lives on Google's servers and can be linked across its ad and analytics products | ⚠️ You control everything — and carry all the responsibility for securing it |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 
 ## Table of Contents
 - [Features](#features)
+- [Comparison](#comparison)
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Usage](#usage)
@@ -29,6 +30,18 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 | ☁️ | **CloudKit Sync** | All data is stored locally with Core Data and synced to a public [CloudKit](https://developer.apple.com/icloud/cloudkit/) database. No custom backend required. |
 | 🌐 | **Multiple Backends** | Sync to CloudKit, to one or more self-hosted [Scout servers](https://github.com/kasianov-mikhail/scout-server), or to any combination of them at once. |
 | 📱 | **SwiftUI Dashboard** | A built-in dashboard with charts, event lists, crash details, and activity tracking for debugging in development builds. |
+
+## Comparison
+
+How Scout compares to a hosted analytics SDK and to rolling your own backend:
+
+| | **Scout (CloudKit)** | **Firebase** | **Custom backend** |
+|-|-|-|-|
+| **Cost** | Free within [CloudKit's limits](https://developer.apple.com/icloud/cloudkit/) — no servers to pay for, and the quota grows with your app | Free tier, then metered [Blaze](https://firebase.google.com/pricing) billing as reads and traffic grow | Servers, database, and bandwidth billed from day one |
+| **Data privacy** | Data stays in your own CloudKit container on Apple's infrastructure — no third-party analytics vendor, and Apple doesn't mine it for advertising | Data lives on Google's servers and can be linked across its ad and analytics products | You control everything — and carry all the responsibility for securing it |
+| **Infrastructure** | Zero servers — Apple runs the backend | Managed by Google, with vendor lock-in | You deploy and maintain it yourself |
+| **Scaling** | Automatic, within the container quota | Automatic, but the bill scales too | Manual — you provision and pay for capacity |
+| **Setup** | Already included with your Apple Developer account | New project, SDK, and API keys | Build the API, schema, and deployment |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 
 How Scout compares to a hosted analytics SDK and to rolling your own backend:
 
-🟢 strength &nbsp; 🟡 trade-off &nbsp; 🔴 cost or burden
+![strength](https://img.shields.io/badge/strength-brightgreen?style=flat-square) &nbsp; ![trade-off](https://img.shields.io/badge/trade--off-yellow?style=flat-square) &nbsp; ![cost or burden](https://img.shields.io/badge/cost_or_burden-red?style=flat-square)
 
 | | **Scout (CloudKit)**<br><img width="255" height="1" src="https://placehold.co/255x1/ffffff00/ffffff00.png"> | **Firebase**<br><img width="255" height="1" src="https://placehold.co/255x1/ffffff00/ffffff00.png"> | **Custom backend**<br><img width="255" height="1" src="https://placehold.co/255x1/ffffff00/ffffff00.png"> |
 |-|-|-|-|
-| **Cost** | 🟢<br>Free within [CloudKit's limits](https://developer.apple.com/icloud/cloudkit/) — no servers to pay for, and the quota grows with your app | 🟡<br>Free tier, then metered [Blaze](https://firebase.google.com/pricing) billing as reads and traffic grow | 🔴<br>Servers, database, and bandwidth billed from day one |
-| **Data privacy** | 🟢<br>Data stays in your own CloudKit container on Apple's infrastructure — no third-party analytics vendor, and Apple doesn't mine it for advertising | 🔴<br>Data lives on Google's servers and can be linked across its ad and analytics products | 🟡<br>You control everything — and carry all the responsibility for securing it |
-| **Infrastructure** | 🟢<br>Zero servers — Apple runs the backend | 🟡<br>Managed by Google, with vendor lock-in | 🔴<br>You deploy and maintain it yourself |
-| **Scaling** | 🟢<br>Automatic, within the container quota | 🟡<br>Automatic, but the bill scales too | 🔴<br>Manual — you provision and pay for capacity |
-| **Setup** | 🟢<br>Already included with your Apple Developer account | 🟡<br>New project, SDK, and API keys | 🔴<br>Build the API, schema, and deployment |
+| **Cost** | ![Free](https://img.shields.io/badge/Free-brightgreen?style=flat-square)<br>Free within [CloudKit's limits](https://developer.apple.com/icloud/cloudkit/) — no servers to pay for, and the quota grows with your app | ![Metered](https://img.shields.io/badge/Metered-yellow?style=flat-square)<br>Free tier, then metered [Blaze](https://firebase.google.com/pricing) billing as reads and traffic grow | ![Paid](https://img.shields.io/badge/Paid-red?style=flat-square)<br>Servers, database, and bandwidth billed from day one |
+| **Data privacy** | ![Private](https://img.shields.io/badge/Private-brightgreen?style=flat-square)<br>Data stays in your own CloudKit container on Apple's infrastructure — no third-party analytics vendor, and Apple doesn't mine it for advertising | ![Vendor-owned](https://img.shields.io/badge/Vendor--owned-red?style=flat-square)<br>Data lives on Google's servers and can be linked across its ad and analytics products | ![Your responsibility](https://img.shields.io/badge/Your_responsibility-yellow?style=flat-square)<br>You control everything — and carry all the responsibility for securing it |
+| **Infrastructure** | ![Serverless](https://img.shields.io/badge/Serverless-brightgreen?style=flat-square)<br>Zero servers — Apple runs the backend | ![Managed](https://img.shields.io/badge/Managed-yellow?style=flat-square)<br>Managed by Google, with vendor lock-in | ![Self-hosted](https://img.shields.io/badge/Self--hosted-red?style=flat-square)<br>You deploy and maintain it yourself |
+| **Scaling** | ![Automatic](https://img.shields.io/badge/Automatic-brightgreen?style=flat-square)<br>Automatic, within the container quota | ![Metered](https://img.shields.io/badge/Metered-yellow?style=flat-square)<br>Automatic, but the bill scales too | ![Manual](https://img.shields.io/badge/Manual-red?style=flat-square)<br>Manual — you provision and pay for capacity |
+| **Setup** | ![Built-in](https://img.shields.io/badge/Built--in-brightgreen?style=flat-square)<br>Already included with your Apple Developer account | ![Setup needed](https://img.shields.io/badge/Setup_needed-yellow?style=flat-square)<br>New project, SDK, and API keys | ![Build it](https://img.shields.io/badge/Build_it-red?style=flat-square)<br>Build the API, schema, and deployment |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ How Scout compares to a hosted analytics SDK and to rolling your own backend:
 
 ✅ strength &nbsp; ⚠️ trade-off &nbsp; ❌ cost or burden
 
-| | **Scout (CloudKit)**<br><img width="220" height="1" src="https://placehold.co/220x1/ffffff00/ffffff00.png"> | **Firebase**<br><img width="220" height="1" src="https://placehold.co/220x1/ffffff00/ffffff00.png"> | **Custom backend**<br><img width="220" height="1" src="https://placehold.co/220x1/ffffff00/ffffff00.png"> |
+| | **Scout (CloudKit)**<br><img width="255" height="1" src="https://placehold.co/255x1/ffffff00/ffffff00.png"> | **Firebase**<br><img width="255" height="1" src="https://placehold.co/255x1/ffffff00/ffffff00.png"> | **Custom backend**<br><img width="255" height="1" src="https://placehold.co/255x1/ffffff00/ffffff00.png"> |
 |-|-|-|-|
 | **Cost** | ✅ Free within [CloudKit's limits](https://developer.apple.com/icloud/cloudkit/) — no servers to pay for, and the quota grows with your app | ⚠️ Free tier, then metered [Blaze](https://firebase.google.com/pricing) billing as reads and traffic grow | ❌ Servers, database, and bandwidth billed from day one |
 | **Data privacy** | ✅ Data stays in your own CloudKit container on Apple's infrastructure — no third-party analytics vendor, and Apple doesn't mine it for advertising | ❌ Data lives on Google's servers and can be linked across its ad and analytics products | ⚠️ You control everything — and carry all the responsibility for securing it |


### PR DESCRIPTION
Adds a Comparison section to the README, positioned right after Features, contrasting Scout with a hosted analytics SDK (Firebase) and a self-hosted backend. It highlights the two main selling points — cost (CloudKit is free within its limits, no servers to run) and data privacy (analytics stay in your own CloudKit container on Apple's infrastructure, with no third-party ad-tech vendor). The privacy wording matches how Scout actually stores data — the public database of your own container, not a per-user private database. Table of Contents gets a matching entry.