### PR TITLE
Derive HangGroup severity and duration text from its peak hang

### DIFF
--- a/Sources/Scout/UI/Monitoring/Incident/Hang/HangGroup.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Hang/HangGroup.swift
@@ -17,10 +17,15 @@ extension IncidentGroup where Element == Hang {
     }
 
     var severity: HangSeverity {
-        maxDuration >= 8 ? .critical : .warning
+        peak.severity
     }
 
     var durationText: String {
-        maxDuration < 60 ? String(format: "%.1fs", maxDuration) : "\(Int(maxDuration) / 60)m \(Int(maxDuration) % 60)s"
+        peak.durationText
+    }
+
+    // The longest hang in the group; groups always hold at least one record.
+    private var peak: Hang {
+        records.max { $0.duration < $1.duration } ?? representative
     }
 }


### PR DESCRIPTION
HangGroup.severity re-encoded Hang's 8-second critical threshold and HangGroup.durationText re-encoded Hang's exact %.1fs / Xm Ys format string, so the two could silently drift from Hang.swift. Both now delegate to the group's longest-duration hang (Hang.severity / Hang.durationText), which is behaviorally identical since both were already keyed on maxDuration. Found during the whole-project code review.