### PR TITLE
Hoist counts/total/add/+ into the MetricHistogram protocol

### DIFF
--- a/Sources/Scout/UI/Monitoring/Metrics/Distribution/LatencyHistogram.swift
+++ b/Sources/Scout/UI/Monitoring/Metrics/Distribution/LatencyHistogram.swift
@@ -9,25 +9,12 @@
 import Foundation
 
 struct LatencyHistogram: Equatable {
-    private(set) var counts: [Int]
+    var counts: [Int]
+
+    static let bucketCount = LatencyBuckets.categories.count
 
     init() {
-        counts = Array(repeating: 0, count: LatencyBuckets.categories.count)
-    }
-
-    var total: Int {
-        counts.reduce(0, +)
-    }
-
-    mutating func add(count: Int, at index: Int) {
-        guard counts.indices.contains(index) else { return }
-        counts[index] += count
-    }
-
-    static func + (lhs: LatencyHistogram, rhs: LatencyHistogram) -> LatencyHistogram {
-        var sum = LatencyHistogram()
-        sum.counts = zip(lhs.counts, rhs.counts).map(+)
-        return sum
+        counts = Array(repeating: 0, count: Self.bucketCount)
     }
 
     func percentile(_ quantile: Double) -> TimeInterval? {

--- a/Sources/Scout/UI/Monitoring/Metrics/Distribution/MetricHistogram.swift
+++ b/Sources/Scout/UI/Monitoring/Metrics/Distribution/MetricHistogram.swift
@@ -10,11 +10,27 @@ import Foundation
 
 protocol MetricHistogram {
     init()
-    mutating func add(count: Int, at index: Int)
+    var counts: [Int] { get set }
+    static var bucketCount: Int { get }
     static func bucketIndex(of category: String) -> Int?
 }
 
 extension MetricHistogram {
+    var total: Int {
+        counts.reduce(0, +)
+    }
+
+    mutating func add(count: Int, at index: Int) {
+        guard counts.indices.contains(index) else { return }
+        counts[index] += count
+    }
+
+    static func + (lhs: Self, rhs: Self) -> Self {
+        var sum = Self()
+        sum.counts = zip(lhs.counts, rhs.counts).map(+)
+        return sum
+    }
+
     static func buckets(from series: [MetricSeries]) -> [Date: Self] {
         var result: [Date: Self] = [:]
 

--- a/Sources/Scout/UI/Monitoring/Network/Model/StatusBreakdown.swift
+++ b/Sources/Scout/UI/Monitoring/Network/Model/StatusBreakdown.swift
@@ -9,14 +9,12 @@
 import SwiftUI
 
 struct StatusBreakdown: Equatable {
-    private(set) var counts: [Int]
+    var counts: [Int]
+
+    static let bucketCount = StatusBuckets.categories.count
 
     init() {
-        counts = Array(repeating: 0, count: StatusBuckets.categories.count)
-    }
-
-    var total: Int {
-        counts.reduce(0, +)
+        counts = Array(repeating: 0, count: Self.bucketCount)
     }
 
     var successRate: Stability {
@@ -25,17 +23,6 @@ struct StatusBreakdown: Equatable {
 
     private var errors: Int {
         counts.suffix(2).reduce(0, +)
-    }
-
-    mutating func add(count: Int, at index: Int) {
-        guard counts.indices.contains(index) else { return }
-        counts[index] += count
-    }
-
-    static func + (lhs: StatusBreakdown, rhs: StatusBreakdown) -> StatusBreakdown {
-        var sum = StatusBreakdown()
-        sum.counts = zip(lhs.counts, rhs.counts).map(+)
-        return sum
     }
 
     private static let colors: [Color] = [.green, .blue, .orange, .red]


### PR DESCRIPTION
StatusBreakdown and LatencyHistogram both conform to MetricHistogram yet re-implemented the same bucket mechanics — the counts array, total, the bounds-guarded add(count:at:), and the zip-based + operator — which could silently drift (e.g. a fix to + reaching only one). This moves total, add, and + into a MetricHistogram extension, backed by two new requirements (var counts and static bucketCount), so both types share one implementation and keep only their bucket-specific logic. StatusBreakdownTests and LatencyHistogramTests pass unchanged. Found during the whole-project code review.