### PR TITLE
Rename the CScoutHang C target to ScoutHang

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "CScoutHang"
+            name: "ScoutHang"
         ),
         .target(
             name: "Scout",
@@ -32,7 +32,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "ScoutDB", package: "scout-db"),
-                "CScoutHang",
+                "ScoutHang",
             ],
             resources: [
                 .process("Core/Persistence/ScoutModel.xcdatamodeld")

--- a/Sources/Scout/Core/Diagnostics/Hang/MainThreadBacktrace.swift
+++ b/Sources/Scout/Core/Diagnostics/Hang/MainThreadBacktrace.swift
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import CScoutHang
+import ScoutHang
 import Foundation
 import MachO
 

--- a/Sources/Scout/Core/Diagnostics/Hang/MainThreadBacktrace.swift
+++ b/Sources/Scout/Core/Diagnostics/Hang/MainThreadBacktrace.swift
@@ -5,9 +5,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import ScoutHang
 import Foundation
 import MachO
+import ScoutHang
 
 /// Captures the main thread's call stack from a different thread by briefly
 /// suspending it and manually walking its frame-pointer chain.

--- a/Sources/ScoutHang/ScoutHang.c
+++ b/Sources/ScoutHang/ScoutHang.c
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#include "CScoutHang.h"
+#include "ScoutHang.h"
 
 #if defined(__arm64__) || defined(__aarch64__)
 

--- a/Sources/ScoutHang/include/ScoutHang.h
+++ b/Sources/ScoutHang/include/ScoutHang.h
@@ -5,8 +5,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#ifndef SCOUT_C_SCOUT_HANG_H
-#define SCOUT_C_SCOUT_HANG_H
+#ifndef SCOUT_HANG_H
+#define SCOUT_HANG_H
 
 #include <mach/mach.h>
 #include <stdint.h>


### PR DESCRIPTION
Drops the C prefix from the C shim target that exposes the ptrauth-stripping thread-state helpers. The folder, its .c/.h files, the include guard, the Package.swift target and its dependency in Scout, and the import site in MainThreadBacktrace all move from CScoutHang to ScoutHang. Moves went through git mv so the history is preserved, and both the ScoutHang target and the Scout scheme build clean.