### PR TITLE
Share retention rate lookup and legend item across the retention views

### DIFF
--- a/Sources/Scout/UI/Analytics/Retention/RetentionCohort.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionCohort.swift
@@ -60,6 +60,12 @@ extension RetentionCohort {
         var id: Int { day }
     }
 
+    // Looks up a retention rate at a `dayOffsets` milestone; nil if `day` isn't
+    // a milestone or that milestone hasn't elapsed yet.
+    static func rate(_ retention: [Double?], onDay day: Int) -> Double? {
+        dayOffsets.firstIndex(of: day).flatMap { retention[$0] }
+    }
+
     static func stats(for cohorts: [RetentionCohort]) -> [DayStat] {
         dayOffsets.enumerated().compactMap { index, day in
             let rates = cohorts.compactMap { $0.retention[index] }

--- a/Sources/Scout/UI/Analytics/Retention/RetentionCohortDetailView.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionCohortDetailView.swift
@@ -17,11 +17,6 @@ struct RetentionCohortDetailView: View {
         RetentionCohort.stats(for: cohorts)
     }
 
-    private func rate(_ retention: [Double?], day: Int) -> Double? {
-        guard let index = RetentionCohort.dayOffsets.firstIndex(of: day) else { return nil }
-        return retention[index]
-    }
-
     var body: some View {
         List {
             VStack(alignment: .leading, spacing: 4) {
@@ -99,21 +94,8 @@ struct RetentionCohortDetailView: View {
 
     private var legend: some View {
         HStack(spacing: 16) {
-            legendItem(color: .green, dashed: false, title: "This cohort")
-            legendItem(color: Color(.systemGray4), dashed: true, title: "Average")
-        }
-    }
-
-    private func legendItem(color: Color, dashed: Bool, title: String) -> some View {
-        HStack(spacing: 4) {
-            Path { path in
-                path.move(to: CGPoint(x: 0, y: 1))
-                path.addLine(to: CGPoint(x: 14, y: 1))
-            }
-            .stroke(color, style: StrokeStyle(lineWidth: 2, dash: dashed ? [3, 2] : []))
-            .frame(width: 14, height: 2)
-
-            Text(verbatim: title).font(.caption2).foregroundStyle(.secondary)
+            RetentionLegendItem(color: .green, dashed: false, title: "This cohort")
+            RetentionLegendItem(color: Color(.systemGray4), dashed: true, title: "Average")
         }
     }
 
@@ -121,7 +103,7 @@ struct RetentionCohortDetailView: View {
         VStack(spacing: 2) {
             Text(verbatim: "D\(day)").font(.caption2).foregroundStyle(.secondary)
             Text(
-                verbatim: rate(retention, day: day).map {
+                verbatim: RetentionCohort.rate(retention, onDay: day).map {
                     $0.formatted(.retentionRate)
                 } ?? "—"
             )

--- a/Sources/Scout/UI/Analytics/Retention/RetentionHeroChartView.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionHeroChartView.swift
@@ -35,11 +35,6 @@ private struct RetentionHeroChart: View {
         RetentionCohort.stats(for: cohorts)
     }
 
-    private func rate(_ cohort: RetentionCohort, day: Int) -> Double? {
-        guard let index = RetentionCohort.dayOffsets.firstIndex(of: day) else { return nil }
-        return cohort.retention[index]
-    }
-
     var body: some View {
         List {
             VStack(alignment: .leading, spacing: 4) {
@@ -95,7 +90,7 @@ private struct RetentionHeroChart: View {
                         Spacer()
                         Text(verbatim: "\(cohort.size)").font(.caption).foregroundStyle(.secondary)
 
-                        if let day7 = rate(cohort, day: 7) {
+                        if let day7 = RetentionCohort.rate(cohort.retention, onDay: 7) {
                             Text(
                                 verbatim:
                                     "D7 \(day7.formatted(.retentionRate))"

--- a/Sources/Scout/UI/Analytics/Retention/RetentionLegendItem.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionLegendItem.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct RetentionLegendItem: View {
+    let color: Color
+    let dashed: Bool
+    let title: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Path { path in
+                path.move(to: CGPoint(x: 0, y: 1))
+                path.addLine(to: CGPoint(x: 14, y: 1))
+            }
+            .stroke(color, style: StrokeStyle(lineWidth: 2, dash: dashed ? [3, 2] : []))
+            .frame(width: 14, height: 2)
+
+            Text(verbatim: title).font(.caption2).foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Sources/Scout/UI/Analytics/Retention/RetentionSegmentDetailView.swift
+++ b/Sources/Scout/UI/Analytics/Retention/RetentionSegmentDetailView.swift
@@ -99,21 +99,8 @@ struct RetentionSegmentDetailView: View {
 
     private var legend: some View {
         HStack(spacing: 16) {
-            legendItem(color: .orange, dashed: false, title: segment.name)
-            legendItem(color: Color(.systemGray4), dashed: true, title: "Cohort")
-        }
-    }
-
-    private func legendItem(color: Color, dashed: Bool, title: String) -> some View {
-        HStack(spacing: 4) {
-            Path { path in
-                path.move(to: CGPoint(x: 0, y: 1))
-                path.addLine(to: CGPoint(x: 14, y: 1))
-            }
-            .stroke(color, style: StrokeStyle(lineWidth: 2, dash: dashed ? [3, 2] : []))
-            .frame(width: 14, height: 2)
-
-            Text(verbatim: title).font(.caption2).foregroundStyle(.secondary)
+            RetentionLegendItem(color: .orange, dashed: false, title: segment.name)
+            RetentionLegendItem(color: Color(.systemGray4), dashed: true, title: "Cohort")
         }
     }
 


### PR DESCRIPTION
The retention feature carried three copies of two small pieces of logic: legendItem(color:dashed:title:) was byte-for-byte identical in RetentionCohortDetailView and RetentionSegmentDetailView, and the dayOffsets-indexed rate lookup was reimplemented in RetentionCohortDetailView and RetentionHeroChart. This adds a single RetentionCohort.rate(_:onDay:) model helper (used by both charts against cohort and segment retention arrays) and a shared RetentionLegendItem view, removing the duplicates. No behavior change. Found during the whole-project code review.