### PR TITLE
Simplify Sparkline styling into plain parameters

### DIFF
--- a/Sources/Scout/UI/Home/Section/Log/LogView.swift
+++ b/Sources/Scout/UI/Home/Section/Log/LogView.swift
@@ -63,22 +63,14 @@ struct LogView: View {
 }
 
 #Preview {
-    @MainActor func makeLog() -> HomeLogProvider {
-        let provider = HomeLogProvider()
-
-        for period in Period.allCases {
-            provider.period = period
-            provider.result = .success(HomeLogProvider.sample(for: period))
-        }
-
-        provider.period = .today
-        return provider
-    }
+    let log = HomeLogProvider()
+    log.period = .week
+    log.result = .success(HomeLogProvider.sample(for: .week))
 
     let devices = DevicesProvider()
     devices.result = .success(.sample)
 
     return NavigationStack {
-        LogView(period: .today, log: makeLog(), devices: devices)
+        LogView(period: .week, log: log, devices: devices)
     }
 }

--- a/Sources/Scout/UI/Insights/Chart/View/MiniChart.swift
+++ b/Sources/Scout/UI/Insights/Chart/View/MiniChart.swift
@@ -24,9 +24,9 @@ struct MiniChart: View {
     var body: some View {
         Group {
             if let series {
-                Sparkline(series: series, color: color, style: .row)
+                Sparkline(series: series, color: color, lineWidth: 1.5, showsGridlines: false)
             } else {
-                Sparkline(series: .placeholder, color: Color(.systemGray3), style: .row)
+                Sparkline(series: .placeholder, color: Color(.systemGray3), lineWidth: 1.5, showsGridlines: false)
                     .redacted(reason: .placeholder)
             }
         }

--- a/Sources/Scout/UI/Insights/Chart/View/Sparkline.swift
+++ b/Sources/Scout/UI/Insights/Chart/View/Sparkline.swift
@@ -8,18 +8,11 @@
 import Charts
 import SwiftUI
 
-struct SparklineStyle {
-    let lineWidth: Double
-    let columns: Int
-
-    static let card = SparklineStyle(lineWidth: 2, columns: 3)
-    static let row = SparklineStyle(lineWidth: 1.5, columns: 1)
-}
-
 struct Sparkline: View {
     let series: MiniChartSeries
     let color: Color
-    var style: SparklineStyle = .card
+    var lineWidth: Double = 2
+    var showsGridlines = true
 
     var body: some View {
         let values = series.isEmpty ? [] : series.values
@@ -47,16 +40,20 @@ struct Sparkline: View {
             )
             .interpolationMethod(.catmullRom)
             .foregroundStyle(color)
-            .lineStyle(StrokeStyle(lineWidth: style.lineWidth, lineCap: .round))
+            .lineStyle(StrokeStyle(lineWidth: lineWidth, lineCap: .round))
         }
         .chartXAxis {
-            AxisMarks(values: (0...style.columns).map { last * Double($0) / Double(style.columns) }) { _ in
-                AxisGridLine()
+            if showsGridlines {
+                AxisMarks(values: (0...3).map { last * Double($0) / 3 }) { _ in
+                    AxisGridLine()
+                }
             }
         }
         .chartYAxis {
-            AxisMarks(values: [scale.bottom]) { _ in
-                AxisGridLine()
+            if showsGridlines {
+                AxisMarks(values: [scale.bottom, scale.top]) { _ in
+                    AxisGridLine()
+                }
             }
         }
         .chartXScale(domain: 0...last)

--- a/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
+++ b/Sources/Scout/UI/Primitives/Cards/MetricCard.swift
@@ -13,7 +13,7 @@ struct MetricCard: View {
     let summary: MetricSummary?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 4) {
             Text(verbatim: title.uppercased())
                 .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(.secondary)
@@ -38,6 +38,8 @@ struct MetricCard: View {
                         .padding(.top, 2)
                 }
             }
+
+            Spacer().frame(height: 4)
 
             Group {
                 if let series = summary?.series {


### PR DESCRIPTION
SparklineStyle collapsed to two ordinary Sparkline parameters, lineWidth and showsGridlines, since after the recent gridline changes the only real differences between the card and row variants were the stroke width and whether the grid shows at all. The card sparkline gains a matching gridline along the top of its domain, and row sparklines (Log, Releases, Stat rows) drop their gridlines entirely for a cleaner inline look. Also folds in a small metric-card spacing tweak and a Log preview simplification from the same pass.