### PR TITLE
Fix flaky logging tests by sharing one NSManagedObjectModel

### DIFF
--- a/Sources/Scout/Core/Persistence/PersistentContainer.swift
+++ b/Sources/Scout/Core/Persistence/PersistentContainer.swift
@@ -19,9 +19,15 @@ let persistentContainer: NSPersistentContainer = {
     return container
 }()
 
-extension NSPersistentContainer {
-    convenience init(named name: String) {
-        guard let modelURL = Bundle.module.url(forResource: name, withExtension: "momd") else {
+extension NSManagedObjectModel {
+    // Loading ScoutModel.momd more than once registers a duplicate
+    // NSEntityDescription per NSManagedObject subclass, and the resulting
+    // ambiguous class→entity resolution races under parallel test runs —
+    // intermittently escalating a constraint-conflict save into a fatal
+    // "Unable to recover from optimistic locking failure". Every container
+    // must share this single instance.
+    nonisolated(unsafe) static let scout: NSManagedObjectModel = {
+        guard let modelURL = Bundle.module.url(forResource: "ScoutModel", withExtension: "momd") else {
             fatalError("Failed to find data model")
         }
 
@@ -29,7 +35,13 @@ extension NSPersistentContainer {
             fatalError("Failed to create model from file: \(modelURL)")
         }
 
-        self.init(name: name, managedObjectModel: model)
+        return model
+    }()
+}
+
+extension NSPersistentContainer {
+    convenience init(named name: String) {
+        self.init(name: name, managedObjectModel: .scout)
     }
 }
 

--- a/Tests/ScoutTests/Core/Persistence/MigrationTests.swift
+++ b/Tests/ScoutTests/Core/Persistence/MigrationTests.swift
@@ -15,7 +15,7 @@ struct MigrationTests {
     @Test("Every historical model version migrates to the current model")
     func historicalVersionsMigrate() throws {
         let momdURL = try #require(Bundle.module.url(forResource: "ScoutModel", withExtension: "momd"))
-        let current = try #require(NSManagedObjectModel(contentsOf: momdURL))
+        let current = NSManagedObjectModel.scout
 
         let versions = try FileManager.default
             .contentsOfDirectory(at: momdURL, includingPropertiesForKeys: nil)


### PR DESCRIPTION
The logging XCTest suite (testLogEvent, testLogNestedMetadata, testLogDictionaryMetadata, testLogArrayMetadata) intermittently failed on the CI iOS 18 leg with "SQLite bind[2] = nil" and a fatal "Unable to recover from optimistic locking failure" around an EventEntry insert. The root cause is that NSPersistentContainer(named:) loaded ScoutModel.momd afresh on every call, so each in-memory test container built its own NSManagedObjectModel. Multiple live copies of the same model register duplicate NSEntityDescription instances for each NSManagedObject subclass, and the resulting ambiguous class-to-entity resolution races under the parallel test runner, occasionally turning a constraint-conflict save into an unrecoverable failure.

The model is now loaded once into a shared NSManagedObjectModel.scout that every container reuses, and MigrationTests reuses the same instance. Verified locally by running the full suite (632 tests) repeatedly under test-without-building on the simulator with no failures.