### PR TITLE
Draw loading and empty chart states in MetricCard

### DIFF
--- a/Sources/Scout/UI/Delivery/Releases/View/ReleaseRow.swift
+++ b/Sources/Scout/UI/Delivery/Releases/View/ReleaseRow.swift
@@ -89,21 +89,6 @@ private struct ReleasePercent: View {
     }
 }
 
-#if os(macOS)
-    import AppKit
-
-    extension NSColor {
-        // Stand-in for the iOS-only tiered system gray, matching its light and dark values.
-        fileprivate static var systemGray5: NSColor {
-            NSColor(name: nil) { appearance in
-                appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                    ? NSColor(red: 44 / 255, green: 44 / 255, blue: 46 / 255, alpha: 1)
-                    : NSColor(red: 229 / 255, green: 229 / 255, blue: 234 / 255, alpha: 1)
-            }
-        }
-    }
-#endif
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Insights/Chart/Model/MiniChartSeries.swift
+++ b/Sources/Scout/UI/Insights/Chart/Model/MiniChartSeries.swift
@@ -64,4 +64,7 @@ extension MiniChartSeries {
 extension MiniChartSeries {
     /// A gentle wave drawn under redaction while the real series loads.
     static let placeholder = MiniChartSeries(values: [3, 5, 4, 6, 5, 7, 6])
+
+    /// No slices at all: a chart with nothing but its gridlines.
+    static let empty = MiniChartSeries(values: [])
 }

--- a/Sources/Scout/UI/Insights/Chart/View/MiniChart.swift
+++ b/Sources/Scout/UI/Insights/Chart/View/MiniChart.swift
@@ -57,21 +57,6 @@ struct MiniChart: View {
     }
 }
 
-#if os(macOS)
-    import AppKit
-
-    extension NSColor {
-        // Stand-in for the iOS-only tiered system gray, matching its light and dark values.
-        fileprivate static var systemGray3: NSColor {
-            NSColor(name: nil) { appearance in
-                appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                    ? NSColor(red: 72 / 255, green: 72 / 255, blue: 74 / 255, alpha: 1)
-                    : NSColor(red: 199 / 255, green: 199 / 255, blue: 204 / 255, alpha: 1)
-            }
-        }
-    }
-#endif
-
 #Preview {
     NavigationStack {
         List {

--- a/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
+++ b/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
@@ -34,21 +34,27 @@ struct MetricCard: View {
 
             if let series = summary?.series {
                 Sparkline(series: series, color: color)
+            } else if summary != nil {
+                Sparkline(series: .placeholder, color: Color(.systemGray3)).redacted(reason: .placeholder)
             } else {
-                Color.clear
+                Sparkline(series: .empty, color: color)
             }
         }
     }
 }
 
-#Preview {
-    HStack(spacing: 24) {
-        MetricCard(
-            summary: MetricSummary(count: 8420, previous: 7500, values: [3, 5, 4, 7, 6, 9, 12]),
-            color: .purple
-        )
+#Preview("MetricCard") {
+    VStack(spacing: 24) {
+        let summary = MetricSummary(count: 8420, previous: 7500, values: [3, 5, 4, 7, 6, 9, 12])
+
+        MetricCard(summary: summary, color: .purple)
+            .frame(width: 162, height: 100)
+
         MetricCard(summary: .loading, color: .green)
+            .frame(width: 162, height: 100)
+
         MetricCard(summary: nil, color: .green)
+            .frame(width: 162, height: 100)
     }
     .padding()
 }

--- a/Sources/Scout/UI/Primitives/Platform/NSColor+macOS.swift
+++ b/Sources/Scout/UI/Primitives/Platform/NSColor+macOS.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#if os(macOS)
+    import AppKit
+
+    // Stand-ins for the iOS-only tiered system grays, matching their light and dark values.
+    extension NSColor {
+        static var systemGray3: NSColor {
+            NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                    ? NSColor(red: 72 / 255, green: 72 / 255, blue: 74 / 255, alpha: 1)
+                    : NSColor(red: 199 / 255, green: 199 / 255, blue: 204 / 255, alpha: 1)
+            }
+        }
+
+        static var systemGray5: NSColor {
+            NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                    ? NSColor(red: 44 / 255, green: 44 / 255, blue: 46 / 255, alpha: 1)
+                    : NSColor(red: 229 / 255, green: 229 / 255, blue: 234 / 255, alpha: 1)
+            }
+        }
+    }
+#endif


### PR DESCRIPTION
MetricCard left the chart area blank whenever it had no series, so a card looked half-empty both while loading and when there was nothing to show. Loading now draws the same redacted placeholder sparkline the release rows already use, and the empty state keeps the chart's gridlines so the card holds its shape. The preview covers all three states side by side at a fixed card size.

Along the way the macOS stand-ins for the iOS-only system grays turned out to be duplicated in MiniChart and ReleaseRow, so they move into a shared Platform file rather than gaining a third copy.