### PR TITLE
Use Text(verbatim:) in AnchoredScroll preview

### DIFF
--- a/Sources/ScoutUI/Insights/Timeline/View/Anchor/AnchoredScroll.swift
+++ b/Sources/ScoutUI/Insights/Timeline/View/Anchor/AnchoredScroll.swift
@@ -118,10 +118,10 @@ extension EnvironmentValues {
         LazyVStack(spacing: 0) {
             ForEach(0..<40, id: \.self) { row in
                 HStack {
-                    Text("Row \(row)").monospaced()
+                    Text(verbatim: "Row \(row)").monospaced()
                     Spacer()
                     if row == anchor {
-                        Text("anchor").foregroundStyle(.tint).font(.caption)
+                        Text(verbatim: "anchor").foregroundStyle(.tint).font(.caption)
                     }
                 }
                 .padding()


### PR DESCRIPTION
The AnchoredScroll preview built its row labels with Text literals instead of Text(verbatim:), so they would resolve through the host app's LocalizedStringKey catalog instead of always rendering the source English.
