### PR TITLE
Read a missing DAU level as zero instead of loading

### DIFF
--- a/Sources/Scout/UI/Insights/Chart/Model/MetricSummary.swift
+++ b/Sources/Scout/UI/Insights/Chart/Model/MetricSummary.swift
@@ -26,13 +26,11 @@ extension MetricSummary {
     }
 
     init(levels: [ChartPoint<Int>], period: some ChartTimeScale) {
-        let current = levels.latest(in: period.initialRange)
-        let previous = levels.latest(in: period.previousRange)
+        let current = levels.latest(in: period.initialRange) ?? 0
+        let previous = levels.latest(in: period.previousRange) ?? 0
 
         count = current
-        delta = current.flatMap { current in
-            previous.flatMap { Delta(current: current, previous: $0) }
-        }
+        delta = Delta(current: current, previous: previous)
         series = MiniChartSeries(points: levels, range: period.initialRange, aggregation: .latest)
     }
 

--- a/Tests/ScoutTests/UI/Insights/Chart/Model/MetricSummaryTests.swift
+++ b/Tests/ScoutTests/UI/Insights/Chart/Model/MetricSummaryTests.swift
@@ -52,12 +52,21 @@ struct MetricSummaryTests {
         #expect(try #require(summary.delta).formatted == "+33%")
     }
 
-    @Test("Levels outside the window leave nothing to show")
+    @Test("Levels outside the window read as a zero level, not as loading")
     func levelsOutsideWindow() {
         let summary = MetricSummary(levels: [makePoint(day: 1, hour: 0, count: 100)], period: scale)
 
-        #expect(summary.count == nil)
+        #expect(summary.count == 0)
         #expect(summary.delta == nil)
+    }
+
+    @Test("An empty level series reads as a zero level, not as loading")
+    func emptyLevels() throws {
+        let summary = MetricSummary(levels: [], period: scale)
+
+        #expect(summary.count == 0)
+        #expect(summary.delta == nil)
+        #expect(try #require(summary.series).values.allSatisfy { $0 == .zero })
     }
 
     @Test("Distinct counts pass their slices through untouched")


### PR DESCRIPTION
On an empty database the DAU card stayed in its loading state forever. The fetch actually succeeded — it just returned an empty series, and `MetricSummary` encodes "loading" as a nil count, which is exactly what the level-based initializer produced when `latest(in:)` found no point. `RedactedText` then drew the grey placeholder indefinitely. Sessions escaped this because its count is a sum, so an empty result gives a plain 0 and renders as "—".

The level initializer now treats a missing point as a zero level for both the current and the previous period. The delta takes care of itself, since `Delta.init?` already returns nil when the previous value isn't positive, so the manual flatMap cascade goes away and both initializers end up the same shape. Tests cover an empty level series and the existing out-of-window case now expects zero rather than nil.