### PR TITLE
Fold the RecordCacheStore open-and-stamp retry into a loop

### DIFF
--- a/Sources/Cache/RecordCacheStore.swift
+++ b/Sources/Cache/RecordCacheStore.swift
@@ -90,14 +90,14 @@ enum RecordCacheStore {
         if defaults.integer(forKey: versionKey) != Row.schemaVersion {
             destroyStore(at: url)
         }
-        if let container = openContainer(for: row, at: url) {
-            defaults.set(Row.schemaVersion, forKey: versionKey)
-            return container
+        for _ in 0..<2 {
+            if let container = openContainer(for: row, at: url) {
+                defaults.set(Row.schemaVersion, forKey: versionKey)
+                return container
+            }
+            destroyStore(at: url)
         }
-        destroyStore(at: url)
-        guard let container = openContainer(for: row, at: url) else { return nil }
-        defaults.set(Row.schemaVersion, forKey: versionKey)
-        return container
+        return nil
     }
 
     static func destroyStore(at url: URL) {


### PR DESCRIPTION
The container factory spelled out the open-store, stamp-the-version, return branch twice — once on the first attempt and again after destroying a store that failed to open. This collapses the two attempts into a for _ in 0..<2 loop so the open-and-stamp logic lives in one place. The cache-store tests (fresh open, version mismatch, unreadable store recovery) still pass.