### PR TITLE
Flesh out the Home retention section with a sparkline and milestones

### DIFF
--- a/Sources/Scout/UI/Analytics/Retention/RetentionCohort.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionCohort.swift
@@ -10,6 +10,7 @@ import Foundation
 
 struct RetentionCohort: Identifiable, Hashable {
     static let dayOffsets = [0, 1, 3, 7, 14, 30]
+    static let summaryOffsets = [1, 7, 30]
 
     let id: Date
     let size: Int
@@ -43,6 +44,12 @@ let cohortDateFormatter: DateFormatter = {
     formatter.dateFormat = "MMM d"
     return formatter
 }()
+
+extension FormatStyle where Self == FloatingPointFormatStyle<Double>.Percent {
+    static var retentionRate: FloatingPointFormatStyle<Double>.Percent {
+        .percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0))
+    }
+}
 
 extension RetentionCohort {
     struct DayStat: Identifiable {

--- a/Sources/Scout/UI/Analytics/Retention/RetentionCohortDetailView.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionCohortDetailView.swift
@@ -64,8 +64,7 @@ struct RetentionCohortDetailView: View {
                         AxisGridLine()
                         if let rate = value.as(Double.self) {
                             AxisValueLabel(
-                                rate.formatted(
-                                    .percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0))))
+                                rate.formatted(.retentionRate))
                         }
                     }
                 }
@@ -123,7 +122,7 @@ struct RetentionCohortDetailView: View {
             Text(verbatim: "D\(day)").font(.caption2).foregroundStyle(.secondary)
             Text(
                 verbatim: rate(retention, day: day).map {
-                    $0.formatted(.percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0)))
+                    $0.formatted(.retentionRate)
                 } ?? "—"
             )
             .font(.caption.weight(.semibold))

--- a/Sources/Scout/UI/Analytics/Retention/RetentionHeroChartView.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionHeroChartView.swift
@@ -75,8 +75,7 @@ private struct RetentionHeroChart: View {
                         AxisGridLine()
                         if let rate = value.as(Double.self) {
                             AxisValueLabel(
-                                rate.formatted(
-                                    .percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0))))
+                                rate.formatted(.retentionRate))
                         }
                     }
                 }
@@ -99,7 +98,7 @@ private struct RetentionHeroChart: View {
                         if let day7 = rate(cohort, day: 7) {
                             Text(
                                 verbatim:
-                                    "D7 \(day7.formatted(.percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0))))"
+                                    "D7 \(day7.formatted(.retentionRate))"
                             )
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(.green)

--- a/Sources/Scout/UI/Analytics/Retention/RetentionSegmentDetailView.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionSegmentDetailView.swift
@@ -64,8 +64,7 @@ struct RetentionSegmentDetailView: View {
                         AxisGridLine()
                         if let rate = value.as(Double.self) {
                             AxisValueLabel(
-                                rate.formatted(
-                                    .percent.locale(Locale(identifier: "en_US")).precision(.fractionLength(0))))
+                                rate.formatted(.retentionRate))
                         }
                     }
                 }

--- a/Sources/Scout/UI/Home/HomeList.swift
+++ b/Sources/Scout/UI/Home/HomeList.swift
@@ -46,6 +46,7 @@ struct HomeList: View {
                 path: $path
             )
             HomeRetentionSection(
+                retention: retention,
                 path: $path
             )
         }
@@ -78,6 +79,9 @@ struct HomeList: View {
     let sessions = StatProvider(eventName: "Session", periods: Period.summary)
     sessions.result = .success([.sample(name: "Session")])
 
+    let retention = RetentionProvider()
+    retention.result = .success(.samples)
+
     let releases = ReleaseHealthProvider()
     releases.result = .success(.samples)
 
@@ -102,6 +106,7 @@ struct HomeList: View {
         HomeList(
             path: .constant([]),
             activities: activities,
+            retention: retention,
             sessions: sessions,
             releases: releases,
             logs: logs,

--- a/Sources/Scout/UI/Home/Section/Metric/HomeMetricSection.swift
+++ b/Sources/Scout/UI/Home/Section/Metric/HomeMetricSection.swift
@@ -40,6 +40,7 @@ struct HomeMetricSection: View {
             }
             .buttonStyle(.plain)
         }
+        .padding(.bottom, -11)
         .listRowSeparator(.hidden)
     }
 

--- a/Sources/Scout/UI/Home/Section/Retention/HomeRetentionRow.swift
+++ b/Sources/Scout/UI/Home/Section/Retention/HomeRetentionRow.swift
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct HomeRetentionRow: View {
+    let series: MiniChartSeries
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Sparkline(series: series, color: .green, gridlinesAtPoints: true)
+                .frame(height: 72)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 12)
+        }
+        .buttonStyle(.plain)
+        .listRowSeparator(.hidden)
+        .listRowInsets(EdgeInsets())
+    }
+}
+
+#Preview {
+    List {
+        HomeRetentionRow(series: MiniChartSeries(values: [100, 42, 28, 19, 13, 8])) {}
+    }
+    .listStyle(.plain)
+}

--- a/Sources/Scout/UI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/Scout/UI/Home/Section/Retention/HomeRetentionSection.swift
@@ -8,19 +8,96 @@
 import SwiftUI
 
 struct HomeRetentionSection: View {
+    @Environment(\.database) var database
+
+    @ObservedObject var retention: RetentionProvider
+
     @Binding var path: [HomeDestination]
 
     var body: some View {
         Header(title: "Retention") {
-            AllButton { path.append(.retention) }
+            if let cohorts = try? retention.result?.get(), cohorts.count > 0 {
+                AllButton { path.append(.retention) }
+            }
+        }
+        .task { await retention.fetchIfNeeded(in: database) }
+
+        switch retention.result {
+        case .success(let cohorts) where cohorts.count > 0:
+            RetentionContent(cohorts: cohorts, path: $path)
+
+        case .success:
+            Text(verbatim: "No results")
+                .placeholderTextStyle()
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 20)
+                .listRowSeparator(.hidden)
+
+        default:
+            RetentionPlaceholder()
         }
     }
 }
 
+private struct RetentionContent: View {
+    let cohorts: [RetentionCohort]
+
+    @Binding var path: [HomeDestination]
+
+    var body: some View {
+        let stats = RetentionCohort.stats(for: cohorts)
+        let series = MiniChartSeries(values: stats.map { Int(($0.average * 100).rounded()) })
+
+        HomeRetentionRow(series: series) { path.append(.retention) }
+
+        ForEach(RetentionCohort.summaryOffsets, id: \.self) { day in
+            RetentionMilestoneRow(day: day, rate: stats.first { $0.day == day }?.average) {
+                path.append(.retention)
+            }
+        }
+    }
+}
+
+private struct RetentionPlaceholder: View {
+    var body: some View {
+        HomeRetentionRow(series: .placeholder) {}
+            .redacted(reason: .placeholder)
+
+        ForEach(RetentionCohort.summaryOffsets, id: \.self) { day in
+            RetentionMilestoneRow(day: day, rate: nil) {}
+                .redacted(reason: .placeholder)
+        }
+    }
+}
+
+private struct RetentionMilestoneRow: View {
+    let day: Int
+    let rate: Double?
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Text(verbatim: "Day \(day)")
+                    .font(.subheadline)
+                Spacer()
+                Text(verbatim: rate?.formatted(.retentionRate) ?? "—")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.green)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 #Preview {
-    NavigationStack {
+    let retention = RetentionProvider()
+    retention.result = .success(.samples)
+
+    return NavigationStack {
         List {
-            HomeRetentionSection(path: .constant([]))
+            HomeRetentionSection(retention: retention, path: .constant([]))
+            HomeRetentionSection(retention: RetentionProvider(), path: .constant([]))
         }
         .listStyle(.plain)
     }

--- a/Sources/Scout/UI/Insights/Chart/View/Sparkline.swift
+++ b/Sources/Scout/UI/Insights/Chart/View/Sparkline.swift
@@ -19,7 +19,8 @@ struct Sparkline: View {
         let values = series.isEmpty ? [] : series.values
         let scale = SparklineScale(values: values)
         let last = Double(max(values.count - 1, 1))
-        let xGridlines = gridlinesAtPoints
+        let xGridlines =
+            gridlinesAtPoints
             ? Array(stride(from: 0, through: last, by: 1))
             : (0...3).map { last * Double($0) / 3 }
 

--- a/Sources/Scout/UI/Insights/Chart/View/Sparkline.swift
+++ b/Sources/Scout/UI/Insights/Chart/View/Sparkline.swift
@@ -13,11 +13,15 @@ struct Sparkline: View {
     let color: Color
     var lineWidth: Double = 2
     var showsGridlines = true
+    var gridlinesAtPoints = false
 
     var body: some View {
         let values = series.isEmpty ? [] : series.values
         let scale = SparklineScale(values: values)
         let last = Double(max(values.count - 1, 1))
+        let xGridlines = gridlinesAtPoints
+            ? Array(stride(from: 0, through: last, by: 1))
+            : (0...3).map { last * Double($0) / 3 }
 
         Chart(Array(values.enumerated()), id: \.offset) { index, value in
             AreaMark(
@@ -44,7 +48,7 @@ struct Sparkline: View {
         }
         .chartXAxis {
             if showsGridlines {
-                AxisMarks(values: (0...3).map { last * Double($0) / 3 }) { _ in
+                AxisMarks(values: xGridlines) { _ in
                     AxisGridLine()
                 }
             }


### PR DESCRIPTION
The Home "Retention" entry was a bare navigation button, out of place next to the Log and Releases sections. This turns it into a real provider-driven section: a full-width average-retention sparkline row followed by Day 1 / Day 7 / Day 30 readout rows, with loading and empty states to match. The sparkline height (72) and gridline behavior line up with the top metric cards.

Along the way the section now fetches retention itself via fetchIfNeeded instead of joining the shared rotatingProviders group, so a retention backend failure degrades only this section rather than blanking the whole Home screen the way it would through the global error gate. Sparkline gains an opt-in gridlinesAtPoints mode (releases keep the default thirds), the D1/D7/D30 subset moves onto RetentionCohort as summaryOffsets, and the repeated percent format is pulled into a shared FormatStyle.retentionRate reused across the retention screens.

UI-only; verified in Xcode previews.