### PR TITLE
Publish DocC documentation to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Docs
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-26
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Generate documentation
+        run: |
+          swift package \
+            --allow-writing-to-directory .docs \
+            generate-documentation \
+            --target Scout \
+            --disable-indexing \
+            --transform-for-static-hosting \
+            --hosting-base-path scout \
+            --output-path .docs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: .docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.docs
 /Packages
 xcuserdata/
 .swiftpm/

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/kasianov-mikhail/scout-db.git", from: "0.10.0"),
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.4.0"),
     ],
     targets: [
         .target(
@@ -31,6 +32,9 @@ let package = Package(
                 .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "ScoutDB", package: "scout-db"),
                 "CScoutHang",
+            ],
+            resources: [
+                .process("Core/Persistence/ScoutModel.xcdatamodeld")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Adds swift-docc-plugin and a Docs workflow that generates the Scout module's DocC documentation on every push to main and deploys it to GitHub Pages (enabled in workflow mode), so the public API reference lives at kasianov-mikhail.github.io/scout/documentation/scout/. The ScoutModel.xcdatamodeld resource is now declared explicitly in Package.swift because the plugin builds the target in isolation, where SwiftPM doesn't auto-process the model and Bundle.module fails to generate; regular builds are unaffected.