### PR TITLE
Drop the icon from MetricCard and combine its previews

### DIFF
--- a/Sources/Scout/UI/Home/HomeList.swift
+++ b/Sources/Scout/UI/Home/HomeList.swift
@@ -35,7 +35,6 @@ struct HomeList: View {
                     } label: {
                         MetricCard(
                             title: period.activityPeriod?.acronym ?? "Users",
-                            image: "person.2",
                             color: .green,
                             summary: activitySummary
                         )
@@ -48,7 +47,6 @@ struct HomeList: View {
                     } label: {
                         MetricCard(
                             title: "Sessions",
-                            image: "clock",
                             color: .purple,
                             summary: sessionSummary
                         )

--- a/Sources/Scout/UI/Home/Section/Log/LogView.swift
+++ b/Sources/Scout/UI/Home/Section/Log/LogView.swift
@@ -32,7 +32,6 @@ struct LogView: View {
                         } label: {
                             MetricCard(
                                 title: category.title,
-                                image: category.systemImage,
                                 color: category.color,
                                 summary: report?.summary(for: category) ?? .loading
                             )

--- a/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
+++ b/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
@@ -14,76 +14,69 @@ struct MetricCard: View {
     let summary: MetricSummary?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 8) {
-                Image(systemName: image)
-                    .foregroundColor(color)
+        VStack(alignment: .leading, spacing: 4) {
+            Text(verbatim: title.uppercased())
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            HStack(alignment: .top) {
+                Group {
+                    if let summary {
+                        RedactedText(count: summary.count)
+                    } else {
+                        Text(verbatim: "—")
+                    }
+                }
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+
                 Spacer()
-                Text(verbatim: title.uppercased())
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.secondary)
+
+                if let delta = summary?.delta {
+                    Text(verbatim: delta.formatted)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(delta.isPositive ? .green : .red)
+                        .padding(.top, 2)
+                }
             }
 
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(alignment: .top) {
-                    let font = Font.system(size: 24, weight: .bold, design: .rounded)
-
-                    if let summary {
-                        RedactedText(count: summary.count).font(font)
-                    } else {
-                        Text(verbatim: "—").font(font)
-                    }
-
-                    Spacer()
-
-                    if let delta = summary?.delta {
-                        Text(verbatim: delta.formatted)
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(delta.isPositive ? .green : .red)
-                            .padding(.top, 2)
-                    }
-                }
-
-                if let series = summary?.series {
-                    Sparkline(series: series, color: color)
-                } else if summary != nil {
-                    Sparkline(series: .placeholder, color: Color(.systemGray3)).redacted(reason: .placeholder)
-                } else {
-                    Sparkline(series: .empty, color: color)
-                }
+            if let series = summary?.series {
+                Sparkline(series: series, color: color)
+            } else if summary != nil {
+                Sparkline(series: .placeholder, color: Color(.systemGray3)).redacted(reason: .placeholder)
+            } else {
+                Sparkline(series: .empty, color: color)
             }
         }
     }
 }
 
 #Preview("MetricCard") {
-    HStack(spacing: 24) {
-        MetricCard(
-            title: "Sessions",
-            image: "clock",
-            color: .purple,
-            summary: MetricSummary(count: 8420, previous: 7500, values: [3, 5, 4, 7, 6, 9, 12])
-        )
-        MetricCard(
-            title: "Crashes",
-            image: "exclamationmark.triangle",
-            color: .red,
-            summary: MetricSummary(count: 87, previous: 101, values: [9, 7, 8, 6, 7, 5, 4])
-        )
-    }
-    .padding()
-}
+    let columns = [GridItem(.fixed(162), spacing: 24), GridItem(.fixed(162), spacing: 24)]
 
-#Preview("MetricCard — states") {
-    VStack(spacing: 24) {
-        MetricCard(
-            title: "Empty",
-            image: "clock",
-            color: .red,
-            summary: MetricSummary(count: 0, previous: 0, values: [0, 0, 0, 0, 0, 0, 0])
-        )
-        MetricCard(title: "Loading", image: "clock", color: .green, summary: .loading)
-        MetricCard(title: "Missing", image: "clock", color: .green, summary: nil)
+    LazyVGrid(columns: columns, spacing: 24) {
+        Group {
+            MetricCard(
+                title: "Sessions",
+                image: "clock",
+                color: .purple,
+                summary: MetricSummary(count: 8420, previous: 7500, values: [3, 5, 4, 7, 6, 9, 12])
+            )
+            MetricCard(
+                title: "Crashes",
+                image: "exclamationmark.triangle",
+                color: .red,
+                summary: MetricSummary(count: 87, previous: 101, values: [9, 7, 8, 6, 7, 5, 4])
+            )
+            MetricCard(
+                title: "Empty",
+                image: "clock",
+                color: .red,
+                summary: MetricSummary(count: 0, previous: 0, values: [0, 0, 0, 0, 0, 0, 0])
+            )
+            MetricCard(title: "Loading", image: "clock", color: .green, summary: .loading)
+            MetricCard(title: "Missing", image: "clock", color: .green, summary: nil)
+        }
+        .frame(height: 120)
     }
     .padding()
 }

--- a/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
+++ b/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct MetricCard: View {
     let title: String
-    let image: String
     let color: Color
     let summary: MetricSummary?
 
@@ -57,24 +56,21 @@ struct MetricCard: View {
         Group {
             MetricCard(
                 title: "Sessions",
-                image: "clock",
                 color: .purple,
                 summary: MetricSummary(count: 8420, previous: 7500, values: [3, 5, 4, 7, 6, 9, 12])
             )
             MetricCard(
                 title: "Crashes",
-                image: "exclamationmark.triangle",
                 color: .red,
                 summary: MetricSummary(count: 87, previous: 101, values: [9, 7, 8, 6, 7, 5, 4])
             )
             MetricCard(
                 title: "Empty",
-                image: "clock",
                 color: .red,
                 summary: MetricSummary(count: 0, previous: 0, values: [0, 0, 0, 0, 0, 0, 0])
             )
-            MetricCard(title: "Loading", image: "clock", color: .green, summary: .loading)
-            MetricCard(title: "Missing", image: "clock", color: .green, summary: nil)
+            MetricCard(title: "Loading", color: .green, summary: .loading)
+            MetricCard(title: "Missing", color: .green, summary: nil)
         }
         .frame(height: 120)
     }


### PR DESCRIPTION
MetricCard no longer draws the leading icon: the header is now just the uppercase title above the value, delta, and sparkline, giving the card a calmer top row. With the icon gone the image parameter had no use, so it is removed from the initializer and from the Home and Log grid call sites. The two separate previews are merged into a single LazyVGrid that lays out the Sessions, Crashes, empty, loading, and missing states at a fixed card size.