### PR TITLE
Require the full cohort week to elapse before a retention milestone matures

### DIFF
--- a/Sources/Scout/Activity/RetentionCohort+Build.swift
+++ b/Sources/Scout/Activity/RetentionCohort+Build.swift
@@ -54,7 +54,7 @@ extension RetentionCohort {
             let cohortCounts = counts[week] ?? [:]
 
             let retained = dayOffsets.enumerated().map { index, offset -> Int? in
-                let matured = calendar.date(byAdding: .day, value: 6 + offset, to: week)!
+                let matured = calendar.date(byAdding: .day, value: 7 + offset, to: week)!
                 guard matured < asOf else {
                     return nil
                 }

--- a/Tests/ScoutTests/Activity/RetentionCohortBuildTests.swift
+++ b/Tests/ScoutTests/Activity/RetentionCohortBuildTests.swift
@@ -77,6 +77,26 @@ struct RetentionCohortBuildTests {
         #expect(rate(cohort, day: 30) == nil)
     }
 
+    @Test("A milestone stays nil until the full cohort week plus the offset has elapsed")
+    func maturityRequiresTheFullCohortWeek() throws {
+        let week = installDay.startOfWeek
+
+        func dayZero(asOf: Date) throws -> Double? {
+            let cohorts = RetentionCohort.build(
+                installDays: ["a": installDay],
+                sessionDays: ["a": [installDay]],
+                in: week..<week.addingDay(7),
+                asOf: asOf
+            )
+            let cohort = try #require(cohorts.first { $0.id == week })
+            return rate(cohort, day: 0)
+        }
+
+        // The cohort week spans week+0..week+6 and only fully elapses at week+7.
+        #expect(try dayZero(asOf: week.addingDay(7)) == nil)
+        #expect(try dayZero(asOf: week.addingDay(7).addingTimeInterval(1)) == 1)
+    }
+
     @Test("Installs outside the range are excluded")
     func installsOutsideRangeExcluded() {
         let cohorts = RetentionCohort.build(


### PR DESCRIPTION
Fixes a code-review finding in `RetentionCohort.build`, where a milestone was declared mature as soon as `asOf` passed the start of the last install day's day-N calendar day. The maturity threshold used `6 + offset`, but the cohort week spans days week+0..week+6 and only fully elapses at week+7, so an install from the week's last day whose day-N day was still in progress got counted as not-retained instead of left `nil` — systematically understating the freshest mature cohort's day-N retention. The threshold is now `7 + offset`, matching the method's own documented contract that a milestone whose window has not fully elapsed by `asOf` stays `nil`. A boundary test pins the exact maturity edge.

Note on parity: this metric is the client-side twin of scout-server's `RetentionService`. If the server still uses the same `6 + offset` threshold, the client change alone diverges client/server parity, so this needs a matching check/PR in kasianov-mikhail/scout-server (see the repo's server-contract convention; `ServerContractTests.retentionCohort` exercises the live server side).
