### PR TITLE
Draw the incident breakdown as a donut with segment drill-down

### DIFF
--- a/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
@@ -11,6 +11,18 @@ import SwiftUI
 struct IncidentBreakdown: Equatable {
     let devices: [Segment]
     let osVersions: [Segment]
+    let modelsByDevice: [UUID: String]
+    let versionsBySession: [UUID: String]
+
+    init(
+        devices: [Segment], osVersions: [Segment], modelsByDevice: [UUID: String] = [:],
+        versionsBySession: [UUID: String] = [:]
+    ) {
+        self.devices = devices
+        self.osVersions = osVersions
+        self.modelsByDevice = modelsByDevice
+        self.versionsBySession = versionsBySession
+    }
 }
 
 extension IncidentBreakdown {
@@ -31,6 +43,45 @@ extension IncidentBreakdown {
     }
 
     private static let colors: [Color] = [.blue, .indigo, .purple, .teal]
+}
+
+extension IncidentBreakdown {
+    enum Dimension {
+        case devices
+        case osVersions
+    }
+
+    func records<Element: SessionContext>(from records: [Element], in dimension: Dimension, matching segment: Segment)
+        -> [Element]
+    {
+        guard segment.label == "Other" else {
+            return records.filter { label(of: $0, in: dimension) == segment.label }
+        }
+
+        let named = Set(segments(in: dimension).map(\.label))
+        return records.filter { record in
+            guard let label = label(of: record, in: dimension) else { return false }
+            return !named.contains(label)
+        }
+    }
+
+    private func segments(in dimension: Dimension) -> [Segment] {
+        switch dimension {
+        case .devices:
+            devices
+        case .osVersions:
+            osVersions
+        }
+    }
+
+    private func label<Element: SessionContext>(of record: Element, in dimension: Dimension) -> String? {
+        switch dimension {
+        case .devices:
+            record.deviceID.flatMap { modelsByDevice[$0] }
+        case .osVersions:
+            record.sessionID.flatMap { versionsBySession[$0] }
+        }
+    }
 }
 
 extension IncidentBreakdown {

--- a/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentBreakdownProvider.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentBreakdownProvider.swift
@@ -25,30 +25,40 @@ final class IncidentBreakdownProvider: ObservableObject, Provider {
         async let versions = osVersions(in: database)
 
         return IncidentBreakdown(
-            devices: IncidentBreakdown.segments(from: try await models),
-            osVersions: IncidentBreakdown.segments(from: try await versions)
+            devices: IncidentBreakdown.segments(from: Array(try await models.values)),
+            osVersions: IncidentBreakdown.segments(from: Array(try await versions.values)),
+            modelsByDevice: try await models,
+            versionsBySession: try await versions
         )
     }
 
-    private func deviceModels(in database: DatabaseReader) async throws -> [String] {
-        guard deviceIDs.count > 0 else { return [] }
+    private func deviceModels(in database: DatabaseReader) async throws -> [UUID: String] {
+        guard deviceIDs.count > 0 else { return [:] }
 
         let query = RecordQuery(
             recordType: Device.self,
             filters: [RecordQuery.Filter(field: "device_id", op: .in, value: .strings(deviceIDs.map(\.uuidString)))]
         )
         let records: [Record] = try await database.readAll(matching: query, fields: ["device_id", "model"])
-        return records.compactMap { (record: Record) -> String? in record["model"] }
+        return dictionary(from: records, key: "device_id", value: "model")
     }
 
-    private func osVersions(in database: DatabaseReader) async throws -> [String] {
-        guard sessionIDs.count > 0 else { return [] }
+    private func osVersions(in database: DatabaseReader) async throws -> [UUID: String] {
+        guard sessionIDs.count > 0 else { return [:] }
 
         let query = RecordQuery(
             recordType: Session.self,
             filters: [RecordQuery.Filter(field: "session_id", op: .in, value: .strings(sessionIDs.map(\.uuidString)))]
         )
         let records: [Record] = try await database.readAll(matching: query, fields: ["session_id", "os_version"])
-        return records.compactMap { (record: Record) -> String? in record["os_version"] }
+        return dictionary(from: records, key: "session_id", value: "os_version")
+    }
+
+    private func dictionary(from records: [Record], key: String, value: String) -> [UUID: String] {
+        let pairs = records.compactMap { (record: Record) -> (UUID, String)? in
+            guard let id = record[key].flatMap(UUID.init), let label: String = record[value] else { return nil }
+            return (id, label)
+        }
+        return Dictionary(pairs, uniquingKeysWith: { first, _ in first })
     }
 }

--- a/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentBreakdownSection.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentBreakdownSection.swift
@@ -1,0 +1,68 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct IncidentBreakdownSection<Element: Incident, RowContent: View>: View {
+    let breakdown: IncidentBreakdown
+    let records: [Element]
+    @ViewBuilder let row: (Element) -> RowContent
+
+    var body: some View {
+        if breakdown.devices.count > 0 {
+            Header(title: "Top Devices")
+            chart(for: .devices, segments: breakdown.devices, caption: "devices")
+                .listRowSeparator(.hidden, edges: .bottom)
+        }
+
+        if breakdown.osVersions.count > 0 {
+            Header(title: "OS Versions")
+            chart(for: .osVersions, segments: breakdown.osVersions, caption: "sessions")
+                .listRowSeparator(.hidden, edges: .bottom)
+        }
+    }
+
+    @ViewBuilder
+    private func chart(for dimension: IncidentBreakdown.Dimension, segments: [Segment], caption: String) -> some View {
+        if #available(iOS 17.0, macOS 14.0, *) {
+            IncidentDonut(segments: segments, caption: caption) { segment in
+                matches(in: dimension, segment: segment).count
+            } destination: { segment in
+                SegmentOccurrenceList(
+                    title: segment.label,
+                    records: matches(in: dimension, segment: segment),
+                    row: row
+                )
+            }
+        } else {
+            SegmentBar(segments: segments)
+        }
+    }
+
+    private func matches(in dimension: IncidentBreakdown.Dimension, segment: Segment) -> [Element] {
+        breakdown.records(from: records, in: dimension, matching: segment)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        List {
+            IncidentBreakdownSection(breakdown: .sample, records: [Crash].samples) { crash in
+                Row {
+                    if let date = crash.date {
+                        UTCTimestampText(date: date, size: 14)
+                    }
+                } destination: {
+                    CrashDetailView(crash: crash)
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+    .environmentObject(Tint())
+}

--- a/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentDonut.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Breakdown/IncidentDonut.swift
@@ -1,0 +1,147 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Charts
+import SwiftUI
+
+extension [Segment] {
+    var total: Int {
+        reduce(0) { $0 + $1.count }
+    }
+
+    func segment(at angle: Double) -> Segment? {
+        var cumulative = 0
+        for segment in self {
+            cumulative += segment.count
+            if angle < Double(cumulative) { return segment }
+        }
+        return last
+    }
+
+    func percent(of segment: Segment) -> String {
+        let total = self.total
+        guard total > 0 else { return "0%" }
+        return "\(Int((Double(segment.count) / Double(total) * 100).rounded()))%"
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, *)
+struct IncidentDonut<Destination: View>: View {
+    let segments: [Segment]
+    let caption: String
+    let drillDownCount: (Segment) -> Int
+    @ViewBuilder let destination: (Segment) -> Destination
+
+    @State private var angle: Double?
+    @State private var selected: Segment?
+
+    var body: some View {
+        VStack(spacing: 12) {
+            chart
+
+            if let selected {
+                drillDownLink(for: selected)
+            } else {
+                legend.padding(.vertical, 10)
+            }
+        }
+    }
+
+    private var chart: some View {
+        Chart(segments) { segment in
+            SectorMark(
+                angle: .value("Count", segment.count),
+                innerRadius: .ratio(0.618),
+                outerRadius: .ratio(selected == segment ? 1.0 : 0.92),
+                angularInset: 1.5
+            )
+            .cornerRadius(3)
+            .foregroundStyle(segment.color)
+            .opacity(selected == nil || selected == segment ? 1 : 0.3)
+        }
+        .chartAngleSelection(value: $angle)
+        .frame(height: 190)
+        .overlay { center }
+        .onChange(of: angle) { _, angle in
+            guard let angle else { return }
+            let hit = segments.segment(at: angle)
+            selected = hit == selected ? nil : hit
+        }
+        .animation(.snappy(duration: 0.25), value: selected)
+    }
+
+    private var center: some View {
+        VStack(spacing: 2) {
+            Text(verbatim: "\(selected?.count ?? segments.total)")
+                .font(.title2.weight(.semibold))
+                .monospacedDigit()
+                .foregroundStyle(selected?.color ?? .primary)
+            Text(verbatim: selected.map(segments.percent) ?? caption)
+                .font(.caption)
+                .foregroundStyle(.gray)
+        }
+    }
+
+    private var legend: some View {
+        HStack(spacing: 16) {
+            ForEach(segments) { segment in
+                HStack(spacing: 5) {
+                    Circle().fill(segment.color).frame(width: 7, height: 7)
+                    Text(verbatim: segment.label)
+                        .font(.caption)
+                        .foregroundStyle(.gray)
+                }
+            }
+        }
+    }
+
+    private func drillDownLink(for segment: Segment) -> some View {
+        NavigationLink {
+            destination(segment)
+        } label: {
+            HStack {
+                Text(verbatim: "Show \(ExportFormat.counted(drillDownCount(segment), .occurrence)) · \(segment.label)")
+                    .font(.footnote.weight(.medium))
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+            }
+            .foregroundStyle(segment.color)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(segment.color.opacity(0.12), in: Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview("Devices") {
+    if #available(iOS 17.0, macOS 14.0, *) {
+        NavigationStack {
+            IncidentDonut(segments: IncidentBreakdown.sample.devices, caption: "devices") { segment in
+                segment.count
+            } destination: { segment in
+                Text(verbatim: segment.label)
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview("OS Versions") {
+    if #available(iOS 17.0, macOS 14.0, *) {
+        NavigationStack {
+            IncidentDonut(segments: IncidentBreakdown.sample.osVersions, caption: "sessions") { segment in
+                segment.count
+            } destination: { segment in
+                Text(verbatim: segment.label)
+            }
+            .padding()
+        }
+    }
+}

--- a/Sources/Scout/UI/Monitoring/Incident/Breakdown/SegmentOccurrenceList.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Breakdown/SegmentOccurrenceList.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+struct SegmentOccurrenceList<Element: Incident, RowContent: View>: View {
+    let title: String
+    let records: [Element]
+    @ViewBuilder let row: (Element) -> RowContent
+
+    var body: some View {
+        List {
+            ForEach(records, content: row)
+        }
+        .listStyle(.plain)
+        .monospacedNavigationTitle(en: title)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SegmentOccurrenceList(title: "iPhone15,3", records: [Crash].samples) { crash in
+            Row {
+                if let date = crash.date {
+                    UTCTimestampText(date: date, size: 14)
+                }
+            } destination: {
+                CrashDetailView(crash: crash)
+            }
+        }
+    }
+    .environmentObject(Tint())
+}

--- a/Sources/Scout/UI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
@@ -69,17 +69,7 @@ struct CrashGroupDetailView: View {
     @ViewBuilder
     private var breakdownSection: some View {
         if let value = try? breakdown.result?.get() {
-            if value.devices.count > 0 {
-                Header(title: "Top Devices")
-                SegmentBar(segments: value.devices)
-                    .listRowSeparator(.hidden, edges: .bottom)
-            }
-
-            if value.osVersions.count > 0 {
-                Header(title: "OS Versions")
-                SegmentBar(segments: value.osVersions)
-                    .listRowSeparator(.hidden, edges: .bottom)
-            }
+            IncidentBreakdownSection(breakdown: value, records: group.records, row: occurrenceRow)
         }
     }
 
@@ -87,23 +77,25 @@ struct CrashGroupDetailView: View {
     private var occurrencesSection: some View {
         Header(title: "Occurrences")
 
-        ForEach(group.records) { crash in
-            Row {
-                if let date = crash.date {
-                    UTCTimestampText(date: date, size: 14)
-                }
+        ForEach(group.records, content: occurrenceRow)
+    }
 
-                Spacer()
-
-                if let sessionID = crash.sessionID {
-                    Text(ExportFormat.shortID(sessionID))
-                        .font(.footnote)
-                        .monospaced()
-                        .foregroundStyle(Color.gray)
-                }
-            } destination: {
-                CrashDetailView(crash: crash)
+    private func occurrenceRow(_ crash: Crash) -> some View {
+        Row {
+            if let date = crash.date {
+                UTCTimestampText(date: date, size: 14)
             }
+
+            Spacer()
+
+            if let sessionID = crash.sessionID {
+                Text(ExportFormat.shortID(sessionID))
+                    .font(.footnote)
+                    .monospaced()
+                    .foregroundStyle(Color.gray)
+            }
+        } destination: {
+            CrashDetailView(crash: crash)
         }
     }
 }

--- a/Sources/Scout/UI/Monitoring/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Hang/HangGroupDetailView.swift
@@ -65,17 +65,7 @@ struct HangGroupDetailView: View {
     @ViewBuilder
     private var breakdownSection: some View {
         if let value = try? breakdown.result?.get() {
-            if value.devices.count > 0 {
-                Header(title: "Top Devices")
-                SegmentBar(segments: value.devices)
-                    .listRowSeparator(.hidden, edges: .bottom)
-            }
-
-            if value.osVersions.count > 0 {
-                Header(title: "OS Versions")
-                SegmentBar(segments: value.osVersions)
-                    .listRowSeparator(.hidden, edges: .bottom)
-            }
+            IncidentBreakdownSection(breakdown: value, records: group.records, row: occurrenceRow)
         }
     }
 
@@ -83,21 +73,23 @@ struct HangGroupDetailView: View {
     private var occurrencesSection: some View {
         Header(title: "Occurrences")
 
-        ForEach(group.records) { hang in
-            Row {
-                if let date = hang.date {
-                    UTCTimestampText(date: date, size: 14)
-                }
+        ForEach(group.records, content: occurrenceRow)
+    }
 
-                Spacer()
-
-                Text(verbatim: hang.durationText)
-                    .font(.footnote)
-                    .monospacedDigit()
-                    .foregroundStyle(hang.severity.color)
-            } destination: {
-                HangDetailView(hang: hang)
+    private func occurrenceRow(_ hang: Hang) -> some View {
+        Row {
+            if let date = hang.date {
+                UTCTimestampText(date: date, size: 14)
             }
+
+            Spacer()
+
+            Text(verbatim: hang.durationText)
+                .font(.footnote)
+                .monospacedDigit()
+                .foregroundStyle(hang.severity.color)
+        } destination: {
+            HangDetailView(hang: hang)
         }
     }
 }

--- a/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentBreakdownProviderTests.swift
+++ b/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentBreakdownProviderTests.swift
@@ -32,6 +32,7 @@ struct IncidentBreakdownProviderTests {
         let breakdown = try #require(try? provider.result?.get())
 
         #expect(Set(breakdown.devices.map(\.label)) == ["iPhone15,3", "iPhone14,2"])
+        #expect(breakdown.modelsByDevice == [deviceA: "iPhone15,3", deviceB: "iPhone14,2"])
     }
 
     @Test("Groups OS versions for the requested session IDs")
@@ -56,6 +57,7 @@ struct IncidentBreakdownProviderTests {
 
         #expect(breakdown.osVersions.map(\.label) == ["iOS 17.4"])
         #expect(breakdown.osVersions.first?.count == 2)
+        #expect(breakdown.versionsBySession == [sessionA: "iOS 17.4", sessionB: "iOS 17.4"])
     }
 
     @Test("Skips fetching when there are no IDs to resolve")

--- a/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentBreakdownTests.swift
+++ b/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentBreakdownTests.swift
@@ -6,6 +6,7 @@
 // https://opensource.org/licenses/MIT.
 //
 
+import Foundation
 import Testing
 
 @testable import Scout
@@ -50,5 +51,85 @@ struct IncidentBreakdownTests {
     @Test("Returns no segments for empty input")
     func emptyInput() {
         #expect(IncidentBreakdown.segments(from: []).isEmpty)
+    }
+}
+
+extension IncidentBreakdownTests {
+    private struct Context: SessionContext {
+        let sessionID: UUID?
+        let deviceID: UUID?
+    }
+
+    private func makeContext(deviceID: UUID? = nil, sessionID: UUID? = nil) -> Context {
+        Context(sessionID: sessionID, deviceID: deviceID)
+    }
+
+    @Test("Filters records matching a device segment")
+    func filtersByDeviceSegment() throws {
+        let deviceA = UUID()
+        let deviceB = UUID()
+        let breakdown = IncidentBreakdown(
+            devices: IncidentBreakdown.segments(from: ["iPhone15,3", "iPhone14,2"]),
+            osVersions: [],
+            modelsByDevice: [deviceA: "iPhone15,3", deviceB: "iPhone14,2"]
+        )
+        let records = [
+            makeContext(deviceID: deviceA),
+            makeContext(deviceID: deviceA),
+            makeContext(deviceID: deviceB),
+            makeContext(),
+        ]
+
+        let segment = try #require(breakdown.devices.first { $0.label == "iPhone15,3" })
+        let matched = breakdown.records(from: records, in: .devices, matching: segment)
+
+        #expect(matched.count == 2)
+        #expect(matched.allSatisfy { $0.deviceID == deviceA })
+    }
+
+    @Test("Filters records matching an OS version segment")
+    func filtersByOSVersionSegment() throws {
+        let sessionA = UUID()
+        let sessionB = UUID()
+        let breakdown = IncidentBreakdown(
+            devices: [],
+            osVersions: IncidentBreakdown.segments(from: ["iOS 17.4", "iOS 16.7"]),
+            versionsBySession: [sessionA: "iOS 17.4", sessionB: "iOS 16.7"]
+        )
+        let records = [
+            makeContext(sessionID: sessionA),
+            makeContext(sessionID: sessionB),
+        ]
+
+        let segment = try #require(breakdown.osVersions.first { $0.label == "iOS 16.7" })
+        let matched = breakdown.records(from: records, in: .osVersions, matching: segment)
+
+        #expect(matched.count == 1)
+        #expect(matched.first?.sessionID == sessionB)
+    }
+
+    @Test("Matches the Other segment to labels outside the top cutoff")
+    func filtersByOtherSegment() throws {
+        let deviceA = UUID()
+        let deviceB = UUID()
+        let deviceC = UUID()
+        let breakdown = IncidentBreakdown(
+            devices: IncidentBreakdown.segments(from: ["A", "A", "B", "C"], top: 1),
+            osVersions: [],
+            modelsByDevice: [deviceA: "A", deviceB: "B", deviceC: "C"]
+        )
+        let records = [
+            makeContext(deviceID: deviceA),
+            makeContext(deviceID: deviceB),
+            makeContext(deviceID: deviceC),
+            makeContext(deviceID: UUID()),
+            makeContext(),
+        ]
+
+        let other = try #require(breakdown.devices.first { $0.label == "Other" })
+        let matched = breakdown.records(from: records, in: .devices, matching: other)
+
+        #expect(matched.count == 2)
+        #expect(Set(matched.compactMap(\.deviceID)) == [deviceB, deviceC])
     }
 }

--- a/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentDonutTests.swift
+++ b/Tests/ScoutTests/UI/Monitoring/Incident/Breakdown/IncidentDonutTests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+import Testing
+
+@testable import Scout
+
+@Suite("IncidentDonut segments")
+struct IncidentDonutTests {
+    private let segments = [
+        Segment(label: "A", count: 5, color: .blue),
+        Segment(label: "B", count: 3, color: .indigo),
+        Segment(label: "C", count: 2, color: .purple),
+    ]
+
+    @Test("Sums segment counts into a total")
+    func total() {
+        #expect(segments.total == 10)
+        #expect([Segment]().total == 0)
+    }
+
+    @Test("Maps an angle value to the segment covering it")
+    func segmentAtAngle() {
+        #expect(segments.segment(at: 0)?.label == "A")
+        #expect(segments.segment(at: 4.9)?.label == "A")
+        #expect(segments.segment(at: 5)?.label == "B")
+        #expect(segments.segment(at: 7.9)?.label == "B")
+        #expect(segments.segment(at: 8)?.label == "C")
+        #expect(segments.segment(at: 9.9)?.label == "C")
+    }
+
+    @Test("Clamps an out-of-range angle to the last segment")
+    func segmentBeyondTotal() {
+        #expect(segments.segment(at: 42)?.label == "C")
+        #expect([Segment]().segment(at: 0) == nil)
+    }
+
+    @Test("Formats a segment share as a whole percent")
+    func percent() {
+        #expect(segments.percent(of: segments[0]) == "50%")
+        #expect(segments.percent(of: segments[2]) == "20%")
+    }
+
+    @Test("Returns zero percent when the total is empty")
+    func percentOfEmpty() {
+        #expect([Segment]().percent(of: segments[0]) == "0%")
+    }
+}


### PR DESCRIPTION
The device and OS version breakdowns on crash and hang group screens are now interactive donut charts instead of static segment bars. Tapping a sector pops it out, shows its count and share in the center, and offers a drill-down link into the occurrences that belong to that segment, including the Other bucket. To support the filtering, IncidentBreakdown now carries the device-to-model and session-to-OS-version maps that the provider already fetches, and the shared breakdown section falls back to the old segment bar on iOS 16 where SectorMark is unavailable.