### PR TITLE
Build ActivityPoint samples with Date.addingDay

### DIFF
--- a/Sources/ScoutUI/Analytics/Activity/ActivityProvider.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityProvider.swift
@@ -19,15 +19,13 @@ class ActivityProvider: ObservableObject, Provider {
 extension ActivityPoint: Fixture {
     static var samples: [ActivityPoint] {
         let end = Date().startOfDay
-        return (0..<365).compactMap { day in
-            Calendar.utc.date(byAdding: .day, value: -day, to: end).map {
-                ActivityPoint(
-                    date: $0.millisecondsSince1970,
-                    dau: 80 + day % 90 + (day / 7) % 20,
-                    wau: 360 + day % 120 + (day / 5) % 80,
-                    mau: 950 + day % 240 + (day / 11) % 160
-                )
-            }
+        return (0..<365).map { day in
+            ActivityPoint(
+                date: end.addingDay(-day).millisecondsSince1970,
+                dau: 80 + day % 90 + (day / 7) % 20,
+                wau: 360 + day % 120 + (day / 5) % 80,
+                mau: 950 + day % 240 + (day / 11) % 160
+            )
         }
     }
 }


### PR DESCRIPTION
The ActivityPoint sample fixtures reached for Calendar.utc.date(byAdding:.day,...) and a compactMap over its optional result, when the codebase already has the non-optional Date.addingDay helper (itself backed by Calendar.utc). This switches to end.addingDay(-day) and a plain map, matching how the rest of the fixtures build dates.