### PR TITLE
Add a roadmap section and move requirements into the installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 - [Comparison](#comparison)
 - [Dashboard](#dashboard)
 - [Installation](#installation)
-- [Roadmap — option 1: table](#roadmap--option-1-table)
-- [Roadmap — option 2: checkboxes](#roadmap--option-2-checkboxes)
-- [Roadmap — option 3: status badges](#roadmap--option-3-status-badges)
+- [Roadmap](#roadmap)
 - [License](#license)
 
 ## Features
@@ -84,49 +82,16 @@ The built-in SwiftUI dashboard lets you inspect logs, metrics, and crash reports
 
 To add the package and set up CloudKit, see the [Installation Guide](docs/INSTALLATION.md).
 
-## Roadmap — option 1: table
+## Roadmap
 
 What's being worked on next, roughly in the order it's planned:
 
 | | | |
 |:-:|-|-|
-| 🚧 | **Hosted Scout** | A managed instance of [scout-server](https://github.com/kasianov-mikhail/scout-server) — point the SDK at a URL and skip both CloudKit setup and self-hosting. *In progress.* |
-| 🤖 | **AI tools** | An MCP server over the Scout backend so an agent can query events, dig into a crash, and answer questions about your app's telemetry. |
-| 🌍 | **More platforms** | Extend the SDK beyond iOS to macOS, watchOS, tvOS, and visionOS — one framework across every Apple platform your app ships on. |
+| 🚧 | **Hosted&nbsp;Scout**<br>*(in&nbsp;progress)* | A managed instance of [scout-server](https://github.com/kasianov-mikhail/scout-server) — point the SDK at a URL and skip both CloudKit setup and self-hosting. |
+| 🤖 | **AI&nbsp;tools** | An MCP server over the Scout backend so an agent can query events, dig into a crash, and answer questions about your app's telemetry. |
+| 🌍 | **More&nbsp;platforms** | Extend the SDK beyond iOS to macOS, watchOS, tvOS, and visionOS — one framework across every Apple platform your app ships on. |
 | 🔌 | **OpenTelemetry** | Speak [OTLP](https://opentelemetry.io) so Scout can feed any observability stack, and any OTel-instrumented service can feed Scout. |
-
-Have an idea, or want one of these sooner? Open an [issue](https://github.com/kasianov-mikhail/scout/issues).
-
-## Roadmap — option 2: checkboxes
-
-What's being worked on next, roughly in the order it's planned:
-
-- [ ] 🚧 **Hosted Scout** *(in progress)* — a managed instance of [scout-server](https://github.com/kasianov-mikhail/scout-server): point the SDK at a URL and skip both CloudKit setup and self-hosting.
-- [ ] **AI tools** — an MCP server over the Scout backend, so an agent can query events, dig into a crash, and answer questions about your app's telemetry.
-- [ ] **More platforms** — extend the SDK beyond iOS to macOS, watchOS, tvOS, and visionOS: one framework across every Apple platform your app ships on.
-- [ ] **OpenTelemetry** — speak [OTLP](https://opentelemetry.io), so Scout can feed any observability stack and any OTel-instrumented service can feed Scout.
-
-Have an idea, or want one of these sooner? Open an [issue](https://github.com/kasianov-mikhail/scout/issues).
-
-## Roadmap — option 3: status badges
-
-What's being worked on next, roughly in the order it's planned:
-
-#### ![In progress](https://img.shields.io/badge/In_progress-yellow?style=flat-square) Hosted Scout
-
-A managed instance of [scout-server](https://github.com/kasianov-mikhail/scout-server) — point the SDK at a URL and skip both CloudKit setup and self-hosting.
-
-#### ![Planned](https://img.shields.io/badge/Planned-lightgrey?style=flat-square) AI tools
-
-An MCP server over the Scout backend, so an agent can query events, dig into a crash, and answer questions about your app's telemetry.
-
-#### ![Planned](https://img.shields.io/badge/Planned-lightgrey?style=flat-square) More platforms
-
-Extend the SDK beyond iOS to macOS, watchOS, tvOS, and visionOS — one framework across every Apple platform your app ships on.
-
-#### ![Planned](https://img.shields.io/badge/Planned-lightgrey?style=flat-square) OpenTelemetry
-
-Speak [OTLP](https://opentelemetry.io) so Scout can feed any observability stack, and any OTel-instrumented service can feed Scout.
 
 Have an idea, or want one of these sooner? Open an [issue](https://github.com/kasianov-mikhail/scout/issues).
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Scout is an iOS logging and analytics framework backed by CloudKit. It collects 
 - [Features](#features)
 - [Comparison](#comparison)
 - [Dashboard](#dashboard)
-- [Requirements](#requirements)
 - [Installation](#installation)
+- [Roadmap — option 1: table](#roadmap--option-1-table)
+- [Roadmap — option 2: checkboxes](#roadmap--option-2-checkboxes)
+- [Roadmap — option 3: status badges](#roadmap--option-3-status-badges)
 - [License](#license)
 
 ## Features
@@ -78,15 +80,55 @@ The built-in SwiftUI dashboard lets you inspect logs, metrics, and crash reports
 
 <img width="200" src="https://github.com/user-attachments/assets/0987c808-6d08-4e99-8ca7-1218d352e0bf"> <img width="200" src="https://github.com/user-attachments/assets/a70ae4d9-3680-48d3-8129-2febdc466030"> <img width="200" src="https://github.com/user-attachments/assets/6043911e-fd0b-4f6e-9785-c262dab1c6d7"> <img width="200" src="https://github.com/user-attachments/assets/dcec26e1-4e44-473c-b2e9-cde8ea2ffe2f">
 
-## Requirements
-
-- iOS 16.0+
-- Swift 6.0+
-- [Apple Developer](https://developer.apple.com) account with [CloudKit](https://developer.apple.com/icloud/cloudkit/) enabled
-
 ## Installation
 
 To add the package and set up CloudKit, see the [Installation Guide](docs/INSTALLATION.md).
+
+## Roadmap — option 1: table
+
+What's being worked on next, roughly in the order it's planned:
+
+| | | |
+|:-:|-|-|
+| 🚧 | **Hosted Scout** | A managed instance of [scout-server](https://github.com/kasianov-mikhail/scout-server) — point the SDK at a URL and skip both CloudKit setup and self-hosting. *In progress.* |
+| 🤖 | **AI tools** | An MCP server over the Scout backend so an agent can query events, dig into a crash, and answer questions about your app's telemetry. |
+| 🌍 | **More platforms** | Extend the SDK beyond iOS to macOS, watchOS, tvOS, and visionOS — one framework across every Apple platform your app ships on. |
+| 🔌 | **OpenTelemetry** | Speak [OTLP](https://opentelemetry.io) so Scout can feed any observability stack, and any OTel-instrumented service can feed Scout. |
+
+Have an idea, or want one of these sooner? Open an [issue](https://github.com/kasianov-mikhail/scout/issues).
+
+## Roadmap — option 2: checkboxes
+
+What's being worked on next, roughly in the order it's planned:
+
+- [ ] 🚧 **Hosted Scout** *(in progress)* — a managed instance of [scout-server](https://github.com/kasianov-mikhail/scout-server): point the SDK at a URL and skip both CloudKit setup and self-hosting.
+- [ ] **AI tools** — an MCP server over the Scout backend, so an agent can query events, dig into a crash, and answer questions about your app's telemetry.
+- [ ] **More platforms** — extend the SDK beyond iOS to macOS, watchOS, tvOS, and visionOS: one framework across every Apple platform your app ships on.
+- [ ] **OpenTelemetry** — speak [OTLP](https://opentelemetry.io), so Scout can feed any observability stack and any OTel-instrumented service can feed Scout.
+
+Have an idea, or want one of these sooner? Open an [issue](https://github.com/kasianov-mikhail/scout/issues).
+
+## Roadmap — option 3: status badges
+
+What's being worked on next, roughly in the order it's planned:
+
+#### ![In progress](https://img.shields.io/badge/In_progress-yellow?style=flat-square) Hosted Scout
+
+A managed instance of [scout-server](https://github.com/kasianov-mikhail/scout-server) — point the SDK at a URL and skip both CloudKit setup and self-hosting.
+
+#### ![Planned](https://img.shields.io/badge/Planned-lightgrey?style=flat-square) AI tools
+
+An MCP server over the Scout backend, so an agent can query events, dig into a crash, and answer questions about your app's telemetry.
+
+#### ![Planned](https://img.shields.io/badge/Planned-lightgrey?style=flat-square) More platforms
+
+Extend the SDK beyond iOS to macOS, watchOS, tvOS, and visionOS — one framework across every Apple platform your app ships on.
+
+#### ![Planned](https://img.shields.io/badge/Planned-lightgrey?style=flat-square) OpenTelemetry
+
+Speak [OTLP](https://opentelemetry.io) so Scout can feed any observability stack, and any OTel-instrumented service can feed Scout.
+
+Have an idea, or want one of these sooner? Open an [issue](https://github.com/kasianov-mikhail/scout/issues).
 
 ## License
 Scout is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -84,13 +84,11 @@ To add the package and set up CloudKit, see the [Installation Guide](docs/INSTAL
 
 ## Roadmap
 
-What's being worked on next, roughly in the order it's planned:
-
 | | | |
 |:-:|-|-|
 | 🚧 | **Hosted&nbsp;Scout**<br>*(in&nbsp;progress)* | A managed instance of [scout-server](https://github.com/kasianov-mikhail/scout-server) — point the SDK at a URL and skip both CloudKit setup and self-hosting. |
 | 🤖 | **AI&nbsp;tools** | An MCP server over the Scout backend so an agent can query events, dig into a crash, and answer questions about your app's telemetry. |
-| 🌍 | **More&nbsp;platforms** | Extend the SDK beyond iOS to macOS, watchOS, tvOS, and visionOS — one framework across every Apple platform your app ships on. |
+| 🌍 | **More&nbsp;platforms** | Extend the SDK beyond iOS to macOS, watchOS, tvOS, and visionOS — one framework across every Apple platform. |
 | 🔌 | **OpenTelemetry** | Speak [OTLP](https://opentelemetry.io) so Scout can feed any observability stack, and any OTel-instrumented service can feed Scout. |
 
 Have an idea, or want one of these sooner? Open an [issue](https://github.com/kasianov-mikhail/scout/issues).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,5 +1,11 @@
 # Installation
 
+## Requirements
+
+- iOS 16.0+
+- Swift 6.0+
+- [Apple Developer](https://developer.apple.com) account with [CloudKit](https://developer.apple.com/icloud/cloudkit/) enabled
+
 ## Enable CloudKit
 
 Ensure CloudKit is enabled in your Apple Developer account and configured for your project. Refer to [Enabling CloudKit in Your App](https://developer.apple.com/documentation/cloudkit/enabling_cloudkit_in_your_app).


### PR DESCRIPTION
Adds a Roadmap section to the README, placed after Installation, covering the four things planned next: hosted Scout (in progress), AI tools over the backend, extending the SDK to the other Apple platforms, and OpenTelemetry support. It's laid out as a table, matching the Features section, with the in-progress marker sitting under the entry's title.

Requirements moves out of the README and into `docs/INSTALLATION.md`, where it now opens the guide — right before the CloudKit setup steps that depend on it.