### PR TITLE
Give the MetricCard sparkline a fixed height

### DIFF
--- a/Sources/Scout/UI/Home/HomeList.swift
+++ b/Sources/Scout/UI/Home/HomeList.swift
@@ -26,7 +26,6 @@ struct HomeList: View {
             List {
                 SegmentStrip(selection: $period, distribution: .justified, title: \.shortTitle)
                     .padding(.top, 8)
-                    .padding(.bottom, 4)
                     .listRowSeparator(.hidden)
 
                 HStack(spacing: 24) {
@@ -34,7 +33,7 @@ struct HomeList: View {
                         path.append(.activity)
                     } label: {
                         MetricCard(
-                            title: period.activityPeriod?.acronym ?? "Users",
+                            title: "Users",
                             color: .green,
                             summary: activitySummary
                         )

--- a/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
+++ b/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
@@ -13,10 +13,11 @@ struct MetricCard: View {
     let summary: MetricSummary?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 8) {
             Text(verbatim: title.uppercased())
                 .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(.secondary)
+                .padding(.leading, 1)
 
             HStack(alignment: .top) {
                 Group {
@@ -38,13 +39,16 @@ struct MetricCard: View {
                 }
             }
 
-            if let series = summary?.series {
-                Sparkline(series: series, color: color)
-            } else if summary != nil {
-                Sparkline(series: .placeholder, color: Color(.systemGray3)).redacted(reason: .placeholder)
-            } else {
-                Sparkline(series: .empty, color: color)
+            Group {
+                if let series = summary?.series {
+                    Sparkline(series: series, color: color)
+                } else if summary != nil {
+                    Sparkline(series: .placeholder, color: Color(.systemGray3)).redacted(reason: .placeholder)
+                } else {
+                    Sparkline(series: .empty, color: color)
+                }
             }
+            .frame(height: 72)
         }
     }
 }
@@ -53,26 +57,31 @@ struct MetricCard: View {
     let columns = [GridItem(.fixed(162), spacing: 24), GridItem(.fixed(162), spacing: 24)]
 
     LazyVGrid(columns: columns, spacing: 24) {
-        Group {
-            MetricCard(
-                title: "Sessions",
-                color: .purple,
-                summary: MetricSummary(count: 8420, previous: 7500, values: [3, 5, 4, 7, 6, 9, 12])
-            )
-            MetricCard(
-                title: "Crashes",
-                color: .red,
-                summary: MetricSummary(count: 87, previous: 101, values: [9, 7, 8, 6, 7, 5, 4])
-            )
-            MetricCard(
-                title: "Empty",
-                color: .red,
-                summary: MetricSummary(count: 0, previous: 0, values: [0, 0, 0, 0, 0, 0, 0])
-            )
-            MetricCard(title: "Loading", color: .green, summary: .loading)
-            MetricCard(title: "Missing", color: .green, summary: nil)
-        }
-        .frame(height: 120)
+        MetricCard(
+            title: "Sessions",
+            color: .purple,
+            summary: MetricSummary(count: 8420, previous: 7500, values: [3, 5, 4, 7, 6, 9, 12])
+        )
+        MetricCard(
+            title: "Crashes",
+            color: .red,
+            summary: MetricSummary(count: 87, previous: 101, values: [9, 7, 8, 6, 7, 5, 4])
+        )
+        MetricCard(
+            title: "Empty",
+            color: .red,
+            summary: MetricSummary(count: 0, previous: 0, values: [0, 0, 0, 0, 0, 0, 0])
+        )
+        MetricCard(
+            title: "Loading",
+            color: .green,
+            summary: .loading
+        )
+        MetricCard(
+            title: "Missing",
+            color: .green,
+            summary: nil
+        )
     }
     .padding()
 }


### PR DESCRIPTION
The sparkline now renders at a fixed 72pt height instead of stretching to whatever the surrounding layout offers, so the two Home cards no longer disagree on height when one has data and the other is empty. The title gains a hair of leading padding and the card's vertical rhythm is loosened slightly, the combined preview drops its outer fixed-height frame since each card now sizes itself, and a leftover bottom padding under the Home period strip is removed.