### PR TITLE
Keep release markers out of the event count and model-less devices in the list

### DIFF
--- a/Sources/Scout/UI/Delivery/Devices/Model/DeviceSummary.swift
+++ b/Sources/Scout/UI/Delivery/Devices/Model/DeviceSummary.swift
@@ -9,18 +9,18 @@ import Foundation
 
 struct DeviceSummary: Identifiable, Equatable {
     let id: UUID
-    let model: String
+    let model: String?
     let osVersion: String
     let lastSeen: Date
     let sessions: Int
     let crashes: Int
 
     var modelName: String {
-        DeviceModel(identifier: model).name
+        model.map { DeviceModel(identifier: $0).name } ?? "Unknown"
     }
 
     var symbol: String {
-        DeviceModel(identifier: model).symbol
+        DeviceModel(identifier: model ?? "").symbol
     }
 }
 
@@ -32,11 +32,7 @@ extension DeviceSummary {
             uniquingKeysWith: +)
 
         return devices.compactMap { device -> DeviceSummary? in
-            guard let deviceID: String = device["device_id"], let uuid = UUID(uuidString: deviceID),
-                let model: String = device["model"]
-            else {
-                return nil
-            }
+            guard let deviceID: String = device["device_id"], let uuid = UUID(uuidString: deviceID) else { return nil }
 
             guard let latest = (sessionsByDevice[deviceID] ?? []).max(by: { $0.startDate < $1.startDate }) else {
                 return nil
@@ -44,7 +40,7 @@ extension DeviceSummary {
 
             return DeviceSummary(
                 id: uuid,
-                model: model,
+                model: device["model"],
                 osVersion: latest.osVersion,
                 lastSeen: latest.startDate,
                 sessions: sessionsByDevice[deviceID]?.count ?? 0,

--- a/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/Scout/UI/Home/Section/Log/HomeLogProvider.swift
@@ -54,6 +54,8 @@ private let lifecycleNames: Set = [
     DeviceEntry.recordType,
     InstallEntry.recordType,
     LaunchEntry.recordType,
+    MarkerEntry.crashName,
+    MarkerEntry.installName,
     SessionEntry.recordType,
     VersionEntry.recordType,
 ]

--- a/Tests/ScoutTests/UI/Delivery/Devices/Model/DeviceSummaryTests.swift
+++ b/Tests/ScoutTests/UI/Delivery/Devices/Model/DeviceSummaryTests.swift
@@ -53,8 +53,8 @@ struct DeviceSummaryTests {
         #expect(summaries.isEmpty)
     }
 
-    @Test("Excludes devices with no model")
-    func summariesExcludeModellessDevices() {
+    @Test("Keeps devices with no model, naming them Unknown")
+    func summariesKeepModellessDevices() throws {
         let deviceID = UUID()
 
         let summaries = DeviceSummary.summaries(
@@ -66,7 +66,10 @@ struct DeviceSummaryTests {
             crashes: []
         )
 
-        #expect(summaries.isEmpty)
+        let summary = try #require(summaries.first)
+        #expect(summaries.count == 1)
+        #expect(summary.model == nil)
+        #expect(summary.modelName == "Unknown")
     }
 
     @Test("Keeps devices independent")

--- a/Tests/ScoutTests/UI/Home/Section/Log/HomeLogProviderTests.swift
+++ b/Tests/ScoutTests/UI/Home/Section/Log/HomeLogProviderTests.swift
@@ -57,6 +57,23 @@ struct HomeLogProviderTests {
         #expect(Set(result.0.map(\.name)) == ["login", "Crash"])
     }
 
+    @Test("Fetch drops the release markers so they never count as events")
+    func fetchDropsMarkers() async throws {
+        let database = DatabaseStub()
+        database.add(
+            makeRecord(name: "login", value: 3),
+            makeRecord(name: MarkerEntry.installName, value: 1),
+            makeRecord(name: MarkerEntry.crashName, value: 1)
+        )
+
+        let provider = HomeLogProvider()
+        provider.period = .today
+        await provider.fetchIfNeeded(in: database)
+        let result = try #require(try provider.result?.get())
+
+        #expect(Set(result.0.map(\.name)) == ["login"])
+    }
+
     @Test("Records of the same matrix merge into one")
     func mergesDuplicates() async throws {
         let date = Date()


### PR DESCRIPTION
The home Log section read the Events row from the synthesized int matrices, which also carry the VersionInstall and VersionCrash release markers. Those have no category and are named neither Crash nor Hang, so they were counted as events — a single install of the current release pushed the Events number above what the event list actually contains, and a crash would have been counted twice. HomeLogProvider now drops both marker names along with the other lifecycle names.

The Devices screen had the mirror problem: the home count comes from the device ids on sessions, while the list comes from Device records, and DeviceSummary dropped any device without a model. The model field only entered the native schema in #861 and a DeviceEntry is delivered once, so a device synced before that stores no model and disappeared from the list while sessions kept counting it. The model is optional now and falls back to Unknown.

Tests cover both: the provider drops the markers, and a model-less device survives with an Unknown name.