### PR TITLE
Reserve the Retry button's height while retrying so the error view stays put

### DIFF
--- a/Sources/Scout/UI/Primitives/States/ErrorView.swift
+++ b/Sources/Scout/UI/Primitives/States/ErrorView.swift
@@ -46,13 +46,8 @@ struct ErrorView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    @ViewBuilder
     private func retryControl(_ retry: @escaping () async -> Void) -> some View {
-        if isRetrying {
-            RingIndicator(size: 22)
-                .frame(maxWidth: .infinity)
-                .padding(10)
-        } else {
+        ZStack {
             Button {
                 isRetrying = true
                 Task {
@@ -63,6 +58,12 @@ struct ErrorView: View {
                 Text(verbatim: "Retry")
             }
             .buttonStyle(.pill)
+            .opacity(isRetrying ? 0 : 1)
+            .disabled(isRetrying)
+
+            if isRetrying {
+                RingIndicator(size: 22)
+            }
         }
     }
 }


### PR DESCRIPTION
The retry control swapped a full-width pill button for a much shorter ring indicator while retrying, and since the error view centres its contents between spacers the whole stack jumped vertically on every state change. The button now stays in the layout at all times inside a ZStack — hidden with an opacity toggle and disabled while retrying — with the spinner overlaid in its place, so the control keeps a constant height and the error view no longer shifts. Follow-up to #960.