### PR TITLE
Watch Swift package dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+
+  - package-ecosystem: swift
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Dependabot already watches the GitHub Actions used by the workflows; this adds the swift ecosystem on the same monthly cadence, so releases of swift-log, swift-metrics, scout-db, and swift-snapshot-testing arrive as reviewable PRs instead of surfacing unannounced through fresh resolution — the way a scout-db release recently broke the API baseline build.