### PR TITLE
Drive sync delivery from a single SyncableEntry registry

### DIFF
--- a/Sources/Scout/Core/Sync/SyncableEntry.swift
+++ b/Sources/Scout/Core/Sync/SyncableEntry.swift
@@ -15,3 +15,22 @@ class SyncableEntry: DateEntry {
         deliveries.first { $0.backendID == backendID }
     }
 }
+
+extension SyncableEntry {
+    // The single registry of concrete entry types delivered during a sync;
+    // synchronize() iterates this instead of hardcoding the list at the call
+    // site, so a new syncable type is added in one place.
+    static let deliverableTypes: [any (SyncableEntry & RecordEncodable).Type] = [
+        EventEntry.self,
+        SessionEntry.self,
+        VisitEntry.self,
+        LaunchEntry.self,
+        VersionEntry.self,
+        InstallEntry.self,
+        DeviceEntry.self,
+        CrashEntry.self,
+        HangEntry.self,
+        IntMetricsEntry.self,
+        DoubleMetricsEntry.self,
+    ]
+}

--- a/Sources/Scout/Core/Sync/Synchronize.swift
+++ b/Sources/Scout/Core/Sync/Synchronize.swift
@@ -23,21 +23,9 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
 
                 let recordSender = RecordSender(backend: backend)
 
-                func deliver<T: SyncableEntry & RecordEncodable>(_ type: T.Type) {
+                for type in SyncableEntry.deliverableTypes {
                     group.addTask { try? await recordSender.deliver(type: type, in: context) }
                 }
-
-                deliver(EventEntry.self)
-                deliver(SessionEntry.self)
-                deliver(VisitEntry.self)
-                deliver(LaunchEntry.self)
-                deliver(VersionEntry.self)
-                deliver(InstallEntry.self)
-                deliver(DeviceEntry.self)
-                deliver(CrashEntry.self)
-                deliver(HangEntry.self)
-                deliver(IntMetricsEntry.self)
-                deliver(DoubleMetricsEntry.self)
             }
         }
         try Task.checkCancellation()


### PR DESCRIPTION
synchronize() delivered records by hand-listing eleven deliver(Type.self) calls, a registry that had to be kept in sync with the SyncableEntry subclasses by memory — a new syncable type compiles fine while never being delivered. This centralizes the list as SyncableEntry.deliverableTypes and drives the sync loop off it, so the deliverable set lives in one named place that the delivery loop iterates (and that a future model-coverage test can assert against). DeliverTests and SyncableEntryPlanTests pass unchanged. Found during the whole-project code review.