### PR TITLE
Use partial clone in history-dependent CI jobs

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -20,9 +20,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # blob:none avoids downloading every historical blob (snapshot PNGs
+      # included): only HEAD is materialized at checkout, and `git worktree add`
+      # below batch-fetches just the baseline commit's blobs on demand.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       # The package does not build with plain SwiftPM (Scout.xcdatamodeld is
       # only processed by the Xcode build system), so instead of

--- a/.github/workflows/coredata.yml
+++ b/.github/workflows/coredata.yml
@@ -15,9 +15,13 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      # blob:none keeps the full-history fetch below from downloading every
+      # historical blob (snapshot PNGs included): the name-status diff only
+      # walks commit trees, so content is never needed.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Check model version rules
         run: |

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -57,9 +57,14 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
+      # blob:none keeps the full-history fetch below from downloading every
+      # historical blob (snapshot PNGs included): this job only greps the
+      # working tree and diffs file names, so historical content is never
+      # needed.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       # Tripwire against filter drift. The path filter below duplicates the
       # knowledge of where the wire code lives, so a future move out of the


### PR DESCRIPTION
The three jobs that fetch full history (Core Data model check, the Server changes filter, and the API baseline dump) only walk commit trees, diff file names, or materialize at most one historical commit — yet a plain `fetch-depth: 0` downloads every historical blob, a cost that grows with binary churn such as the snapshot baselines added in #926. Adding `filter: blob:none` turns these checkouts into partial clones: git fetches only commits and trees, materializes HEAD, and lazily batch-fetches the API baseline's blobs during `git worktree add`. All three access patterns were verified against a real blob:none clone of this repository.