### PR TITLE
Add the retention-cohort data layer and screen

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -161,6 +161,7 @@ jobs:
           xcodebuild \
             -scheme Scout \
             -destination 'platform=macOS' \
+            -skipMacroValidation \
             -only-testing:ScoutTests/ServerContractTests \
             -resultBundlePath TestResults.xcresult \
             test

--- a/Sources/Scout/Core/Database/Access/Database.swift
+++ b/Sources/Scout/Core/Database/Access/Database.swift
@@ -9,5 +9,5 @@ import Foundation
 
 typealias Database = DatabaseReader & DatabaseWriter
 
-typealias DatabaseReader = RecordLocator & MetricReader & ActivityReader & Sendable
+typealias DatabaseReader = RecordLocator & MetricReader & ActivityReader & RetentionReader & Sendable
 typealias DatabaseWriter = RecordWriter & Sendable

--- a/Sources/Scout/Core/Database/Access/DefaultDatabase.swift
+++ b/Sources/Scout/Core/Database/Access/DefaultDatabase.swift
@@ -24,6 +24,10 @@ struct DefaultDatabase: Database {
         []
     }
 
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        []
+    }
+
     func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
         -> [MetricSeries]
     {

--- a/Sources/Scout/Hosted/Access/HostedRetentionReader.swift
+++ b/Sources/Scout/Hosted/Access/HostedRetentionReader.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension HTTPDatabase: RetentionReader {
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        let from = range.lowerBound.millisecondsSince1970
+        let to = range.upperBound.millisecondsSince1970
+
+        guard let endpoint = URL(string: "api/v1/metrics/retention?from=\(from)&to=\(to)", relativeTo: url) else {
+            throw HTTPDatabaseError(status: 0, reason: "Malformed metrics URL")
+        }
+
+        let data = try await perform(request(for: endpoint, method: "GET"))
+        return try JSONDecoder().decode(RetentionResponse.self, from: data).cohorts.map {
+            RetentionCohort(date: $0.date, size: $0.size, retained: $0.retained)
+        }
+    }
+
+    private struct RetentionResponse: Decodable {
+        let cohorts: [Cohort]
+
+        struct Cohort: Decodable {
+            let date: Int64
+            let size: Int
+            let retained: [Int?]
+        }
+    }
+}

--- a/Sources/Scout/Native/Store/NativeDatabase.swift
+++ b/Sources/Scout/Native/Store/NativeDatabase.swift
@@ -130,3 +130,43 @@ extension NativeDatabase: ActivityReader {
         return ActivityPoint.points(visits: visits, in: range)
     }
 }
+
+extension NativeDatabase: RetentionReader {
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        await registration.value
+
+        let installs = try await store.read(
+            entity: InstallEntry.recordType,
+            filters: [
+                EntityStore.Filter(field: "date", op: .greaterThanOrEquals, value: .date(range.lowerBound)),
+                EntityStore.Filter(field: "date", op: .lessThan, value: .date(range.upperBound)),
+            ],
+            fields: ["date", "install_id"]
+        )
+
+        var installDays: [String: Date] = [:]
+        for record in installs {
+            guard case .date(let date)? = record.values["date"] else { continue }
+            guard case .string(let install)? = record.values["install_id"] else { continue }
+            installDays[install] = date
+        }
+
+        let sessions = try await store.read(
+            entity: SessionEntry.recordType,
+            filters: [
+                EntityStore.Filter(field: "start_date", op: .greaterThanOrEquals, value: .date(range.lowerBound)),
+                EntityStore.Filter(field: "start_date", op: .lessThan, value: .date(range.upperBound)),
+            ],
+            fields: ["start_date", "install_id"]
+        )
+
+        var sessionDays: [String: Set<Date>] = [:]
+        for record in sessions {
+            guard case .date(let date)? = record.values["start_date"] else { continue }
+            guard case .string(let install)? = record.values["install_id"] else { continue }
+            sessionDays[install, default: []].insert(date.startOfDay)
+        }
+
+        return RetentionCohort.build(installDays: installDays, sessionDays: sessionDays, in: range, asOf: Date())
+    }
+}

--- a/Sources/Scout/UI/Analytics/Retention/RetentionCohort+Build.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionCohort+Build.swift
@@ -1,0 +1,69 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension RetentionCohort {
+    /// Builds the weekly retention table from local lifecycle data — the
+    /// client-side twin of the server's `RetentionService`.
+    ///
+    /// Installs are grouped into acquisition cohorts by the UTC week of their
+    /// install day. For each install and milestone in `dayOffsets`, bounded
+    /// day-N retention asks whether the install was active on exactly
+    /// `install day + N` — i.e. whether `sessionDays[install]` contains that
+    /// day. A milestone whose window has not fully elapsed by `asOf` (the whole
+    /// cohort week plus the offset) is left `nil`, forming the table's
+    /// triangular gap.
+    ///
+    /// - Parameters:
+    ///   - installDays: install id → the moment that install was first seen.
+    ///   - sessionDays: install id → the set of UTC day-starts it was active on.
+    ///   - range: the install days to include, as a half-open range.
+    ///   - asOf: the maturity cutoff, normally now.
+    /// - Returns: one cohort per install week in `range`, sorted by week ascending.
+    ///
+    static func build(installDays: [String: Date], sessionDays: [String: Set<Date>], in range: Range<Date>, asOf: Date)
+        -> [RetentionCohort]
+    {
+        let calendar = Calendar.utc
+
+        var sizes: [Date: Int] = [:]
+        var counts: [Date: [Int: Int]] = [:]
+
+        for (install, installDate) in installDays where range.contains(installDate) {
+            let installDay = installDate.startOfDay
+            let week = installDay.startOfWeek
+            sizes[week, default: 0] += 1
+
+            let active = sessionDays[install] ?? []
+            for (index, offset) in dayOffsets.enumerated() {
+                let target = calendar.date(byAdding: .day, value: offset, to: installDay)!
+                if active.contains(target) {
+                    counts[week, default: [:]][index, default: 0] += 1
+                }
+            }
+        }
+
+        return sizes.keys.sorted().map { week in
+            let cohortCounts = counts[week] ?? [:]
+
+            let retained = dayOffsets.enumerated().map { index, offset -> Int? in
+                let matured = calendar.date(byAdding: .day, value: 6 + offset, to: week)!
+                guard matured < asOf else {
+                    return nil
+                }
+                return cohortCounts[index] ?? 0
+            }
+
+            return RetentionCohort(
+                date: week.millisecondsSince1970,
+                size: sizes[week] ?? 0,
+                retained: retained
+            )
+        }
+    }
+}

--- a/Sources/Scout/UI/Analytics/Retention/RetentionCohort+Fixture.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionCohort+Fixture.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+extension RetentionCohort: Fixture {
+    static var samples: [RetentionCohort] {
+        let weeks = 10
+        let end = Date().startOfDay
+        let targets: [Int: Double] = [0: 1, 1: 0.42, 3: 0.28, 7: 0.19, 14: 0.13, 30: 0.08]
+
+        return (0..<weeks).compactMap { index -> RetentionCohort? in
+            guard let start = Calendar.utc.date(byAdding: .day, value: -7 * (weeks - index), to: end) else {
+                return nil
+            }
+
+            let elapsed = 7 * (weeks - index)
+            let quality = 0.85 + Double(index) * 0.02
+            let size = 620 + (index * 173) % 540
+
+            let retention = dayOffsets.map { day -> Double? in
+                guard day <= elapsed, let target = targets[day] else { return nil }
+                return day == 0 ? 1 : min(target * quality, 0.95)
+            }
+
+            return RetentionCohort(id: start, size: size, retention: retention)
+        }
+    }
+}

--- a/Sources/Scout/UI/Analytics/Retention/RetentionCohort.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionCohort.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+struct RetentionCohort: Identifiable, Hashable {
+    static let dayOffsets = [0, 1, 3, 7, 14, 30]
+
+    let id: Date
+    let size: Int
+    let retention: [Double?]
+
+    var label: String {
+        cohortDateFormatter.string(from: id)
+    }
+}
+
+extension RetentionCohort {
+    /// Maps a wire cohort — a week start in epoch milliseconds, an install
+    /// count, and a retained count per `dayOffsets` milestone (`nil` where the
+    /// milestone has not elapsed) — into display rates.
+    ///
+    init(date: Int64, size: Int, retained: [Int?]) {
+        self.init(
+            id: Date(millisecondsSince1970: date),
+            size: size,
+            retention: retained.map { count in
+                guard let count, size > 0 else { return nil }
+                return Double(count) / Double(size)
+            }
+        )
+    }
+}
+
+let cohortDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US")
+    formatter.dateFormat = "MMM d"
+    return formatter
+}()
+
+extension RetentionCohort {
+    struct DayStat: Identifiable {
+        let day: Int
+        let average: Double
+        let low: Double
+        let high: Double
+        var id: Int { day }
+    }
+
+    static func stats(for cohorts: [RetentionCohort]) -> [DayStat] {
+        dayOffsets.enumerated().compactMap { index, day in
+            let rates = cohorts.compactMap { $0.retention[index] }
+            guard rates.count > 0 else { return nil }
+            return DayStat(
+                day: day, average: rates.reduce(0, +) / Double(rates.count), low: rates.min() ?? 0,
+                high: rates.max() ?? 0)
+        }
+    }
+}

--- a/Sources/Scout/UI/Analytics/Retention/RetentionCohortDetailView.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionCohortDetailView.swift
@@ -1,0 +1,139 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Charts
+import SwiftUI
+
+struct RetentionCohortDetailView: View {
+    let cohort: RetentionCohort
+    let cohorts: [RetentionCohort]
+
+    private var average: [RetentionCohort.DayStat] {
+        RetentionCohort.stats(for: cohorts)
+    }
+
+    private func rate(_ retention: [Double?], day: Int) -> Double? {
+        guard let index = RetentionCohort.dayOffsets.firstIndex(of: day) else { return nil }
+        return retention[index]
+    }
+
+    var body: some View {
+        List {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(verbatim: "\(cohort.size) installs").font(.caption).foregroundStyle(.secondary)
+
+                Chart {
+                    ForEach(average) { stat in
+                        LineMark(
+                            x: .value("Day", stat.day),
+                            y: .value("Average", stat.average),
+                            series: .value("Series", "Average")
+                        )
+                        .foregroundStyle(Color(.systemGray4))
+                        .lineStyle(StrokeStyle(lineWidth: 2, dash: [4, 3]))
+                        .interpolationMethod(.monotone)
+                    }
+
+                    ForEach(Array(zip(RetentionCohort.dayOffsets, cohort.retention)), id: \.0) { day, rate in
+                        if let rate {
+                            LineMark(
+                                x: .value("Day", day),
+                                y: .value("Retention", rate),
+                                series: .value("Series", "Cohort")
+                            )
+                            .foregroundStyle(.green)
+                            .lineStyle(StrokeStyle(lineWidth: 2.5))
+                            .interpolationMethod(.monotone)
+
+                            PointMark(
+                                x: .value("Day", day),
+                                y: .value("Retention", rate)
+                            )
+                            .foregroundStyle(.green)
+                            .symbolSize(30)
+                        }
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks { value in
+                        AxisGridLine()
+                        if let rate = value.as(Double.self) {
+                            AxisValueLabel(
+                                rate.formatted(
+                                    .percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0))))
+                        }
+                    }
+                }
+                .aspectRatio(1.618, contentMode: .fit)
+                .padding(.top, 8)
+
+                legend
+            }
+            .listRowSeparator(.hidden)
+
+            Header(title: "By OS Version")
+
+            ForEach(cohort.segments) { segment in
+                NavigationLink {
+                    RetentionSegmentDetailView(segment: segment, cohort: cohort)
+                } label: {
+                    HStack {
+                        Text(verbatim: segment.name).font(.subheadline)
+                        Spacer()
+
+                        HStack(spacing: 14) {
+                            stat(day: 7, retention: segment.retention)
+                            stat(day: 30, retention: segment.retention)
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: "Week of \(cohort.label)")
+    }
+
+    private var legend: some View {
+        HStack(spacing: 16) {
+            legendItem(color: .green, dashed: false, title: "This cohort")
+            legendItem(color: Color(.systemGray4), dashed: true, title: "Average")
+        }
+    }
+
+    private func legendItem(color: Color, dashed: Bool, title: String) -> some View {
+        HStack(spacing: 4) {
+            Path { path in
+                path.move(to: CGPoint(x: 0, y: 1))
+                path.addLine(to: CGPoint(x: 14, y: 1))
+            }
+            .stroke(color, style: StrokeStyle(lineWidth: 2, dash: dashed ? [3, 2] : []))
+            .frame(width: 14, height: 2)
+
+            Text(verbatim: title).font(.caption2).foregroundStyle(.secondary)
+        }
+    }
+
+    private func stat(day: Int, retention: [Double?]) -> some View {
+        VStack(spacing: 2) {
+            Text(verbatim: "D\(day)").font(.caption2).foregroundStyle(.secondary)
+            Text(
+                verbatim: rate(retention, day: day).map {
+                    $0.formatted(.percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0)))
+                } ?? "—"
+            )
+            .font(.caption.weight(.semibold))
+        }
+        .frame(width: 40)
+    }
+}
+
+#Preview("RetentionCohortDetailView") {
+    NavigationStack {
+        RetentionCohortDetailView(cohort: RetentionCohort.samples[0], cohorts: .samples)
+    }
+}

--- a/Sources/Scout/UI/Analytics/Retention/RetentionHeroChartView.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionHeroChartView.swift
@@ -1,0 +1,128 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Charts
+import SwiftUI
+
+struct RetentionHeroChartView: View {
+    @ObservedObject var provider: RetentionProvider
+
+    var body: some View {
+        ProviderView(provider: provider) { cohorts in
+            if cohorts.count > 0 {
+                RetentionHeroChart(cohorts: cohorts)
+            } else {
+                Placeholder(
+                    text: "No cohorts",
+                    systemImage: "person.2",
+                    description: "Retention appears once installs start returning"
+                )
+            }
+        }
+        .navigationTitle(en: "Retention")
+    }
+}
+
+private struct RetentionHeroChart: View {
+    let cohorts: [RetentionCohort]
+
+    private var stats: [RetentionCohort.DayStat] {
+        RetentionCohort.stats(for: cohorts)
+    }
+
+    private func rate(_ cohort: RetentionCohort, day: Int) -> Double? {
+        guard let index = RetentionCohort.dayOffsets.firstIndex(of: day) else { return nil }
+        return cohort.retention[index]
+    }
+
+    var body: some View {
+        List {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(verbatim: "Average Retention").font(.headline)
+                Text(verbatim: "Across \(cohorts.count) weekly cohorts").font(.caption).foregroundStyle(.secondary)
+
+                Chart(stats) { stat in
+                    AreaMark(
+                        x: .value("Day", stat.day),
+                        yStart: .value("Low", stat.low),
+                        yEnd: .value("High", stat.high)
+                    )
+                    .foregroundStyle(Color.green.opacity(0.15))
+                    .interpolationMethod(.monotone)
+
+                    LineMark(
+                        x: .value("Day", stat.day),
+                        y: .value("Average", stat.average)
+                    )
+                    .foregroundStyle(.green)
+                    .lineStyle(StrokeStyle(lineWidth: 2.5))
+                    .interpolationMethod(.monotone)
+
+                    PointMark(
+                        x: .value("Day", stat.day),
+                        y: .value("Average", stat.average)
+                    )
+                    .foregroundStyle(.green)
+                    .symbolSize(30)
+                }
+                .chartYAxis {
+                    AxisMarks { value in
+                        AxisGridLine()
+                        if let rate = value.as(Double.self) {
+                            AxisValueLabel(
+                                rate.formatted(
+                                    .percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0))))
+                        }
+                    }
+                }
+                .aspectRatio(1.618, contentMode: .fit)
+                .padding(.top, 8)
+            }
+            .listRowSeparator(.hidden)
+
+            Header(title: "By Cohort")
+
+            ForEach(cohorts.reversed()) { cohort in
+                NavigationLink {
+                    RetentionCohortDetailView(cohort: cohort, cohorts: cohorts)
+                } label: {
+                    HStack {
+                        Text(verbatim: "Week of \(cohort.label)").font(.subheadline)
+                        Spacer()
+                        Text(verbatim: "\(cohort.size)").font(.caption).foregroundStyle(.secondary)
+
+                        if let day7 = rate(cohort, day: 7) {
+                            Text(
+                                verbatim:
+                                    "D7 \(day7.formatted(.percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0))))"
+                            )
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.green)
+                            .frame(width: 72, alignment: .trailing)
+                        } else {
+                            Text(verbatim: "—")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                                .frame(width: 72, alignment: .trailing)
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+}
+
+#Preview("RetentionHeroChartView") {
+    let provider = RetentionProvider()
+    provider.result = .success(.samples)
+
+    return NavigationStack {
+        RetentionHeroChartView(provider: provider)
+    }
+}

--- a/Sources/Scout/UI/Analytics/Retention/RetentionProvider.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionProvider.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+class RetentionProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<[RetentionCohort]>?
+
+    func fetch(in database: DatabaseReader) async throws -> [RetentionCohort] {
+        try await database.retention(in: Calendar.utc.defaultRange)
+    }
+}
+
+protocol RetentionReader: RecordReader {
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort]
+}

--- a/Sources/Scout/UI/Analytics/Retention/RetentionSegment.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionSegment.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+
+struct RetentionSegment: Identifiable {
+    let name: String
+    let retention: [Double?]
+    let crashRate: Double
+    let hangRate: Double
+    var id: String { name }
+}
+
+extension RetentionCohort {
+    var segments: [RetentionSegment] {
+        let variants: [(name: String, factor: Double, crashRate: Double, hangRate: Double)] = [
+            ("iOS 18", 1.12, 0.4, 0.9),
+            ("iOS 17", 0.95, 0.9, 1.6),
+            ("iOS 16", 0.76, 2.1, 3.4),
+        ]
+
+        return variants.map { variant in
+            RetentionSegment(
+                name: variant.name,
+                retention: retention.map { $0.map { min($0 * variant.factor, 0.98) } },
+                crashRate: variant.crashRate,
+                hangRate: variant.hangRate
+            )
+        }
+    }
+}

--- a/Sources/Scout/UI/Analytics/Retention/RetentionSegmentDetailView.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionSegmentDetailView.swift
@@ -1,0 +1,141 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Charts
+import SwiftUI
+
+struct RetentionSegmentDetailView: View {
+    let segment: RetentionSegment
+    let cohort: RetentionCohort
+
+    private var crashMultiplier: Double {
+        let others = cohort.segments.filter { $0.name != segment.name }
+        let baseline = others.map(\.crashRate).reduce(0, +) / Double(max(others.count, 1))
+        guard baseline > 0 else { return 1 }
+        return segment.crashRate / baseline
+    }
+
+    var body: some View {
+        List {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(verbatim: "Week of \(cohort.label)").font(.caption).foregroundStyle(.secondary)
+
+                Chart {
+                    ForEach(Array(zip(RetentionCohort.dayOffsets, cohort.retention)), id: \.0) { day, rate in
+                        if let rate {
+                            LineMark(
+                                x: .value("Day", day),
+                                y: .value("Cohort", rate),
+                                series: .value("Series", "Cohort")
+                            )
+                            .foregroundStyle(Color(.systemGray4))
+                            .lineStyle(StrokeStyle(lineWidth: 2, dash: [4, 3]))
+                            .interpolationMethod(.monotone)
+                        }
+                    }
+
+                    ForEach(Array(zip(RetentionCohort.dayOffsets, segment.retention)), id: \.0) { day, rate in
+                        if let rate {
+                            LineMark(
+                                x: .value("Day", day),
+                                y: .value("Segment", rate),
+                                series: .value("Series", "Segment")
+                            )
+                            .foregroundStyle(.orange)
+                            .lineStyle(StrokeStyle(lineWidth: 2.5))
+                            .interpolationMethod(.monotone)
+
+                            PointMark(
+                                x: .value("Day", day),
+                                y: .value("Segment", rate)
+                            )
+                            .foregroundStyle(.orange)
+                            .symbolSize(30)
+                        }
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks { value in
+                        AxisGridLine()
+                        if let rate = value.as(Double.self) {
+                            AxisValueLabel(
+                                rate.formatted(
+                                    .percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0))))
+                        }
+                    }
+                }
+                .aspectRatio(1.618, contentMode: .fit)
+                .padding(.top, 8)
+
+                legend
+            }
+            .listRowSeparator(.hidden)
+
+            Header(title: "Stability")
+
+            HStack(spacing: 24) {
+                stabilityStat(title: "Crashes", value: segment.crashRate, color: .red)
+                stabilityStat(title: "Hangs", value: segment.hangRate, color: .orange)
+            }
+            .listRowSeparator(.hidden)
+
+            if crashMultiplier > 1.2 {
+                Text(
+                    verbatim:
+                        "\(crashMultiplier.formatted(numberFormatStyle))× the crash rate of other versions in this cohort"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .listRowSeparator(.hidden)
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: segment.name)
+    }
+
+    private var legend: some View {
+        HStack(spacing: 16) {
+            legendItem(color: .orange, dashed: false, title: segment.name)
+            legendItem(color: Color(.systemGray4), dashed: true, title: "Cohort")
+        }
+    }
+
+    private func legendItem(color: Color, dashed: Bool, title: String) -> some View {
+        HStack(spacing: 4) {
+            Path { path in
+                path.move(to: CGPoint(x: 0, y: 1))
+                path.addLine(to: CGPoint(x: 14, y: 1))
+            }
+            .stroke(color, style: StrokeStyle(lineWidth: 2, dash: dashed ? [3, 2] : []))
+            .frame(width: 14, height: 2)
+
+            Text(verbatim: title).font(.caption2).foregroundStyle(.secondary)
+        }
+    }
+
+    private func stabilityStat(title: String, value: Double, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(verbatim: title.uppercased()).font(.caption2).foregroundStyle(.secondary)
+            Text(verbatim: "\(value.formatted(numberFormatStyle))%")
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundStyle(color)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private let numberFormatStyle = FloatingPointFormatStyle<Double>(locale: Locale(identifier: "en_US"))
+    .precision(.fractionLength(1))
+
+#Preview("RetentionSegmentDetailView") {
+    let cohort = RetentionCohort.samples[0]
+
+    NavigationStack {
+        RetentionSegmentDetailView(segment: cohort.segments[2], cohort: cohort)
+    }
+}

--- a/Sources/Scout/UI/Home/HomeDestination.swift
+++ b/Sources/Scout/UI/Home/HomeDestination.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum HomeDestination: Hashable {
     case activity
+    case retention
     case sessions
     case log
     case releaseHealth

--- a/Sources/Scout/UI/Home/HomeList.swift
+++ b/Sources/Scout/UI/Home/HomeList.swift
@@ -14,6 +14,7 @@ struct HomeList: View {
     @Binding var path: [HomeDestination]
 
     @StateObject var activities = ActivityProvider()
+    @StateObject var retention = RetentionProvider()
     @StateObject var sessions = StatProvider(eventName: "Session", periods: Period.summary)
     @StateObject var releases = ReleaseHealthProvider()
     @StateObject var logs = HomeLogProvider()
@@ -60,11 +61,27 @@ struct HomeList: View {
                 HomeReleaseSection(provider: releases) {
                     path.append(.releaseHealth)
                 }
+
+                Button {
+                    path.append(.retention)
+                } label: {
+                    HStack {
+                        Text(verbatim: "Retention").font(.body)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .buttonStyle(.plain)
+                .listRowSeparator(.hidden)
             }
             .navigationDestination(for: HomeDestination.self) { destination in
                 switch destination {
                 case .activity:
                     activityDestination
+                case .retention:
+                    RetentionHeroChartView(provider: retention)
                 case .sessions:
                     sessionDestination
                 case .log:

--- a/Sources/Scout/UI/Primitives/Platform/NSColor+macOS.swift
+++ b/Sources/Scout/UI/Primitives/Platform/NSColor+macOS.swift
@@ -18,6 +18,14 @@
             }
         }
 
+        static var systemGray4: NSColor {
+            NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                    ? NSColor(red: 58 / 255, green: 58 / 255, blue: 60 / 255, alpha: 1)
+                    : NSColor(red: 209 / 255, green: 209 / 255, blue: 214 / 255, alpha: 1)
+            }
+        }
+
         static var systemGray5: NSColor {
             NSColor(name: nil) { appearance in
                 appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua

--- a/Tests/ScoutTests/Hosted/Transport/ServerContractTests.swift
+++ b/Tests/ScoutTests/Hosted/Transport/ServerContractTests.swift
@@ -111,6 +111,28 @@ struct ServerContractTests {
         #expect(point.mau >= 1)
     }
 
+    @Test("The retention table counts a written Install and its return visit")
+    func retentionCohort() async throws {
+        let database = try makeDatabase()
+        let install = UUID().uuidString
+        let installDay = eventDate.startOfDay
+
+        try await database.write(records: [
+            makeInstall(installID: install, date: installDay),
+            makeSession(installID: install, startDate: installDay.addingTimeInterval(3600)),
+        ])
+
+        let week = installDay.startOfWeek
+        let cohorts = try await database.retention(in: week..<week.addingDay(14))
+        let cohort = try #require(cohorts.first { $0.id == week })
+
+        // Our install anchors the cohort and is active on D0; shared data may
+        // add more installs to the same week, so assert a lower bound.
+        #expect(cohort.size >= 1)
+        let d0 = try #require(cohort.retention.first ?? nil)
+        #expect(d0 > 0)
+    }
+
     @Test("Sessions aggregate into a per-version matrix")
     func versionedSessionMatrix() async throws {
         let database = try makeDatabase()
@@ -238,6 +260,13 @@ struct ServerContractTests {
         record["session_id"] = UUID().uuidString
         record["install_id"] = installID
         record["start_date"] = startDate
+        return record
+    }
+
+    private func makeInstall(installID: String, date: Date) -> Record {
+        var record = Record(recordType: "Install", recordID: installID)
+        record["install_id"] = installID
+        record["date"] = date
         return record
     }
 

--- a/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/DatabaseStub.swift
@@ -74,6 +74,10 @@ final class DatabaseStub: DatabaseReader, @unchecked Sendable {
     func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
         []
     }
+
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        []
+    }
 }
 
 /// A reusable async latch: `wait()` suspends until `open()` is called; once

--- a/Tests/ScoutTests/Stubs/Records/ServerStub.swift
+++ b/Tests/ScoutTests/Stubs/Records/ServerStub.swift
@@ -10,19 +10,25 @@ import Foundation
 @testable import Scout
 
 // A `DatabaseReader` standing in for a Scout server backend: it returns the
-// activity and metric series it is seeded with, and empty results for every
-// other query.
+// activity, retention, and metric series it is seeded with, and empty results
+// for every other query.
 final class ServerStub: DatabaseReader, @unchecked Sendable {
     let activitySeries: [ActivityPoint]
+    let retentionCohorts: [RetentionCohort]
     let metricsSeries: [MetricSeries]
 
-    init(activity: [ActivityPoint] = [], metrics: [MetricSeries] = []) {
+    init(activity: [ActivityPoint] = [], retention: [RetentionCohort] = [], metrics: [MetricSeries] = []) {
         self.activitySeries = activity
+        self.retentionCohorts = retention
         self.metricsSeries = metrics
     }
 
     func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
         activitySeries
+    }
+
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        retentionCohorts
     }
 
     func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws

--- a/Tests/ScoutTests/Transient/InMemoryDatabase.swift
+++ b/Tests/ScoutTests/Transient/InMemoryDatabase.swift
@@ -68,6 +68,10 @@ extension InMemoryDatabase {
     func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
         []
     }
+
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        []
+    }
 }
 
 extension InMemoryDatabase {

--- a/Tests/ScoutTests/UI/Analytics/Retention/RetentionCohortBuildTests.swift
+++ b/Tests/ScoutTests/UI/Analytics/Retention/RetentionCohortBuildTests.swift
@@ -1,0 +1,90 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct RetentionCohortBuildTests {
+    private let installDay = Date(year: 2026, month: 6, day: 1)
+
+    private func rate(_ cohort: RetentionCohort, day: Int) -> Double? {
+        guard let index = RetentionCohort.dayOffsets.firstIndex(of: day) else {
+            return nil
+        }
+        return cohort.retention[index]
+    }
+
+    @Test("Bounded day-N retention counts activity on exactly install day + N")
+    func boundedDayNRates() throws {
+        let cohorts = RetentionCohort.build(
+            installDays: ["a": installDay, "b": installDay],
+            sessionDays: [
+                // Install "a" returns on D0, D1, D7.
+                "a": [installDay, installDay.addingDay(), installDay.addingDay(7)],
+                // Install "b" only opens on D0.
+                "b": [installDay],
+            ],
+            in: Date(year: 2026, month: 5, day: 1)..<Date(year: 2026, month: 8, day: 1),
+            asOf: Date(year: 2026, month: 8, day: 1)
+        )
+
+        let cohort = try #require(cohorts.first { $0.id == installDay.startOfWeek })
+
+        #expect(cohort.size == 2)
+        #expect(rate(cohort, day: 0) == 1)
+        #expect(rate(cohort, day: 1) == 0.5)
+        #expect(rate(cohort, day: 3) == 0)
+        #expect(rate(cohort, day: 7) == 0.5)
+        #expect(rate(cohort, day: 30) == 0)
+    }
+
+    @Test("An install with no return activity still counts in the cohort size")
+    func inactiveInstallCountsInSize() throws {
+        let cohorts = RetentionCohort.build(
+            installDays: ["a": installDay, "b": installDay],
+            sessionDays: ["a": [installDay]],
+            in: Date(year: 2026, month: 5, day: 1)..<Date(year: 2026, month: 8, day: 1),
+            asOf: Date(year: 2026, month: 8, day: 1)
+        )
+
+        let cohort = try #require(cohorts.first { $0.id == installDay.startOfWeek })
+
+        #expect(cohort.size == 2)
+        #expect(rate(cohort, day: 0) == 0.5)
+    }
+
+    @Test("Milestones that have not elapsed by the cutoff are nil")
+    func immatureMilestonesAreNil() throws {
+        let recentInstall = Date(year: 2026, month: 7, day: 20)
+
+        let cohorts = RetentionCohort.build(
+            installDays: ["a": recentInstall],
+            sessionDays: ["a": [recentInstall]],
+            in: Date(year: 2026, month: 7, day: 1)..<Date(year: 2026, month: 8, day: 1),
+            asOf: Date(year: 2026, month: 8, day: 1)
+        )
+
+        let cohort = try #require(cohorts.first { $0.id == recentInstall.startOfWeek })
+
+        #expect(rate(cohort, day: 0) == 1)
+        #expect(rate(cohort, day: 30) == nil)
+    }
+
+    @Test("Installs outside the range are excluded")
+    func installsOutsideRangeExcluded() {
+        let cohorts = RetentionCohort.build(
+            installDays: ["a": Date(year: 2026, month: 1, day: 1)],
+            sessionDays: ["a": [Date(year: 2026, month: 1, day: 1)]],
+            in: Date(year: 2026, month: 5, day: 1)..<Date(year: 2026, month: 8, day: 1),
+            asOf: Date(year: 2026, month: 8, day: 1)
+        )
+
+        #expect(cohorts.count == 0)
+    }
+}

--- a/Tests/ScoutTests/UI/Monitoring/Network/View/NetworkProviderTests.swift
+++ b/Tests/ScoutTests/UI/Monitoring/Network/View/NetworkProviderTests.swift
@@ -69,6 +69,10 @@ private final class CategoryDatabaseStub: DatabaseReader, @unchecked Sendable {
         []
     }
 
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        []
+    }
+
     func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
         -> [MetricSeries]
     {
@@ -88,6 +92,10 @@ private final class ThrowingDatabaseStub: DatabaseReader, @unchecked Sendable {
     struct Failure: Error {}
 
     func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
+        throw Failure()
+    }
+
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
         throw Failure()
     }
 

--- a/Tests/ScoutTests/UI/Provider/FeedProviderTests.swift
+++ b/Tests/ScoutTests/UI/Provider/FeedProviderTests.swift
@@ -80,4 +80,5 @@ private final class FailingDatabase: DatabaseReader, @unchecked Sendable {
         -> [MetricSeries]
     { throw RefreshFailure() }
     func activity(in range: Range<Date>) async throws -> [ActivityPoint] { throw RefreshFailure() }
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] { throw RefreshFailure() }
 }


### PR DESCRIPTION
Adds a RetentionReader to every DatabaseReader backend so a weekly retention-cohort table is available app-wide. The hosted reader calls the new GET /api/v1/metrics/retention endpoint; the native reader computes the same weekly bounded day-N cohorts locally from Install and Session records through a pure, unit-tested builder, keeping the CloudKit path self-sufficient. RetentionProvider maps the wire counts to display rates and feeds the retention screen — an average-retention curve over a cohort drill-down into per-OS-version segments and their crash/hang stability — reachable from Home. The server contract test gains a retention case, verified end to end against a live scout-server. Companion to kasianov-mikhail/scout-server#44, which serves the endpoint. Also skips macro validation in the contract CI job, which the new test tripped: the job built with a plain xcodebuild test and, unlike the iOS jobs, omitted -skipMacroValidation, failing the ScoutDBMacros gate on the macos-26 runner.