### PR TITLE
Drop stale Home Log fetches when the period changes mid-flight

### DIFF
--- a/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
@@ -30,10 +30,18 @@ class HomeLogProvider: ObservableObject, Provider {
     }
 
     func fetch(in database: DatabaseReader) async throws -> Output {
+        let period = period
         let window = period.previousRange.lowerBound..<period.initialRange.upperBound
         let series = try await database.series(
             matching: SeriesQuery(bucket: period.logBucket, range: window)
         )
+
+        // The fetch was started under `period`; if the user switched meanwhile, dropping the
+        // completion keeps its wrong-bucket series out of the newly selected period's slot.
+        guard period == self.period else {
+            throw CancellationError()
+        }
+
         return series.filter { !lifecycleNames.contains($0.name) }
     }
 }

--- a/Tests/ScoutUITests/Home/Section/Log/HomeLogProviderTests.swift
+++ b/Tests/ScoutUITests/Home/Section/Log/HomeLogProviderTests.swift
@@ -114,6 +114,34 @@ struct HomeLogProviderTests {
         #expect(provider.result != nil)
     }
 
+    @Test("A fetch that finishes after a period switch never fills the new period's slot")
+    func staleFetchSkipsSwitchedPeriod() async throws {
+        let database = DatabaseStub()
+        database.add(series: makeSeries(name: "login", value: .int(3)))
+        let gate = Gate()
+        database.gate = gate
+
+        let provider = HomeLogProvider()
+        provider.period = .today
+
+        let inFlight = Task { await provider.fetchLatest(in: database) }
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        provider.period = .week
+        gate.open()
+        _ = await inFlight.value
+
+        #expect(provider.result == nil)
+        provider.period = .today
+        #expect(provider.result == nil)
+
+        provider.period = .week
+        await provider.fetchIfNeeded(in: database)
+        #expect(try provider.result?.get() != nil)
+    }
+
     private func makeSeries(name: String, category: String? = nil, date: Date = Date(), value: MetricValue)
         -> MetricSeries
     {

--- a/Tests/ScoutUITests/Stubs/DatabaseStub.swift
+++ b/Tests/ScoutUITests/Stubs/DatabaseStub.swift
@@ -82,7 +82,8 @@ final class DatabaseStub: DatabaseReader, @unchecked Sendable {
     }
 
     func series(matching query: SeriesQuery) async throws -> [MetricSeries] {
-        seriesChunk(matching: query)
+        await gate?.wait()
+        return seriesChunk(matching: query)
     }
 
     private func seriesChunk(matching query: SeriesQuery) -> [MetricSeries] {


### PR DESCRIPTION
Fixes a code-review finding in the Home Log section. `HomeLogProvider.fetch` read the live `period` to build its query window but the completion wrote its series through `result`, which is also keyed on the live `period`. When Home's rotating auto-refresh had a fetch in flight and the user switched the SegmentStrip, the stale completion landed under the newly selected period with the wrong bucket granularity, and the section's `.task(id: period)` then skipped refetching because its `guard result == nil` was already satisfied.

The fetch now captures the period it started under and throws `CancellationError` if that no longer matches the live period on completion, which the shared Provider extension already treats as "leave the result untouched", so the stale series is dropped and `fetchIfNeeded` still fetches fresh data for the current period. Adds a focused test that gates a fetch mid-flight, switches the period, and asserts the stale completion never fills the new slot; the test stub's series read now honors the existing gate.