### PR TITLE
Demote installHangHandler doc comment to an inline note

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Hang/HangHandler.swift
+++ b/Sources/Scout/Core/Diagnostics/Hang/HangHandler.swift
@@ -25,8 +25,8 @@ private let pingInterval: TimeInterval = 1
 private let warningThreshold: TimeInterval = 3
 private let criticalThreshold: TimeInterval = 8
 
-/// Installs a watchdog that detects an unresponsive main thread and
-/// captures its stack trace before the system watchdog can kill the app.
+// Installs a watchdog that detects an unresponsive main thread and captures
+// its stack trace before the system watchdog can kill the app.
 func installHangHandler(identity: Identity) {
     guard !isInstalled else { return }
     isInstalled = true


### PR DESCRIPTION
The project convention documents only public/open declarations with `///`. installHangHandler is an internal function, so its two-line `///` doc comment (which also lacked the required trailing empty `///` line) is converted to a plain `//` note, preserving the why. Found during the whole-project code review.