### PR TITLE
Cache settled backend data locally in a SwiftData store

### DIFF
--- a/Sources/Scout/Core/Database/Cache/CachedDatabase.swift
+++ b/Sources/Scout/Core/Database/Cache/CachedDatabase.swift
@@ -1,0 +1,164 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+@available(iOS 17, macOS 14, *)
+struct CachedDatabase: Database {
+    let base: any Database
+    let scope: String
+    let cache: RecordCache
+
+    // Matrices are keyed by start of week, and late uploads from offline devices can still
+    // mutate recently closed weeks, so only weeks that ended over a week ago are frozen.
+    var settledCutoff: @Sendable () -> Date = { Date().startOfWeek.addingWeek(-1) }
+
+    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
+        guard fields == nil, let plan = CachedQuery(query: query, scope: scope, cutoff: settledCutoff()) else {
+            return try await base.read(matching: query, fields: fields)
+        }
+
+        var cachedUpper = await cachedUpper(for: plan.fingerprint, in: plan.range, frozenUpper: plan.frozenUpper)
+
+        var cached: [Record] = []
+        if cachedUpper > plan.range.lowerBound {
+            if let records = await cache.records(for: plan.fingerprint, in: plan.range.lowerBound..<cachedUpper) {
+                cached = records
+            } else {
+                cachedUpper = plan.range.lowerBound
+            }
+        }
+
+        guard cachedUpper < plan.range.upperBound else {
+            return RecordChunk(records: cached, cursor: nil)
+        }
+
+        let remainder = cachedUpper..<plan.range.upperBound
+        let fetched = try await base.readAll(matching: plan.query(in: remainder), fields: nil)
+
+        if remainder.lowerBound < plan.frozenUpper {
+            await cache.store(fetched, for: plan.fingerprint, covering: remainder.lowerBound..<plan.frozenUpper)
+        }
+        return RecordChunk(records: cached + fetched, cursor: nil)
+    }
+
+    func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
+        try await base.read(matching: query, fields: fields, limit: limit)
+    }
+
+    func lookup(recordName: String, fields: [String]?) async throws -> Record {
+        let fieldsKey = fields.map { $0.sorted().joined(separator: ",") } ?? "*"
+        let fingerprint = [scope, "lookup", recordName, fieldsKey].joined(separator: "|")
+
+        if let record = await cache.lookupRecord(for: fingerprint) {
+            return record
+        }
+        let record = try await base.lookup(recordName: recordName, fields: fields)
+        if cachedLookupTypes.contains(record.recordType) {
+            await cache.storeLookup(record, for: fingerprint)
+        }
+        return record
+    }
+
+    func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
+        try await base.activity(in: range)
+    }
+
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        try await base.retention(in: range)
+    }
+
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
+        let frozenUpper = min(range.upperBound, settledCutoff())
+        guard range.lowerBound < frozenUpper else {
+            return try await base.metricSeries(valueType, category: category, in: range)
+        }
+
+        let fingerprint = CachedMetricSeries.fingerprint(scope: scope, values: T.seriesValues, category: category)
+        var cachedUpper = await cachedUpper(for: fingerprint, in: range, frozenUpper: frozenUpper)
+
+        var cached: [Record] = []
+        if cachedUpper > range.lowerBound {
+            if let records = await cache.records(for: fingerprint, in: range.lowerBound..<cachedUpper) {
+                cached = records
+            } else {
+                cachedUpper = range.lowerBound
+            }
+        }
+
+        var fetched: [MetricSeries] = []
+        if cachedUpper < range.upperBound {
+            fetched = try await base.metricSeries(valueType, category: category, in: cachedUpper..<range.upperBound)
+
+            if cachedUpper < frozenUpper {
+                let records = CachedMetricSeries.records(from: fetched)
+                await cache.store(records, for: fingerprint, covering: cachedUpper..<frozenUpper)
+            }
+        }
+        return CachedMetricSeries.series(cached: cached, fetched: fetched)
+    }
+
+    private func cachedUpper(for fingerprint: String, in range: Range<Date>, frozenUpper: Date) async -> Date {
+        guard let covered = await cache.coveredRange(for: fingerprint),
+            covered.lowerBound <= range.lowerBound, covered.upperBound > range.lowerBound
+        else {
+            return range.lowerBound
+        }
+        return min(covered.upperBound, frozenUpper)
+    }
+
+    func write(record: Record) async throws {
+        try await base.write(record: record)
+    }
+
+    func write(records: [Record]) async throws {
+        try await base.write(records: records)
+    }
+}
+
+private let cachedLookupTypes: Set<String> = [EventEntry.recordType]
+
+extension Backend {
+    @MainActor var cachedDatabase: any Database {
+        if #available(iOS 17, macOS 14, *) {
+            return DatabaseCacheRegistry.database(for: self)
+        }
+        return database
+    }
+}
+
+@available(iOS 17, macOS 14, *)
+@MainActor
+enum DatabaseCacheRegistry {
+    private static var databases: [String: any Database] = [:]
+    private static var cache: RecordCache??
+
+    static func database(for backend: Backend) -> any Database {
+        if let database = databases[backend.id] {
+            return database
+        }
+        let database: any Database =
+            if let cache = sharedCache() {
+                CachedDatabase(base: backend.database, scope: backend.id, cache: cache)
+            } else {
+                backend.database
+            }
+        databases[backend.id] = database
+        return database
+    }
+
+    private static func sharedCache() -> RecordCache? {
+        if let cache {
+            return cache
+        }
+        let created = RecordCacheStore.container().map { RecordCache(modelContainer: $0) }
+        cache = .some(created)
+        return created
+    }
+}

--- a/Sources/Scout/Core/Database/Cache/CachedMetricSeries.swift
+++ b/Sources/Scout/Core/Database/Cache/CachedMetricSeries.swift
@@ -1,0 +1,78 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+enum CachedMetricSeries {
+    static func fingerprint(scope: String, values: String, category: String) -> String {
+        [scope, "series", values, category].joined(separator: "|")
+    }
+
+    static func records(from series: [MetricSeries]) -> [Record] {
+        series.flatMap { series in
+            series.points.map { point in
+                var record = Record(recordType: "MetricSeriesPoint", recordID: UUID().uuidString)
+                record.fields["date"] = .date(Date(millisecondsSince1970: point.date))
+                record.fields["name"] = .string(series.name)
+                record.fields["category"] = series.category.map(RecordValue.string)
+                record.fields["value"] = recordValue(point.value)
+                return record
+            }
+        }
+    }
+
+    static func series(cached: [Record], fetched: [MetricSeries]) -> [MetricSeries] {
+        var points: [SeriesKey: [MetricSeriesPoint]] = [:]
+
+        for record in cached {
+            guard case .date(let date)? = record.fields["date"] else { continue }
+            guard case .string(let name)? = record.fields["name"] else { continue }
+            guard let value = metricValue(record.fields["value"]) else { continue }
+
+            let category: String? =
+                if case .string(let category)? = record.fields["category"] { category } else { nil }
+            let point = MetricSeriesPoint(date: date.millisecondsSince1970, value: value)
+            points[SeriesKey(name: name, category: category), default: []].append(point)
+        }
+
+        for series in fetched {
+            points[SeriesKey(name: series.name, category: series.category), default: []] += series.points
+        }
+
+        return
+            points
+            .sorted { ($0.key.name, $0.key.category ?? "") < ($1.key.name, $1.key.category ?? "") }
+            .map { key, points in
+                MetricSeries(name: key.name, category: key.category, points: points.sorted { $0.date < $1.date })
+            }
+    }
+
+    private struct SeriesKey: Hashable {
+        let name: String
+        let category: String?
+    }
+
+    private static func recordValue(_ value: MetricValue) -> RecordValue {
+        switch value {
+        case .int(let value):
+            .int(Int64(value))
+        case .double(let value):
+            .double(value)
+        }
+    }
+
+    private static func metricValue(_ value: RecordValue?) -> MetricValue? {
+        switch value {
+        case .int(let value):
+            .int(Int(value))
+        case .double(let value):
+            .double(value)
+        default:
+            nil
+        }
+    }
+}

--- a/Sources/Scout/Core/Database/Cache/CachedQuery.swift
+++ b/Sources/Scout/Core/Database/Cache/CachedQuery.swift
@@ -1,0 +1,76 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct CachedQuery {
+    let recordType: any RecordDecodable.Type
+    let range: Range<Date>
+    let frozenUpper: Date
+    let fingerprint: String
+
+    private let restFilters: [RecordQuery.Filter]
+
+    init?(query: RecordQuery, scope: String, cutoff: Date) {
+        guard query.sort.count == 0 else { return nil }
+        guard cachedRecordTypes.contains(query.recordType.recordType) else { return nil }
+
+        var lower: Date?
+        var upper: Date?
+        var rest: [RecordQuery.Filter] = []
+
+        for filter in query.filters {
+            if filter.field == "date", filter.op == .greaterThanOrEquals, case .date(let date) = filter.value,
+                lower == nil
+            {
+                lower = date
+            } else if filter.field == "date", filter.op == .lessThan, case .date(let date) = filter.value, upper == nil
+            {
+                upper = date
+            } else if filter.field == "date" {
+                return nil
+            } else {
+                rest.append(filter)
+            }
+        }
+
+        guard let lower, let upper, lower < upper, lower < cutoff else { return nil }
+        guard let fingerprint = Self.fingerprint(scope: scope, recordType: query.recordType.recordType, filters: rest)
+        else {
+            return nil
+        }
+
+        self.recordType = query.recordType
+        self.range = lower..<upper
+        self.frozenUpper = min(upper, cutoff)
+        self.fingerprint = fingerprint
+        self.restFilters = rest
+    }
+
+    func query(in range: Range<Date>) -> RecordQuery {
+        RecordQuery(recordType: recordType, filters: range.dateFilters + restFilters)
+    }
+
+    private static func fingerprint(scope: String, recordType: String, filters: [RecordQuery.Filter]) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        var parts: [String] = []
+        for filter in filters {
+            guard let data = try? encoder.encode(filter), let part = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            parts.append(part)
+        }
+        return ([scope, recordType] + parts.sorted()).joined(separator: "|")
+    }
+}
+
+private let cachedRecordTypes: Set<String> = [
+    GridMatrix<Int>.recordType,
+    GridMatrix<Double>.recordType,
+]

--- a/Sources/Scout/Core/Database/Cache/CachedRecordPayload.swift
+++ b/Sources/Scout/Core/Database/Cache/CachedRecordPayload.swift
@@ -1,0 +1,26 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct CachedRecordPayload: Codable {
+    let recordType: String
+    let recordID: String
+    let fields: [String: RecordValue]
+    let metadata: Data?
+
+    init(record: Record) {
+        self.recordType = record.recordType
+        self.recordID = record.recordID
+        self.fields = record.fields
+        self.metadata = record.metadata
+    }
+
+    var record: Record {
+        Record(recordType: recordType, recordID: recordID, fields: fields, metadata: metadata)
+    }
+}

--- a/Sources/Scout/Core/Database/Cache/RecordCache.swift
+++ b/Sources/Scout/Core/Database/Cache/RecordCache.swift
@@ -1,0 +1,99 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import SwiftData
+
+@available(iOS 17, macOS 14, *)
+@ModelActor
+actor RecordCache {
+    func coveredRange(for fingerprint: String) -> Range<Date>? {
+        guard let span = span(for: fingerprint), span.lowerDate < span.upperDate else { return nil }
+        return span.lowerDate..<span.upperDate
+    }
+
+    func records(for fingerprint: String, in range: Range<Date>) -> [Record]? {
+        let lower = range.lowerBound
+        let upper = range.upperBound
+        let predicate = #Predicate<CachedRecord> {
+            $0.fingerprint == fingerprint && $0.date >= lower && $0.date < upper
+        }
+        let descriptor = FetchDescriptor(predicate: predicate, sortBy: [SortDescriptor(\.date)])
+        guard let entries = try? modelContext.fetch(descriptor) else { return nil }
+
+        let decoder = JSONDecoder()
+        let records = entries.compactMap { try? decoder.decode(CachedRecordPayload.self, from: $0.payload).record }
+        guard records.count == entries.count else { return nil }
+        return records
+    }
+
+    func store(_ records: [Record], for fingerprint: String, covering range: Range<Date>) {
+        let encoder = JSONEncoder()
+        var entries: [CachedRecord] = []
+
+        for record in records {
+            guard case .date(let date)? = record.fields["date"] else { return }
+            guard range.contains(date) else { continue }
+            guard let payload = try? encoder.encode(CachedRecordPayload(record: record)) else { return }
+            entries.append(CachedRecord(fingerprint: fingerprint, date: date, payload: payload))
+        }
+
+        if let span = span(for: fingerprint), span.lowerDate <= range.lowerBound, range.lowerBound <= span.upperDate {
+            deleteRecords(for: fingerprint, in: range)
+            span.upperDate = max(span.upperDate, range.upperBound)
+        } else {
+            deleteAll(for: fingerprint)
+            modelContext.insert(
+                CachedSpan(fingerprint: fingerprint, lowerDate: range.lowerBound, upperDate: range.upperBound))
+        }
+
+        for entry in entries {
+            modelContext.insert(entry)
+        }
+        try? modelContext.save()
+    }
+
+    func lookupRecord(for fingerprint: String) -> Record? {
+        let predicate = #Predicate<CachedRecord> { $0.fingerprint == fingerprint }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        guard let entry = try? modelContext.fetch(descriptor).first else { return nil }
+        return try? JSONDecoder().decode(CachedRecordPayload.self, from: entry.payload).record
+    }
+
+    func storeLookup(_ record: Record, for fingerprint: String) {
+        guard let payload = try? JSONEncoder().encode(CachedRecordPayload(record: record)) else { return }
+        let predicate = #Predicate<CachedRecord> { $0.fingerprint == fingerprint }
+        try? modelContext.delete(model: CachedRecord.self, where: predicate)
+        modelContext.insert(CachedRecord(fingerprint: fingerprint, date: .distantPast, payload: payload))
+        try? modelContext.save()
+    }
+
+    private func span(for fingerprint: String) -> CachedSpan? {
+        let predicate = #Predicate<CachedSpan> { $0.fingerprint == fingerprint }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        return try? modelContext.fetch(descriptor).first
+    }
+
+    private func deleteRecords(for fingerprint: String, in range: Range<Date>) {
+        let lower = range.lowerBound
+        let upper = range.upperBound
+        let predicate = #Predicate<CachedRecord> {
+            $0.fingerprint == fingerprint && $0.date >= lower && $0.date < upper
+        }
+        try? modelContext.delete(model: CachedRecord.self, where: predicate)
+    }
+
+    private func deleteAll(for fingerprint: String) {
+        let recordPredicate = #Predicate<CachedRecord> { $0.fingerprint == fingerprint }
+        try? modelContext.delete(model: CachedRecord.self, where: recordPredicate)
+
+        let spanPredicate = #Predicate<CachedSpan> { $0.fingerprint == fingerprint }
+        try? modelContext.delete(model: CachedSpan.self, where: spanPredicate)
+    }
+}

--- a/Sources/Scout/Core/Database/Cache/RecordCacheStore.swift
+++ b/Sources/Scout/Core/Database/Cache/RecordCacheStore.swift
@@ -1,0 +1,77 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import SwiftData
+
+@available(iOS 17, macOS 14, *)
+@Model
+final class CachedRecord {
+    var fingerprint: String
+    var date: Date
+    var payload: Data
+
+    init(fingerprint: String, date: Date, payload: Data) {
+        self.fingerprint = fingerprint
+        self.date = date
+        self.payload = payload
+    }
+}
+
+@available(iOS 17, macOS 14, *)
+@Model
+final class CachedSpan {
+    var fingerprint: String
+    var lowerDate: Date
+    var upperDate: Date
+
+    init(fingerprint: String, lowerDate: Date, upperDate: Date) {
+        self.fingerprint = fingerprint
+        self.lowerDate = lowerDate
+        self.upperDate = upperDate
+    }
+}
+
+@available(iOS 17, macOS 14, *)
+enum RecordCacheStore {
+    static let schemaVersion = 1
+
+    private static let versionKey = "scout_record_cache_schema_version"
+
+    static func container() -> ModelContainer? {
+        let directory = URL.applicationSupportDirectory.appending(path: "Scout", directoryHint: .isDirectory)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return container(at: directory.appending(path: "RecordCache.store"), defaults: .standard)
+    }
+
+    // The cache is disposable: any schema mismatch destroys the store instead of migrating.
+    static func container(at url: URL, defaults: UserDefaults) -> ModelContainer? {
+        if defaults.integer(forKey: versionKey) != schemaVersion {
+            destroyStore(at: url)
+        }
+        if let container = openContainer(at: url) {
+            defaults.set(schemaVersion, forKey: versionKey)
+            return container
+        }
+        destroyStore(at: url)
+        guard let container = openContainer(at: url) else { return nil }
+        defaults.set(schemaVersion, forKey: versionKey)
+        return container
+    }
+
+    static func destroyStore(at url: URL) {
+        for suffix in ["", "-shm", "-wal"] {
+            try? FileManager.default.removeItem(atPath: url.path + suffix)
+        }
+    }
+
+    private static func openContainer(at url: URL) -> ModelContainer? {
+        let schema = Schema([CachedRecord.self, CachedSpan.self])
+        let configuration = ModelConfiguration(schema: schema, url: url)
+        return try? ModelContainer(for: schema, configurations: [configuration])
+    }
+}

--- a/Sources/Scout/UI/Home/HomeView.swift
+++ b/Sources/Scout/UI/Home/HomeView.swift
@@ -52,7 +52,7 @@ struct HomeView: View {
         .imageScale(.medium)
         .dynamicTypeSize(.large)
         .tint(tint.value)
-        .environment(\.database, backend?.database ?? DefaultDatabase())
+        .environment(\.database, backend?.cachedDatabase ?? DefaultDatabase())
         .environmentObject(tint)
     }
 }

--- a/Tests/ScoutTests/Core/Database/Cache/CachedDatabaseTests.swift
+++ b/Tests/ScoutTests/Core/Database/Cache/CachedDatabaseTests.swift
@@ -1,0 +1,237 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Scout
+
+struct CachedDatabaseTests {
+    let lower = Date(timeIntervalSince1970: 0)
+    let cutoff = Date(timeIntervalSince1970: 3_000_000)
+    let upper = Date(timeIntervalSince1970: 4_000_000)
+
+    @available(iOS 17, macOS 14, *)
+    func makeDatabase(base: SpyDatabase) throws -> CachedDatabase {
+        let schema = Schema([CachedRecord.self, CachedSpan.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        let frozen = cutoff
+
+        return CachedDatabase(
+            base: base,
+            scope: "test",
+            cache: RecordCache(modelContainer: container),
+            settledCutoff: { frozen }
+        )
+    }
+
+    func makeQuery(in range: Range<Date>) -> RecordQuery {
+        RecordQuery(
+            recordType: GridMatrix<Int>.self,
+            filters: range.dateFilters + [RecordQuery.Filter(field: "name", op: .equals, value: .string("Session"))]
+        )
+    }
+
+    func makeRecord(date: Date) -> Record {
+        var record = Record(recordType: GridMatrix<Int>.recordType, recordID: UUID().uuidString)
+        record.fields["date"] = .date(date)
+        record.fields["name"] = .string("Session")
+        record.fields["cell_1_00"] = .int(5)
+        return record
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("A repeated query only fetches the live remainder")
+    func fetchesRemainderOnly() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base)
+        let frozen = makeRecord(date: Date(timeIntervalSince1970: 1_000_000))
+        let live = makeRecord(date: Date(timeIntervalSince1970: 3_500_000))
+        base.records = [frozen, live]
+
+        let first = try await database.readAll(matching: makeQuery(in: lower..<upper), fields: nil)
+        let second = try await database.readAll(matching: makeQuery(in: lower..<upper), fields: nil)
+
+        #expect(first.map(\.recordID) == [frozen, live].map(\.recordID))
+        #expect(second.map(\.recordID) == [frozen, live].map(\.recordID))
+        #expect(base.queries.count == 2)
+
+        let fullLower = RecordQuery.Filter(field: "date", op: .greaterThanOrEquals, value: .date(lower))
+        let remainderLower = RecordQuery.Filter(field: "date", op: .greaterThanOrEquals, value: .date(cutoff))
+        #expect(base.queries.first?.filters.contains(fullLower) == true)
+        #expect(base.queries.last?.filters.contains(remainderLower) == true)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("A fully frozen query is served from the cache alone")
+    func servesFrozenFromCache() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base)
+        base.records = [makeRecord(date: Date(timeIntervalSince1970: 1_000_000))]
+
+        let first = try await database.readAll(matching: makeQuery(in: lower..<cutoff), fields: nil)
+        let second = try await database.readAll(matching: makeQuery(in: lower..<cutoff), fields: nil)
+
+        #expect(first.count == 1)
+        #expect(first.map(\.recordID) == second.map(\.recordID))
+        #expect(base.queries.count == 1)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Non-matrix queries pass through unchanged")
+    func passesThroughOtherQueries() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base)
+        let query = RecordQuery(
+            recordType: Event.self,
+            filters: (lower..<upper).dateFilters,
+            sort: [RecordQuery.Sort(field: "date", ascending: false)]
+        )
+
+        _ = try await database.readAll(matching: query, fields: nil)
+        _ = try await database.readAll(matching: query, fields: nil)
+
+        #expect(base.queries.count == 2)
+        #expect(base.queries.first?.filters == query.filters)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("A repeated series request only fetches the live remainder")
+    func seriesFetchesRemainderOnly() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base)
+        base.series = [
+            MetricSeries(
+                name: "2xx",
+                category: "http_status",
+                points: [
+                    MetricSeriesPoint(date: 1_000_000_000, value: .int(4)),
+                    MetricSeriesPoint(date: 3_500_000_000, value: .int(7)),
+                ]
+            )
+        ]
+
+        let first = try await database.metricSeries(Int.self, category: "http_status", in: lower..<upper)
+        let second = try await database.metricSeries(Int.self, category: "http_status", in: lower..<upper)
+
+        #expect(base.seriesRanges == [lower..<upper, cutoff..<upper])
+        #expect(first.count == 1)
+        #expect(second.count == 1)
+        #expect(second.first?.name == "2xx")
+        #expect(second.first?.category == "http_status")
+        #expect(second.first?.points.map(\.date) == first.first?.points.map(\.date))
+        #expect(second.first?.points.map(\.value) == [.int(4), .int(7)])
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Series caches are split by scalar type and category")
+    func seriesSeparatesFingerprints() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base)
+        base.series = [
+            MetricSeries(
+                name: "latency",
+                category: "http_latency",
+                points: [MetricSeriesPoint(date: 1_000_000_000, value: .double(0.2))]
+            )
+        ]
+
+        _ = try await database.metricSeries(Double.self, category: "http_latency", in: lower..<upper)
+        _ = try await database.metricSeries(Int.self, category: "http_status", in: lower..<upper)
+
+        #expect(base.seriesRanges == [lower..<upper, lower..<upper])
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("An event lookup is served from the cache after the first fetch")
+    func cachesEventLookup() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base)
+        var event = Record(recordType: EventEntry.recordType, recordID: "event-1")
+        event.fields["params"] = .bytes(Data("payload".utf8))
+        base.records = [event]
+
+        let first = try await database.lookup(recordName: "event-1", fields: ["params"])
+        let second = try await database.lookup(recordName: "event-1", fields: ["params"])
+
+        #expect(first.fields == second.fields)
+        #expect(second.recordType == EventEntry.recordType)
+        #expect(base.lookups == ["event-1"])
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Lookups of mutable record types are not cached")
+    func skipsMutableLookup() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base)
+        base.records = [Record(recordType: SessionEntry.recordType, recordID: "session-1")]
+
+        _ = try await database.lookup(recordName: "session-1", fields: nil)
+        _ = try await database.lookup(recordName: "session-1", fields: nil)
+
+        #expect(base.lookups == ["session-1", "session-1"])
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Lookups with different field sets are cached separately")
+    func separatesLookupFields() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base)
+        base.records = [Record(recordType: EventEntry.recordType, recordID: "event-1")]
+
+        _ = try await database.lookup(recordName: "event-1", fields: ["params"])
+        _ = try await database.lookup(recordName: "event-1", fields: nil)
+        _ = try await database.lookup(recordName: "event-1", fields: nil)
+
+        #expect(base.lookups == ["event-1", "event-1"])
+    }
+}
+
+final class SpyDatabase: Database, @unchecked Sendable {
+    var records: [Record] = []
+    var queries: [RecordQuery] = []
+    var lookups: [String] = []
+    var series: [MetricSeries] = []
+    var seriesRanges: [Range<Date>] = []
+
+    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
+        queries.append(query)
+        return RecordChunk(records: records.filter { $0.matches(query) }, cursor: nil)
+    }
+
+    func lookup(recordName: String, fields: [String]?) async throws -> Record {
+        lookups.append(recordName)
+        guard let record = records.first(where: { $0.recordID == recordName }) else {
+            throw RecordNotFoundError()
+        }
+        return record
+    }
+
+    func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
+        []
+    }
+
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        []
+    }
+
+    func metricSeries<T: SeriesScalar>(_ valueType: T.Type, category: String, in range: Range<Date>) async throws
+        -> [MetricSeries]
+    {
+        seriesRanges.append(range)
+        return series.compactMap { series in
+            let points = series.points.filter { range.contains(Date(millisecondsSince1970: $0.date)) }
+            guard points.count > 0 else { return nil }
+            return MetricSeries(name: series.name, category: series.category, points: points)
+        }
+    }
+
+    func write(record: Record) async throws {}
+    func write(records: [Record]) async throws {}
+}

--- a/Tests/ScoutTests/Core/Database/Cache/CachedQueryTests.swift
+++ b/Tests/ScoutTests/Core/Database/Cache/CachedQueryTests.swift
@@ -1,0 +1,105 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+struct CachedQueryTests {
+    let lower = Date(timeIntervalSince1970: 0)
+    let upper = Date(timeIntervalSince1970: 4_000_000)
+    let cutoff = Date(timeIntervalSince1970: 3_000_000)
+
+    func makeQuery(filters: [RecordQuery.Filter] = [], sort: [RecordQuery.Sort] = []) -> RecordQuery {
+        RecordQuery(
+            recordType: GridMatrix<Int>.self,
+            filters: (lower..<upper).dateFilters + filters,
+            sort: sort
+        )
+    }
+
+    @Test("Parses a matrix query with a date range")
+    func parsesMatrixQuery() throws {
+        let plan = try #require(CachedQuery(query: makeQuery(), scope: "s", cutoff: cutoff))
+
+        #expect(plan.range == lower..<upper)
+        #expect(plan.frozenUpper == cutoff)
+    }
+
+    @Test("Frozen upper bound stops at the query upper bound")
+    func frozenUpperClamped() throws {
+        let plan = try #require(CachedQuery(query: makeQuery(), scope: "s", cutoff: upper.addingDay()))
+
+        #expect(plan.frozenUpper == upper)
+    }
+
+    @Test("Rejects sorted queries")
+    func rejectsSort() {
+        let query = makeQuery(sort: [RecordQuery.Sort(field: "date", ascending: false)])
+
+        #expect(CachedQuery(query: query, scope: "s", cutoff: cutoff) == nil)
+    }
+
+    @Test("Rejects non-matrix record types")
+    func rejectsOtherRecordTypes() {
+        let query = RecordQuery(recordType: Event.self, filters: (lower..<upper).dateFilters)
+
+        #expect(CachedQuery(query: query, scope: "s", cutoff: cutoff) == nil)
+    }
+
+    @Test("Rejects queries without a date range")
+    func rejectsMissingRange() {
+        let query = RecordQuery(recordType: GridMatrix<Int>.self)
+
+        #expect(CachedQuery(query: query, scope: "s", cutoff: cutoff) == nil)
+    }
+
+    @Test("Rejects fully live ranges")
+    func rejectsLiveRange() {
+        #expect(CachedQuery(query: makeQuery(), scope: "s", cutoff: lower) == nil)
+    }
+
+    @Test("Fingerprint is stable across date ranges")
+    func fingerprintIgnoresDates() throws {
+        let name = RecordQuery.Filter(field: "name", op: .equals, value: .string("Session"))
+        let narrow = RecordQuery(
+            recordType: GridMatrix<Int>.self,
+            filters: (lower..<cutoff).dateFilters + [name]
+        )
+
+        let a = try #require(CachedQuery(query: makeQuery(filters: [name]), scope: "s", cutoff: cutoff))
+        let b = try #require(CachedQuery(query: narrow, scope: "s", cutoff: cutoff))
+
+        #expect(a.fingerprint == b.fingerprint)
+    }
+
+    @Test("Fingerprint separates filters and scopes")
+    func fingerprintSeparates() throws {
+        let session = RecordQuery.Filter(field: "name", op: .equals, value: .string("Session"))
+        let crash = RecordQuery.Filter(field: "name", op: .equals, value: .string("Crash"))
+
+        let a = try #require(CachedQuery(query: makeQuery(filters: [session]), scope: "s", cutoff: cutoff))
+        let b = try #require(CachedQuery(query: makeQuery(filters: [crash]), scope: "s", cutoff: cutoff))
+        let c = try #require(CachedQuery(query: makeQuery(filters: [session]), scope: "t", cutoff: cutoff))
+
+        #expect(a.fingerprint != b.fingerprint)
+        #expect(a.fingerprint != c.fingerprint)
+    }
+
+    @Test("Rebuilds the query for a subrange")
+    func rebuildsQuery() throws {
+        let name = RecordQuery.Filter(field: "name", op: .equals, value: .string("Session"))
+        let plan = try #require(CachedQuery(query: makeQuery(filters: [name]), scope: "s", cutoff: cutoff))
+
+        let rebuilt = plan.query(in: cutoff..<upper)
+
+        #expect(rebuilt.recordType.recordType == GridMatrix<Int>.recordType)
+        #expect(rebuilt.filters == (cutoff..<upper).dateFilters + [name])
+        #expect(rebuilt.sort.count == 0)
+    }
+}

--- a/Tests/ScoutTests/Core/Database/Cache/RecordCacheStoreTests.swift
+++ b/Tests/ScoutTests/Core/Database/Cache/RecordCacheStoreTests.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Scout
+
+struct RecordCacheStoreTests {
+    let url: URL
+    let defaults: UserDefaults
+
+    init() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        url = directory.appending(path: "RecordCache.store")
+        defaults = UserDefaults(suiteName: "RecordCacheStoreTests-\(UUID().uuidString)")!
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Opens a fresh store and stamps the schema version")
+    func opensFreshStore() {
+        #expect(RecordCacheStore.container(at: url, defaults: defaults) != nil)
+        #expect(defaults.integer(forKey: "scout_record_cache_schema_version") == RecordCacheStore.schemaVersion)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("A version mismatch destroys the existing store")
+    func destroysOnVersionMismatch() throws {
+        try Data("garbage".utf8).write(to: url)
+        defaults.set(RecordCacheStore.schemaVersion + 1, forKey: "scout_record_cache_schema_version")
+
+        #expect(RecordCacheStore.container(at: url, defaults: defaults) != nil)
+        #expect(defaults.integer(forKey: "scout_record_cache_schema_version") == RecordCacheStore.schemaVersion)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("An unreadable store is destroyed and recreated")
+    func recoversFromUnreadableStore() throws {
+        try Data("garbage".utf8).write(to: url)
+        defaults.set(RecordCacheStore.schemaVersion, forKey: "scout_record_cache_schema_version")
+
+        #expect(RecordCacheStore.container(at: url, defaults: defaults) != nil)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Destroying the store removes its sidecar files")
+    func destroysSidecars() throws {
+        for suffix in ["", "-shm", "-wal"] {
+            try Data("garbage".utf8).write(to: URL(filePath: url.path + suffix))
+        }
+
+        RecordCacheStore.destroyStore(at: url)
+
+        for suffix in ["", "-shm", "-wal"] {
+            #expect(!FileManager.default.fileExists(atPath: url.path + suffix))
+        }
+    }
+}

--- a/Tests/ScoutTests/Core/Database/Cache/RecordCacheTests.swift
+++ b/Tests/ScoutTests/Core/Database/Cache/RecordCacheTests.swift
@@ -1,0 +1,127 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Scout
+
+struct RecordCacheTests {
+    @available(iOS 17, macOS 14, *)
+    func makeCache() throws -> RecordCache {
+        let schema = Schema([CachedRecord.self, CachedSpan.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        return RecordCache(modelContainer: container)
+    }
+
+    func makeRecord(date: Date, name: String = "Session") -> Record {
+        var record = Record(recordType: GridMatrix<Int>.recordType, recordID: UUID().uuidString)
+        record.fields["date"] = .date(date)
+        record.fields["name"] = .string(name)
+        record.fields["cell_1_00"] = .int(5)
+        return record
+    }
+
+    func date(_ interval: TimeInterval) -> Date {
+        Date(timeIntervalSince1970: interval)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Stored records round-trip through the cache")
+    func roundTrip() async throws {
+        let cache = try makeCache()
+        let records = [makeRecord(date: date(100)), makeRecord(date: date(200))]
+
+        await cache.store(records, for: "fp", covering: date(0)..<date(300))
+
+        let cached = try #require(await cache.records(for: "fp", in: date(0)..<date(300)))
+        #expect(cached.map(\.recordID) == records.map(\.recordID))
+        #expect(cached.first?.fields == records.first?.fields)
+        #expect(await cache.coveredRange(for: "fp") == date(0)..<date(300))
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Contiguous stores extend the covered span")
+    func extendsSpan() async throws {
+        let cache = try makeCache()
+
+        await cache.store([makeRecord(date: date(100))], for: "fp", covering: date(0)..<date(300))
+        await cache.store([makeRecord(date: date(400))], for: "fp", covering: date(300)..<date(600))
+
+        #expect(await cache.coveredRange(for: "fp") == date(0)..<date(600))
+
+        let cached = try #require(await cache.records(for: "fp", in: date(0)..<date(600)))
+        #expect(cached.count == 2)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("A disjoint store replaces the previous span")
+    func replacesDisjointSpan() async throws {
+        let cache = try makeCache()
+
+        await cache.store([makeRecord(date: date(100))], for: "fp", covering: date(0)..<date(300))
+        await cache.store([makeRecord(date: date(700))], for: "fp", covering: date(600)..<date(900))
+
+        #expect(await cache.coveredRange(for: "fp") == date(600)..<date(900))
+
+        let cached = try #require(await cache.records(for: "fp", in: date(0)..<date(900)))
+        #expect(cached.count == 1)
+        #expect(cached.first?.fields["date"] == .date(date(700)))
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Overlapping stores do not duplicate records")
+    func deduplicatesOverlap() async throws {
+        let cache = try makeCache()
+        let record = makeRecord(date: date(100))
+
+        await cache.store([record], for: "fp", covering: date(0)..<date(300))
+        await cache.store([record], for: "fp", covering: date(0)..<date(300))
+
+        let cached = try #require(await cache.records(for: "fp", in: date(0)..<date(300)))
+        #expect(cached.count == 1)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Fingerprints are isolated from each other")
+    func isolatesFingerprints() async throws {
+        let cache = try makeCache()
+
+        await cache.store([makeRecord(date: date(100))], for: "a", covering: date(0)..<date(300))
+
+        #expect(await cache.coveredRange(for: "b") == nil)
+
+        let cached = try #require(await cache.records(for: "b", in: date(0)..<date(300)))
+        #expect(cached.count == 0)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("A record without a date aborts the store")
+    func abortsWithoutDate() async throws {
+        let cache = try makeCache()
+        let record = Record(recordType: GridMatrix<Int>.recordType, recordID: UUID().uuidString)
+
+        await cache.store([record], for: "fp", covering: date(0)..<date(300))
+
+        #expect(await cache.coveredRange(for: "fp") == nil)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    @Test("Records outside the covered range are skipped")
+    func skipsOutOfRange() async throws {
+        let cache = try makeCache()
+        let records = [makeRecord(date: date(100)), makeRecord(date: date(500))]
+
+        await cache.store(records, for: "fp", covering: date(0)..<date(300))
+
+        let cached = try #require(await cache.records(for: "fp", in: date(0)..<date(900)))
+        #expect(cached.count == 1)
+        #expect(cached.first?.fields["date"] == .date(date(100)))
+    }
+}


### PR DESCRIPTION
Providers refetch a year-wide window from the backend on every screen visit, even though most of that data can no longer change: matrices are keyed by start of week, series points by hour, and anything older than a one-week settling margin (to absorb late uploads from offline devices) is frozen forever. A new CachedDatabase decorator, wired in where HomeView injects the backend's database, serves the frozen part of matrix and metric-series reads from a local SwiftData store and only fetches the live remainder, and also caches immutable Event lookups (per record name and field set) for the params screen. The feature is gated to iOS 17/macOS 14 — the package still targets iOS 16 and older systems keep the direct path. The cache is deliberately disposable: there are no migrations, and any schema-version mismatch or failure to open the store destroys and recreates it. Covered by unit tests for query parsing, span coverage, store recovery, and the split fetch paths.