### PR TITLE
Rewrap the current backend database on each cache lookup

### DIFF
--- a/Sources/Cache/CachedDatabase.swift
+++ b/Sources/Cache/CachedDatabase.swift
@@ -109,21 +109,11 @@ enum DatabaseCacheRegistry {
         case ready(any RecordCaching)
     }
 
-    private static var databases: [String: any Database] = [:]
     private static var state: CacheState = .unresolved
 
     static func database(for backend: Backend) -> any Database {
-        if let database = databases[backend.id] {
-            return database
-        }
-        let database: any Database =
-            if let cache = sharedCache() {
-                CachedDatabase(base: backend.database, scope: backend.id, cache: cache)
-            } else {
-                backend.database
-            }
-        databases[backend.id] = database
-        return database
+        guard let cache = sharedCache() else { return backend.database }
+        return CachedDatabase(base: backend.database, scope: backend.id, cache: cache)
     }
 
     private static func sharedCache() -> (any RecordCaching)? {

--- a/Tests/CacheTests/CachedDatabaseTests.swift
+++ b/Tests/CacheTests/CachedDatabaseTests.swift
@@ -178,6 +178,34 @@ struct CachedDatabaseTests {
     }
 
     @available(iOS 17, macOS 14, *)
+    @Test("A backend recreated with a rotated key resolves to the current database")
+    @MainActor
+    func rotatingKeyRebindsDatabase() throws {
+        let stale = SpyDatabase()
+        let rotated = SpyDatabase()
+
+        let first = DatabaseCacheRegistry.database(
+            for: Backend(
+                id: "https://example.com", database: stale, checkAvailability: { true }, displayName: "example")
+        )
+        let second = DatabaseCacheRegistry.database(
+            for: Backend(
+                id: "https://example.com", database: rotated, checkAvailability: { true }, displayName: "example")
+        )
+
+        #expect(spyBase(of: first) === stale)
+        #expect(spyBase(of: second) === rotated)
+    }
+
+    @available(iOS 17, macOS 14, *)
+    private func spyBase(of database: any Database) -> SpyDatabase? {
+        if let cached = database as? CachedDatabase {
+            return cached.base as? SpyDatabase
+        }
+        return database as? SpyDatabase
+    }
+
+    @available(iOS 17, macOS 14, *)
     @Test("Lookups with different field sets are cached separately")
     func separatesLookupFields() async throws {
         let base = SpyDatabase()


### PR DESCRIPTION
Fixes a code-review finding in the record-cache registry. `DatabaseCacheRegistry` memoized the wrapped `CachedDatabase` per `backend.id` for the process lifetime, but `Backend.server` derives its id from the URL alone, so a backend recreated with the same URL and a rotated apiKey kept resolving to the stale `HTTPDatabase` holding the old key — every read then failed with 401 until relaunch, even though ping succeeded because `probeStatus` builds a fresh database each call. The fix drops the per-id database memo and rewraps the current `backend.database` on each lookup; `CachedDatabase` is a cheap struct and the shared SwiftData record cache still keys on `backend.id`, so cross-call cache reuse for the same backend is unchanged. Added a Cache test asserting that two `Backend` values with the same URL but different databases resolve to their respective underlying databases rather than a shared stale one.