### PR TITLE
Render the onboarding step badge with Text(verbatim:)

### DIFF
--- a/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
+++ b/Sources/Scout/UI/Home/Onboarding/SetupPage.swift
@@ -49,7 +49,7 @@ struct SetupPage: View {
         var body: some View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 10) {
-                    Text("\(number)")
+                    Text(verbatim: "\(number)")
                         .font(.stepBadge)
                         .foregroundStyle(.white)
                         .frame(width: 22, height: 22)


### PR DESCRIPTION
Scout UI string literals must render in source English via Text(verbatim:) so they don't resolve through the host app's LocalizedStringKey catalog. The onboarding step badge used Text("\(number)"), which goes through the LocalizedStringKey initializer; this switches it to Text(verbatim:). Found during the whole-project code review.