### PR TITLE
Format hang durations through TimeInterval.duration directly

### DIFF
--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
@@ -60,7 +60,7 @@ struct DeviceDetailView: View {
                             UTCTimestampText(date: date, size: 14)
                         }
                         Spacer()
-                        Text(verbatim: hang.durationText)
+                        Text(verbatim: hang.duration.duration)
                             .font(.footnote)
                             .foregroundStyle(Color.gray)
                     } destination: {

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/Hang+Incident.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/Hang+Incident.swift
@@ -14,8 +14,4 @@ extension Hang {
     var severity: HangSeverity {
         duration >= 8 ? .critical : .warning
     }
-
-    var durationText: String {
-        duration < 60 ? String(format: "%.1fs", duration) : "\(Int(duration) / 60)m \(Int(duration) % 60)s"
-    }
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangDetailView.swift
@@ -21,7 +21,7 @@ struct HangDetailView: View {
                 HStack(spacing: 6) {
                     Image(systemName: hang.severity.systemImage)
                         .foregroundStyle(hang.severity.color)
-                    Text(verbatim: "\(hang.severity.label) · \(hang.durationText)")
+                    Text(verbatim: "\(hang.severity.label) · \(hang.duration.duration)")
                         .fontWeight(.bold)
                         .foregroundStyle(hang.severity.color)
                 }

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangExport.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangExport.swift
@@ -15,7 +15,7 @@ struct HangExport {
         IncidentExport(
             incident: hang,
             kind: "Hang",
-            detail: [.blank, .text("Duration: \(hang.durationText)")]
+            detail: [.blank, .text("Duration: \(hang.duration.duration)")]
         ).text
     }
 }
@@ -28,7 +28,7 @@ struct HangGroupExport {
             group: group,
             kind: "Hang",
             summaryDetail: [.blank, .text("Max duration: \(group.durationText)")],
-            rowSuffix: { "  \($0.durationText)" }
+            rowSuffix: { "  \($0.duration.duration)" }
         ).text
     }
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroup.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroup.swift
@@ -22,7 +22,7 @@ extension IncidentGroup where Element == Hang {
     }
 
     var durationText: String {
-        peak.durationText
+        peak.duration.duration
     }
 
     // The longest hang in the group; groups always hold at least one record.

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
@@ -85,7 +85,7 @@ struct HangGroupDetailView: View {
 
             Spacer()
 
-            Text(verbatim: hang.durationText)
+            Text(verbatim: hang.duration.duration)
                 .font(.footnote)
                 .monospacedDigit()
                 .foregroundStyle(hang.severity.color)

--- a/Tests/ScoutUITests/Monitoring/Incident/Hang/HangExportTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Incident/Hang/HangExportTests.swift
@@ -32,7 +32,7 @@ struct HangExportTests {
 
         #expect(text.hasPrefix("# Scout Hang — Main Thread Blocked"))
         #expect(text.contains(ExportFormat.timestamp(at(0))))
-        #expect(text.contains("Duration: 4.2s"))
+        #expect(text.contains("Duration: 4.2 s"))
         #expect(text.contains("Reason: found nil"))
         #expect(text.contains("## Stack Trace"))
         #expect(text.contains("0 A 0x1 f + 1"))
@@ -42,7 +42,7 @@ struct HangExportTests {
     @Test("A bare hang exports just its title and duration")
     func testSingleHangExportOmitsEmptyParts() {
         let hang = Hang.stub(name: "E", reason: nil, stackTrace: [], duration: 3.5, date: nil)
-        #expect(HangExport(hang: hang).text == "# Scout Hang — E\n\nDuration: 3.5s")
+        #expect(HangExport(hang: hang).text == "# Scout Hang — E\n\nDuration: 3.5 s")
     }
 
     @Test("A group renders its summary, top frame, and occurrence rows")
@@ -77,12 +77,12 @@ struct HangExportTests {
         #expect(text.hasPrefix("# Scout Hang Issue — Image Layout Pass"))
         #expect(text.contains("2 occurrences · 1 device · 1 session"))
         #expect(text.contains("First seen") && text.contains("Last seen"))
-        #expect(text.contains("Max duration: 9.8s"))
+        #expect(text.contains("Max duration: 9.8 s"))
         #expect(text.contains("Top frame: 2 Scout 0xdef layout + 99"))
         #expect(text.contains("## Occurrences"))
         #expect(
             text.contains(
-                "- \(ExportFormat.timestamp(at(3600)))  9.8s  (device \(ExportFormat.shortID(device)), session \(ExportFormat.shortID(session)))"
+                "- \(ExportFormat.timestamp(at(3600)))  9.8 s  (device \(ExportFormat.shortID(device)), session \(ExportFormat.shortID(session)))"
             )
         )
     }


### PR DESCRIPTION
Hang.durationText was a thin alias reimplementing a seconds/minutes format that TimeInterval.duration already centralises. This drops the property and calls duration.duration at the hang call sites (device detail, hang detail, group detail, export). HangGroup.durationText stays since it does real work picking the peak hang, now formatting through the shared helper too. The rendered text changes (e.g. "12.3 s" and "2 min 5 s" instead of "12.3s" and "2m 5s"); HangExportTests is updated to match.