### PR TITLE
Speed up CI with dependency and baseline caches

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -28,6 +28,13 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
+      - name: Cache Swift package checkouts
+        uses: actions/cache@v4
+        with:
+          path: /tmp/spm
+          key: spm-${{ hashFiles('Package.swift') }}
+          restore-keys: spm-
+
       # The package does not build with plain SwiftPM (Scout.xcdatamodeld is
       # only processed by the Xcode build system), so instead of
       # `swift package diagnose-api-breaking-changes` we build both versions
@@ -38,6 +45,7 @@ jobs:
             -scheme Scout \
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath /tmp/dd-current \
+            -clonedSourcePackagesDirPath /tmp/spm \
             -skipMacroValidation \
             -quiet \
             build
@@ -55,7 +63,18 @@ jobs:
             -I /tmp/dd-current/Build/Products/Debug-iphonesimulator \
             "${digester_flags[@]}"
 
+      # The baseline dump depends only on the base commit, which changes far
+      # less often than the PR head: on a cache hit the whole baseline build
+      # is skipped.
+      - name: Cache baseline API dump
+        id: baseline-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/baseline.json
+          key: api-baseline-${{ github.event.pull_request.base.sha }}
+
       - name: Dump baseline API
+        if: steps.baseline-cache.outputs.cache-hit != 'true'
         run: |
           # Compare against the PR's base (main), so the check flags only the
           # API changes this PR introduces — not cumulative drift since release.
@@ -74,6 +93,7 @@ jobs:
             -scheme Scout \
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath /tmp/dd-baseline \
+            -clonedSourcePackagesDirPath /tmp/spm \
             -skipMacroValidation \
             -quiet \
             build; then

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -35,13 +35,19 @@ jobs:
 
     strategy:
       matrix:
+        # Coverage is collected on one leg only: the reports differ between
+        # legs by fractions of a percent, and instrumentation, xcresult
+        # conversion, and the Codecov upload cost minutes on every run. The
+        # iOS 26 leg carries it because the snapshot suites only execute there.
         include:
           - os: macos-15
             device: iPhone 16
             ios: 18
+            coverage: false
           - os: macos-26
             device: iPhone 17
             ios: 26
+            coverage: true
 
     steps:
       - uses: actions/checkout@v7
@@ -52,12 +58,24 @@ jobs:
             xcodebuild -downloadPlatform iOS
           fi
 
+      # Package.resolved is not committed, so the key falls back to the
+      # manifest: any Package.swift change starts a fresh cache, and
+      # restore-keys reuse the previous checkouts for the git fetches that
+      # resolution still performs.
+      - name: Cache Swift package checkouts
+        uses: actions/cache@v4
+        with:
+          path: /tmp/spm
+          key: spm-${{ hashFiles('Package.swift') }}
+          restore-keys: spm-
+
       - name: Build
         run: |
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
-            -enableCodeCoverage YES \
+            -clonedSourcePackagesDirPath /tmp/spm \
+            -enableCodeCoverage ${{ matrix.coverage && 'YES' || 'NO' }} \
             -skipMacroValidation \
             build-for-testing
 
@@ -66,11 +84,12 @@ jobs:
           xcodebuild \
             -scheme Scout \
             -destination 'platform=iOS Simulator,name=${{ matrix.device }}' \
-            -enableCodeCoverage YES \
+            -enableCodeCoverage ${{ matrix.coverage && 'YES' || 'NO' }} \
             -resultBundlePath TestResults.xcresult \
             test-without-building
 
       - name: Report coverage
+        if: matrix.coverage
         run: |
           {
             echo "### Coverage (iOS ${{ matrix.ios }})"


### PR DESCRIPTION
Two costs dominated every PR run. First, each job resolved and cloned all Swift package dependencies from scratch — now heavier since swift-snapshot-testing brought swift-syntax along — so the Swift and API workflows route xcodebuild through a cached `-clonedSourcePackagesDirPath`, keyed on Package.swift since Package.resolved is not committed. Second, the API workflow rebuilt the baseline from the PR's base commit on every push; the digester dump now lives in a cache keyed on that base SHA, skipping the entire baseline build when the base hasn't moved. Coverage instrumentation and the xccov summary also move to a single matrix leg (iOS 26, where the snapshot suites run) — the two legs' reports differed by fractions of a percent while costing minutes each.