### PR TITLE
Add .listStyle(.plain) to Header/Row/StatRow previews

### DIFF
--- a/Sources/ScoutUI/Primitives/Rows/Header.swift
+++ b/Sources/ScoutUI/Primitives/Rows/Header.swift
@@ -38,4 +38,5 @@ struct Header<Trailing: View>: View {
             AllButton {}
         }
     }
+    .listStyle(.plain)
 }

--- a/Sources/ScoutUI/Primitives/Rows/Row.swift
+++ b/Sources/ScoutUI/Primitives/Rows/Row.swift
@@ -40,5 +40,6 @@ struct Row<Content: View, Destination: View>: View {
                 Text(verbatim: "Detail")
             }
         }
+        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Primitives/Stats/StatRow.swift
+++ b/Sources/ScoutUI/Primitives/Stats/StatRow.swift
@@ -56,5 +56,6 @@ struct StatRow<Destination: View>: View {
                 Text(verbatim: "Detail")
             }
         }
+        .listStyle(.plain)
     }
 }


### PR DESCRIPTION
Header, Row, and StatRow previewed their List without .listStyle(.plain), the only style used across the codebase's previews. Added it to all three.
