### PR TITLE
Probe backend availability concurrently during sync

### DIFF
--- a/Sources/Scout/Sync/Synchronize.swift
+++ b/Sources/Scout/Sync/Synchronize.swift
@@ -17,8 +17,22 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
     try DateEntry.cleanup(backends: backends, in: context)
 
     try await dispatcher.performEnsuringBackground {
+        // Probe every backend at once: awaiting availability in the loop
+        // condition let a slow or timing-out backend stall delivery for all
+        // the others queued behind it.
+        let availability = await withTaskGroup(of: (Int, Bool).self) { group in
+            for (offset, backend) in backends.enumerated() {
+                group.addTask { (offset, await backend.checkAvailability()) }
+            }
+            var flags = [Bool](repeating: false, count: backends.count)
+            for await (offset, isAvailable) in group {
+                flags[offset] = isAvailable
+            }
+            return flags
+        }
+
         await withTaskGroup(of: Void.self) { group in
-            for backend in backends where await backend.checkAvailability() {
+            for (backend, isAvailable) in zip(backends, availability) where isAvailable {
                 let recordSender = RecordSender(backend: backend)
 
                 for type in SyncableEntry.deliverableTypes {


### PR DESCRIPTION
`synchronize` decided which backends to deliver to by awaiting `checkAvailability()` in the `for backend in backends where …` loop condition, so the probes ran one at a time. A slow or timing-out backend delayed the availability check — and therefore delivery — for every backend queued behind it. This probes all backends at once in a task group, preserving their original order, then delivers to the ones that came back available.