### PR TITLE
Count a delivery attempt only on a real send failure

### DIFF
--- a/Sources/Scout/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Database/Access/RecordSender.swift
@@ -42,10 +42,17 @@ extension RecordSender {
             }
         }
 
-        if objects.count > 0 {
+        guard objects.count > 0 else { return }
+
+        do {
             try await database.write(records: objects.map(\.record))
             deliveries.forEach { $0.isPending = false }
+        } catch {
+            deliveries.forEach { $0.attempts += 1 }
             try context.save()
+            throw error
         }
+
+        try context.save()
     }
 }

--- a/Sources/Scout/Sync/DeliveryEntry.swift
+++ b/Sources/Scout/Sync/DeliveryEntry.swift
@@ -16,24 +16,6 @@ final class DeliveryEntry: NSManagedObject {
     @NSManaged var attempts: Int16
     @NSManaged var object: SyncableEntry
 
-    @MainActor static func recordAttempt(for backendID: String, in context: NSManagedObjectContext) {
-        let request = NSFetchRequest<DeliveryEntry>(entityName: "DeliveryEntry")
-        request.predicate = NSPredicate(
-            format: "backendID == %@ AND isPending == YES AND attempts < %d",
-            backendID,
-            DeliveryEntry.maxAttempts
-        )
-
-        do {
-            for delivery in try context.fetch(request) {
-                delivery.attempts += 1
-            }
-            try context.save()
-        } catch {
-            print("Failed to record delivery attempt: \(error.localizedDescription)")
-        }
-    }
-
     static func retainedIDs(to backendIDs: Set<String>, in context: NSManagedObjectContext) throws -> Set<
         NSManagedObjectID
     > {

--- a/Sources/Scout/Sync/Synchronize.swift
+++ b/Sources/Scout/Sync/Synchronize.swift
@@ -19,8 +19,6 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
     try await dispatcher.performEnsuringBackground {
         await withTaskGroup(of: Void.self) { group in
             for backend in backends where await backend.checkAvailability() {
-                await DeliveryEntry.recordAttempt(for: backend.id, in: context)
-
                 let recordSender = RecordSender(backend: backend)
 
                 for type in SyncableEntry.deliverableTypes {

--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -43,9 +43,11 @@ struct DeliverTests {
         [cloudBackend, serverBackend]
     }
 
-    /// Run the delivery engine for a type the way `synchronize` does: raw records to every backend.
+    /// Run the delivery engine for a type the way `synchronize` does: skip an
+    /// unavailable backend, otherwise send its raw records and let the send itself
+    /// count the attempt on failure.
     func deliver<T: SyncableEntry & RecordEncodable>(_ type: T.Type, to backend: Backend) async throws {
-        DeliveryEntry.recordAttempt(for: backend.id, in: context)
+        guard await backend.checkAvailability() else { return }
         try await RecordSender(backend: backend).deliver(type: type, in: context)
     }
 
@@ -139,6 +141,63 @@ struct DeliverTests {
         #expect(server.records.count(of: "Event") == 1)
         // Cloud's raw record was written exactly once.
         #expect(cloud.records.count(of: "Event") == 1)
+    }
+
+    @Test("Offline passes cost nothing: an unavailable backend keeps its full budget")
+    func offlinePassesPreserveAttempts() async throws {
+        let event = EventEntry.stub(name: "login", in: context)
+        try context.save()
+        try SyncableEntry.plan(backends: backends, in: context)
+
+        let offlineServer = Backend(
+            id: "server",
+            database: server,
+            checkAvailability: { false },
+            displayName: "server"
+        )
+
+        // Many sync passes fire while the backend is unreachable...
+        for _ in 0..<(DeliveryEntry.maxAttempts * 2) {
+            try await deliver(EventEntry.self, to: offlineServer)
+        }
+
+        // ...yet not one attempt is spent, so the record is still deliverable.
+        #expect(event.delivery(for: "server")?.attempts == 0)
+        #expect(event.delivery(for: "server")?.isPending == true)
+        #expect(server.records.count(of: "Event") == 0)
+
+        // Connectivity returns and the record delivers on the first real send.
+        try await deliver(EventEntry.self, to: serverBackend)
+        #expect(event.delivery(for: "server")?.isDelivered == true)
+        #expect(server.records.count(of: "Event") == 1)
+    }
+
+    @Test("A record is retried the full attempt budget before being abandoned")
+    func fullAttemptBudget() async throws {
+        let event = EventEntry.stub(name: "login", in: context)
+        try context.save()
+        try SyncableEntry.plan(backends: [serverBackend], in: context)
+
+        // The server rejects every write for the whole attempt budget.
+        for _ in 0..<DeliveryEntry.maxAttempts {
+            server.writeErrors.append(Self.testError)
+        }
+
+        for _ in 0..<DeliveryEntry.maxAttempts {
+            await #expect(throws: (any Error).self) {
+                try await deliver(EventEntry.self, to: serverBackend)
+            }
+        }
+
+        // Every attempt in the budget was a real send: the ceiling is reached only
+        // after maxAttempts writes, not one short of it.
+        #expect(server.writeErrors.isEmpty)
+        #expect(event.delivery(for: "server")?.attempts == Int16(DeliveryEntry.maxAttempts))
+        #expect(event.delivery(for: "server")?.isAbandoned == true)
+
+        // Once abandoned, no further write is attempted.
+        try await deliver(EventEntry.self, to: serverBackend)
+        #expect(server.records.count(of: "Event") == 0)
     }
 
     @Test("Dropping a never-reached backend lets cleanup reclaim the record")


### PR DESCRIPTION
Fixes a code-review finding in the sync engine. `synchronize()` bumped `attempts` on every pending row for any backend whose `checkAvailability()` returned true, before a single send was tried. Since `HostedBackend` hardcodes availability to `true`, an offline device — where a sync pass fires on every log event and every foreground transition — would burn through the whole attempt budget in seconds while the HTTP write failed silently under `try?`, permanently abandoning records that would otherwise have delivered once connectivity returned. The same pre-fetch increment also gave each record only nine real send tries instead of ten.

The fix moves the increment onto the actual write-failure path inside `RecordSender.deliver`, so a pass that never reaches a backend costs nothing and each record now receives the full `maxAttempts` real sends before it is abandoned. The now-unused `DeliveryEntry.recordAttempt` is removed and the `DeliverTests` helper updated to mirror the new flow, with two added cases covering that offline passes preserve the budget and that a record is retried the full number of times.

This keeps the change client-side only. The deeper follow-up is a real reachability signal for the HTTP backend so `HostedBackend.checkAvailability` reports `false` while offline (via a cached `NWPathMonitor` rather than a per-event probe, since availability is checked on every log event) — that would let the CloudKit-style skip path protect the hosted backend too, on top of the engine-level fix here.