### PR TITLE
Bin and tick chart axes in UTC to match UTC data and labels

### DIFF
--- a/Sources/ScoutUI/Insights/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/ScoutUI/Insights/Chart/Comparison/ComparisonChartView.swift
@@ -62,6 +62,8 @@ struct ComparisonChartView<T: ChartNumeric>: View {
         .padding()
         .padding(.bottom)
         .listRowInsets(EdgeInsets())
+        .environment(\.calendar, .utc)
+        .environment(\.timeZone, Calendar.utc.timeZone)
     }
 
     /// The bar for the current value, plus an invisible mark at the previous

--- a/Sources/ScoutUI/Insights/Chart/Scale/ChartTiming.swift
+++ b/Sources/ScoutUI/Insights/Chart/Scale/ChartTiming.swift
@@ -15,12 +15,14 @@ protocol ChartTiming {
 
 /// The time slot a bucket occupies on the x axis.
 ///
-/// `BarMark` bins dates with the local calendar, so charts derive their bar
-/// slots, domains, and ticks from the same bins to stay pixel-aligned with
-/// the binned marks.
+/// Series data is UTC-bucketed and the axis labels are formatted in UTC, so
+/// bar slots, domains, and ticks are derived with `Calendar.utc` to name the
+/// right bucket in any time zone. The chart views set the same UTC calendar
+/// and time zone in their environment so `BarMark`'s own unit-binning agrees
+/// and the marks stay pixel-aligned with these bins.
 ///
 func binRange(of date: Date, unit: Calendar.Component) -> Range<Date> {
-    let interval = Calendar.autoupdatingCurrent.dateInterval(of: unit, for: date)!
+    let interval = Calendar.utc.dateInterval(of: unit, for: date)!
     return interval.start..<interval.end
 }
 

--- a/Sources/ScoutUI/Insights/Chart/View/ChartView.swift
+++ b/Sources/ScoutUI/Insights/Chart/View/ChartView.swift
@@ -36,6 +36,8 @@ struct ChartView<T: ChartNumeric>: View {
         .padding()
         .padding(.bottom)
         .listRowInsets(EdgeInsets())
+        .environment(\.calendar, .utc)
+        .environment(\.timeZone, Calendar.utc.timeZone)
     }
 }
 

--- a/Tests/ScoutUITests/Insights/Chart/Scale/ChartTimingTests.swift
+++ b/Tests/ScoutUITests/Insights/Chart/Scale/ChartTimingTests.swift
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+@testable import ScoutUI
+
+struct ChartTimingTests {
+    private let utc = Calendar.utc
+
+    @Test("Day bins start at UTC midnight") func dayBinAlignsToUTC() {
+        let date = Date(timeIntervalSince1970: 1_752_759_000)  // 2025-07-17 13:30 UTC
+        let start = binRange(of: date, unit: .day).lowerBound
+
+        #expect(start == utc.startOfDay(for: date))
+        #expect(utc.component(.hour, from: start) == 0)
+        #expect(utc.component(.minute, from: start) == 0)
+    }
+
+    @Test("Hour bins start at the UTC hour boundary") func hourBinAlignsToUTC() {
+        let date = Date(timeIntervalSince1970: 1_752_759_000)  // 2025-07-17 13:30 UTC
+        let start = binRange(of: date, unit: .hour).lowerBound
+
+        #expect(utc.component(.hour, from: start) == 13)
+        #expect(utc.component(.minute, from: start) == 0)
+        #expect(utc.component(.second, from: start) == 0)
+    }
+
+    @Test("Day-unit ticks land on UTC midnights") func dayTicksAlignToUTC() {
+        let base = Date(timeIntervalSince1970: 1_752_759_000)  // 2025-07-17 13:30 UTC
+        let points = (0..<7).map { day in
+            ChartPoint(date: base.addingTimeInterval(Double(day) * 86400), count: day)
+        }
+        let extent = ChartExtent(period: Period.week)
+
+        for tick in extent.tickDates(for: points) {
+            #expect(utc.component(.hour, from: tick) == 0)
+            #expect(utc.component(.minute, from: tick) == 0)
+        }
+    }
+}


### PR DESCRIPTION
Fixes a code-review finding where chart x-axis ticks were off by a bucket in non-UTC time zones. The series data is UTC-bucketed and the axis labels are formatted forcing UTC, but the tick and bin math in binRange used Calendar.autoupdatingCurrent, so on a device in a non-UTC zone a UTC day-bucket fell into the wrong local day and the UTC formatter rendered the neighbouring day's label under each bar; fractional-offset zones shifted hourly labels too. This switches binRange to Calendar.utc and sets the UTC calendar and time zone in the ChartView and ComparisonChartView environments so SwiftUI Charts' BarMark unit-binning agrees with the bins, ticks, and labels. The month path already used UTC date math via ChartExtent.tickValues and is unaffected. Adds ChartTimingTests asserting day and hour bins and day-unit ticks land on UTC boundaries.