### PR TITLE
Percent-encode reserved delimiters in hosted query parameters

### DIFF
--- a/Sources/Scout/Connectors/Hosted/HostedReader.swift
+++ b/Sources/Scout/Connectors/Hosted/HostedReader.swift
@@ -32,16 +32,7 @@ extension HTTPDatabase: DatabaseReader {
     }
 
     func lookup(recordName: String, fields: [String]?) async throws -> Record {
-        let allowed = CharacterSet.urlPathAllowed.subtracting(CharacterSet(charactersIn: "/"))
-        let name = recordName.addingPercentEncoding(withAllowedCharacters: allowed) ?? recordName
-
-        var path = "api/v1/records/\(name)"
-        if let fields {
-            let list = fields.joined(separator: ",")
-            path += "?fields=\(list.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? list)"
-        }
-
-        guard let endpoint = URL(string: path, relativeTo: url) else {
+        guard let endpoint = recordEndpoint(recordName: recordName, fields: fields) else {
             throw HTTPDatabaseError(status: 0, reason: "Malformed record URL")
         }
 
@@ -49,7 +40,27 @@ extension HTTPDatabase: DatabaseReader {
         return try JSONDecoder().decode(HTTPRecord.self, from: data).toRecord()
     }
 
+    func recordEndpoint(recordName: String, fields: [String]?) -> URL? {
+        let allowed = CharacterSet.urlPathAllowed.subtracting(CharacterSet(charactersIn: "/"))
+        let name = recordName.addingPercentEncoding(withAllowedCharacters: allowed) ?? recordName
+
+        var path = "api/v1/records/\(name)"
+        if let fields {
+            path += "?fields=\(Self.encode(fields.joined(separator: ",")))"
+        }
+        return URL(string: path, relativeTo: url)
+    }
+
     func series(matching query: SeriesQuery) async throws -> [MetricSeries] {
+        guard let endpoint = seriesEndpoint(for: query) else {
+            throw HTTPDatabaseError(status: 0, reason: "Malformed metrics URL")
+        }
+
+        let data = try await perform(request(for: endpoint, method: "GET"))
+        return try JSONDecoder().decode(MetricSeriesResponse.self, from: data).series
+    }
+
+    func seriesEndpoint(for query: SeriesQuery) -> URL? {
         var params = [
             "bucket=\(query.bucket.rawValue)",
             "from=\(query.range.lowerBound.millisecondsSince1970)",
@@ -62,23 +73,19 @@ extension HTTPDatabase: DatabaseReader {
             params.append("category=\(Self.encode(category))")
         }
         if let values = query.values {
-            params.append("values=\(values)")
+            params.append("values=\(Self.encode(values))")
         }
         if query.byVersion {
             params.append("by=version")
         }
 
-        let path = "api/v1/metrics/series?" + params.joined(separator: "&")
-        guard let endpoint = URL(string: path, relativeTo: url) else {
-            throw HTTPDatabaseError(status: 0, reason: "Malformed metrics URL")
-        }
-
-        let data = try await perform(request(for: endpoint, method: "GET"))
-        return try JSONDecoder().decode(MetricSeriesResponse.self, from: data).series
+        return URL(string: "api/v1/metrics/series?" + params.joined(separator: "&"), relativeTo: url)
     }
 
+    private static let queryAllowed = CharacterSet.urlQueryAllowed.subtracting(CharacterSet(charactersIn: "&=+?/"))
+
     private static func encode(_ value: String) -> String {
-        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+        value.addingPercentEncoding(withAllowedCharacters: queryAllowed) ?? value
     }
 
     private struct MetricSeriesResponse: Decodable {

--- a/Tests/ScoutTests/Connectors/Hosted/HostedQueryEncodingTests.swift
+++ b/Tests/ScoutTests/Connectors/Hosted/HostedQueryEncodingTests.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import HostedConnector
+@testable import Scout
+
+/// Verifies that `HTTPDatabase` percent-encodes query parameters so reserved
+/// delimiters survive the trip to the server.
+@Suite("Hosted query encoding")
+struct HostedQueryEncodingTests {
+    private let database = HTTPDatabase(url: URL(string: "https://example.com/")!, apiKey: nil)
+    private let day = Date(timeIntervalSince1970: 1_750_000_000).startOfDay
+
+    @Test("The series name, category, and values parameters are percent-encoded")
+    func seriesParametersAreEncoded() throws {
+        let url = try #require(
+            database.seriesEndpoint(
+                for: SeriesQuery(
+                    name: "Save & Exit",
+                    category: "a=b/c?d",
+                    values: "int+long",
+                    range: day..<day.addingDay()
+                )
+            )
+        )
+        let items = queryItems(of: url)
+
+        #expect(items["name"] == "Save & Exit")
+        #expect(items["category"] == "a=b/c?d")
+        #expect(items["values"] == "int+long")
+
+        // URLComponents decodes reserved delimiters but reads a literal `+` as
+        // itself, so assert on the raw encoding to guard against a server that
+        // form-decodes `+` into a space.
+        #expect(try rawQuery(of: url).contains("int%2Blong"))
+    }
+
+    @Test("The lookup field list is percent-encoded")
+    func lookupFieldsAreEncoded() throws {
+        let url = try #require(database.recordEndpoint(recordName: "abc", fields: ["a b", "c+d"]))
+
+        #expect(queryItems(of: url)["fields"] == "a b,c+d")
+        #expect(try rawQuery(of: url).contains("c%2Bd"))
+    }
+
+    private func queryItems(of url: URL) -> [String: String] {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        return (components?.queryItems ?? []).reduce(into: [:]) { $0[$1.name] = $1.value }
+    }
+
+    private func rawQuery(of url: URL) throws -> String {
+        try #require(URLComponents(url: url, resolvingAgainstBaseURL: true)?.percentEncodedQuery)
+    }
+}

--- a/Tests/ScoutTests/Connectors/Hosted/ServerContractTests.swift
+++ b/Tests/ScoutTests/Connectors/Hosted/ServerContractTests.swift
@@ -265,6 +265,34 @@ struct ServerContractTests {
         #expect(bucketSeries.points.map(\.value.doubleValue).reduce(0, +) == 2)
     }
 
+    @Test("A metric series round-trips a name carrying reserved query characters")
+    func specialCharacterNameSeries() async throws {
+        let database = try makeDatabase()
+        // Reserved delimiters (& = + ? /) and spaces must survive percent
+        // encoding on the way to the server, or the name filter silently
+        // mismatches and the series comes back empty.
+        let marker = "Save & Exit / C++ ?=\(UUID().uuidString)"
+        let category = LatencyBuckets.category(for: 0.1)
+
+        try await database.write(records: [
+            makeMetric(name: marker, category: category),
+            makeMetric(name: marker, category: category),
+        ])
+
+        let series = try await database.series(
+            matching: SeriesQuery(
+                name: marker,
+                category: category,
+                values: Int.seriesValues,
+                range: eventDate.startOfDay..<eventDate.startOfDay.addingDay()
+            )
+        )
+        let matched = try #require(series.first { $0.name == marker })
+
+        #expect(matched.category == category)
+        #expect(matched.points.map(\.value.doubleValue).reduce(0, +) == 2)
+    }
+
     @Test("A reachability ping succeeds against a live server")
     func reachabilityPing() async throws {
         let database = try makeDatabase()


### PR DESCRIPTION
Fixes a code-review finding in HostedReader: the metrics-series and record-lookup query strings were percent-encoded with .urlQueryAllowed, which leaves the reserved delimiters & = + ? / untouched, and the values parameter was interpolated with no encoding at all. A name like "Save & Exit" or "C++" therefore reached scout-server mangled — split into junk parameters or form-decoded into spaces — so the request silently returned empty or wrong series. The encode helper now subtracts & = + ? / from the allowed set and is applied to every parameter including values, and the URL-building for both endpoints is pulled into small internal helpers so it can be unit-tested without a live server.

This lives in the scout↔scout-server wire-format area, but no server change is needed since the server already expects proper encoding. A HostedQueryEncodingTests unit suite asserts the round-trip locally, and ServerContractTests gains a special-character name case ("Save & Exit / C++ ?=") that exercises it end to end against a running server.