### PR TITLE
Gate the iOS test matrix on lint and fail-fast the legs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -26,6 +26,7 @@ jobs:
 
   tests:
     name: test-ios-${{ matrix.ios }}
+    needs: lint
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 
@@ -34,9 +35,11 @@ jobs:
       id-token: write
 
     strategy:
-      # The xcode-27 leg runs a public-preview image; keep a failure there from
-      # cancelling the stable legs, whose checks are required on main.
-      fail-fast: false
+      # A failure in any leg cancels the remaining in-progress legs, including
+      # the stable iOS 18 / iOS 26 legs whose checks are required on main. Note
+      # this also lets a flake on the xcode-27 public-preview image tear down the
+      # whole run.
+      fail-fast: true
       matrix:
         # Coverage is collected on one leg only: the reports differ between
         # legs by fractions of a percent, and instrumentation, xcresult


### PR DESCRIPTION
Makes the tests job depend on lint so a formatting failure fails fast on the cheap check before the expensive macOS test matrix spins up, saving runner minutes on an avoidable lint break. Also flips the matrix to fail-fast so a failing leg cancels the remaining in-progress legs instead of letting the whole run drag on. The trade-off is noted in the workflow comment: this also lets a flake on the xcode-27 public-preview leg tear down the stable legs.