### PR TITLE
Add a systemGray6 stand-in so the calendar primitives build on macOS

### DIFF
--- a/Sources/Scout/UI/Primitives/Platform/NSColor+macOS.swift
+++ b/Sources/Scout/UI/Primitives/Platform/NSColor+macOS.swift
@@ -33,5 +33,13 @@
                     : NSColor(red: 229 / 255, green: 229 / 255, blue: 234 / 255, alpha: 1)
             }
         }
+
+        static var systemGray6: NSColor {
+            NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                    ? NSColor(red: 28 / 255, green: 28 / 255, blue: 30 / 255, alpha: 1)
+                    : NSColor(red: 242 / 255, green: 242 / 255, blue: 247 / 255, alpha: 1)
+            }
+        }
     }
 #endif


### PR DESCRIPTION
The calendar range picker (#920) styles out-of-month days and capsule fills with Color(.systemGray6), which only exists on UIKit, so the macOS build has been broken since it landed — unnoticed because the only macOS build in CI is the path-gated Server workflow, which did not run on that PR (it surfaced on #923, whose Core/Database changes triggered the contract job). This extends the existing NSColor gray stand-ins in NSColor+macOS.swift with systemGray6 using the same light and dark component values UIKit uses.