### PR TITLE
Bound native paginated reads with keyset paging

### DIFF
--- a/Sources/Scout/Connectors/Native/NativeDatabase.swift
+++ b/Sources/Scout/Connectors/Native/NativeDatabase.swift
@@ -43,28 +43,52 @@ extension NativeDatabase: DatabaseWriter {
 
 extension NativeDatabase: DatabaseReader {
     func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
-        try await read(matching: query, fields: fields, limit: Int.max)
-    }
-
-    func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
         await registration.value
-        let entity = query.recordType.recordType
-
         let records = try await store.read(
-            entity: entity,
+            entity: query.recordType.recordType,
             filters: query.filters.map(\.storeFilter),
             sort: query.sort.map { EntityStore.Sort(field: $0.field, ascending: $0.ascending) },
             fields: fields.map { keys in keys.filter { $0 != "uuid" } }
         )
-        return Self.chunk(records.map(Record.init(entityRecord:)), limit: limit)
+        return RecordChunk(records: records.map(Record.init(entityRecord:)), cursor: nil)
     }
 
-    private static func chunk(_ records: [Record], limit: Int) -> RecordChunk {
-        guard records.count > limit else { return RecordChunk(records: records, cursor: nil) }
-        let rest = Array(records.dropFirst(limit))
+    func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
+        await registration.value
+        // The keyset pager orders by a single field, so a query without a sort
+        // has no page order to follow — fall back to the full read.
+        guard let sort = query.sort.first else {
+            return try await read(matching: query, fields: fields)
+        }
+        return try await page(
+            entity: query.recordType.recordType,
+            filters: query.filters.map(\.storeFilter),
+            field: sort.field,
+            ascending: sort.ascending,
+            limit: limit,
+            after: nil
+        )
+    }
+
+    // Reads one keyset page and wraps its continuation cursor so the next page
+    // re-queries the store for the following bounded slice instead of retaining
+    // the whole pre-fetched tail in memory.
+    private func page(
+        entity: String, filters: [EntityStore.Filter], field: String, ascending: Bool, limit: Int,
+        after cursor: FieldCursor?
+    ) async throws
+        -> RecordChunk
+    {
+        let page = try await store.read(
+            entity: entity, filters: filters, orderedBy: field, descending: !ascending, limit: limit, after: cursor)
         return RecordChunk(
-            records: Array(records.prefix(limit)),
-            cursor: RecordCursor { _ in Self.chunk(rest, limit: limit) }
+            records: page.records.map(Record.init(entityRecord:)),
+            cursor: page.cursor.map { next in
+                RecordCursor { _ in
+                    try await self.page(
+                        entity: entity, filters: filters, field: field, ascending: ascending, limit: limit, after: next)
+                }
+            }
         )
     }
 }

--- a/Tests/ScoutTests/Connectors/Native/NativeDatabaseTests.swift
+++ b/Tests/ScoutTests/Connectors/Native/NativeDatabaseTests.swift
@@ -67,6 +67,30 @@ struct NativeDatabaseTests {
         #expect(rest.cursor == nil)
     }
 
+    @Test("A limited read walks the full ordered set across pages without gaps or dupes")
+    func multiPageContinuation() async throws {
+        for index in 0..<5 {
+            try await database.write(record: makeSessionRecord(id: "s-\(index)", device: "a", day: index))
+        }
+
+        let query = RecordQuery(
+            recordType: Session.self,
+            sort: [RecordQuery.Sort(field: "start_date", ascending: false)]
+        )
+
+        var ids: [String] = []
+        var chunk = try await database.read(matching: query, fields: Session.desiredKeys, limit: 2)
+        #expect(chunk.records.count == 2)
+        ids += chunk.records.map(\.recordID)
+        while let cursor = chunk.cursor {
+            chunk = try await database.readMore(from: cursor, fields: Session.desiredKeys)
+            #expect(chunk.records.count <= 2)
+            ids += chunk.records.map(\.recordID)
+        }
+
+        #expect(ids == ["s-4", "s-3", "s-2", "s-1", "s-0"])
+    }
+
     @Test("Lookup restores a record by its identifier")
     func lookup() async throws {
         try await database.write(record: makeEventRecord(id: "e-9", name: "open"))


### PR DESCRIPTION
Fixes a code-review finding on the native backend. NativeDatabase's limited read fetched every matching record from the store and sliced the array in memory, with the continuation cursor capturing the whole remaining tail, so the very first timeline chunk loaded and converted the device's entire matching history regardless of the requested page size — paging saved nothing. It now passes the requested limit down to EntityStore's field-ordered keyset read and re-queries the next bounded slice through the continuation cursor, so read cost and memory track the page size rather than total history while first-page-plus-readMore still yields the same ordered set. The no-limit read keeps scanning, since the visits and retention paths legitimately need every in-range row. This relies only on the keyset paging already exposed by the pinned scout-db 0.10.0, so no companion scout-db change is needed.