### PR TITLE
Show the in-flight CloudKit request count in the toolbar

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
-        .package(url: "https://github.com/kasianov-mikhail/scout-db.git", from: "0.8.1"),
+        .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
+        .package(url: "https://github.com/kasianov-mikhail/scout-db.git", from: "0.9.0"),
     ],
     targets: [
         .target(

--- a/Sources/Scout/Core/Lifecycle/Base/SystemInfo.swift
+++ b/Sources/Scout/Core/Lifecycle/Base/SystemInfo.swift
@@ -29,16 +29,29 @@ enum SystemInfo {
         Locale.current.identifier
     }
 
-    static var channel: String {
+    enum Channel: String {
+        case debug = "Debug"
+        case simulator = "Simulator"
+        case testFlight = "TestFlight"
+        case appStore = "App Store"
+    }
+
+    static var buildChannel: Channel {
         #if DEBUG
-            "Debug"
+            .debug
         #elseif targetEnvironment(simulator)
-            "Simulator"
+            .simulator
         #else
-            Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
-                ? "TestFlight"
-                : "App Store"
+            Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" ? .testFlight : .appStore
         #endif
+    }
+
+    static var channel: String {
+        buildChannel.rawValue
+    }
+
+    static var isInternalBuild: Bool {
+        buildChannel != .appStore
     }
 
     private static var osName: String {

--- a/Sources/Scout/Native/Request/RequestActivity.swift
+++ b/Sources/Scout/Native/Request/RequestActivity.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Combine
+import ScoutDB
+
+/// The in-flight CloudKit requests the toolbar gauge draws.
+///
+/// ScoutDB throttles every request and reports its slots to `cloudKitRequestActivity`;
+/// this mirrors that count onto the main actor so SwiftUI can observe it.
+///
+@MainActor final class RequestActivity: ObservableObject {
+    static let shared = RequestActivity(limit: cloudKitParallelismLimit)
+
+    let limit: Int
+
+    @Published private(set) var running = 0
+
+    init(limit: Int) {
+        self.limit = limit
+    }
+
+    var fraction: Double {
+        limit > 0 ? min(Double(running) / Double(limit), 1) : 0
+    }
+
+    var isSaturated: Bool {
+        running >= limit
+    }
+
+    func track(_ updates: AsyncStream<Int>) async {
+        for await count in updates {
+            running = count
+        }
+    }
+}

--- a/Sources/Scout/UI/Analytics/Activity/ActivityView.swift
+++ b/Sources/Scout/UI/Analytics/Activity/ActivityView.swift
@@ -56,6 +56,7 @@ struct ActivityView: View {
             }
         }
         .navigationTitle(en: "Active Users")
+        .requestGauge()
     }
 }
 

--- a/Sources/Scout/UI/Analytics/Event/Param/ParamList.swift
+++ b/Sources/Scout/UI/Analytics/Event/Param/ParamList.swift
@@ -31,6 +31,7 @@ struct ParamList: View {
             }
         }
         .resetsTint()
+        .requestGauge()
     }
 }
 

--- a/Sources/Scout/UI/Delivery/Devices/View/DevicesListView.swift
+++ b/Sources/Scout/UI/Delivery/Devices/View/DevicesListView.swift
@@ -37,6 +37,7 @@ struct DevicesListView: View {
                 }
             }
         }
+        .requestGauge()
     }
 }
 

--- a/Sources/Scout/UI/Delivery/Releases/View/ReleaseHealthView.swift
+++ b/Sources/Scout/UI/Delivery/Releases/View/ReleaseHealthView.swift
@@ -28,6 +28,7 @@ struct ReleaseHealthView: View {
             }
         }
         .navigationTitle(en: "Releases")
+        .requestGauge()
     }
 }
 

--- a/Sources/Scout/UI/Home/Connection/ConnectionToolbar.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionToolbar.swift
@@ -32,6 +32,7 @@ private struct ConnectionToolbar: ViewModifier {
                     }
                 }
             }
+            .requestGauge()
             .sheet(isPresented: $isSettingsPresented) {
                 NavigationStack {
                     SettingsOverviewView(backends: backends, activeID: $activeID)

--- a/Sources/Scout/UI/Home/HomeList.swift
+++ b/Sources/Scout/UI/Home/HomeList.swift
@@ -99,6 +99,7 @@ struct HomeList: View {
         StatView(showList: false, extent: ChartExtent(period: period), stat: sessions)
             .environment(\.chartColor, .purple)
             .navigationTitle(en: "Sessions")
+            .requestGauge()
     }
 
     private var activitySummary: MetricSummary? {

--- a/Sources/Scout/UI/Home/Section/Log/LogCategory.swift
+++ b/Sources/Scout/UI/Home/Section/Log/LogCategory.swift
@@ -71,19 +71,22 @@ struct LogDestination: View {
     let category: LogCategory
 
     var body: some View {
-        switch category {
-        case .events:
-            AnalyticsView()
-        case .metrics:
-            MetricsList().navigationTitle(en: "Metrics")
-        case .network:
-            NetworkView()
-        case .devices:
-            DevicesView()
-        case .crashes:
-            CrashListView()
-        case .hangs:
-            HangListView()
+        Group {
+            switch category {
+            case .events:
+                AnalyticsView()
+            case .metrics:
+                MetricsList().navigationTitle(en: "Metrics")
+            case .network:
+                NetworkView()
+            case .devices:
+                DevicesView()
+            case .crashes:
+                CrashListView()
+            case .hangs:
+                HangListView()
+            }
         }
+        .requestGauge()
     }
 }

--- a/Sources/Scout/UI/Home/Section/Log/LogView.swift
+++ b/Sources/Scout/UI/Home/Section/Log/LogView.swift
@@ -48,6 +48,7 @@ struct LogView: View {
             await log.fetchIfNeeded(in: database)
         }
         .navigationTitle(en: "Log")
+        .requestGauge()
     }
 
     private var report: LogReport? {

--- a/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointsView.swift
+++ b/Sources/Scout/UI/Monitoring/Network/View/NetworkEndpointsView.swift
@@ -33,6 +33,7 @@ struct NetworkEndpointsView: View {
         }
         .listStyle(.plain)
         .navigationTitle(en: "Endpoints")
+        .requestGauge()
     }
 }
 

--- a/Sources/Scout/UI/Primitives/Request/RequestGauge.swift
+++ b/Sources/Scout/UI/Primitives/Request/RequestGauge.swift
@@ -1,0 +1,85 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import ScoutDB
+import SwiftUI
+
+extension View {
+    /// Puts the in-flight request gauge in the trailing toolbar of internal builds.
+    func requestGauge() -> some View {
+        toolbar {
+            if SystemInfo.isInternalBuild {
+                ToolbarItem(placement: .topBarTrailing) {
+                    RequestGauge()
+                }
+            }
+        }
+    }
+}
+
+struct RequestGauge: View {
+    @ObservedObject var activity = RequestActivity.shared
+    var updates: AsyncStream<Int> = cloudKitRequestActivity.updates
+
+    private let sweep = 240.0 / 360
+    private let rotation = 150.0
+    private let width = 2.5
+
+    var body: some View {
+        ZStack {
+            Arc(sweep: sweep)
+                .stroke(.quaternary, style: StrokeStyle(lineWidth: width, lineCap: .round))
+            Arc(sweep: sweep * activity.fraction)
+                .stroke(
+                    activity.isSaturated ? Color.red : .accentColor,
+                    style: StrokeStyle(lineWidth: width, lineCap: .round)
+                )
+        }
+        .rotationEffect(.degrees(rotation))
+        .frame(width: 20, height: 20)
+        .animation(.easeOut(duration: 0.2), value: activity.fraction)
+        .accessibilityLabel(Text(verbatim: "\(activity.running) of \(activity.limit) requests in flight"))
+        .task {
+            await activity.track(updates)
+        }
+    }
+}
+
+private struct Arc: Shape {
+    var sweep: Double
+
+    var animatableData: Double {
+        get { sweep }
+        set { sweep = newValue }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        Circle().trim(from: 0, to: sweep).path(in: rect)
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, *)
+#Preview {
+    @Previewable @StateObject var activity = RequestActivity(limit: 8)
+
+    NavigationStack {
+        List {
+            Text(verbatim: "Events")
+            Text(verbatim: "Sessions")
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: "Home")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                RequestGauge(activity: activity, updates: AsyncStream { $0.yield(3) })
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Image(systemName: "gearshape")
+            }
+        }
+    }
+}

--- a/Sources/Scout/UI/Primitives/Rows/Row.swift
+++ b/Sources/Scout/UI/Primitives/Rows/Row.swift
@@ -18,7 +18,7 @@ struct Row<Content: View, Destination: View>: View {
             }
 
             NavigationLink {
-                destination()
+                destination().requestGauge()
             } label: {
                 EmptyView()
             }

--- a/Tests/ScoutTests/Core/Lifecycle/Base/SystemInfoTests.swift
+++ b/Tests/ScoutTests/Core/Lifecycle/Base/SystemInfoTests.swift
@@ -32,5 +32,11 @@ struct SystemInfoTests {
     @Test("channel is one of the known distribution channels")
     func channel() {
         #expect(["Debug", "Simulator", "TestFlight", "App Store"].contains(SystemInfo.channel))
+        #expect(SystemInfo.channel == SystemInfo.buildChannel.rawValue)
+    }
+
+    @Test("every channel but the App Store counts as an internal build")
+    func internalBuild() {
+        #expect(SystemInfo.isInternalBuild == (SystemInfo.buildChannel != .appStore))
     }
 }

--- a/Tests/ScoutTests/Native/Request/RequestActivityTests.swift
+++ b/Tests/ScoutTests/Native/Request/RequestActivityTests.swift
@@ -1,0 +1,87 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import ScoutDB
+import Testing
+
+@testable import Scout
+
+@Suite("RequestActivity")
+@MainActor struct RequestActivityTests {
+    @Test("Starts empty")
+    func testStartsEmpty() {
+        let activity = RequestActivity(limit: 8)
+
+        #expect(activity.running == 0)
+        #expect(activity.fraction == 0)
+        #expect(!activity.isSaturated)
+    }
+
+    @Test("Mirrors the counts the stream publishes")
+    func testMirrorsStream() async {
+        let activity = RequestActivity(limit: 8)
+        let (stream, continuation) = AsyncStream.makeStream(of: Int.self)
+
+        let tracking = Task { await activity.track(stream) }
+        continuation.yield(3)
+        while activity.running != 3 {
+            await Task.yield()
+        }
+
+        #expect(activity.fraction == 0.375)
+        #expect(!activity.isSaturated)
+
+        continuation.finish()
+        await tracking.value
+    }
+
+    @Test("Saturates at the limit")
+    func testSaturatesAtLimit() async {
+        let activity = RequestActivity(limit: 8)
+        let (stream, continuation) = AsyncStream.makeStream(of: Int.self)
+
+        let tracking = Task { await activity.track(stream) }
+        continuation.yield(8)
+        while activity.running != 8 {
+            await Task.yield()
+        }
+
+        #expect(activity.isSaturated)
+        #expect(activity.fraction == 1)
+
+        continuation.finish()
+        await tracking.value
+    }
+
+    @Test("Clamps the fraction to a full arc above the limit")
+    func testClampsFraction() async {
+        let activity = RequestActivity(limit: 8)
+        let (stream, continuation) = AsyncStream.makeStream(of: Int.self)
+
+        let tracking = Task { await activity.track(stream) }
+        continuation.yield(10)
+        while activity.running != 10 {
+            await Task.yield()
+        }
+
+        #expect(activity.fraction == 1)
+        #expect(activity.isSaturated)
+
+        continuation.finish()
+        await tracking.value
+    }
+
+    @Test("A zero limit leaves the arc empty")
+    func testZeroLimit() {
+        #expect(RequestActivity(limit: 0).fraction == 0)
+    }
+
+    @Test("Tracks the limit ScoutDB throttles to")
+    func testSharedLimit() {
+        #expect(RequestActivity.shared.limit == cloudKitParallelismLimit)
+    }
+}


### PR DESCRIPTION
Internal builds now carry a small gauge in the trailing toolbar: a 240° arc that fills with the number of CloudKit requests currently in flight and turns red when all eight slots are taken. It reads its count from scout-db 0.9.0, whose CloudKitRequestLimiter publishes slot occupancy as an AsyncStream (kasianov-mikhail/scout-db#131), so the arc reflects true occupancy — a request counts through rate-limit backoff and past the backstop timeout, until it actually settles.

RequestActivity mirrors that stream onto the main actor and does the arithmetic the view would otherwise carry; the gauge itself takes the stream as a parameter so previews can drive it without real traffic. Every screen declares .requestGauge() in its own body next to its own toolbar, and the modifier is a no-op outside internal builds, which SystemInfo now expresses with a typed build channel instead of a bare string (the analytics string stays its raw value, so nothing on the wire changed). App Store builds see no gauge.