### PR TITLE
Demote TimelineProvider's non-public doc comments to inline notes

### DIFF
--- a/Sources/Scout/UI/Insights/Timeline/Provider/TimelineProvider.swift
+++ b/Sources/Scout/UI/Insights/Timeline/Provider/TimelineProvider.swift
@@ -18,12 +18,12 @@ final class TimelineProvider: ObservableObject {
         }
     }
 
-    /// Derived from `result` once per change, so view body re-evaluations
-    /// (legend toggles, scroll) don't rebuild the row list from the tree.
+    // Derived from `result` once per change, so view body re-evaluations
+    // (legend toggles, scroll) don't rebuild the row list from the tree.
     private(set) var items: [TimelineItem] = []
 
-    /// The Markdown export of `result`, rebuilt once per change rather than
-    /// on every toolbar render.
+    // The Markdown export of `result`, rebuilt once per change rather than
+    // on every toolbar render.
     private(set) var exportText: String?
 
     let older = RailLane(ascending: false)


### PR DESCRIPTION
TimelineProvider's items/exportText carried `///` doc comments on non-public properties; the project documents only public API, so they become plain `//` notes (the why is preserved). The originally-bundled single-line signature tweaks were dropped: those declarations are long enough that swift-format --strict wraps them, so the single-line convention yields to the formatter there. Found during the whole-project code review.