### PR TITLE
Make AnchoredScroll view modifier private

### DIFF
--- a/Sources/ScoutUI/Insights/Timeline/View/Anchor/AnchoredScroll.swift
+++ b/Sources/ScoutUI/Insights/Timeline/View/Anchor/AnchoredScroll.swift
@@ -8,7 +8,7 @@
 import Scout
 import SwiftUI
 
-struct AnchoredScroll<ID: Hashable>: ViewModifier {
+private struct AnchoredScroll<ID: Hashable>: ViewModifier {
     let id: ID?
 
     /// The anchor's position in the list (rows above it).


### PR DESCRIPTION
AnchoredScroll wasn't marked private even though it's only ever used through the anchoredScroll(id:revision:) View extension, which is the pattern every other ViewModifier in the codebase follows.