### PR TITLE
Index the record cache on iOS 18 through a generic row split

### DIFF
--- a/Sources/Scout/Core/Database/Cache/CachedDatabase.swift
+++ b/Sources/Scout/Core/Database/Cache/CachedDatabase.swift
@@ -11,7 +11,7 @@ import Foundation
 struct CachedDatabase: Database {
     let base: any Database
     let scope: String
-    let cache: RecordCache
+    let cache: any RecordCaching
 
     // Series buckets are cut at week starts, and late uploads from offline devices can
     // still mutate recently closed weeks, so only weeks that ended over a week ago are frozen.
@@ -111,8 +111,14 @@ extension Backend {
 @available(iOS 17, macOS 14, *)
 @MainActor
 enum DatabaseCacheRegistry {
+    private enum CacheState {
+        case unresolved
+        case unavailable
+        case ready(any RecordCaching)
+    }
+
     private static var databases: [String: any Database] = [:]
-    private static var cache: RecordCache??
+    private static var state: CacheState = .unresolved
 
     static func database(for backend: Backend) -> any Database {
         if let database = databases[backend.id] {
@@ -128,12 +134,16 @@ enum DatabaseCacheRegistry {
         return database
     }
 
-    private static func sharedCache() -> RecordCache? {
-        if let cache {
+    private static func sharedCache() -> (any RecordCaching)? {
+        switch state {
+        case .unresolved:
+            let created = RecordCacheStore.cache()
+            state = created.map(CacheState.ready) ?? .unavailable
+            return created
+        case .unavailable:
+            return nil
+        case .ready(let cache):
             return cache
         }
-        let created = RecordCacheStore.container().map { RecordCache(modelContainer: $0) }
-        cache = .some(created)
-        return created
     }
 }

--- a/Sources/Scout/Core/Database/Cache/RecordCache.swift
+++ b/Sources/Scout/Core/Database/Cache/RecordCache.swift
@@ -9,8 +9,17 @@ import Foundation
 import SwiftData
 
 @available(iOS 17, macOS 14, *)
+protocol RecordCaching: Actor {
+    func coveredRange(for fingerprint: String) -> Range<Date>?
+    func records(for fingerprint: String, in range: Range<Date>) -> [Record]?
+    func store(_ records: [Record], for fingerprint: String, covering range: Range<Date>)
+    func lookupRecord(for fingerprint: String) -> Record?
+    func storeLookup(_ record: Record, for fingerprint: String)
+}
+
+@available(iOS 17, macOS 14, *)
 @ModelActor
-actor RecordCache {
+actor RecordCache<Row: CachedRecordModel> {
     func coveredRange(for fingerprint: String) -> Range<Date>? {
         guard let span = span(for: fingerprint), span.lowerDate < span.upperDate else { return nil }
         return span.lowerDate..<span.upperDate
@@ -19,10 +28,10 @@ actor RecordCache {
     func records(for fingerprint: String, in range: Range<Date>) -> [Record]? {
         let lower = range.lowerBound
         let upper = range.upperBound
-        let predicate = #Predicate<CachedRecord> {
+        let predicate = #Predicate<Row> {
             $0.fingerprint == fingerprint && $0.date >= lower && $0.date < upper
         }
-        let descriptor = FetchDescriptor(predicate: predicate, sortBy: [SortDescriptor(\.date)])
+        let descriptor = FetchDescriptor(predicate: predicate, sortBy: [SortDescriptor(\Row.date)])
         guard let entries = try? modelContext.fetch(descriptor) else { return nil }
 
         let decoder = JSONDecoder()
@@ -33,13 +42,13 @@ actor RecordCache {
 
     func store(_ records: [Record], for fingerprint: String, covering range: Range<Date>) {
         let encoder = JSONEncoder()
-        var entries: [CachedRecord] = []
+        var entries: [Row] = []
 
         for record in records {
             guard case .date(let date)? = record.fields["date"] else { return }
             guard range.contains(date) else { continue }
             guard let payload = try? encoder.encode(CachedRecordPayload(record: record)) else { return }
-            entries.append(CachedRecord(fingerprint: fingerprint, date: date, payload: payload))
+            entries.append(Row(fingerprint: fingerprint, date: date, payload: payload))
         }
 
         if let span = span(for: fingerprint), span.lowerDate <= range.lowerBound, range.lowerBound <= span.upperDate {
@@ -58,7 +67,7 @@ actor RecordCache {
     }
 
     func lookupRecord(for fingerprint: String) -> Record? {
-        let predicate = #Predicate<CachedRecord> { $0.fingerprint == fingerprint }
+        let predicate = #Predicate<Row> { $0.fingerprint == fingerprint }
         var descriptor = FetchDescriptor(predicate: predicate)
         descriptor.fetchLimit = 1
         guard let entry = try? modelContext.fetch(descriptor).first else { return nil }
@@ -67,9 +76,9 @@ actor RecordCache {
 
     func storeLookup(_ record: Record, for fingerprint: String) {
         guard let payload = try? JSONEncoder().encode(CachedRecordPayload(record: record)) else { return }
-        let predicate = #Predicate<CachedRecord> { $0.fingerprint == fingerprint }
-        try? modelContext.delete(model: CachedRecord.self, where: predicate)
-        modelContext.insert(CachedRecord(fingerprint: fingerprint, date: .distantPast, payload: payload))
+        let predicate = #Predicate<Row> { $0.fingerprint == fingerprint }
+        try? modelContext.delete(model: Row.self, where: predicate)
+        modelContext.insert(Row(fingerprint: fingerprint, date: .distantPast, payload: payload))
         try? modelContext.save()
     }
 
@@ -83,17 +92,20 @@ actor RecordCache {
     private func deleteRecords(for fingerprint: String, in range: Range<Date>) {
         let lower = range.lowerBound
         let upper = range.upperBound
-        let predicate = #Predicate<CachedRecord> {
+        let predicate = #Predicate<Row> {
             $0.fingerprint == fingerprint && $0.date >= lower && $0.date < upper
         }
-        try? modelContext.delete(model: CachedRecord.self, where: predicate)
+        try? modelContext.delete(model: Row.self, where: predicate)
     }
 
     private func deleteAll(for fingerprint: String) {
-        let recordPredicate = #Predicate<CachedRecord> { $0.fingerprint == fingerprint }
-        try? modelContext.delete(model: CachedRecord.self, where: recordPredicate)
+        let recordPredicate = #Predicate<Row> { $0.fingerprint == fingerprint }
+        try? modelContext.delete(model: Row.self, where: recordPredicate)
 
         let spanPredicate = #Predicate<CachedSpan> { $0.fingerprint == fingerprint }
         try? modelContext.delete(model: CachedSpan.self, where: spanPredicate)
     }
 }
+
+@available(iOS 17, macOS 14, *)
+extension RecordCache: RecordCaching {}

--- a/Sources/Scout/Core/Database/Cache/RecordCache.swift
+++ b/Sources/Scout/Core/Database/Cache/RecordCache.swift
@@ -19,7 +19,7 @@ protocol RecordCaching: Actor {
 
 @available(iOS 17, macOS 14, *)
 @ModelActor
-actor RecordCache<Row: CachedRecordModel> {
+actor RecordCache<Row: CacheRow> {
     func coveredRange(for fingerprint: String) -> Range<Date>? {
         guard let span = span(for: fingerprint), span.lowerDate < span.upperDate else { return nil }
         return span.lowerDate..<span.upperDate

--- a/Sources/Scout/Core/Database/Cache/RecordCacheStore.swift
+++ b/Sources/Scout/Core/Database/Cache/RecordCacheStore.swift
@@ -9,8 +9,39 @@ import Foundation
 import SwiftData
 
 @available(iOS 17, macOS 14, *)
+protocol CachedRecordModel: PersistentModel {
+    static var schemaVersion: Int { get }
+
+    var fingerprint: String { get }
+    var date: Date { get }
+    var payload: Data { get }
+
+    init(fingerprint: String, date: Date, payload: Data)
+}
+
+@available(iOS 17, macOS 14, *)
 @Model
-final class CachedRecord {
+final class CachedRecord: CachedRecordModel {
+    static let schemaVersion = 2
+
+    var fingerprint: String
+    var date: Date
+    var payload: Data
+
+    init(fingerprint: String, date: Date, payload: Data) {
+        self.fingerprint = fingerprint
+        self.date = date
+        self.payload = payload
+    }
+}
+
+@available(iOS 18, macOS 15, *)
+@Model
+final class IndexedCachedRecord: CachedRecordModel {
+    #Index<IndexedCachedRecord>([\.fingerprint, \.date])
+
+    static let schemaVersion = 3
+
     var fingerprint: String
     var date: Date
     var payload: Data
@@ -38,28 +69,34 @@ final class CachedSpan {
 
 @available(iOS 17, macOS 14, *)
 enum RecordCacheStore {
-    static let schemaVersion = 1
-
     private static let versionKey = "scout_record_cache_schema_version"
 
-    static func container() -> ModelContainer? {
+    static func cache() -> (any RecordCaching)? {
         let directory = URL.applicationSupportDirectory.appending(path: "Scout", directoryHint: .isDirectory)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return container(at: directory.appending(path: "RecordCache.store"), defaults: .standard)
+        let url = directory.appending(path: "RecordCache.store")
+        if #available(iOS 18, macOS 15, *) {
+            return cache(IndexedCachedRecord.self, at: url, defaults: .standard)
+        }
+        return cache(CachedRecord.self, at: url, defaults: .standard)
+    }
+
+    static func cache<Row: CachedRecordModel>(_ row: Row.Type, at url: URL, defaults: UserDefaults) -> RecordCache<Row>? {
+        container(for: row, at: url, defaults: defaults).map { RecordCache<Row>(modelContainer: $0) }
     }
 
     // The cache is disposable: any schema mismatch destroys the store instead of migrating.
-    static func container(at url: URL, defaults: UserDefaults) -> ModelContainer? {
-        if defaults.integer(forKey: versionKey) != schemaVersion {
+    static func container<Row: CachedRecordModel>(for row: Row.Type, at url: URL, defaults: UserDefaults) -> ModelContainer? {
+        if defaults.integer(forKey: versionKey) != Row.schemaVersion {
             destroyStore(at: url)
         }
-        if let container = openContainer(at: url) {
-            defaults.set(schemaVersion, forKey: versionKey)
+        if let container = openContainer(for: row, at: url) {
+            defaults.set(Row.schemaVersion, forKey: versionKey)
             return container
         }
         destroyStore(at: url)
-        guard let container = openContainer(at: url) else { return nil }
-        defaults.set(schemaVersion, forKey: versionKey)
+        guard let container = openContainer(for: row, at: url) else { return nil }
+        defaults.set(Row.schemaVersion, forKey: versionKey)
         return container
     }
 
@@ -69,8 +106,8 @@ enum RecordCacheStore {
         }
     }
 
-    private static func openContainer(at url: URL) -> ModelContainer? {
-        let schema = Schema([CachedRecord.self, CachedSpan.self])
+    private static func openContainer<Row: CachedRecordModel>(for row: Row.Type, at url: URL) -> ModelContainer? {
+        let schema = Schema([Row.self, CachedSpan.self])
         let configuration = ModelConfiguration(schema: schema, url: url)
         return try? ModelContainer(for: schema, configurations: [configuration])
     }

--- a/Sources/Scout/Core/Database/Cache/RecordCacheStore.swift
+++ b/Sources/Scout/Core/Database/Cache/RecordCacheStore.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftData
 
 @available(iOS 17, macOS 14, *)
-protocol CachedRecordModel: PersistentModel {
+protocol CacheRow: PersistentModel {
     static var schemaVersion: Int { get }
 
     var fingerprint: String { get }
@@ -21,7 +21,7 @@ protocol CachedRecordModel: PersistentModel {
 
 @available(iOS 17, macOS 14, *)
 @Model
-final class CachedRecord: CachedRecordModel {
+final class CachedRecord: CacheRow {
     static let schemaVersion = 2
 
     var fingerprint: String
@@ -37,7 +37,7 @@ final class CachedRecord: CachedRecordModel {
 
 @available(iOS 18, macOS 15, *)
 @Model
-final class IndexedCachedRecord: CachedRecordModel {
+final class IndexedCachedRecord: CacheRow {
     #Index<IndexedCachedRecord>([\.fingerprint, \.date])
 
     static let schemaVersion = 3
@@ -81,12 +81,12 @@ enum RecordCacheStore {
         return cache(CachedRecord.self, at: url, defaults: .standard)
     }
 
-    static func cache<Row: CachedRecordModel>(_ row: Row.Type, at url: URL, defaults: UserDefaults) -> RecordCache<Row>? {
+    static func cache<Row: CacheRow>(_ row: Row.Type, at url: URL, defaults: UserDefaults) -> RecordCache<Row>? {
         container(for: row, at: url, defaults: defaults).map { RecordCache<Row>(modelContainer: $0) }
     }
 
     // The cache is disposable: any schema mismatch destroys the store instead of migrating.
-    static func container<Row: CachedRecordModel>(for row: Row.Type, at url: URL, defaults: UserDefaults) -> ModelContainer? {
+    static func container<Row: CacheRow>(for row: Row.Type, at url: URL, defaults: UserDefaults) -> ModelContainer? {
         if defaults.integer(forKey: versionKey) != Row.schemaVersion {
             destroyStore(at: url)
         }
@@ -106,7 +106,7 @@ enum RecordCacheStore {
         }
     }
 
-    private static func openContainer<Row: CachedRecordModel>(for row: Row.Type, at url: URL) -> ModelContainer? {
+    private static func openContainer<Row: CacheRow>(for row: Row.Type, at url: URL) -> ModelContainer? {
         let schema = Schema([Row.self, CachedSpan.self])
         let configuration = ModelConfiguration(schema: schema, url: url)
         return try? ModelContainer(for: schema, configurations: [configuration])

--- a/Tests/ScoutTests/Core/Database/Cache/CachedDatabaseTests.swift
+++ b/Tests/ScoutTests/Core/Database/Cache/CachedDatabaseTests.swift
@@ -18,15 +18,17 @@ struct CachedDatabaseTests {
 
     @available(iOS 17, macOS 14, *)
     func makeDatabase(base: SpyDatabase) throws -> CachedDatabase {
-        let schema = Schema([CachedRecord.self, CachedSpan.self])
-        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: schema, configurations: [configuration])
+        try makeDatabase(base: base, row: CachedRecord.self)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    func makeDatabase<Row: CachedRecordModel>(base: SpyDatabase, row: Row.Type) throws -> CachedDatabase {
         let frozen = cutoff
 
         return CachedDatabase(
             base: base,
             scope: "test",
-            cache: RecordCache(modelContainer: container),
+            cache: try makeRecordCache(row),
             settledCutoff: { frozen }
         )
     }
@@ -118,6 +120,30 @@ struct CachedDatabaseTests {
         #expect(first.map(\.version) == ["1.2.0"])
         #expect(second.map(\.version) == ["1.2.0"])
         #expect(second.first?.points.map(\.value) == [.int(4)])
+    }
+
+    @available(iOS 18, macOS 15, *)
+    @Test("A repeated series request hits the indexed cache")
+    func seriesRoundTripsThroughIndexedRows() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base, row: IndexedCachedRecord.self)
+        base.series = [
+            MetricSeries(
+                name: "2xx",
+                category: "http_status",
+                points: [
+                    MetricSeriesPoint(date: 1_000_000_000, value: .int(4)),
+                    MetricSeriesPoint(date: 3_500_000_000, value: .int(7)),
+                ]
+            )
+        ]
+
+        let first = try await database.metricSeries(Int.self, category: "http_status", in: lower..<upper)
+        let second = try await database.metricSeries(Int.self, category: "http_status", in: lower..<upper)
+
+        #expect(base.seriesRanges == [lower..<upper, cutoff..<upper])
+        #expect(second.first?.points.map(\.date) == first.first?.points.map(\.date))
+        #expect(second.first?.points.map(\.value) == [.int(4), .int(7)])
     }
 
     @available(iOS 17, macOS 14, *)

--- a/Tests/ScoutTests/Core/Database/Cache/CachedDatabaseTests.swift
+++ b/Tests/ScoutTests/Core/Database/Cache/CachedDatabaseTests.swift
@@ -22,7 +22,7 @@ struct CachedDatabaseTests {
     }
 
     @available(iOS 17, macOS 14, *)
-    func makeDatabase<Row: CachedRecordModel>(base: SpyDatabase, row: Row.Type) throws -> CachedDatabase {
+    func makeDatabase<Row: CacheRow>(base: SpyDatabase, row: Row.Type) throws -> CachedDatabase {
         let frozen = cutoff
 
         return CachedDatabase(

--- a/Tests/ScoutTests/Core/Database/Cache/RecordCacheStoreTests.swift
+++ b/Tests/ScoutTests/Core/Database/Cache/RecordCacheStoreTests.swift
@@ -25,27 +25,37 @@ struct RecordCacheStoreTests {
     @available(iOS 17, macOS 14, *)
     @Test("Opens a fresh store and stamps the schema version")
     func opensFreshStore() {
-        #expect(RecordCacheStore.container(at: url, defaults: defaults) != nil)
-        #expect(defaults.integer(forKey: "scout_record_cache_schema_version") == RecordCacheStore.schemaVersion)
+        #expect(RecordCacheStore.container(for: CachedRecord.self, at: url, defaults: defaults) != nil)
+        #expect(defaults.integer(forKey: "scout_record_cache_schema_version") == CachedRecord.schemaVersion)
     }
 
     @available(iOS 17, macOS 14, *)
     @Test("A version mismatch destroys the existing store")
     func destroysOnVersionMismatch() throws {
         try Data("garbage".utf8).write(to: url)
-        defaults.set(RecordCacheStore.schemaVersion + 1, forKey: "scout_record_cache_schema_version")
+        defaults.set(CachedRecord.schemaVersion + 1, forKey: "scout_record_cache_schema_version")
 
-        #expect(RecordCacheStore.container(at: url, defaults: defaults) != nil)
-        #expect(defaults.integer(forKey: "scout_record_cache_schema_version") == RecordCacheStore.schemaVersion)
+        #expect(RecordCacheStore.container(for: CachedRecord.self, at: url, defaults: defaults) != nil)
+        #expect(defaults.integer(forKey: "scout_record_cache_schema_version") == CachedRecord.schemaVersion)
+    }
+
+    @available(iOS 18, macOS 15, *)
+    @Test("Switching to the indexed row variant restamps the store")
+    func restampsOnVariantSwitch() {
+        #expect(RecordCacheStore.container(for: CachedRecord.self, at: url, defaults: defaults) != nil)
+        #expect(defaults.integer(forKey: "scout_record_cache_schema_version") == CachedRecord.schemaVersion)
+
+        #expect(RecordCacheStore.container(for: IndexedCachedRecord.self, at: url, defaults: defaults) != nil)
+        #expect(defaults.integer(forKey: "scout_record_cache_schema_version") == IndexedCachedRecord.schemaVersion)
     }
 
     @available(iOS 17, macOS 14, *)
     @Test("An unreadable store is destroyed and recreated")
     func recoversFromUnreadableStore() throws {
         try Data("garbage".utf8).write(to: url)
-        defaults.set(RecordCacheStore.schemaVersion, forKey: "scout_record_cache_schema_version")
+        defaults.set(CachedRecord.schemaVersion, forKey: "scout_record_cache_schema_version")
 
-        #expect(RecordCacheStore.container(at: url, defaults: defaults) != nil)
+        #expect(RecordCacheStore.container(for: CachedRecord.self, at: url, defaults: defaults) != nil)
     }
 
     @available(iOS 17, macOS 14, *)

--- a/Tests/ScoutTests/Core/Database/Cache/RecordCacheTests.swift
+++ b/Tests/ScoutTests/Core/Database/Cache/RecordCacheTests.swift
@@ -12,7 +12,7 @@ import Testing
 @testable import Scout
 
 @available(iOS 17, macOS 14, *)
-func makeRecordCache<Row: CachedRecordModel>(_ row: Row.Type) throws -> RecordCache<Row> {
+func makeRecordCache<Row: CacheRow>(_ row: Row.Type) throws -> RecordCache<Row> {
     let schema = Schema([Row.self, CachedSpan.self])
     let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
     let container = try ModelContainer(for: schema, configurations: [configuration])

--- a/Tests/ScoutTests/Core/Database/Cache/RecordCacheTests.swift
+++ b/Tests/ScoutTests/Core/Database/Cache/RecordCacheTests.swift
@@ -11,15 +11,15 @@ import Testing
 
 @testable import Scout
 
-struct RecordCacheTests {
-    @available(iOS 17, macOS 14, *)
-    func makeCache() throws -> RecordCache {
-        let schema = Schema([CachedRecord.self, CachedSpan.self])
-        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: schema, configurations: [configuration])
-        return RecordCache(modelContainer: container)
-    }
+@available(iOS 17, macOS 14, *)
+func makeRecordCache<Row: CachedRecordModel>(_ row: Row.Type) throws -> RecordCache<Row> {
+    let schema = Schema([Row.self, CachedSpan.self])
+    let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    let container = try ModelContainer(for: schema, configurations: [configuration])
+    return RecordCache<Row>(modelContainer: container)
+}
 
+struct RecordCacheTests {
     func makeRecord(date: Date, name: String = "Session") -> Record {
         var record = Record(recordType: "MetricSeriesPoint", recordID: UUID().uuidString)
         record.fields["date"] = .date(date)
@@ -35,7 +35,7 @@ struct RecordCacheTests {
     @available(iOS 17, macOS 14, *)
     @Test("Stored records round-trip through the cache")
     func roundTrip() async throws {
-        let cache = try makeCache()
+        let cache = try makeRecordCache(CachedRecord.self)
         let records = [makeRecord(date: date(100)), makeRecord(date: date(200))]
 
         await cache.store(records, for: "fp", covering: date(0)..<date(300))
@@ -49,7 +49,7 @@ struct RecordCacheTests {
     @available(iOS 17, macOS 14, *)
     @Test("Contiguous stores extend the covered span")
     func extendsSpan() async throws {
-        let cache = try makeCache()
+        let cache = try makeRecordCache(CachedRecord.self)
 
         await cache.store([makeRecord(date: date(100))], for: "fp", covering: date(0)..<date(300))
         await cache.store([makeRecord(date: date(400))], for: "fp", covering: date(300)..<date(600))
@@ -63,7 +63,7 @@ struct RecordCacheTests {
     @available(iOS 17, macOS 14, *)
     @Test("A disjoint store replaces the previous span")
     func replacesDisjointSpan() async throws {
-        let cache = try makeCache()
+        let cache = try makeRecordCache(CachedRecord.self)
 
         await cache.store([makeRecord(date: date(100))], for: "fp", covering: date(0)..<date(300))
         await cache.store([makeRecord(date: date(700))], for: "fp", covering: date(600)..<date(900))
@@ -78,7 +78,7 @@ struct RecordCacheTests {
     @available(iOS 17, macOS 14, *)
     @Test("Overlapping stores do not duplicate records")
     func deduplicatesOverlap() async throws {
-        let cache = try makeCache()
+        let cache = try makeRecordCache(CachedRecord.self)
         let record = makeRecord(date: date(100))
 
         await cache.store([record], for: "fp", covering: date(0)..<date(300))
@@ -91,7 +91,7 @@ struct RecordCacheTests {
     @available(iOS 17, macOS 14, *)
     @Test("Fingerprints are isolated from each other")
     func isolatesFingerprints() async throws {
-        let cache = try makeCache()
+        let cache = try makeRecordCache(CachedRecord.self)
 
         await cache.store([makeRecord(date: date(100))], for: "a", covering: date(0)..<date(300))
 
@@ -104,7 +104,7 @@ struct RecordCacheTests {
     @available(iOS 17, macOS 14, *)
     @Test("A record without a date aborts the store")
     func abortsWithoutDate() async throws {
-        let cache = try makeCache()
+        let cache = try makeRecordCache(CachedRecord.self)
         let record = Record(recordType: "MetricSeriesPoint", recordID: UUID().uuidString)
 
         await cache.store([record], for: "fp", covering: date(0)..<date(300))
@@ -115,7 +115,7 @@ struct RecordCacheTests {
     @available(iOS 17, macOS 14, *)
     @Test("Records outside the covered range are skipped")
     func skipsOutOfRange() async throws {
-        let cache = try makeCache()
+        let cache = try makeRecordCache(CachedRecord.self)
         let records = [makeRecord(date: date(100)), makeRecord(date: date(500))]
 
         await cache.store(records, for: "fp", covering: date(0)..<date(300))
@@ -123,5 +123,18 @@ struct RecordCacheTests {
         let cached = try #require(await cache.records(for: "fp", in: date(0)..<date(900)))
         #expect(cached.count == 1)
         #expect(cached.first?.fields["date"] == .date(date(100)))
+    }
+
+    @available(iOS 18, macOS 15, *)
+    @Test("Indexed records round-trip through range predicates")
+    func indexedRoundTrip() async throws {
+        let cache = try makeRecordCache(IndexedCachedRecord.self)
+        let records = [makeRecord(date: date(100)), makeRecord(date: date(200)), makeRecord(date: date(500))]
+
+        await cache.store(records, for: "fp", covering: date(0)..<date(600))
+
+        let inRange = try #require(await cache.records(for: "fp", in: date(0)..<date(300)))
+        #expect(inRange.map(\.recordID) == Array(records.prefix(2)).map(\.recordID))
+        #expect(await cache.coveredRange(for: "fp") == date(0)..<date(600))
     }
 }


### PR DESCRIPTION
RecordCache is now generic over a small CacheRow row protocol, so one implementation serves two SwiftData model variants: the existing CachedRecord on iOS 17 and a new IndexedCachedRecord with a compound (fingerprint, date) #Index on iOS 18, where the macro is available. A simulator benchmark showed the index turns cache range reads from a linear table scan into a near-constant lookup once the store grows into tens of thousands of rows, which hourly series over a year-long range reach quickly.

The cache schema version now lives on the row type (plain 2, indexed 3), so upgrading the OS restamps and rebuilds the disposable store deterministically instead of trusting lightweight migration, which could otherwise carry stale coverage spans over an empty record table and serve empty series without hitting the backend. The single availability fork that picks the row type sits in RecordCacheStore, so the container schema and the cache actor cannot disagree. Tests cover both row variants, including the restamp-on-variant-switch path and a CachedDatabase round-trip over the indexed rows.