### PR TITLE
Add an Xcode 27 runner image test leg

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -48,6 +48,14 @@ jobs:
             device: iPhone 17
             ios: 26
             coverage: true
+          # Public-preview image, labelled by Xcode major version rather than
+          # the OS and arm64-only. It runs alongside the stable legs and is not
+          # a required check, so its failures don't block merges. Snapshot
+          # baselines are iOS 26 only, so those suites skip on this leg.
+          - os: xcode-27
+            device: iPhone 18
+            ios: 27
+            coverage: false
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,6 +34,9 @@ jobs:
       id-token: write
 
     strategy:
+      # The xcode-27 leg runs a public-preview image; keep a failure there from
+      # cancelling the stable legs, whose checks are required on main.
+      fail-fast: false
       matrix:
         # Coverage is collected on one leg only: the reports differ between
         # legs by fractions of a percent, and instrumentation, xcresult
@@ -53,7 +56,7 @@ jobs:
           # a required check, so its failures don't block merges. Snapshot
           # baselines are iOS 26 only, so those suites skip on this leg.
           - os: xcode-27
-            device: iPhone 18
+            device: iPhone 17
             ios: 27
             coverage: false
 


### PR DESCRIPTION
Adds a third leg to the Swift test matrix running on the new `xcode-27` public-preview runner image (iOS 27), alongside the existing macos-15/iOS 18 and macos-26/iOS 26 legs. The image is labelled by Xcode major version rather than the OS and is arm64-only.

The leg reuses the existing simulator-prep logic, which downloads the iOS runtime and creates the device by name if the image doesn't ship it, so nothing else needs changing. It runs as a separate `test-ios-27` check that isn't in the required set, so a preview-image failure won't block merges; `continue-on-error` is intentionally left off so failures stay visible. Coverage stays on the iOS 26 leg, and the snapshot suites skip here since their baselines are iOS 26 only.