### PR TITLE
Extract shared logIncident from logCrash and logHang

### DIFF
--- a/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
+++ b/Sources/Scout/Core/Diagnostics/Crash/LogCrash.swift
@@ -8,41 +8,16 @@
 import CoreData
 
 func logCrash(_ crash: CrashInfo, id: UUID = UUID(), deviceID: UUID, context: NSManagedObjectContext) throws {
-    // The id doubles as the archive file's UUID, so a flush interrupted
-    // between the save and the file removal doesn't insert a duplicate
-    // on the next launch.
-    let request = NSFetchRequest<CrashEntry>(entityName: "CrashEntry")
-    request.predicate = NSPredicate(format: "crashID == %@", id as CVarArg)
-    request.fetchLimit = 1
-    guard try context.count(for: request) == 0 else { return }
-
-    let object = context.insert(CrashEntry.self)
-
-    object.crashID = id
-    object.date = crash.date
-    object.appVersion = crash.appVersion
-    object.name = crash.name
-    object.fingerprint = CrashFingerprint(name: crash.name, reason: crash.reason, stackTrace: crash.stackTrace).value
-    object.reason = crash.reason
-    object.stackTrace = try? JSONEncoder().encode(crash.stackTrace)
-
-    // Reattach to the session/launch/install chain captured at crash time,
-    // materializing any hub the faulted run didn't persist.
-    let session = try context.linkedSession(
+    try logIncident(
+        crash,
+        id: id,
         deviceID: deviceID,
-        installID: crash.installID,
-        launchID: crash.launchID,
-        sessionID: crash.sessionID,
-        date: crash.date
-    )
-    object.session = session
-
-    try MarkerEntry.mark(
-        name: MarkerEntry.crashName,
-        install: session.launch?.install,
-        appVersion: crash.appVersion,
-        in: context
-    )
-
-    try context.save()
+        entityName: "CrashEntry",
+        idKey: "crashID",
+        markerName: MarkerEntry.crashName,
+        context: context
+    ) { (entry: CrashEntry, session) in
+        entry.crashID = id
+        entry.session = session
+    }
 }

--- a/Sources/Scout/Core/Diagnostics/Hang/LogHang.swift
+++ b/Sources/Scout/Core/Diagnostics/Hang/LogHang.swift
@@ -8,42 +8,17 @@
 import CoreData
 
 func logHang(_ hang: HangInfo, id: UUID = UUID(), deviceID: UUID, context: NSManagedObjectContext) throws {
-    // The id doubles as the archive file's UUID, so a flush interrupted
-    // between the save and the file removal doesn't insert a duplicate
-    // on the next launch.
-    let request = NSFetchRequest<HangEntry>(entityName: "HangEntry")
-    request.predicate = NSPredicate(format: "hangID == %@", id as CVarArg)
-    request.fetchLimit = 1
-    guard try context.count(for: request) == 0 else { return }
-
-    let object = context.insert(HangEntry.self)
-
-    object.hangID = id
-    object.date = hang.date
-    object.appVersion = hang.appVersion
-    object.name = hang.name
-    object.fingerprint = CrashFingerprint(name: hang.name, reason: hang.reason, stackTrace: hang.stackTrace).value
-    object.reason = hang.reason
-    object.stackTrace = try? JSONEncoder().encode(hang.stackTrace)
-    object.duration = hang.duration
-
-    // Reattach to the session/launch/install chain captured at hang time,
-    // materializing any hub the faulted run didn't persist.
-    let session = try context.linkedSession(
+    try logIncident(
+        hang,
+        id: id,
         deviceID: deviceID,
-        installID: hang.installID,
-        launchID: hang.launchID,
-        sessionID: hang.sessionID,
-        date: hang.date
-    )
-    object.session = session
-
-    try MarkerEntry.mark(
-        name: MarkerEntry.hangName,
-        install: session.launch?.install,
-        appVersion: hang.appVersion,
-        in: context
-    )
-
-    try context.save()
+        entityName: "HangEntry",
+        idKey: "hangID",
+        markerName: MarkerEntry.hangName,
+        context: context
+    ) { (entry: HangEntry, session) in
+        entry.hangID = id
+        entry.session = session
+        entry.duration = hang.duration
+    }
 }

--- a/Sources/Scout/Core/Diagnostics/Incident/LogIncident.swift
+++ b/Sources/Scout/Core/Diagnostics/Incident/LogIncident.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+protocol IncidentInfo {
+    var name: String { get }
+    var reason: String? { get }
+    var stackTrace: [String] { get }
+    var date: Date { get }
+    var installID: UUID { get }
+    var launchID: UUID { get }
+    var sessionID: UUID { get }
+    var appVersion: String? { get }
+}
+
+extension CrashInfo: IncidentInfo {}
+extension HangInfo: IncidentInfo {}
+
+func logIncident<Entry: IncidentEntry, Info: IncidentInfo>(
+    _ info: Info, id: UUID, deviceID: UUID, entityName: String, idKey: String, markerName: String,
+    context: NSManagedObjectContext, configure: (Entry, SessionEntry) -> Void
+) throws {
+    // The id doubles as the archive file's UUID, so a flush interrupted
+    // between the save and the file removal doesn't insert a duplicate
+    // on the next launch.
+    let request = NSFetchRequest<Entry>(entityName: entityName)
+    request.predicate = NSPredicate(format: "%K == %@", idKey, id as CVarArg)
+    request.fetchLimit = 1
+    guard try context.count(for: request) == 0 else { return }
+
+    let object = context.insert(Entry.self)
+
+    object.date = info.date
+    object.appVersion = info.appVersion
+    object.name = info.name
+    object.fingerprint = CrashFingerprint(name: info.name, reason: info.reason, stackTrace: info.stackTrace).value
+    object.reason = info.reason
+    object.stackTrace = try? JSONEncoder().encode(info.stackTrace)
+
+    // Reattach to the session/launch/install chain captured at incident time,
+    // materializing any hub the faulted run didn't persist.
+    let session = try context.linkedSession(
+        deviceID: deviceID,
+        installID: info.installID,
+        launchID: info.launchID,
+        sessionID: info.sessionID,
+        date: info.date
+    )
+    configure(object, session)
+
+    try MarkerEntry.mark(
+        name: markerName,
+        install: session.launch?.install,
+        appVersion: info.appVersion,
+        in: context
+    )
+
+    try context.save()
+}


### PR DESCRIPTION
logCrash and logHang were ~40-line near-duplicates — the same interrupted-flush dedup fetch, the same base-field population, the same linkedSession reattachment, and the same marker write — differing only in entity type, id key, marker name, and the hang's extra duration. This pulls the shared body into a generic logIncident over IncidentEntry (with an IncidentInfo protocol on CrashInfo/HangInfo), leaving logCrash and logHang as thin wrappers that supply the entity, id key, marker name, and a configure closure for the type-specific fields. The existing LogCrashTests and LogHangTests pass unchanged. Found during the whole-project code review.