### PR TITLE
Extract Calendar.mondayBasedWeekday for the Monday-based weekday index

### DIFF
--- a/Sources/ScoutUI/Insights/Heatmap/HeatmapGrid.swift
+++ b/Sources/ScoutUI/Insights/Heatmap/HeatmapGrid.swift
@@ -21,9 +21,8 @@ struct HeatmapGrid {
         var counts = [[Int]](repeating: [Int](repeating: 0, count: 24), count: 7)
 
         for point in points where range.contains(point.date) {
-            let weekday = calendar.component(.weekday, from: point.date)
             let hour = calendar.component(.hour, from: point.date)
-            counts[(weekday + 5) % 7][hour] += point.count
+            counts[calendar.mondayBasedWeekday(from: point.date)][hour] += point.count
         }
 
         self.init(counts: counts)

--- a/Sources/ScoutUI/Primitives/Calendar/CalendarMonth.swift
+++ b/Sources/ScoutUI/Primitives/Calendar/CalendarMonth.swift
@@ -48,8 +48,7 @@ struct CalendarMonth {
     }
 
     var weeks: [[Day]] {
-        let weekday = calendar.component(.weekday, from: month)
-        let leading = (weekday + 5) % 7
+        let leading = calendar.mondayBasedWeekday(from: month)
         let first = month.addingDay(-leading)
         let days = (0..<42).map { offset -> Day in
             let date = first.addingDay(offset)

--- a/Sources/ScoutUI/Primitives/Calendar/WeekStripCalendar.swift
+++ b/Sources/ScoutUI/Primitives/Calendar/WeekStripCalendar.swift
@@ -20,8 +20,7 @@ struct WeekStripCalendar: View {
 
     private var month: CalendarMonth { CalendarMonth(containing: reference) }
     private var week: [CalendarMonth.Day] {
-        let weekday = Calendar.utc.component(.weekday, from: reference)
-        let first = reference.addingDay(-((weekday + 5) % 7))
+        let first = reference.addingDay(-Calendar.utc.mondayBasedWeekday(from: reference))
         return (0..<7).map { offset in
             let date = first.addingDay(offset)
             return CalendarMonth.Day(

--- a/Sources/ScoutUI/Utilities/Calendar+Weekday.swift
+++ b/Sources/ScoutUI/Utilities/Calendar+Weekday.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension Calendar {
+    // Maps the calendar weekday (1 = Sunday … 7 = Saturday) to a Monday-based
+    // index (0 = Monday … 6 = Sunday) used by the grid and calendar layouts.
+    func mondayBasedWeekday(from date: Date) -> Int {
+        (component(.weekday, from: date) + 5) % 7
+    }
+}


### PR DESCRIPTION
HeatmapGrid, WeekStripCalendar, and CalendarMonth each repeated the (weekday + 5) % 7 trick to turn a Sunday-first calendar weekday into a Monday-based index. This moves that into a single Calendar.mondayBasedWeekday(from:) helper the three call sites now share. Heatmap and calendar grid tests still pass.