### PR TITLE
Gate ScoutSnapshotTests behind canImport(UIKit) so the macOS contract leg builds

### DIFF
--- a/Tests/ScoutSnapshotTests/HeatmapViewSnapshotTests.swift
+++ b/Tests/ScoutSnapshotTests/HeatmapViewSnapshotTests.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#if canImport(UIKit)
 import SnapshotTesting
 import SwiftUI
 import Testing
@@ -28,3 +29,4 @@ import Testing
         assertSnapshot(of: HeatmapView(grid: grid).padding(), as: .scout(height: 320))
     }
 }
+#endif

--- a/Tests/ScoutSnapshotTests/HeatmapViewSnapshotTests.swift
+++ b/Tests/ScoutSnapshotTests/HeatmapViewSnapshotTests.swift
@@ -6,27 +6,27 @@
 // https://opensource.org/licenses/MIT.
 
 #if canImport(UIKit)
-import SnapshotTesting
-import SwiftUI
-import Testing
+    import SnapshotTesting
+    import SwiftUI
+    import Testing
 
-@testable import Scout
+    @testable import Scout
 
-@Suite(.enabled(if: ViewSnapshot.isSupported))
-@MainActor struct HeatmapViewSnapshotTests {
-    @Test("Populated grid")
-    func populated() {
-        guard ViewSnapshot.isSupported else { return }
+    @Suite(.enabled(if: ViewSnapshot.isSupported))
+    @MainActor struct HeatmapViewSnapshotTests {
+        @Test("Populated grid")
+        func populated() {
+            guard ViewSnapshot.isSupported else { return }
 
-        assertSnapshot(of: HeatmapView(grid: .sample).padding(), as: .scout(height: 320))
+            assertSnapshot(of: HeatmapView(grid: .sample).padding(), as: .scout(height: 320))
+        }
+
+        @Test("Empty grid")
+        func empty() {
+            guard ViewSnapshot.isSupported else { return }
+
+            let grid = HeatmapGrid(counts: [[Int]](repeating: [Int](repeating: 0, count: 24), count: 7))
+            assertSnapshot(of: HeatmapView(grid: grid).padding(), as: .scout(height: 320))
+        }
     }
-
-    @Test("Empty grid")
-    func empty() {
-        guard ViewSnapshot.isSupported else { return }
-
-        let grid = HeatmapGrid(counts: [[Int]](repeating: [Int](repeating: 0, count: 24), count: 7))
-        assertSnapshot(of: HeatmapView(grid: grid).padding(), as: .scout(height: 320))
-    }
-}
 #endif

--- a/Tests/ScoutSnapshotTests/SegmentBarSnapshotTests.swift
+++ b/Tests/ScoutSnapshotTests/SegmentBarSnapshotTests.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#if canImport(UIKit)
 import SnapshotTesting
 import SwiftUI
 import Testing
@@ -34,3 +35,4 @@ import Testing
         assertSnapshot(of: SegmentBar(segments: breakdown.segments).padding(), as: .scout(height: 80))
     }
 }
+#endif

--- a/Tests/ScoutSnapshotTests/SegmentBarSnapshotTests.swift
+++ b/Tests/ScoutSnapshotTests/SegmentBarSnapshotTests.swift
@@ -6,33 +6,33 @@
 // https://opensource.org/licenses/MIT.
 
 #if canImport(UIKit)
-import SnapshotTesting
-import SwiftUI
-import Testing
+    import SnapshotTesting
+    import SwiftUI
+    import Testing
 
-@testable import Scout
+    @testable import Scout
 
-@Suite(.enabled(if: ViewSnapshot.isSupported))
-@MainActor struct SegmentBarSnapshotTests {
-    @Test("Mixed status breakdown")
-    func mixed() {
-        guard ViewSnapshot.isSupported else { return }
+    @Suite(.enabled(if: ViewSnapshot.isSupported))
+    @MainActor struct SegmentBarSnapshotTests {
+        @Test("Mixed status breakdown")
+        func mixed() {
+            guard ViewSnapshot.isSupported else { return }
 
-        let breakdown = StatusBreakdown.sample(
-            success: 8140,
-            redirect: 210,
-            clientError: 96,
-            serverError: 18
-        )
-        assertSnapshot(of: SegmentBar(segments: breakdown.segments).padding(), as: .scout(height: 80))
+            let breakdown = StatusBreakdown.sample(
+                success: 8140,
+                redirect: 210,
+                clientError: 96,
+                serverError: 18
+            )
+            assertSnapshot(of: SegmentBar(segments: breakdown.segments).padding(), as: .scout(height: 80))
+        }
+
+        @Test("Success only")
+        func successOnly() {
+            guard ViewSnapshot.isSupported else { return }
+
+            let breakdown = StatusBreakdown.sample(success: 1200)
+            assertSnapshot(of: SegmentBar(segments: breakdown.segments).padding(), as: .scout(height: 80))
+        }
     }
-
-    @Test("Success only")
-    func successOnly() {
-        guard ViewSnapshot.isSupported else { return }
-
-        let breakdown = StatusBreakdown.sample(success: 1200)
-        assertSnapshot(of: SegmentBar(segments: breakdown.segments).padding(), as: .scout(height: 80))
-    }
-}
 #endif

--- a/Tests/ScoutSnapshotTests/SparklineSnapshotTests.swift
+++ b/Tests/ScoutSnapshotTests/SparklineSnapshotTests.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#if canImport(UIKit)
 import SnapshotTesting
 import SwiftUI
 import Testing
@@ -32,3 +33,4 @@ import Testing
         assertSnapshot(of: view, as: .scout(height: 400))
     }
 }
+#endif

--- a/Tests/ScoutSnapshotTests/SparklineSnapshotTests.swift
+++ b/Tests/ScoutSnapshotTests/SparklineSnapshotTests.swift
@@ -6,31 +6,31 @@
 // https://opensource.org/licenses/MIT.
 
 #if canImport(UIKit)
-import SnapshotTesting
-import SwiftUI
-import Testing
+    import SnapshotTesting
+    import SwiftUI
+    import Testing
 
-@testable import Scout
+    @testable import Scout
 
-@Suite(.enabled(if: ViewSnapshot.isSupported))
-@MainActor struct SparklineSnapshotTests {
-    @Test("Rising, falling, flat, and empty series")
-    func states() {
-        guard ViewSnapshot.isSupported else { return }
+    @Suite(.enabled(if: ViewSnapshot.isSupported))
+    @MainActor struct SparklineSnapshotTests {
+        @Test("Rising, falling, flat, and empty series")
+        func states() {
+            guard ViewSnapshot.isSupported else { return }
 
-        let view = VStack(spacing: 24) {
-            Sparkline(series: MiniChartSeries(values: [3, 5, 4, 7, 6, 9, 12]), color: .purple)
-                .frame(height: 60)
-            Sparkline(series: MiniChartSeries(values: [9, 7, 8, 6, 7, 5, 4]), color: .red)
-                .frame(height: 60)
-            Sparkline(series: MiniChartSeries(values: [4, 4, 4, 4, 4, 4, 4]), color: .green)
-                .frame(height: 60)
-            Sparkline(series: .empty, color: .orange)
-                .frame(height: 60)
+            let view = VStack(spacing: 24) {
+                Sparkline(series: MiniChartSeries(values: [3, 5, 4, 7, 6, 9, 12]), color: .purple)
+                    .frame(height: 60)
+                Sparkline(series: MiniChartSeries(values: [9, 7, 8, 6, 7, 5, 4]), color: .red)
+                    .frame(height: 60)
+                Sparkline(series: MiniChartSeries(values: [4, 4, 4, 4, 4, 4, 4]), color: .green)
+                    .frame(height: 60)
+                Sparkline(series: .empty, color: .orange)
+                    .frame(height: 60)
+            }
+            .padding()
+
+            assertSnapshot(of: view, as: .scout(height: 400))
         }
-        .padding()
-
-        assertSnapshot(of: view, as: .scout(height: 400))
     }
-}
 #endif

--- a/Tests/ScoutSnapshotTests/TimelineRowSnapshotTests.swift
+++ b/Tests/ScoutSnapshotTests/TimelineRowSnapshotTests.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#if canImport(UIKit)
 import SnapshotTesting
 import SwiftUI
 import Testing
@@ -51,3 +52,4 @@ import Testing
         assertSnapshot(of: view, as: .scout(height: 140))
     }
 }
+#endif

--- a/Tests/ScoutSnapshotTests/TimelineRowSnapshotTests.swift
+++ b/Tests/ScoutSnapshotTests/TimelineRowSnapshotTests.swift
@@ -6,50 +6,50 @@
 // https://opensource.org/licenses/MIT.
 
 #if canImport(UIKit)
-import SnapshotTesting
-import SwiftUI
-import Testing
+    import SnapshotTesting
+    import SwiftUI
+    import Testing
 
-@testable import Scout
+    @testable import Scout
 
-@Suite(.enabled(if: ViewSnapshot.isSupported))
-@MainActor struct TimelineRowSnapshotTests {
-    @Test("Rows with a highlighted middle item")
-    func rows() {
-        guard ViewSnapshot.isSupported else { return }
+    @Suite(.enabled(if: ViewSnapshot.isSupported))
+    @MainActor struct TimelineRowSnapshotTests {
+        @Test("Rows with a highlighted middle item")
+        func rows() {
+            guard ViewSnapshot.isSupported else { return }
 
-        let now = Date()
-        let installID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")
-        let launchID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")
-        let sessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000003")
+            let now = Date()
+            let installID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")
+            let launchID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")
+            let sessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000003")
 
-        // Relative labels resolve against the current date, so the offsets sit
-        // mid-bucket ("3m ago", "2m ago", "recently") to stay stable while the
-        // snapshot renders.
-        let items = ["setup", "ip_lookup", "search"].enumerated().map { index, name in
-            TimelineItem(
-                id: name,
-                name: name,
-                date: now.addingTimeInterval([-210, -150, -30][index]),
-                active: [.install, .launch, .session],
-                installID: installID,
-                launchID: launchID,
-                sessionID: sessionID
-            )
-        }
-
-        let view = VStack(spacing: 0) {
-            ForEach(Array(items.enumerated()), id: \.element) { index, _ in
-                TimelineRow(
-                    items: items,
-                    index: index,
-                    timeline: now,
-                    highlighted: index == 1
+            // Relative labels resolve against the current date, so the offsets sit
+            // mid-bucket ("3m ago", "2m ago", "recently") to stay stable while the
+            // snapshot renders.
+            let items = ["setup", "ip_lookup", "search"].enumerated().map { index, name in
+                TimelineItem(
+                    id: name,
+                    name: name,
+                    date: now.addingTimeInterval([-210, -150, -30][index]),
+                    active: [.install, .launch, .session],
+                    installID: installID,
+                    launchID: launchID,
+                    sessionID: sessionID
                 )
             }
-        }
 
-        assertSnapshot(of: view, as: .scout(height: 140))
+            let view = VStack(spacing: 0) {
+                ForEach(Array(items.enumerated()), id: \.element) { index, _ in
+                    TimelineRow(
+                        items: items,
+                        index: index,
+                        timeline: now,
+                        highlighted: index == 1
+                    )
+                }
+            }
+
+            assertSnapshot(of: view, as: .scout(height: 140))
+        }
     }
-}
 #endif

--- a/Tests/ScoutSnapshotTests/ViewSnapshot.swift
+++ b/Tests/ScoutSnapshotTests/ViewSnapshot.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#if canImport(UIKit)
 import SnapshotTesting
 import SwiftUI
 
@@ -31,3 +32,4 @@ extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
         return .image(perceptualPrecision: 0.98, layout: .fixed(width: width, height: height), traits: traits)
     }
 }
+#endif

--- a/Tests/ScoutSnapshotTests/ViewSnapshot.swift
+++ b/Tests/ScoutSnapshotTests/ViewSnapshot.swift
@@ -6,30 +6,30 @@
 // https://opensource.org/licenses/MIT.
 
 #if canImport(UIKit)
-import SnapshotTesting
-import SwiftUI
+    import SnapshotTesting
+    import SwiftUI
 
-@testable import Scout
+    @testable import Scout
 
-enum ViewSnapshot {
-    // Baselines are recorded on iOS 26, so other CI legs skip the snapshot suites
-    // instead of diffing against images rendered by a different OS. #available
-    // checks the simulated iOS runtime; ProcessInfo reports the host macOS
-    // version under the simulator and misgates.
-    static let isSupported: Bool = {
-        guard #available(iOS 26, *) else { return false }
-        if #available(iOS 27, *) { return false }
-        return true
-    }()
-}
-
-extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
-    static func scout(width: CGFloat = 393, height: CGFloat) -> Snapshotting {
-        let traits = UITraitCollection(traitsFrom: [
-            UITraitCollection(userInterfaceStyle: .light),
-            UITraitCollection(displayScale: 2),
-        ])
-        return .image(perceptualPrecision: 0.98, layout: .fixed(width: width, height: height), traits: traits)
+    enum ViewSnapshot {
+        // Baselines are recorded on iOS 26, so other CI legs skip the snapshot suites
+        // instead of diffing against images rendered by a different OS. #available
+        // checks the simulated iOS runtime; ProcessInfo reports the host macOS
+        // version under the simulator and misgates.
+        static let isSupported: Bool = {
+            guard #available(iOS 26, *) else { return false }
+            if #available(iOS 27, *) { return false }
+            return true
+        }()
     }
-}
+
+    extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
+        static func scout(width: CGFloat = 393, height: CGFloat) -> Snapshotting {
+            let traits = UITraitCollection(traitsFrom: [
+                UITraitCollection(userInterfaceStyle: .light),
+                UITraitCollection(displayScale: 2),
+            ])
+            return .image(perceptualPrecision: 0.98, layout: .fixed(width: width, height: height), traits: traits)
+        }
+    }
 #endif


### PR DESCRIPTION
The Server workflow's contract job builds the Scout scheme for the macOS destination, and the snapshot test target added in #926 references UIKit types (`UIImage`, `UITraitCollection`) unconditionally, so the scheme no longer compiles there — main's last green Server run predates #926, and PR #933 was the first branch to hit it. Wrapping the ScoutSnapshotTests sources in `#if canImport(UIKit)` keeps the target an empty shell on macOS while the iOS legs run the suites unchanged (they were already runtime-gated to the iOS 26 baseline).