### PR TITLE
Hoist EventStatList's date formatter to a shared file-scope instance

### DIFF
--- a/Sources/Scout/UI/Analytics/Event/List/EventStatList.swift
+++ b/Sources/Scout/UI/Analytics/Event/List/EventStatList.swift
@@ -14,20 +14,13 @@ struct EventStatList: View {
     @StateObject var provider = EventProvider()
     @Environment(\.database) var database
 
-    let formatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.dateFormat = "d MMM"
-        return formatter
-    }()
-
     var body: some View {
         VStack {
             EventList(provider: provider)
                 .autoRefresh {
                     await provider.fetchLatest(for: query, in: database)
                 }
-                .navigationTitle(range.label(using: formatter))
+                .navigationTitle(range.label(using: eventRangeDateFormatter))
                 .font(.caption)
         }
     }
@@ -36,6 +29,13 @@ struct EventStatList: View {
         EventQuery(name: eventName, dates: range)
     }
 }
+
+private let eventRangeDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US")
+    formatter.dateFormat = "d MMM"
+    return formatter
+}()
 
 #Preview {
     let provider = EventProvider()


### PR DESCRIPTION
EventStatList held its DateFormatter as a stored property initialized inline, so a fresh (ICU-backed, relatively expensive) formatter was allocated every time SwiftUI re-initialized the view struct — on each parent body re-evaluation. This moves it to a private file-scope instance, matching how the codebase shares formatters elsewhere (rangeDateFormatter, utcDateFormatter, CalendarMonth's statics). No behavior change. Found during the whole-project code review.