### PR TITLE
Use the shared rangeDateFormatter for the event stat title

### DIFF
--- a/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
@@ -21,7 +21,7 @@ struct EventStatList: View {
                 .autoRefresh {
                     await provider.fetchLatest(for: query, in: database)
                 }
-                .navigationTitle(range.label(using: eventRangeDateFormatter))
+                .navigationTitle(range.label(using: rangeDateFormatter))
                 .font(.caption)
         }
     }
@@ -30,13 +30,6 @@ struct EventStatList: View {
         EventQuery(name: eventName, dates: range)
     }
 }
-
-private let eventRangeDateFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US")
-    formatter.dateFormat = "d MMM"
-    return formatter
-}()
 
 #Preview {
     let provider = EventProvider()


### PR DESCRIPTION
EventStatList carried a private eventRangeDateFormatter that duplicated the shared rangeDateFormatter, and with a divergent format ("d MMM" versus the shared medium style). This drops the private copy and reuses the shared formatter so the range title matches the other range labels. Note the title text changes from e.g. "5 Jan" to "Jan 5, 2026".