### PR TITLE
Add SPM package snippet to the installation guide

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -6,6 +6,31 @@
 - Swift 6.0+
 - [Apple Developer](https://developer.apple.com) account with [CloudKit](https://developer.apple.com/icloud/cloudkit/) enabled
 
+## Add the Package
+
+In Xcode, go to **File > Add Package Dependencies…** and enter:
+
+```
+https://github.com/kasianov-mikhail/scout.git
+```
+
+Or add it to your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/kasianov-mikhail/scout.git", from: "3.3.0")
+```
+
+Then add `Scout` as a dependency for your target:
+
+```swift
+.target(
+    name: "YourTarget",
+    dependencies: [
+        .product(name: "Scout", package: "scout")
+    ]
+)
+```
+
 ## Enable CloudKit
 
 Ensure CloudKit is enabled in your Apple Developer account and configured for your project. Refer to [Enabling CloudKit in Your App](https://developer.apple.com/documentation/cloudkit/enabling_cloudkit_in_your_app).


### PR DESCRIPTION
Installation.md jumped straight into CloudKit schema setup without ever showing how to add the Scout package itself — the first thing a developer looks for after reading the README. Adds an "Add the Package" section with the Xcode UI steps, the `Package.swift` dependency snippet, and the target dependency snippet.