### PR TITLE
Dedup the fetchMore append path in FeedProvider

### DIFF
--- a/Sources/ScoutUI/Provider/FeedProvider.swift
+++ b/Sources/ScoutUI/Provider/FeedProvider.swift
@@ -48,7 +48,7 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
         do {
             let results = try await database.readMore(from: cursor, fields: nil)
             self.cursor = results.cursor
-            records = (records ?? []) + (try results.records.map(Element.init))
+            records = dedup(new: records ?? [], old: try results.records.map(Element.init))
         } catch {
             message = Message(error.localizedDescription, level: .error)
         }

--- a/Tests/ScoutUITests/Provider/FeedProviderTests.swift
+++ b/Tests/ScoutUITests/Provider/FeedProviderTests.swift
@@ -67,6 +67,58 @@ struct FeedProviderTests {
         #expect(provider.records?.count == 1)
         #expect(provider.message == nil)
     }
+
+    @Test("A refresh that resurrects an exhausted cursor does not let the next fetchMore duplicate records")
+    func fetchMoreStaysDedupedAfterRefreshResurrectsCursor() async throws {
+        let page1 = [
+            Record.eventStub(name: "a", sessionID: UUID(), date: Date()),
+            Record.eventStub(name: "b", sessionID: UUID(), date: Date()),
+        ]
+        let page2 = [
+            Record.eventStub(name: "c", sessionID: UUID(), date: Date()),
+            Record.eventStub(name: "d", sessionID: UUID(), date: Date()),
+        ]
+        let database = PagingDatabase(page1: page1, page2: page2)
+
+        let provider = EventProvider()
+        await provider.fetchLatest(for: EventQuery(), in: database)
+        let firstCursor = try #require(provider.cursor)
+        await provider.fetchMore(cursor: firstCursor, in: database)
+        #expect(provider.cursor == nil)
+        #expect(provider.records?.count == 4)
+
+        await provider.fetchLatest(for: EventQuery(), in: database)
+        let resurrected = try #require(provider.cursor)
+        await provider.fetchMore(cursor: resurrected, in: database)
+
+        let ids = try #require(provider.records).map(\.id)
+        #expect(Set(ids).count == ids.count)
+        #expect(ids.count == 4)
+    }
+}
+
+private final class PagingDatabase: DatabaseReader, @unchecked Sendable {
+    private let page1: [Record]
+    private let page2: [Record]
+
+    init(page1: [Record], page2: [Record]) {
+        self.page1 = page1
+        self.page2 = page2
+    }
+
+    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
+        let page2 = self.page2
+        return RecordChunk(records: page1, cursor: RecordCursor { _ in RecordChunk(records: page2, cursor: nil) })
+    }
+
+    func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
+        try await read(matching: query, fields: fields)
+    }
+
+    func lookup(recordName: String, fields: [String]?) async throws -> Record { throw RecordNotFoundError() }
+    func series(matching query: SeriesQuery) async throws -> [MetricSeries] { [] }
+    func activity(in range: Range<Date>) async throws -> [ActivityPoint] { [] }
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] { [] }
 }
 
 private struct RefreshFailure: Error {}


### PR DESCRIPTION
Fixes a code-review finding in FeedProvider's pagination. The fetchMore path appended a fetched page onto records without deduplication, while fetchLatest merged through the shared dedup helper. Once pagination was exhausted the chunk cursor became nil, and a later periodic fetchLatest resurrected a fresh page-1 cursor (cursor == nil so it adopted the new results cursor); the subsequent fetchMore then re-appended already-present page-2+ records, producing duplicate Identifiable ids in the ForEach across EventStatList, CrashListView, and HangListView. Routing the fetchMore append through the same dedup helper keeps auto-refresh picking up genuinely new head records while never re-adding records already in the list. Added a FeedProviderTests case that exhausts pagination, auto-refreshes to resurrect the cursor, and asserts the next fetchMore introduces no duplicate ids.