### PR TITLE
Compute the chart segment once per StatView render

### DIFF
--- a/Sources/Scout/UI/Primitives/Stats/StatView.swift
+++ b/Sources/Scout/UI/Primitives/Stats/StatView.swift
@@ -21,11 +21,11 @@ struct StatView: View {
             PeriodPicker(extent: $extent, periods: stat.periods)
 
             ProviderView(provider: stat) { points in
+                let segment = extent.segment(from: points)
+
                 RangeControl(extent: $extent)
 
                 List {
-                    let segment = extent.segment(from: points)
-
                     ComparableChart(
                         segment: segment, points: points, extent: extent, color: color, isComparing: isComparing
                     )
@@ -61,7 +61,7 @@ struct StatView: View {
                         ChartExportButton(
                             title: stat.eventName, rangeLabel: extent.domain.label(using: rangeDateFormatter)
                         ) {
-                            ChartView(segment: extent.segment(from: points), timing: extent)
+                            ChartView(segment: segment, timing: extent)
                                 .foregroundStyle(color)
                         }
                     }


### PR DESCRIPTION
StatView computed extent.segment(from: points) twice per render — once for the chart/toggle/total and again inside the toolbar's export closure. This hoists it to a single let at the top of the ProviderView content so both uses share one computation. No behavior change. Found during the whole-project code review.