### PR TITLE
Add haptic feedback across the dashboard's interactive controls

### DIFF
--- a/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
+++ b/Sources/Scout/UI/Home/Connection/ConnectionMenu.swift
@@ -51,6 +51,7 @@ struct ConnectionMenu: View {
             }
             .padding(.vertical, 8)
             .frame(minWidth: 240)
+            .hapticFeedback(.selection, trigger: activeID)
             .task {
                 connections = await connections.refreshingStatuses()
             }

--- a/Sources/Scout/UI/Insights/Chart/Comparison/ComparisonToggle.swift
+++ b/Sources/Scout/UI/Insights/Chart/Comparison/ComparisonToggle.swift
@@ -16,6 +16,7 @@ struct ComparisonToggle: View {
             Text(verbatim: "Compare with previous period")
         }
         .listRowSeparator(.hidden)
+        .hapticFeedback(.selection, trigger: isOn)
     }
 }
 

--- a/Sources/Scout/UI/Insights/Chart/Range/RangeControl.swift
+++ b/Sources/Scout/UI/Insights/Chart/Range/RangeControl.swift
@@ -37,6 +37,7 @@ struct RangeControl<T: ChartTimeScale>: View {
         }
         .padding(.top)
         .padding(.horizontal)
+        .hapticFeedback(.selection, trigger: extent.domain)
     }
 
     struct MoveButton: View {

--- a/Sources/Scout/UI/Insights/Timeline/View/Legend/Legend.swift
+++ b/Sources/Scout/UI/Insights/Timeline/View/Legend/Legend.swift
@@ -54,5 +54,6 @@ struct Legend: View {
 
             Divider()
         }
+        .hapticFeedback(.selection, trigger: expanded)
     }
 }

--- a/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/Scout/UI/Primitives/Pickers/SegmentStrip.swift
@@ -35,6 +35,7 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
                     indicator = newValue
                 }
             }
+            .hapticFeedback(.selection, trigger: selection)
     }
 
     @ViewBuilder

--- a/Sources/Scout/UI/Primitives/Platform/View+HapticFeedback.swift
+++ b/Sources/Scout/UI/Primitives/Platform/View+HapticFeedback.swift
@@ -26,19 +26,6 @@ extension View {
             self
         }
     }
-
-    /// Plays haptic feedback when `trigger` changes and `condition` holds for
-    /// the old and new value, degrading to no feedback on the iOS 16 /
-    /// macOS 13 floor where `sensoryFeedback` is unavailable.
-    ///
-    @ViewBuilder
-    func hapticFeedback<T: Equatable>(_ feedback: HapticFeedback, trigger: T, condition: @escaping (T, T) -> Bool) -> some View {
-        if #available(iOS 17.0, macOS 14.0, *) {
-            sensoryFeedback(feedback.resolved, trigger: trigger, condition: condition)
-        } else {
-            self
-        }
-    }
 }
 
 @available(iOS 17.0, macOS 14.0, *)

--- a/Sources/Scout/UI/Primitives/Platform/View+HapticFeedback.swift
+++ b/Sources/Scout/UI/Primitives/Platform/View+HapticFeedback.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import SwiftUI
+
+enum HapticFeedback {
+    case selection
+    case success
+    case impact
+}
+
+extension View {
+    /// Plays haptic feedback when `trigger` changes, degrading to no feedback
+    /// on the iOS 16 / macOS 13 floor where `sensoryFeedback` is unavailable.
+    ///
+    @ViewBuilder
+    func hapticFeedback<T: Equatable>(_ feedback: HapticFeedback, trigger: T) -> some View {
+        if #available(iOS 17.0, macOS 14.0, *) {
+            sensoryFeedback(feedback.resolved, trigger: trigger)
+        } else {
+            self
+        }
+    }
+
+    /// Plays haptic feedback when `trigger` changes and `condition` holds for
+    /// the old and new value, degrading to no feedback on the iOS 16 /
+    /// macOS 13 floor where `sensoryFeedback` is unavailable.
+    ///
+    @ViewBuilder
+    func hapticFeedback<T: Equatable>(_ feedback: HapticFeedback, trigger: T, condition: @escaping (T, T) -> Bool) -> some View {
+        if #available(iOS 17.0, macOS 14.0, *) {
+            sensoryFeedback(feedback.resolved, trigger: trigger, condition: condition)
+        } else {
+            self
+        }
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, *)
+extension HapticFeedback {
+    fileprivate var resolved: SensoryFeedback {
+        switch self {
+        case .selection: .selection
+        case .success: .success
+        case .impact: .impact
+        }
+    }
+}

--- a/Sources/Scout/UI/Primitives/Rows/CopyButton.swift
+++ b/Sources/Scout/UI/Primitives/Rows/CopyButton.swift
@@ -14,6 +14,7 @@ struct CopyButton: View {
     let text: String
 
     @State private var isCopied = false
+    @State private var copyCount = 0
     @State private var revert = DebouncedReset()
 
     var body: some View {
@@ -25,6 +26,7 @@ struct CopyButton: View {
                 NSPasteboard.general.setString(text, forType: .string)
             #endif
             isCopied = true
+            copyCount += 1
 
             revert.schedule(after: .seconds(2)) {
                 isCopied = false
@@ -33,7 +35,7 @@ struct CopyButton: View {
             Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
         }
         .animation(.easeInOut(duration: 0.15), value: isCopied)
-        .hapticFeedback(.success, trigger: isCopied) { _, copied in copied }
+        .hapticFeedback(.success, trigger: copyCount)
     }
 }
 

--- a/Sources/Scout/UI/Primitives/Rows/CopyButton.swift
+++ b/Sources/Scout/UI/Primitives/Rows/CopyButton.swift
@@ -33,6 +33,7 @@ struct CopyButton: View {
             Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
         }
         .animation(.easeInOut(duration: 0.15), value: isCopied)
+        .hapticFeedback(.success, trigger: isCopied) { _, copied in copied }
     }
 }
 


### PR DESCRIPTION
A version-gated `hapticFeedback(_:trigger:)` helper sits alongside `View+DisabledBounce`, mapping to `sensoryFeedback` on iOS 17 / macOS 14 and degrading to no feedback on the project's iOS 16 floor so call sites stay clean and version-agnostic. Its own `HapticFeedback` enum (`.selection` / `.success` / `.impact`) keeps them readable, and a `condition` overload fires only on the intended transition.

Feedback is wired into the discrete, reusable interaction points rather than sprayed everywhere — navigation pushes and sheet presentations are deliberately left alone. `SegmentStrip` plays a selection tick on segment change (this covers every chart's period picker), `RangeControl` on range navigation, `CopyButton` a success tap on copy, `Legend` on expanding a series, `ComparisonToggle` on toggling, and `ConnectionMenu` on switching the active backend. Every trigger keys off existing state, so nothing fires on first appearance — only on real user changes.

Builds cleanly for the iOS Simulator.