### PR TITLE
Extract shared IncidentArchive from CrashArchive and HangArchive

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/CrashArchive.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/CrashArchive.swift
@@ -7,13 +7,14 @@
 
 import Foundation
 
-/// Handles file-based persistence and recovery of crash reports.
-///
-/// Crash data is written synchronously to disk to ensure it's saved
-/// before the application terminates.
-///
+// Crash data is written synchronously to disk to ensure it's saved before the
+// application terminates.
 struct CrashArchive {
-    let directory: URL
+    private let archive: IncidentArchive<CrashInfo>
+
+    init(directory: URL) {
+        archive = IncidentArchive(directory: directory, pathExtension: "crash", persist: logCrash)
+    }
 
     static let system = CrashArchive(
         directory: FileManager.default
@@ -23,46 +24,10 @@ struct CrashArchive {
     )
 
     func write(_ crash: CrashInfo) {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-
-        guard let data = try? encoder.encode(crash) else {
-            return
-        }
-
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-
-        let fileName = "\(UUID().uuidString).crash"
-        let fileURL = directory.appendingPathComponent(fileName)
-
-        try? data.write(to: fileURL, options: .atomic)
+        archive.write(crash)
     }
 
     func flush(deviceID: UUID) async {
-        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-        else {
-            return
-        }
-
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-
-        for file in files where file.pathExtension == "crash" {
-            guard let data = try? Data(contentsOf: file), let crash = try? decoder.decode(CrashInfo.self, from: data)
-            else {
-                try? FileManager.default.removeItem(at: file)
-                continue
-            }
-
-            do {
-                let id = UUID(uuidString: file.deletingPathExtension().lastPathComponent) ?? UUID()
-                try await persistentContainer.performBackgroundTask { context in
-                    try logCrash(crash, id: id, deviceID: deviceID, context: context)
-                }
-                try FileManager.default.removeItem(at: file)
-            } catch {
-                print("Failed to process crash: \(error.localizedDescription)")
-            }
-        }
+        await archive.flush(deviceID: deviceID)
     }
 }

--- a/Sources/Scout/Core/Diagnostics/Hang/HangArchive.swift
+++ b/Sources/Scout/Core/Diagnostics/Hang/HangArchive.swift
@@ -7,15 +7,15 @@
 
 import Foundation
 
-/// Handles file-based persistence and recovery of hang reports.
-///
-/// Hang data is written synchronously to disk from the watchdog thread so
-/// a report survives even if the watchdog terminates the app afterward.
-///
+// Hang data is written synchronously to disk from the watchdog thread so a
+// report survives even if the watchdog terminates the app afterward.
 struct HangArchive {
-    let directory: URL
+    private let archive: IncidentArchive<HangInfo>
 
-    /// The default hang archive using the Application Support directory.
+    init(directory: URL) {
+        archive = IncidentArchive(directory: directory, pathExtension: "hang", persist: logHang)
+    }
+
     static let system = HangArchive(
         directory: FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)
@@ -23,53 +23,11 @@ struct HangArchive {
             .appendingPathComponent("Scout/Hangs", isDirectory: true)
     )
 
-    /// Writes a hang report to disk synchronously.
     func write(_ hang: HangInfo) {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-
-        guard let data = try? encoder.encode(hang) else {
-            return
-        }
-
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-
-        let fileName = "\(UUID().uuidString).hang"
-        let fileURL = directory.appendingPathComponent(fileName)
-
-        try? data.write(to: fileURL, options: .atomic)
+        archive.write(hang)
     }
 
-    /// Flushes any pending hang reports from previous sessions.
-    ///
-    /// Call this method after CoreData is initialized to migrate hang files
-    /// into the database for syncing.
-    ///
     func flush(deviceID: UUID) async {
-        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-        else {
-            return
-        }
-
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-
-        for file in files where file.pathExtension == "hang" {
-            guard let data = try? Data(contentsOf: file), let hang = try? decoder.decode(HangInfo.self, from: data)
-            else {
-                try? FileManager.default.removeItem(at: file)
-                continue
-            }
-
-            do {
-                let id = UUID(uuidString: file.deletingPathExtension().lastPathComponent) ?? UUID()
-                try await persistentContainer.performBackgroundTask { context in
-                    try logHang(hang, id: id, deviceID: deviceID, context: context)
-                }
-                try FileManager.default.removeItem(at: file)
-            } catch {
-                print("Failed to process hang: \(error.localizedDescription)")
-            }
-        }
+        await archive.flush(deviceID: deviceID)
     }
 }

--- a/Sources/Scout/Core/Diagnostics/Incident/IncidentArchive.swift
+++ b/Sources/Scout/Core/Diagnostics/Incident/IncidentArchive.swift
@@ -1,0 +1,58 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+struct IncidentArchive<Payload: Codable & Sendable> {
+    let directory: URL
+    let pathExtension: String
+    let persist: @Sendable (Payload, UUID, UUID, NSManagedObjectContext) throws -> Void
+
+    func write(_ payload: Payload) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        guard let data = try? encoder.encode(payload) else {
+            return
+        }
+
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let fileName = "\(UUID().uuidString).\(pathExtension)"
+        let fileURL = directory.appendingPathComponent(fileName)
+
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    func flush(deviceID: UUID) async {
+        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        else {
+            return
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        for file in files where file.pathExtension == pathExtension {
+            guard let data = try? Data(contentsOf: file), let payload = try? decoder.decode(Payload.self, from: data)
+            else {
+                try? FileManager.default.removeItem(at: file)
+                continue
+            }
+
+            do {
+                let id = UUID(uuidString: file.deletingPathExtension().lastPathComponent) ?? UUID()
+                try await persistentContainer.performBackgroundTask { context in
+                    try persist(payload, id, deviceID, context)
+                }
+                try FileManager.default.removeItem(at: file)
+            } catch {
+                print("Failed to process \(pathExtension): \(error.localizedDescription)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
CrashArchive and HangArchive were near line-for-line copies — the same encode/write, directory creation, and flush/decode/persist/delete recovery loop, differing only in directory, file extension, and the log function. This pulls that logic into a single generic `IncidentArchive<Payload>` under Core/Diagnostics/Incident, and leaves CrashArchive and HangArchive as thin wrappers that delegate to it, so their public shape, call sites, and tests are unchanged. Now a fix to the persistence or recovery path lives in one place instead of drifting between two. Found during the whole-project code review.