### PR TITLE
Run a command batch in a single background context

### DIFF
--- a/Sources/Scout/Identity/Command.swift
+++ b/Sources/Scout/Identity/Command.swift
@@ -13,8 +13,10 @@ protocol Command: Sendable {
 
 extension NSPersistentContainer {
     func run(_ commands: any Command...) async throws {
-        for command in commands {
-            try await performBackgroundTask { try command.execute(in: $0) }
+        try await performBackgroundTask { context in
+            for command in commands {
+                try command.execute(in: context)
+            }
         }
     }
 }


### PR DESCRIPTION
`NSPersistentContainer.run` spun up a fresh `performBackgroundTask` — a separate background context — for every command. Bootstrap alone issues nine commands across two `run` calls, so it created nine background contexts where two would do. This runs each batch inside one `performBackgroundTask`, threading every command through the same context. Ordering and the cross-command entity lookups are preserved (each command still saves), and the two bootstrap batches now use one context apiece.