### PR TITLE
Route home navigation through a single typed destination

### DIFF
--- a/Sources/Scout/UI/Home/HomeDestination.swift
+++ b/Sources/Scout/UI/Home/HomeDestination.swift
@@ -1,0 +1,15 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+enum HomeDestination: Hashable {
+    case activity
+    case sessions
+    case log
+    case releaseHealth
+}

--- a/Sources/Scout/UI/Home/HomeList.swift
+++ b/Sources/Scout/UI/Home/HomeList.swift
@@ -11,14 +11,13 @@ struct HomeList: View {
     @Environment(\.database) var database
     @AppStorage("scout_home_period") var period = Period.today
 
+    @Binding var path: [HomeDestination]
+
     @StateObject var activities = ActivityProvider()
     @StateObject var sessions = StatProvider(eventName: "Session", periods: Period.summary)
     @StateObject var releases = ReleaseHealthProvider()
     @StateObject var logs = HomeLogProvider()
     @StateObject var devices = DevicesProvider()
-
-    @State var showLog = false
-    @State var showReleaseHealth = false
 
     var body: some View {
         if let error = HomeErrorView(providers: [sessions, activities, logs, releases, devices]) {
@@ -31,8 +30,8 @@ struct HomeList: View {
                     .listRowSeparator(.hidden)
 
                 HStack(spacing: 24) {
-                    NavigationLink {
-                        activityDestination
+                    Button {
+                        path.append(.activity)
                     } label: {
                         MetricColumn(
                             title: period.activityPeriod?.acronym ?? "Users",
@@ -44,10 +43,8 @@ struct HomeList: View {
                     .buttonStyle(.plain)
                     .disabled(period.activityPeriod == nil)
 
-                    NavigationLink {
-                        StatView(showList: false, extent: ChartExtent(period: period), stat: sessions)
-                            .environment(\.chartColor, .purple)
-                            .navigationTitle(en: "Sessions")
+                    Button {
+                        path.append(.sessions)
                     } label: {
                         MetricColumn(
                             title: "Sessions",
@@ -60,14 +57,24 @@ struct HomeList: View {
                 }
                 .listRowSeparator(.hidden)
 
-                HomeLogSection(period: period, log: logs, devices: devices, showLog: $showLog)
-                HomeReleaseSection(provider: releases, showReleaseHealth: $showReleaseHealth)
+                HomeLogSection(period: period, log: logs, devices: devices) {
+                    path.append(.log)
+                }
+                HomeReleaseSection(provider: releases) {
+                    path.append(.releaseHealth)
+                }
             }
-            .navigationDestination(isPresented: $showLog) {
-                LogView(period: period, log: logs, devices: devices)
-            }
-            .navigationDestination(isPresented: $showReleaseHealth) {
-                ReleaseHealthView(provider: releases)
+            .navigationDestination(for: HomeDestination.self) { destination in
+                switch destination {
+                case .activity:
+                    activityDestination
+                case .sessions:
+                    sessionDestination
+                case .log:
+                    LogView(period: period, log: logs, devices: devices)
+                case .releaseHealth:
+                    ReleaseHealthView(provider: releases)
+                }
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
@@ -86,6 +93,12 @@ struct HomeList: View {
         if let activityPeriod = period.activityPeriod {
             ActivityView(activity: activities, period: activityPeriod)
         }
+    }
+
+    private var sessionDestination: some View {
+        StatView(showList: false, extent: ChartExtent(period: period), stat: sessions)
+            .environment(\.chartColor, .purple)
+            .navigationTitle(en: "Sessions")
     }
 
     private var activitySummary: MetricSummary? {
@@ -135,6 +148,7 @@ struct HomeList: View {
 
     return NavigationStack {
         HomeList(
+            path: .constant([]),
             activities: activities,
             sessions: sessions,
             releases: releases,

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -11,6 +11,7 @@ struct HomeView: View {
     let backends: [Backend]
 
     @AppStorage("scout_active_backend") private var activeID = ""
+    @State private var path: [HomeDestination] = []
     @StateObject private var tint = Tint()
 
     init(backends: [Backend]) {
@@ -30,10 +31,10 @@ struct HomeView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             Group {
                 if let backend {
-                    HomeList().iCloudWarning(backend.accountWarning)
+                    HomeList(path: $path).iCloudWarning(backend.accountWarning)
                 } else {
                     ErrorView(description: "Pass at least one backend to inspect Scout data.", retry: nil)
                 }

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogSection.swift
@@ -15,11 +15,11 @@ struct HomeLogSection: View {
     @ObservedObject var log: HomeLogProvider
     @ObservedObject var devices: DevicesProvider
 
-    @Binding var showLog: Bool
+    let showAll: () -> Void
 
     var body: some View {
         Header(title: "Log") {
-            AllButton { showLog = true }
+            AllButton(action: showAll)
         }
         .task(id: period) {
             log.period = period
@@ -81,7 +81,7 @@ struct HomeLogSection: View {
                 period: .today,
                 log: makeLog(),
                 devices: devices,
-                showLog: .constant(false)
+                showAll: {}
             )
         }
         .listStyle(.plain)

--- a/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/Scout/UI/Home/Section/Release/HomeReleaseSection.swift
@@ -9,12 +9,13 @@ import SwiftUI
 
 struct HomeReleaseSection: View {
     @ObservedObject var provider: ReleaseHealthProvider
-    @Binding var showReleaseHealth: Bool
+
+    let showAll: () -> Void
 
     var body: some View {
         Header(title: "Releases") {
             if let releases = try? provider.result?.get(), releases.count > 0 {
-                AllButton { showReleaseHealth = true }
+                AllButton(action: showAll)
             }
         }
 
@@ -45,8 +46,8 @@ struct HomeReleaseSection: View {
 
     return NavigationStack {
         List {
-            HomeReleaseSection(provider: provider, showReleaseHealth: .constant(false))
-            HomeReleaseSection(provider: ReleaseHealthProvider(releases: []), showReleaseHealth: .constant(false))
+            HomeReleaseSection(provider: provider, showAll: {})
+            HomeReleaseSection(provider: ReleaseHealthProvider(releases: []), showAll: {})
         }
         .listStyle(.plain)
     }


### PR DESCRIPTION
The metric cards on the home screen were wrapped in navigation links, so the list drew a disclosure chevron over each sparkline and highlighted the whole row on tap. They are plain buttons now, which removes both.

Since the buttons navigate programmatically, the screen used to carry one isPresented flag per destination, and several navigationDestination(isPresented:) modifiers in the same stack conflict — a tap on either card pushed two screens at once. All four destinations now go through a single HomeDestination path owned by the NavigationStack, so exactly one screen is pushed. The Log and Releases sections take a showAll closure instead of a Bool binding for the same reason.