### PR TITLE
Split compact switch cases onto separate lines

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Metrics/MetricReader.swift
+++ b/Sources/Scout/Core/Diagnostics/Metrics/MetricReader.swift
@@ -48,8 +48,10 @@ enum MetricValue: Decodable, Equatable {
 extension MetricValue {
     var doubleValue: Double {
         switch self {
-        case .int(let value): Double(value)
-        case .double(let value): value
+        case .int(let value):
+            Double(value)
+        case .double(let value):
+            value
         }
     }
 }

--- a/Sources/Scout/Native/Store/EntityCatalog.swift
+++ b/Sources/Scout/Native/Store/EntityCatalog.swift
@@ -176,13 +176,20 @@ enum EntityCatalog {
 
     private static func pool(for type: FieldType) -> Pool {
         switch type {
-        case .string: .string
-        case .text: .text
-        case .int: .int
-        case .double: .double
-        case .timestamp: .timestamp
-        case .bytes: .bytes
-        default: fatalError("Unsupported field type \(type)")
+        case .string:
+            .string
+        case .text:
+            .text
+        case .int:
+            .int
+        case .double:
+            .double
+        case .timestamp:
+            .timestamp
+        case .bytes:
+            .bytes
+        default:
+            fatalError("Unsupported field type \(type)")
         }
     }
 }

--- a/Sources/Scout/Native/Store/MatrixSeries.swift
+++ b/Sources/Scout/Native/Store/MatrixSeries.swift
@@ -159,11 +159,16 @@ struct MatrixSeries {
 
     private static func layout(of source: Source) -> (entity: String, dateField: String, matrixName: String) {
         switch source {
-        case .sessions: (SessionEntry.recordType, "start_date", SessionEntry.recordType)
-        case .crashes: (CrashEntry.recordType, "date", CrashEntry.recordType)
-        case .hangs: (HangEntry.recordType, "date", HangEntry.recordType)
-        case .versionInstalls: (VersionEntry.recordType, "date", MarkerEntry.installName)
-        case .versionCrashes: (CrashEntry.recordType, "date", MarkerEntry.crashName)
+        case .sessions:
+            (SessionEntry.recordType, "start_date", SessionEntry.recordType)
+        case .crashes:
+            (CrashEntry.recordType, "date", CrashEntry.recordType)
+        case .hangs:
+            (HangEntry.recordType, "date", HangEntry.recordType)
+        case .versionInstalls:
+            (VersionEntry.recordType, "date", MarkerEntry.installName)
+        case .versionCrashes:
+            (CrashEntry.recordType, "date", MarkerEntry.crashName)
         }
     }
 

--- a/Sources/Scout/Native/Store/NativeValues.swift
+++ b/Sources/Scout/Native/Store/NativeValues.swift
@@ -11,24 +11,37 @@ import ScoutDB
 extension RecordValue {
     var storeValue: ScoutDB.RecordValue {
         switch self {
-        case .string(let value): .string(value)
-        case .int(let value): .int(value)
-        case .double(let value): .double(value)
-        case .date(let value): .date(value)
-        case .bytes(let value): .bytes(value)
-        case .strings(let value): .strings(value)
+        case .string(let value):
+            .string(value)
+        case .int(let value):
+            .int(value)
+        case .double(let value):
+            .double(value)
+        case .date(let value):
+            .date(value)
+        case .bytes(let value):
+            .bytes(value)
+        case .strings(let value):
+            .strings(value)
         }
     }
 
     init?(storeValue: ScoutDB.RecordValue) {
         switch storeValue {
-        case .string(let value): self = .string(value)
-        case .int(let value): self = .int(value)
-        case .double(let value): self = .double(value)
-        case .date(let value): self = .date(value)
-        case .bytes(let value): self = .bytes(value)
-        case .strings(let value): self = .strings(value)
-        default: return nil
+        case .string(let value):
+            self = .string(value)
+        case .int(let value):
+            self = .int(value)
+        case .double(let value):
+            self = .double(value)
+        case .date(let value):
+            self = .date(value)
+        case .bytes(let value):
+            self = .bytes(value)
+        case .strings(let value):
+            self = .strings(value)
+        default:
+            return nil
         }
     }
 }
@@ -56,14 +69,22 @@ extension RecordQuery.Filter {
 
     private var storeMatch: EntityStore.Match {
         switch op {
-        case .equals: .equals
-        case .notEquals: .notEquals
-        case .greaterThan: .greaterThan
-        case .greaterThanOrEquals: .greaterThanOrEquals
-        case .lessThan: .lessThan
-        case .lessThanOrEquals: .lessThanOrEquals
-        case .in: .in
-        case .beginsWith: .beginsWith
+        case .equals:
+            .equals
+        case .notEquals:
+            .notEquals
+        case .greaterThan:
+            .greaterThan
+        case .greaterThanOrEquals:
+            .greaterThanOrEquals
+        case .lessThan:
+            .lessThan
+        case .lessThanOrEquals:
+            .lessThanOrEquals
+        case .in:
+            .in
+        case .beginsWith:
+            .beginsWith
         }
     }
 }

--- a/Sources/Scout/UI/Analytics/Event/Param/ParamBadge.swift
+++ b/Sources/Scout/UI/Analytics/Event/Param/ParamBadge.swift
@@ -47,10 +47,14 @@ extension ParamValue {
     /// The accent color of the value's kind.
     var color: Color {
         switch self {
-        case .string: .primary
-        case .stringConvertible(let convertible): convertible.color
-        case .dictionary: .indigo
-        case .array: .brown
+        case .string:
+            .primary
+        case .stringConvertible(let convertible):
+            convertible.color
+        case .dictionary:
+            .indigo
+        case .array:
+            .brown
         }
     }
 }
@@ -59,12 +63,18 @@ extension ParamValue.Convertible {
     /// The accent color of the scalar kind.
     var color: Color {
         switch self {
-        case .number: .blue
-        case .boolean(true): .green
-        case .boolean(false): .red
-        case .uuid: .purple
-        case .url: .teal
-        case .date: .orange
+        case .number:
+            .blue
+        case .boolean(true):
+            .green
+        case .boolean(false):
+            .red
+        case .uuid:
+            .purple
+        case .url:
+            .teal
+        case .date:
+            .orange
         }
     }
 }

--- a/Sources/Scout/UI/Analytics/Event/Param/Value/ParamValue+Display.swift
+++ b/Sources/Scout/UI/Analytics/Event/Param/Value/ParamValue+Display.swift
@@ -34,10 +34,14 @@ extension ParamValue {
     ///
     var icon: Icon {
         switch self {
-        case .string: .symbol("textformat")
-        case .stringConvertible(let convertible): .symbol(convertible.iconName)
-        case .dictionary: .symbol("curlybraces")
-        case .array: .text("[ ]")
+        case .string:
+            .symbol("textformat")
+        case .stringConvertible(let convertible):
+            .symbol(convertible.iconName)
+        case .dictionary:
+            .symbol("curlybraces")
+        case .array:
+            .text("[ ]")
         }
     }
 
@@ -62,23 +66,34 @@ extension ParamValue.Convertible {
     /// A short name of the scalar kind, shown in the value badge.
     var label: String {
         switch self {
-        case .number: "Number"
-        case .boolean: "Boolean"
-        case .uuid: "UUID"
-        case .url: "URL"
-        case .date: "Date"
+        case .number:
+            "Number"
+        case .boolean:
+            "Boolean"
+        case .uuid:
+            "UUID"
+        case .url:
+            "URL"
+        case .date:
+            "Date"
         }
     }
 
     /// An SF Symbol of the scalar kind.
     var iconName: String {
         switch self {
-        case .number: "number"
-        case .boolean(true): "checkmark.circle"
-        case .boolean(false): "xmark.circle"
-        case .uuid: "tag"
-        case .url: "link"
-        case .date: "calendar"
+        case .number:
+            "number"
+        case .boolean(true):
+            "checkmark.circle"
+        case .boolean(false):
+            "xmark.circle"
+        case .uuid:
+            "tag"
+        case .url:
+            "link"
+        case .date:
+            "calendar"
         }
     }
 }

--- a/Sources/Scout/UI/Home/Settings/BackendHealth.swift
+++ b/Sources/Scout/UI/Home/Settings/BackendHealth.swift
@@ -60,15 +60,19 @@ extension BackendHealth {
 extension BackendHealth.Engine {
     var label: String {
         switch self {
-        case .cloudKit: "CloudKit"
-        case .server: "Scout Server"
+        case .cloudKit:
+            "CloudKit"
+        case .server:
+            "Scout Server"
         }
     }
 
     var icon: String {
         switch self {
-        case .cloudKit: "icloud"
-        case .server: "server.rack"
+        case .cloudKit:
+            "icloud"
+        case .server:
+            "server.rack"
         }
     }
 }
@@ -76,28 +80,40 @@ extension BackendHealth.Engine {
 extension Backend.Status {
     var healthLabel: String {
         switch self {
-        case .reachable: "Operational"
-        case .readOnly: "Read-Only"
-        case .unreachable, .failed: "Unreachable"
-        case .unknown: "Checking"
+        case .reachable:
+            "Operational"
+        case .readOnly:
+            "Read-Only"
+        case .unreachable, .failed:
+            "Unreachable"
+        case .unknown:
+            "Checking"
         }
     }
 
     var healthColor: Color {
         switch self {
-        case .reachable: .green
-        case .readOnly: .orange
-        case .unreachable, .failed: .red
-        case .unknown: .gray
+        case .reachable:
+            .green
+        case .readOnly:
+            .orange
+        case .unreachable, .failed:
+            .red
+        case .unknown:
+            .gray
         }
     }
 
     var healthIcon: String {
         switch self {
-        case .reachable: "checkmark.circle.fill"
-        case .readOnly: "exclamationmark.triangle.fill"
-        case .unreachable, .failed: "xmark.octagon.fill"
-        case .unknown: "questionmark.circle.fill"
+        case .reachable:
+            "checkmark.circle.fill"
+        case .readOnly:
+            "exclamationmark.triangle.fill"
+        case .unreachable, .failed:
+            "xmark.octagon.fill"
+        case .unknown:
+            "questionmark.circle.fill"
         }
     }
 }

--- a/Sources/Scout/UI/Insights/Timeline/Item/TimelineItem.swift
+++ b/Sources/Scout/UI/Insights/Timeline/Item/TimelineItem.swift
@@ -18,9 +18,12 @@ struct TimelineItem {
 
     func groupID(_ kind: LegendKind) -> UUID? {
         switch kind {
-        case .install: installID
-        case .launch: launchID
-        case .session: sessionID
+        case .install:
+            installID
+        case .launch:
+            launchID
+        case .session:
+            sessionID
         }
     }
 }

--- a/Sources/Scout/UI/Insights/Timeline/View/Legend/LegendKind.swift
+++ b/Sources/Scout/UI/Insights/Timeline/View/Legend/LegendKind.swift
@@ -16,25 +16,34 @@ enum LegendKind: CaseIterable, Hashable {
 extension LegendKind {
     var label: String {
         switch self {
-        case .install: "Install"
-        case .launch: "Launch"
-        case .session: "Session"
+        case .install:
+            "Install"
+        case .launch:
+            "Launch"
+        case .session:
+            "Session"
         }
     }
 
     var color: Color {
         switch self {
-        case .install: .mint
-        case .launch: .blue
-        case .session: .green
+        case .install:
+            .mint
+        case .launch:
+            .blue
+        case .session:
+            .green
         }
     }
 
     var legendDescription: String {
         switch self {
-        case .install: "App installation lifetime"
-        case .launch: "Current app launch"
-        case .session: "Active user session"
+        case .install:
+            "App installation lifetime"
+        case .launch:
+            "Current app launch"
+        case .session:
+            "Active user session"
         }
     }
 }

--- a/Sources/Scout/UI/Insights/Timeline/View/TimelineScope.swift
+++ b/Sources/Scout/UI/Insights/Timeline/View/TimelineScope.swift
@@ -15,8 +15,10 @@ enum TimelineScope: CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .all: "All"
-        case .event: "Event"
+        case .all:
+            "All"
+        case .event:
+            "Event"
         }
     }
 }

--- a/Sources/Scout/UI/Monitoring/Incident/Hang/HangSeverity.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Hang/HangSeverity.swift
@@ -13,22 +13,28 @@ enum HangSeverity {
 
     var label: String {
         switch self {
-        case .warning: "Hang"
-        case .critical: "Severe Hang"
+        case .warning:
+            "Hang"
+        case .critical:
+            "Severe Hang"
         }
     }
 
     var color: Color {
         switch self {
-        case .warning: .orange
-        case .critical: .red
+        case .warning:
+            .orange
+        case .critical:
+            .red
         }
     }
 
     var systemImage: String {
         switch self {
-        case .warning: "hourglass"
-        case .critical: "exclamationmark.octagon"
+        case .warning:
+            "hourglass"
+        case .critical:
+            "exclamationmark.octagon"
         }
     }
 }

--- a/Sources/Scout/UI/Monitoring/Metrics/MetricsList.swift
+++ b/Sources/Scout/UI/Monitoring/Metrics/MetricsList.swift
@@ -17,9 +17,12 @@ struct MetricsList: View {
 
         var telemetry: Telemetry.Export {
             switch self {
-            case .int: .counter
-            case .double: .floatingCounter
-            case .timer: .timer
+            case .int:
+                .counter
+            case .double:
+                .floatingCounter
+            case .timer:
+                .timer
             }
         }
     }

--- a/Tests/ScoutTests/Stubs/Records/RecordMatching.swift
+++ b/Tests/ScoutTests/Stubs/Records/RecordMatching.swift
@@ -36,11 +36,16 @@ extension Record {
         case .greaterThan, .greaterThanOrEquals, .lessThan, .lessThanOrEquals:
             guard let lhs = value.comparable, let rhs = filter.value.comparable else { return false }
             switch filter.op {
-            case .greaterThan: return lhs > rhs
-            case .greaterThanOrEquals: return lhs >= rhs
-            case .lessThan: return lhs < rhs
-            case .lessThanOrEquals: return lhs <= rhs
-            default: return false
+            case .greaterThan:
+                return lhs > rhs
+            case .greaterThanOrEquals:
+                return lhs >= rhs
+            case .lessThan:
+                return lhs < rhs
+            case .lessThanOrEquals:
+                return lhs <= rhs
+            default:
+                return false
             }
         }
     }
@@ -50,10 +55,14 @@ extension RecordValue {
     /// A scalar projection used to order values for range comparisons.
     fileprivate var comparable: Double? {
         switch self {
-        case .int(let value): Double(value)
-        case .double(let value): value
-        case .date(let value): value.timeIntervalSince1970
-        default: nil
+        case .int(let value):
+            Double(value)
+        case .double(let value):
+            value
+        case .date(let value):
+            value.timeIntervalSince1970
+        default:
+            nil
         }
     }
 }


### PR DESCRIPTION
Reformats switch statements whose case labels and bodies were crammed onto a single line so each case gets its own line, matching the rest of the codebase's style. Companion to kasianov-mikhail/scout-db#139.