### PR TITLE
Keep the error view during retry instead of flashing the loader

### DIFF
--- a/Sources/Scout/UI/Home/RotatingProviders.swift
+++ b/Sources/Scout/UI/Home/RotatingProviders.swift
@@ -22,9 +22,7 @@ private struct RotatingProvidersModifier: ViewModifier {
         if let error = providers.compactMap(\.error).first {
             ErrorView(description: error.localizedDescription) {
                 for provider in providers {
-                    Task {
-                        await provider.fetchIfFailed(in: database)
-                    }
+                    await provider.fetchIfFailed(in: database)
                 }
             }
         } else {

--- a/Sources/Scout/UI/Primitives/States/ErrorView.swift
+++ b/Sources/Scout/UI/Primitives/States/ErrorView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 struct ErrorView: View {
     let description: Text
-    let retry: (() -> Void)?
+    let retry: (() async -> Void)?
 
     @State private var isRetrying: Bool
 
-    init(description: Text, retry: (() -> Void)?, isRetrying: Bool = false) {
+    init(description: Text, retry: (() async -> Void)?, isRetrying: Bool = false) {
         self.description = description
         self.retry = retry
         _isRetrying = State(initialValue: isRetrying)
@@ -47,7 +47,7 @@ struct ErrorView: View {
     }
 
     @ViewBuilder
-    private func retryControl(_ retry: @escaping () -> Void) -> some View {
+    private func retryControl(_ retry: @escaping () async -> Void) -> some View {
         if isRetrying {
             RingIndicator(size: 22)
                 .frame(maxWidth: .infinity)
@@ -55,7 +55,10 @@ struct ErrorView: View {
         } else {
             Button {
                 isRetrying = true
-                retry()
+                Task {
+                    await retry()
+                    isRetrying = false
+                }
             } label: {
                 Text(verbatim: "Retry")
             }
@@ -65,7 +68,7 @@ struct ErrorView: View {
 }
 
 extension ErrorView {
-    init(description: String, retry: (() -> Void)?, isRetrying: Bool = false) {
+    init(description: String, retry: (() async -> Void)?, isRetrying: Bool = false) {
         self.init(description: Text(verbatim: description), retry: retry, isRetrying: isRetrying)
     }
 }

--- a/Sources/Scout/UI/Provider/Provider+Fetch.swift
+++ b/Sources/Scout/UI/Provider/Provider+Fetch.swift
@@ -9,15 +9,20 @@ import Foundation
 
 extension Provider {
     func fetchAgain(in database: DatabaseReader) async {
-        result = nil
-        await resolve(in: database)
+        do {
+            result = .success(try await fetch(in: database))
+        } catch is CancellationError {
+            // A cancelled task (e.g. the view was recreated) leaves the result untouched so it retries.
+        } catch {
+            result = .failure(error)
+        }
     }
 
     func fetchIfNeeded(in database: DatabaseReader) async {
         guard result == nil else {
             return
         }
-        await resolve(in: database)
+        await fetchAgain(in: database)
     }
 
     func fetchIfFailed(in database: DatabaseReader) async {
@@ -39,16 +44,6 @@ extension Provider {
                 result = .failure(error)
             }
             return false
-        }
-    }
-
-    private func resolve(in database: DatabaseReader) async {
-        do {
-            result = .success(try await fetch(in: database))
-        } catch is CancellationError {
-            // A cancelled task (e.g. the view was recreated) leaves the result untouched so it retries.
-        } catch {
-            result = .failure(error)
         }
     }
 }

--- a/Sources/Scout/UI/Provider/ProviderView.swift
+++ b/Sources/Scout/UI/Provider/ProviderView.swift
@@ -30,7 +30,7 @@ struct ProviderView<P: Provider, Content: View>: View {
         }
     }
 
-    private func fetch() {
-        Task { await provider.fetchAgain(in: database) }
+    private func fetch() async {
+        await provider.fetchAgain(in: database)
     }
 }


### PR DESCRIPTION
Tapping Retry on a failed provider used to reset the result to nil before refetching, which briefly rendered the full-screen loading indicator — the home screen flashed its loading state between the error and the retried result. The retry path now refetches while keeping the current failure on screen, so the error view stays put and shows only its own inline spinner until the new result arrives. To make that work the retry closure became async so ErrorView can reset its retrying state once the fetch completes, and fetchAgain no longer clears the result up front (fetchIfFailed on the rotating home providers gets the same non-flashing behaviour).