### PR TITLE
Fix duration formatter rounding past unit boundaries

### DIFF
--- a/Sources/ScoutUI/Monitoring/Metrics/Series/MetricsFormatters.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Series/MetricsFormatters.swift
@@ -64,26 +64,49 @@ extension TimeInterval {
     /// - `47_304_000` -> `"1.5 y"`
     ///
     var duration: String {
-        switch self {
-        case 0:
-            "0"
-        case ..<0.001:
-            String(format: "%.0f µs", self * 1_000_000)
-        case ..<1:
-            String(format: "%.0f ms", self * 1_000)
-        case ..<(.minute):
-            String(format: "%.1f s", self)
-        case ..<(.hour):
-            String(format: "%d min %d s", Int(rounded()) / Int(.minute), Int(rounded()) % Int(.minute))
-        case ..<(.day):
-            String(format: "%.0f h", self / .hour)
-        case ..<(.month):
-            String(format: "%.0f d", self / .day)
-        case ..<(.year):
-            String(format: "%.0f mo", self / .month)
-        default:
-            String(format: "%.1f y", self / .year)
+        if self == 0 {
+            return "0"
         }
+        if self < 0.001 {
+            let microseconds = (self * 1_000_000).rounded()
+            if microseconds < 1_000 {
+                return String(format: "%.0f µs", microseconds)
+            }
+        }
+        if self < 1 {
+            let milliseconds = (self * 1_000).rounded()
+            if milliseconds < 1_000 {
+                return String(format: "%.0f ms", milliseconds)
+            }
+        }
+        if self < .minute {
+            let seconds = (self * 10).rounded() / 10
+            if seconds < .minute {
+                return String(format: "%.1f s", seconds)
+            }
+        }
+        if self < .hour {
+            let seconds = Int(rounded())
+            if seconds < Int(.hour) {
+                return String(format: "%d min %d s", seconds / Int(.minute), seconds % Int(.minute))
+            }
+        }
+        if self < .day {
+            let hours = (self / .hour).rounded()
+            if hours < .day / .hour {
+                return String(format: "%.0f h", hours)
+            }
+        }
+        if self < .month {
+            let days = (self / .day).rounded()
+            if days < .month / .day {
+                return String(format: "%.0f d", days)
+            }
+        }
+        if self < .year {
+            return String(format: "%.0f mo", (self / .month).rounded())
+        }
+        return String(format: "%.1f y", self / .year)
     }
 }
 

--- a/Tests/ScoutUITests/Monitoring/Metrics/Series/MetricsFormattersTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Metrics/Series/MetricsFormattersTests.swift
@@ -40,4 +40,18 @@ struct MetricsFormattersTests {
     {
         #expect(seconds.duration == expected)
     }
+
+    @Test(
+        "Promotes a value that rounds up to the next unit boundary",
+        arguments: [
+            (0.0009996, "1 ms"),
+            (0.9996, "1.0 s"),
+            (59.96, "1 min 0 s"),
+            (3599.7, "1 h"),
+            (86_399.0, "1 d"),
+            (2_591_999.0, "1 mo"),
+        ]) func testDurationUnitPromotion(seconds: TimeInterval, expected: String)
+    {
+        #expect(seconds.duration == expected)
+    }
 }


### PR DESCRIPTION
Fixes a code-review finding in `TimeInterval.duration`. The formatter chose its unit branch from the raw seconds value before rounding, so a value just under a unit boundary would round up and render an out-of-range string — 3599.7 s became "60 min 0 s" instead of "1 h", 59.96 s became "60.0 s" instead of "1 min 0 s", and 0.9996 s became "1000 ms" instead of "1 s". The formatter now rounds to each unit's display precision first and promotes to the higher unit when the rounded value reaches that unit's boundary, leaving normal values unchanged. Added boundary tests covering the promotion at every unit step.