### PR TITLE
Extract shared IncidentExport from the crash and hang exporters

### DIFF
--- a/Sources/Scout/UI/Monitoring/Incident/Crash/CrashExport.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Crash/CrashExport.swift
@@ -11,22 +11,7 @@ struct CrashExport {
     let crash: Crash
 
     var text: String {
-        var lines: [ExportLine] = [.heading(level: 1, "Scout Crash — \(crash.name)")]
-
-        if let date = crash.date {
-            lines.append(.text(ExportFormat.timestamp(date)))
-        }
-        if let reason = crash.reason {
-            lines.append(.blank)
-            lines.append(.text("Reason: \(reason)"))
-        }
-        if crash.stackTrace.count > 0 {
-            lines.append(.blank)
-            lines.append(.heading(level: 2, "Stack Trace"))
-            lines.append(.code(crash.stackTrace))
-        }
-
-        return lines.text
+        IncidentExport(incident: crash, kind: "Crash", detail: []).text
     }
 }
 
@@ -34,46 +19,12 @@ struct CrashGroupExport {
     let group: IncidentGroup<Crash>
 
     var text: String {
-        var lines: [ExportLine] = [.heading(level: 1, title), .text(group.exportSummary)]
-
-        if let seen = group.exportSeenLine {
-            lines.append(.text(seen))
-        }
-        if let reason = group.representative.reason {
-            lines.append(.blank)
-            lines.append(.text("Reason: \(reason)"))
-        }
-        if let frame = group.exportTopFrame {
-            lines.append(.blank)
-            lines.append(.text("Top frame: \(frame)"))
-        }
-
-        let rows = group.records.compactMap(row)
-        if rows.count > 0 {
-            lines.append(.blank)
-            lines.append(.heading(level: 2, "Occurrences"))
-            lines.append(contentsOf: rows)
-        }
-
-        return lines.text
-    }
-
-    private var title: String {
-        "Scout Crash Issue — \(group.name)"
-    }
-
-    private func row(for crash: Crash) -> ExportLine? {
-        guard let date = crash.date else { return nil }
-
-        var ids: [String] = []
-        if let deviceID = crash.deviceID {
-            ids.append("device \(ExportFormat.shortID(deviceID))")
-        }
-        if let sessionID = crash.sessionID {
-            ids.append("session \(ExportFormat.shortID(sessionID))")
-        }
-
-        let row = ExportFormat.timestamp(date)
-        return .bullet(ids.count > 0 ? "\(row)  (\(ids.joined(separator: ", ")))" : row)
+        let summaryDetail = group.representative.reason.map { [ExportLine.blank, .text("Reason: \($0)")] } ?? []
+        return IncidentGroupExport(
+            group: group,
+            kind: "Crash",
+            summaryDetail: summaryDetail,
+            rowSuffix: { _ in "" }
+        ).text
     }
 }

--- a/Sources/Scout/UI/Monitoring/Incident/Hang/HangExport.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Hang/HangExport.swift
@@ -11,24 +11,11 @@ struct HangExport {
     let hang: Hang
 
     var text: String {
-        var lines: [ExportLine] = [.heading(level: 1, "Scout Hang — \(hang.name)")]
-
-        if let date = hang.date {
-            lines.append(.text(ExportFormat.timestamp(date)))
-        }
-        lines.append(.blank)
-        lines.append(.text("Duration: \(hang.durationText)"))
-        if let reason = hang.reason {
-            lines.append(.blank)
-            lines.append(.text("Reason: \(reason)"))
-        }
-        if hang.stackTrace.count > 0 {
-            lines.append(.blank)
-            lines.append(.heading(level: 2, "Stack Trace"))
-            lines.append(.code(hang.stackTrace))
-        }
-
-        return lines.text
+        IncidentExport(
+            incident: hang,
+            kind: "Hang",
+            detail: [.blank, .text("Duration: \(hang.durationText)")]
+        ).text
     }
 }
 
@@ -36,44 +23,11 @@ struct HangGroupExport {
     let group: IncidentGroup<Hang>
 
     var text: String {
-        var lines: [ExportLine] = [.heading(level: 1, title), .text(group.exportSummary)]
-
-        if let seen = group.exportSeenLine {
-            lines.append(.text(seen))
-        }
-        lines.append(.blank)
-        lines.append(.text("Max duration: \(group.durationText)"))
-        if let frame = group.exportTopFrame {
-            lines.append(.blank)
-            lines.append(.text("Top frame: \(frame)"))
-        }
-
-        let rows = group.records.compactMap(row)
-        if rows.count > 0 {
-            lines.append(.blank)
-            lines.append(.heading(level: 2, "Occurrences"))
-            lines.append(contentsOf: rows)
-        }
-
-        return lines.text
-    }
-
-    private var title: String {
-        "Scout Hang Issue — \(group.name)"
-    }
-
-    private func row(for hang: Hang) -> ExportLine? {
-        guard let date = hang.date else { return nil }
-
-        var ids: [String] = []
-        if let deviceID = hang.deviceID {
-            ids.append("device \(ExportFormat.shortID(deviceID))")
-        }
-        if let sessionID = hang.sessionID {
-            ids.append("session \(ExportFormat.shortID(sessionID))")
-        }
-
-        let row = "\(ExportFormat.timestamp(date))  \(hang.durationText)"
-        return .bullet(ids.count > 0 ? "\(row)  (\(ids.joined(separator: ", ")))" : row)
+        IncidentGroupExport(
+            group: group,
+            kind: "Hang",
+            summaryDetail: [.blank, .text("Max duration: \(group.durationText)")],
+            rowSuffix: { "  \($0.durationText)" }
+        ).text
     }
 }

--- a/Sources/Scout/UI/Monitoring/Incident/Provider/IncidentExport.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Provider/IncidentExport.swift
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct IncidentExport<Element: Incident> {
+    let incident: Element
+    let kind: String
+    let detail: [ExportLine]
+
+    var text: String {
+        var lines: [ExportLine] = [.heading(level: 1, "Scout \(kind) — \(incident.name)")]
+
+        if let date = incident.date {
+            lines.append(.text(ExportFormat.timestamp(date)))
+        }
+        lines.append(contentsOf: detail)
+        if let reason = incident.reason {
+            lines.append(.blank)
+            lines.append(.text("Reason: \(reason)"))
+        }
+        if incident.stackTrace.count > 0 {
+            lines.append(.blank)
+            lines.append(.heading(level: 2, "Stack Trace"))
+            lines.append(.code(incident.stackTrace))
+        }
+
+        return lines.text
+    }
+}
+
+struct IncidentGroupExport<Element: Incident> {
+    let group: IncidentGroup<Element>
+    let kind: String
+    let summaryDetail: [ExportLine]
+    let rowSuffix: (Element) -> String
+
+    var text: String {
+        var lines: [ExportLine] = [
+            .heading(level: 1, "Scout \(kind) Issue — \(group.name)"), .text(group.exportSummary),
+        ]
+
+        if let seen = group.exportSeenLine {
+            lines.append(.text(seen))
+        }
+        lines.append(contentsOf: summaryDetail)
+        if let frame = group.exportTopFrame {
+            lines.append(.blank)
+            lines.append(.text("Top frame: \(frame)"))
+        }
+
+        let rows = group.records.compactMap(row)
+        if rows.count > 0 {
+            lines.append(.blank)
+            lines.append(.heading(level: 2, "Occurrences"))
+            lines.append(contentsOf: rows)
+        }
+
+        return lines.text
+    }
+
+    private func row(for element: Element) -> ExportLine? {
+        guard let date = element.date else { return nil }
+
+        var ids: [String] = []
+        if let deviceID = element.deviceID {
+            ids.append("device \(ExportFormat.shortID(deviceID))")
+        }
+        if let sessionID = element.sessionID {
+            ids.append("session \(ExportFormat.shortID(sessionID))")
+        }
+
+        let row = "\(ExportFormat.timestamp(date))\(rowSuffix(element))"
+        return .bullet(ids.count > 0 ? "\(row)  (\(ids.joined(separator: ", ")))" : row)
+    }
+}


### PR DESCRIPTION
CrashExport/CrashGroupExport and HangExport/HangGroupExport were near-verbatim copies of the same Markdown layout — heading, timestamp, reason, fenced stack trace, and the group summary/seen/top-frame/occurrences structure — differing only in the kind label, the hang's duration lines, and the per-row duration suffix. This pulls the layout into generic IncidentExport/IncidentGroupExport over Incident, with small per-type hooks (kind, detail lines, row suffix) supplied by the thin Crash/Hang wrappers. The existing CrashExportTests and HangExportTests, which assert exact output strings, pass unchanged. Found during the whole-project code review.