### PR TITLE
Report the swift-format fix command when the lint CI step fails

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,7 +22,20 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Lint
-        run: xcrun swift-format lint --strict --recursive Sources Tests
+        run: |
+          if ! xcrun swift-format lint --strict --recursive Sources Tests; then
+            fix="xcrun swift-format format --in-place --recursive Sources Tests"
+            echo "::error::swift-format found formatting issues. Fix them locally with: $fix"
+            {
+              echo "### swift-format failed"
+              echo "Run this locally and commit the result:"
+              echo '```'
+              echo "$fix"
+              echo '```'
+              echo "Tip: install the pre-commit hook so this is applied automatically on every commit."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
   tests:
     name: test-ios-${{ matrix.ios }}


### PR DESCRIPTION
The Swift workflow's lint step ran the raw swift-format command, so a failure surfaced only the bare violations without saying how to fix them. It now catches a failing lint run, emits a GitHub error annotation and a job summary carrying the exact format-in-place command to run locally, and still exits non-zero so the check keeps blocking. Locally, a global pre-commit hook already formats staged Swift files and blocks commits on unfixable violations, so this is the CI-side safety net for commits that bypass the hook.