### PR TITLE
Clean up direct-CloudKit leftovers after adopting scout-db

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Log/ScoutLogHandler.swift
+++ b/Sources/Scout/Core/Diagnostics/Log/ScoutLogHandler.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Logging
 
-struct CKLogHandler: LogHandler {
+struct ScoutLogHandler: LogHandler {
     let sync: Synchronize
     let session: Protected<UUID>
     let label: String

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryFactory.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryFactory.swift
@@ -13,23 +13,23 @@ struct TelemetryFactory: MetricsFactory {
     let session: Protected<UUID>
 
     func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
-        CKTelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
     }
 
     func makeFloatingPointCounter(label: String, dimensions: [(String, String)]) -> FloatingPointCounterHandler {
-        CKTelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
     }
 
     func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
-        CKTelemetryHandler.Idle()
+        TelemetryHandler.Idle()
     }
 
     func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
-        CKTelemetryHandler.Idle()
+        TelemetryHandler.Idle()
     }
 
     func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
-        CKTelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
     }
 
     func destroyCounter(_ handler: CounterHandler) {}

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -8,7 +8,7 @@
 
 import CoreData
 
-extension CKTelemetryHandler {
+extension TelemetryHandler {
     func logMetrics(telemetry: Telemetry.Export, value: some MetricScalar) {
         logMetrics(category: telemetry.rawValue, value: value)
     }

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler.Idle.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler.Idle.swift
@@ -7,7 +7,7 @@
 
 import Metrics
 
-extension CKTelemetryHandler {
+extension TelemetryHandler {
     final class Idle: MeterHandler, RecorderHandler {
         func set(_ value: Int64) {}
 

--- a/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler.swift
+++ b/Sources/Scout/Core/Diagnostics/Telemetry/TelemetryHandler.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Metrics
 
-final class CKTelemetryHandler: NSObject {
+final class TelemetryHandler: NSObject {
     let label: String
     let dimensions: [(String, String)]
     let sync: Synchronize
@@ -24,7 +24,7 @@ final class CKTelemetryHandler: NSObject {
     func reset() {}
 }
 
-extension CKTelemetryHandler: CounterHandler {
+extension TelemetryHandler: CounterHandler {
     func increment(by value: Int64) {
         if let category = StatusBuckets.category(in: dimensions) {
             logMetrics(category: category, value: Int(value))
@@ -34,13 +34,13 @@ extension CKTelemetryHandler: CounterHandler {
     }
 }
 
-extension CKTelemetryHandler: FloatingPointCounterHandler {
+extension TelemetryHandler: FloatingPointCounterHandler {
     func increment(by value: Double) {
         logMetrics(telemetry: .floatingCounter, value: value)
     }
 }
 
-extension CKTelemetryHandler: TimerHandler {
+extension TelemetryHandler: TimerHandler {
     func recordNanoseconds(_ duration: Int64) {
         logTimer(seconds: Double(duration) / 1_000_000_000)
     }

--- a/Sources/Scout/Core/Setup/Setup.swift
+++ b/Sources/Scout/Core/Setup/Setup.swift
@@ -55,7 +55,7 @@ public func setup(backends: [Backend]) async throws {
     identity.table.startListening(completion: sync)
 
     LoggingSystem.bootstrap {
-        CKLogHandler(sync: sync, session: session, label: $0)
+        ScoutLogHandler(sync: sync, session: session, label: $0)
     }
     MetricsSystem.bootstrap(
         TelemetryFactory(sync: sync, session: session)

--- a/Tests/ScoutTests/Core/Diagnostics/Telemetry/TelemetryFactoryTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Telemetry/TelemetryFactoryTests.swift
@@ -14,41 +14,41 @@ import Testing
 struct TelemetryFactoryTests {
     let factory = TelemetryFactory(sync: {}, session: Protected(UUID()))
 
-    @Test("makeCounter returns CKTelemetryHandler")
+    @Test("makeCounter returns TelemetryHandler")
     func makeCounter() {
         let handler = factory.makeCounter(label: "test", dimensions: [])
-        #expect(handler is CKTelemetryHandler)
+        #expect(handler is TelemetryHandler)
     }
 
-    @Test("makeFloatingPointCounter returns CKTelemetryHandler")
+    @Test("makeFloatingPointCounter returns TelemetryHandler")
     func makeFloatingPointCounter() {
         let handler = factory.makeFloatingPointCounter(label: "test", dimensions: [])
-        #expect(handler is CKTelemetryHandler)
+        #expect(handler is TelemetryHandler)
     }
 
-    @Test("makeTimer returns CKTelemetryHandler")
+    @Test("makeTimer returns TelemetryHandler")
     func makeTimer() {
         let handler = factory.makeTimer(label: "test", dimensions: [])
-        #expect(handler is CKTelemetryHandler)
+        #expect(handler is TelemetryHandler)
     }
 
     @Test("makeMeter returns Idle handler")
     func makeMeter() {
         let handler = factory.makeMeter(label: "test", dimensions: [])
-        #expect(handler is CKTelemetryHandler.Idle)
+        #expect(handler is TelemetryHandler.Idle)
     }
 
     @Test("makeRecorder returns Idle handler")
     func makeRecorder() {
         let handler = factory.makeRecorder(label: "test", dimensions: [], aggregate: false)
-        #expect(handler is CKTelemetryHandler.Idle)
+        #expect(handler is TelemetryHandler.Idle)
     }
 
     @Test("makeCounter preserves label and dimensions")
     func counterPreservesLabel() {
         let dims = [("env", "prod"), ("version", "1.0")]
         let handler = factory.makeCounter(label: "api_calls", dimensions: dims)
-        let telemetry = handler as? CKTelemetryHandler
+        let telemetry = handler as? TelemetryHandler
         #expect(telemetry?.label == "api_calls")
         #expect(telemetry?.dimensions.count == 2)
         #expect(telemetry?.dimensions[0].0 == "env")
@@ -58,7 +58,7 @@ struct TelemetryFactoryTests {
     @Test("makeTimer preserves label")
     func timerPreservesLabel() {
         let handler = factory.makeTimer(label: "response_time", dimensions: [])
-        let telemetry = handler as? CKTelemetryHandler
+        let telemetry = handler as? TelemetryHandler
         #expect(telemetry?.label == "response_time")
     }
 }

--- a/Tests/ScoutTests/Core/Diagnostics/Telemetry/TelemetryHandlerTests.swift
+++ b/Tests/ScoutTests/Core/Diagnostics/Telemetry/TelemetryHandlerTests.swift
@@ -12,16 +12,16 @@ import Testing
 @testable import Scout
 
 struct TelemetryHandlerTests {
-    @Test("CKTelemetryHandler stores label")
+    @Test("TelemetryHandler stores label")
     func storesLabel() {
-        let handler = CKTelemetryHandler(label: "test_label", dimensions: [], sync: {}, session: Protected(UUID()))
+        let handler = TelemetryHandler(label: "test_label", dimensions: [], sync: {}, session: Protected(UUID()))
         #expect(handler.label == "test_label")
     }
 
-    @Test("CKTelemetryHandler stores dimensions")
+    @Test("TelemetryHandler stores dimensions")
     func storesDimensions() {
         let dims = [("key1", "value1"), ("key2", "value2")]
-        let handler = CKTelemetryHandler(label: "test", dimensions: dims, sync: {}, session: Protected(UUID()))
+        let handler = TelemetryHandler(label: "test", dimensions: dims, sync: {}, session: Protected(UUID()))
         #expect(handler.dimensions.count == 2)
         #expect(handler.dimensions[0].0 == "key1")
         #expect(handler.dimensions[1].1 == "value2")


### PR DESCRIPTION
Removes the unreferenced RecordConflictError, a leftover from the direct-CloudKit read-modify-write era — scout-db resolves writes through its views, so the client never sees record conflicts. The setup(backends:) doc comment no longer claims that CloudKit backends receive client-maintained matrix records, which stopped being true with the scout-db migration. CKLogHandler and CKTelemetryHandler lose their misleading CK prefix and become ScoutLogHandler and TelemetryHandler: they persist to Core Data and sync to any backend, not to CloudKit specifically.