### PR TITLE
Download older iOS simulator runtimes by version and add iOS 16/17 legs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -43,9 +43,15 @@ jobs:
         # conversion, and the Codecov upload cost minutes on every run. The
         # iOS 26 leg carries it because the snapshot suites only execute there.
         include:
-          # iOS 17 is not a built-in runtime on the macos-15 image, and a bare
-          # -downloadPlatform iOS only fetches the newest runtime. Pin an exact
-          # version so the download step pulls the iOS 17 runtime explicitly.
+          # iOS 16 and 17 are not built-in runtimes on the macos-15 image, and a
+          # bare -downloadPlatform iOS only fetches the newest runtime. Pin an
+          # exact version so the download step pulls each older runtime
+          # explicitly. iOS 16 is the package's minimum deployment target.
+          - os: macos-15
+            device: iPhone 14
+            ios: 16
+            runtime: "16.4"
+            coverage: false
           - os: macos-15
             device: iPhone 15
             ios: 17

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -43,9 +43,13 @@ jobs:
         # conversion, and the Codecov upload cost minutes on every run. The
         # iOS 26 leg carries it because the snapshot suites only execute there.
         include:
+          # iOS 17 is not a built-in runtime on the macos-15 image, and a bare
+          # -downloadPlatform iOS only fetches the newest runtime. Pin an exact
+          # version so the download step pulls the iOS 17 runtime explicitly.
           - os: macos-15
             device: iPhone 15
             ios: 17
+            runtime: "17.5"
             coverage: false
           - os: macos-15
             device: iPhone 16
@@ -75,7 +79,11 @@ jobs:
         id: sim
         run: |
           if ! xcrun simctl list runtimes | grep -q "^iOS ${{ matrix.ios }}\."; then
-            xcodebuild -downloadPlatform iOS
+            if [ -n "${{ matrix.runtime }}" ]; then
+              xcodebuild -downloadPlatform iOS -buildVersion "${{ matrix.runtime }}"
+            else
+              xcodebuild -downloadPlatform iOS
+            fi
           fi
           runtime=$(xcrun simctl list runtimes --json \
             | jq -r '.runtimes[] | select(.platform == "iOS" and (.version | startswith("${{ matrix.ios }}."))) | .identifier' \


### PR DESCRIPTION
The test-ios-17 leg added in #961 fails in Prepare simulator: the macos-15 image has no built-in iOS 16 or 17 runtime, and a bare xcodebuild -downloadPlatform iOS only fetches the newest runtime, so the step exits with no older runtime available. This pins an exact runtime version per older leg and downloads it explicitly via -downloadPlatform iOS -buildVersion, leaving the newer legs unchanged. It also adds an iOS 16 leg, the package's minimum deployment target, alongside the iOS 17 one. #961 merged on required checks before this fix landed, so the iOS 17 leg is currently red on main.