### PR TITLE
Share the sparkline between cards and rows and draw the empty state

### DIFF
--- a/Sources/Scout/UI/Insights/Chart/Model/MiniChartSeries.swift
+++ b/Sources/Scout/UI/Insights/Chart/Model/MiniChartSeries.swift
@@ -67,4 +67,11 @@ extension MiniChartSeries {
 
     /// No slices at all: a chart with nothing but its gridlines.
     static let empty = MiniChartSeries(values: [])
+
+    /// Whether the series has anything to draw: a series whose every slice
+    /// sits at zero carries no shape and is drawn as `empty`.
+    ///
+    var isEmpty: Bool {
+        values.allSatisfy { $0 == .zero }
+    }
 }

--- a/Sources/Scout/UI/Insights/Chart/View/MiniChart.swift
+++ b/Sources/Scout/UI/Insights/Chart/View/MiniChart.swift
@@ -6,7 +6,6 @@
 // https://opensource.org/licenses/MIT.
 //
 
-import Charts
 import SwiftUI
 
 /// An inline sparkline for Home rows: the period's slice values drawn as a
@@ -25,35 +24,13 @@ struct MiniChart: View {
     var body: some View {
         Group {
             if let series {
-                chart(for: series, tint: color)
+                Sparkline(series: series, color: color, style: .row)
             } else {
-                chart(for: .placeholder, tint: Color(.systemGray3))
+                Sparkline(series: .placeholder, color: Color(.systemGray3), style: .row)
                     .redacted(reason: .placeholder)
             }
         }
         .frame(width: Self.size.width, height: Self.size.height)
-    }
-
-    private func chart(for series: MiniChartSeries, tint: Color) -> some View {
-        Chart(series.values.indices, id: \.self) { index in
-            AreaMark(x: .value("X", index), y: .value("Y", series.values[index]))
-                .interpolationMethod(.catmullRom)
-                .foregroundStyle(gradient(of: tint))
-            LineMark(x: .value("X", index), y: .value("Y", series.values[index]))
-                .interpolationMethod(.catmullRom)
-                .lineStyle(StrokeStyle(lineWidth: 1.5))
-                .foregroundStyle(tint)
-        }
-        .chartXAxis(.hidden)
-        .chartYAxis(.hidden)
-    }
-
-    private func gradient(of tint: Color) -> LinearGradient {
-        LinearGradient(
-            colors: [tint.opacity(0.35), tint.opacity(0.02)],
-            startPoint: .top,
-            endPoint: .bottom
-        )
     }
 }
 

--- a/Sources/Scout/UI/Insights/Chart/View/Sparkline.swift
+++ b/Sources/Scout/UI/Insights/Chart/View/Sparkline.swift
@@ -8,15 +8,25 @@
 import Charts
 import SwiftUI
 
+struct SparklineStyle {
+    let lineWidth: Double
+    let columns: Int
+
+    static let card = SparklineStyle(lineWidth: 2, columns: 3)
+    static let row = SparklineStyle(lineWidth: 1.5, columns: 1)
+}
+
 struct Sparkline: View {
     let series: MiniChartSeries
     let color: Color
+    var style: SparklineStyle = .card
 
     var body: some View {
-        let scale = SparklineScale(values: series.values)
-        let last = Double(max(series.values.count - 1, 1))
+        let values = series.isEmpty ? [] : series.values
+        let scale = SparklineScale(values: values)
+        let last = Double(max(values.count - 1, 1))
 
-        Chart(Array(series.values.enumerated()), id: \.offset) { index, value in
+        Chart(Array(values.enumerated()), id: \.offset) { index, value in
             AreaMark(
                 x: .value("Slice", Double(index)),
                 yStart: .value("Bottom", scale.bottom),
@@ -37,10 +47,10 @@ struct Sparkline: View {
             )
             .interpolationMethod(.catmullRom)
             .foregroundStyle(color)
-            .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round))
+            .lineStyle(StrokeStyle(lineWidth: style.lineWidth, lineCap: .round))
         }
         .chartXAxis {
-            AxisMarks(values: [0, last / 3, last * 2 / 3, last]) { _ in
+            AxisMarks(values: (0...style.columns).map { last * Double($0) / Double(style.columns) }) { _ in
                 AxisGridLine()
             }
         }
@@ -62,6 +72,8 @@ struct Sparkline: View {
         Sparkline(series: MiniChartSeries(values: [9, 7, 8, 6, 7, 5, 4]), color: .red)
             .frame(height: 60)
         Sparkline(series: MiniChartSeries(values: [4, 4, 4, 4, 4, 4, 4]), color: .green)
+            .frame(height: 60)
+        Sparkline(series: .empty, color: .orange)
             .frame(height: 60)
     }
     .padding()

--- a/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
+++ b/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
@@ -33,7 +33,7 @@ struct MetricCard: View {
             }
 
             if let series = summary?.series {
-                Sparkline(series: series, color: color)
+                Sparkline(series: series.isEmpty ? .empty : series, color: color)
             } else if summary != nil {
                 Sparkline(series: .placeholder, color: Color(.systemGray3)).redacted(reason: .placeholder)
             } else {
@@ -48,6 +48,9 @@ struct MetricCard: View {
         let summary = MetricSummary(count: 8420, previous: 7500, values: [3, 5, 4, 7, 6, 9, 12])
 
         MetricCard(summary: summary, color: .purple)
+            .frame(width: 162, height: 100)
+
+        MetricCard(summary: MetricSummary(count: 0, previous: 0, values: [0, 0, 0, 0, 0, 0, 0]), color: .red)
             .frame(width: 162, height: 100)
 
         MetricCard(summary: .loading, color: .green)

--- a/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
+++ b/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
@@ -33,7 +33,7 @@ struct MetricCard: View {
             }
 
             if let series = summary?.series {
-                Sparkline(series: series.isEmpty ? .empty : series, color: color)
+                Sparkline(series: series, color: color)
             } else if summary != nil {
                 Sparkline(series: .placeholder, color: Color(.systemGray3)).redacted(reason: .placeholder)
             } else {

--- a/Tests/ScoutTests/UI/Insights/Chart/Model/MiniChartSeriesTests.swift
+++ b/Tests/ScoutTests/UI/Insights/Chart/Model/MiniChartSeriesTests.swift
@@ -97,4 +97,19 @@ struct MiniChartSeriesTests {
 
         #expect(series.values == [4, 0, 0, 0, 9, 0, 0])
     }
+
+    @Test("An all-zero series counts as empty")
+    func allZeroIsEmpty() {
+        let series = MiniChartSeries(points: [], range: range, aggregation: .total)
+
+        #expect(series.isEmpty)
+        #expect(MiniChartSeries.empty.isEmpty)
+    }
+
+    @Test("A series with any value is not empty")
+    func nonZeroIsNotEmpty() {
+        let series = MiniChartSeries(points: [makePoint(day: 1, count: 1)], range: range, aggregation: .total)
+
+        #expect(!series.isEmpty)
+    }
 }


### PR DESCRIPTION
A metric whose series is all zeros — crashes and hangs on a quiet day — still went down the regular drawing path, so the chart showed a flat line hugging the baseline with a gradient fill under it instead of the empty state we already have. MiniChartSeries now reports an all-zero series as empty and Sparkline draws such a series as bare gridlines, matching the dash the card already shows for a zero count.

Home rows drew their own near-identical chart, so MiniChart now renders through the same Sparkline, picking a style that thins the line and keeps only the baseline and the two side gridlines. That gives the rows the empty state for free and leaves one place where a sparkline is drawn. Two tests cover the new emptiness rule.