### PR TITLE
Keep draining coalesced work when the current item throws

### DIFF
--- a/Sources/Scout/Utilities/Dispatcher/Coalescer.swift
+++ b/Sources/Scout/Utilities/Dispatcher/Coalescer.swift
@@ -18,9 +18,19 @@ actor Coalescer: Dispatcher {
 
         defer { isRunning = false }
 
+        var caught: Error?
+
         while let next = pending {
             pending = nil
-            try await next()
+            do {
+                try await next()
+            } catch {
+                if caught == nil { caught = error }
+            }
+        }
+
+        if let caught {
+            throw caught
         }
     }
 }

--- a/Tests/ScoutTests/Utilities/Dispatcher/CoalescerTests.swift
+++ b/Tests/ScoutTests/Utilities/Dispatcher/CoalescerTests.swift
@@ -85,4 +85,24 @@ struct CoalescerTests {
 
         #expect(box.value == [1, 3])
     }
+
+    @Test("Pending work still runs when the current work throws")
+    func testPendingRunsWhenCurrentWorkThrows() async throws {
+        let dispatcher = Coalescer()
+        let box = Box(false)
+
+        let first = Task {
+            try await dispatcher.perform {
+                try? await Task.sleep(for: .milliseconds(100))
+                throw LifecycleError.notFound
+            }
+        }
+
+        // Let the first work item start, then queue follow-up work behind it.
+        try? await Task.sleep(for: .milliseconds(20))
+        try await dispatcher.perform { box.value = true }
+        _ = try? await first.value
+
+        #expect(box.value)
+    }
 }


### PR DESCRIPTION
This fixes a code-review finding in Coalescer. The drain loop consumed the running work item with `try await next()`, so a throw propagated straight out of `perform` and reset `isRunning` via the `defer`, abandoning any work another caller had coalesced into `pending` while the current item ran. Because a real throw path exists — background-task expiration surfaces as a `CancellationError` and call sites only log it — freshly logged records could sit undelivered indefinitely in a quiet app.

The loop now catches per-iteration errors, keeps draining `pending` to completion, and rethrows the first error afterward, so the coalescing contract (one runner, latest pending wins) and error propagation to the original caller are preserved. Added a focused test in CoalescerTests covering pending work that must still run after the current item throws.