### PR TITLE
Add an iOS 17 test leg to the Swift matrix

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -44,6 +44,10 @@ jobs:
         # iOS 26 leg carries it because the snapshot suites only execute there.
         include:
           - os: macos-15
+            device: iPhone 15
+            ios: 17
+            coverage: false
+          - os: macos-15
             device: iPhone 16
             ios: 18
             coverage: false


### PR DESCRIPTION
Adds a test-ios-17 leg to the Swift workflow matrix, running on macos-15 with an iPhone 15 simulator and no coverage, mirroring the iOS 18 leg. The Prepare simulator step is already parameterized by matrix.ios, so it downloads the iOS 17 runtime if the image lacks it; the iOS 26-gated snapshot suites skip on this leg.