### PR TITLE
Share one IncidentRow between the crash and hang lists

### DIFF
--- a/Sources/Scout/UI/Monitoring/Incident/Crash/CrashListView.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Crash/CrashListView.swift
@@ -45,24 +45,7 @@ struct CrashListView: View {
     }
 
     private func row(for group: IncidentGroup<Crash>) -> some View {
-        Row {
-            Text(group.name)
-                .font(.body)
-                .lineLimit(1)
-                .monospaced()
-
-            if group.count > 1 {
-                CountBadge(count: group.count, prefix: "×")
-            }
-
-            Spacer()
-
-            if let date = group.lastDate {
-                Text(verbatim: date.relativeString)
-                    .font(.subheadline)
-                    .foregroundStyle(Color.gray)
-            }
-        } destination: {
+        IncidentRow(group: group) { group in
             CrashGroupDetailView(group: group)
         }
     }

--- a/Sources/Scout/UI/Monitoring/Incident/Hang/HangRow.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Hang/HangRow.swift
@@ -11,28 +11,10 @@ struct HangRow: View {
     let group: IncidentGroup<Hang>
 
     var body: some View {
-        Row {
-            Image(systemName: group.severity.systemImage)
-                .frame(width: 20)
-                .foregroundStyle(group.severity.color)
-
-            Text(group.name)
-                .font(.body)
-                .lineLimit(1)
-                .monospaced()
-
-            if group.count > 1 {
-                CountBadge(count: group.count, prefix: "×", color: group.severity.color)
-            }
-
-            Spacer()
-
-            if let date = group.lastDate {
-                Text(verbatim: date.relativeString)
-                    .font(.subheadline)
-                    .foregroundStyle(Color.gray)
-            }
-        } destination: {
+        IncidentRow(
+            group: group,
+            accent: (group.severity.systemImage, group.severity.color)
+        ) { group in
             HangGroupDetailView(group: group)
         }
     }

--- a/Sources/Scout/UI/Monitoring/Incident/Provider/IncidentRow.swift
+++ b/Sources/Scout/UI/Monitoring/Incident/Provider/IncidentRow.swift
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct IncidentRow<Element: Incident, Destination: View>: View {
+    let group: IncidentGroup<Element>
+    var accent: (systemImage: String, color: Color)? = nil
+    @ViewBuilder let destination: (IncidentGroup<Element>) -> Destination
+
+    var body: some View {
+        Row {
+            if let accent {
+                Image(systemName: accent.systemImage)
+                    .frame(width: 20)
+                    .foregroundStyle(accent.color)
+            }
+
+            Text(group.name)
+                .font(.body)
+                .lineLimit(1)
+                .monospaced()
+
+            if group.count > 1 {
+                if let accent {
+                    CountBadge(count: group.count, prefix: "×", color: accent.color)
+                } else {
+                    CountBadge(count: group.count, prefix: "×")
+                }
+            }
+
+            Spacer()
+
+            if let date = group.lastDate {
+                Text(verbatim: date.relativeString)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.gray)
+            }
+        } destination: {
+            destination(group)
+        }
+    }
+}


### PR DESCRIPTION
CrashListView.row(for:) rebuilt the same group row that HangRow already implements — monospaced name, ×-prefixed CountBadge, trailing relative date — differing only in HangRow's leading severity icon and accent color. This generalizes the layout into an IncidentRow over IncidentGroup<Element: Incident> with an optional severity accent and a destination builder; HangRow becomes a thin wrapper that passes its accent, and CrashListView uses IncidentRow directly. The crash row keeps its default (no icon, red badge) and the hang row its severity styling, so both lists render identically. Found during the whole-project code review.