### PR TITLE
Add a weekly day-by-hour heatmap to stat pages

### DIFF
--- a/Sources/Scout/UI/Insights/Heatmap/HeatmapGrid.swift
+++ b/Sources/Scout/UI/Insights/Heatmap/HeatmapGrid.swift
@@ -1,0 +1,63 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct HeatmapGrid {
+    let counts: [[Int]]
+
+    static let dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    init(counts: [[Int]]) {
+        self.counts = counts
+    }
+
+    init(points: [ChartPoint<Int>], range: Range<Date>, calendar: Calendar) {
+        var counts = [[Int]](repeating: [Int](repeating: 0, count: 24), count: 7)
+
+        for point in points where range.contains(point.date) {
+            let weekday = calendar.component(.weekday, from: point.date)
+            let hour = calendar.component(.hour, from: point.date)
+            counts[(weekday + 5) % 7][hour] += point.count
+        }
+
+        self.init(counts: counts)
+    }
+
+    func blockCount(day: Int, block: Int, hours: Int) -> Int {
+        counts[day][block * hours..<(block + 1) * hours].reduce(0, +)
+    }
+
+    func maxBlockCount(hours: Int) -> Int {
+        (0..<7).flatMap { day in
+            (0..<24 / hours).map { blockCount(day: day, block: $0, hours: hours) }
+        }
+        .max() ?? 0
+    }
+}
+
+extension HeatmapGrid {
+    static func recentRange(weeks: Int, now: Date = Date()) -> Range<Date> {
+        let end = now.startOfDay.addingDay()
+        return end.addingWeek(-weeks)..<end
+    }
+}
+
+extension HeatmapGrid {
+    static var sample: HeatmapGrid {
+        HeatmapGrid(counts: (0..<7).map { day in (0..<24).map { sampleCount(day: day, hour: $0) } })
+    }
+
+    private static func sampleCount(day: Int, hour: Int) -> Int {
+        let weekday = day < 5 ? 1.0 : 0.45
+        let time = Double(hour)
+        let daytime = exp(-pow(time - 10, 2) / 18)
+        let evening = 0.7 * exp(-pow(time - 20, 2) / 10)
+        let noise = Double((day * 31 + hour * 17) % 7) / 50
+        return max(0, Int(((daytime + evening) * weekday + noise - 0.07) * 40))
+    }
+}

--- a/Sources/Scout/UI/Insights/Heatmap/HeatmapView.swift
+++ b/Sources/Scout/UI/Insights/Heatmap/HeatmapView.swift
@@ -1,0 +1,69 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct HeatmapView: View {
+    let grid: HeatmapGrid
+
+    @Environment(\.chartColor) var color
+
+    private let hours = 4
+
+    var body: some View {
+        let maxBlock = grid.maxBlockCount(hours: hours)
+
+        Grid(horizontalSpacing: 4, verticalSpacing: 4) {
+            GridRow {
+                Color.clear
+                    .gridCellUnsizedAxes([.horizontal, .vertical])
+                ForEach(0..<24 / hours, id: \.self) { block in
+                    Text(verbatim: "\(block * hours)–\(block * hours + hours)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            ForEach(0..<7) { day in
+                GridRow {
+                    Text(verbatim: HeatmapGrid.dayLabels[day])
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 30, alignment: .leading)
+                    ForEach(0..<24 / hours, id: \.self) { block in
+                        cell(day: day, block: block, maxBlock: maxBlock)
+                    }
+                }
+            }
+        }
+    }
+
+    private func cell(day: Int, block: Int, maxBlock: Int) -> some View {
+        let count = grid.blockCount(day: day, block: block, hours: hours)
+        let intensity = maxBlock > 0 ? Double(count) / Double(maxBlock) : 0
+        return RoundedRectangle(cornerRadius: 6)
+            .fill(count > 0 ? color.opacity(0.12 + 0.88 * intensity) : Color(.systemGray5))
+            .frame(height: 32)
+            .overlay {
+                if count > 0 {
+                    Text(verbatim: "\(count)")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(intensity > 0.55 ? Color.white : .secondary)
+                }
+            }
+    }
+}
+
+#Preview("HeatmapView") {
+    VStack(alignment: .leading, spacing: 24) {
+        Text(verbatim: "With Data").font(.headline)
+        HeatmapView(grid: .sample)
+
+        Text(verbatim: "Empty State").font(.headline)
+        HeatmapView(grid: HeatmapGrid(points: [], range: HeatmapGrid.recentRange(weeks: 4), calendar: .utc))
+    }
+    .padding()
+}

--- a/Sources/Scout/UI/Primitives/Stats/StatView.swift
+++ b/Sources/Scout/UI/Primitives/Stats/StatView.swift
@@ -39,9 +39,24 @@ struct StatView: View {
                     if showList {
                         total(count: segment.total)
                     }
+
+                    Header(title: "Weekly Pattern") {
+                        Text(verbatim: "Last 4 weeks")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    .listRowSeparator(.hidden)
+
+                    HeatmapView(
+                        grid: HeatmapGrid(
+                            points: points,
+                            range: HeatmapGrid.recentRange(weeks: 4),
+                            calendar: .utc
+                        )
+                    )
+                    .listRowSeparator(.hidden)
                 }
                 .listStyle(.plain)
-                .scrollDisabled(true)
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
                         ChartExportButton(

--- a/Tests/ScoutTests/UI/Insights/Heatmap/HeatmapGridTests.swift
+++ b/Tests/ScoutTests/UI/Insights/Heatmap/HeatmapGridTests.swift
@@ -1,0 +1,115 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct HeatmapGridTests {
+    @Test("Points bucket into weekday and hour cells")
+    func bucketing() throws {
+        let monday = try makeDate(year: 2026, month: 7, day: 13, hour: 9)
+        let sunday = try makeDate(year: 2026, month: 7, day: 19, hour: 23)
+        let grid = HeatmapGrid(
+            points: [
+                ChartPoint(date: monday, count: 3),
+                ChartPoint(date: sunday, count: 5),
+            ],
+            range: try weekRange(),
+            calendar: .utc
+        )
+
+        #expect(grid.counts[0][9] == 3)
+        #expect(grid.counts[6][23] == 5)
+        #expect(grid.counts.joined().reduce(0, +) == 8)
+    }
+
+    @Test("Points in the same cell accumulate across weeks")
+    func accumulation() throws {
+        let first = try makeDate(year: 2026, month: 7, day: 13, hour: 9)
+        let second = try makeDate(year: 2026, month: 7, day: 6, hour: 9)
+        let range = try makeDate(year: 2026, month: 7, day: 6)..<makeDate(year: 2026, month: 7, day: 20)
+        let grid = HeatmapGrid(
+            points: [
+                ChartPoint(date: first, count: 3),
+                ChartPoint(date: second, count: 4),
+            ],
+            range: range,
+            calendar: .utc
+        )
+
+        #expect(grid.counts[0][9] == 7)
+    }
+
+    @Test("Points outside the range are ignored")
+    func rangeFiltering() throws {
+        let inside = try makeDate(year: 2026, month: 7, day: 13, hour: 9)
+        let before = try makeDate(year: 2026, month: 7, day: 6, hour: 9)
+        let after = try makeDate(year: 2026, month: 7, day: 20, hour: 0)
+        let grid = HeatmapGrid(
+            points: [
+                ChartPoint(date: inside, count: 3),
+                ChartPoint(date: before, count: 10),
+                ChartPoint(date: after, count: 10),
+            ],
+            range: try weekRange(),
+            calendar: .utc
+        )
+
+        #expect(grid.counts.joined().reduce(0, +) == 3)
+    }
+
+    @Test("Block counts sum the hourly cells they span")
+    func blockCounts() {
+        var counts = [[Int]](repeating: [Int](repeating: 0, count: 24), count: 7)
+        counts[2][8] = 3
+        counts[2][11] = 4
+        counts[2][12] = 5
+        let grid = HeatmapGrid(counts: counts)
+
+        #expect(grid.blockCount(day: 2, block: 2, hours: 4) == 7)
+        #expect(grid.blockCount(day: 2, block: 3, hours: 4) == 5)
+        #expect(grid.blockCount(day: 2, block: 0, hours: 4) == 0)
+    }
+
+    @Test("The busiest block sets the maximum")
+    func maxBlock() {
+        var counts = [[Int]](repeating: [Int](repeating: 0, count: 24), count: 7)
+        counts[0][9] = 3
+        counts[0][10] = 4
+        counts[5][20] = 6
+        let grid = HeatmapGrid(counts: counts)
+
+        #expect(grid.maxBlockCount(hours: 4) == 7)
+    }
+
+    @Test("An empty grid has no block counts")
+    func emptyGrid() throws {
+        let grid = HeatmapGrid(points: [], range: try weekRange(), calendar: .utc)
+
+        #expect(grid.maxBlockCount(hours: 4) == 0)
+    }
+
+    @Test("The recent range covers whole weeks up to tomorrow")
+    func recentRange() throws {
+        let now = try makeDate(year: 2026, month: 7, day: 16, hour: 11)
+        let range = HeatmapGrid.recentRange(weeks: 4, now: now)
+
+        #expect(range.upperBound == (try makeDate(year: 2026, month: 7, day: 17)))
+        #expect(range.lowerBound == (try makeDate(year: 2026, month: 6, day: 19)))
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int, hour: Int = 0) throws -> Date {
+        let components = DateComponents(year: year, month: month, day: day, hour: hour)
+        return try #require(Calendar.utc.date(from: components))
+    }
+
+    private func weekRange() throws -> Range<Date> {
+        try makeDate(year: 2026, month: 7, day: 13)..<makeDate(year: 2026, month: 7, day: 20)
+    }
+}


### PR DESCRIPTION
Adds a Weekly Pattern section under the chart on stat pages (Sessions and per-event stats): a day-of-week by 4-hour-block heatmap built from the grid matrices the page already fetches, so no new backend queries. The grid aggregates the last four full weeks, keeping every weekday equally represented, and tints with the page's chart color. StatView's list becomes scrollable since the content no longer fits one screen. HeatmapGrid's bucketing, block sums, and range window are covered by unit tests.