### PR TITLE
Cache the Home log report in its provider instead of per body

### DIFF
--- a/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
@@ -15,10 +15,24 @@ class HomeLogProvider: ObservableObject, Provider {
     @Published var period: Period {
         didSet {
             UserDefaults.standard.set(period.rawValue, forKey: "scout_home_log_period")
+            rebuildReport()
         }
     }
 
-    @Published private var results: [Period: ProviderResult<Output>] = [:]
+    @Published private var results: [Period: ProviderResult<Output>] = [:] {
+        didSet { rebuildReport() }
+    }
+
+    // Device visits back the "Devices" row of the report; the log section feeds
+    // them in from its sibling DevicesProvider as they arrive.
+    @Published var visits: [DeviceVisit] = [] {
+        didSet { rebuildReport() }
+    }
+
+    // Derived from the current period's series, visits, and period once per
+    // change, so view body re-evaluations (scroll, auto-refresh) read the cached
+    // report instead of rebuilding it and its per-category passes every render.
+    private(set) var report: LogReport?
 
     init() {
         self.period = UserDefaults.standard.string(forKey: "scout_home_log_period").flatMap(Period.init) ?? .today
@@ -27,6 +41,14 @@ class HomeLogProvider: ObservableObject, Provider {
     var result: ProviderResult<Output>? {
         get { results[period] }
         set { results[period] = newValue }
+    }
+
+    private func rebuildReport() {
+        guard let series = try? result?.get() else {
+            report = nil
+            return
+        }
+        report = LogReport(series: series, visits: visits, period: period)
     }
 
     func fetch(in database: DatabaseReader) async throws -> Output {

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
@@ -24,10 +24,10 @@ struct HomeLogSection: View {
         }
         .task(id: period) {
             log.period = period
+            log.visits = visits
             await log.fetchIfNeeded(in: database)
         }
-
-        let report = report
+        .onChange(of: visits) { log.visits = $0 }
 
         ForEach(Array(LogCategory.allCases.enumerated()), id: \.element) { index, category in
             Row {
@@ -36,7 +36,7 @@ struct HomeLogSection: View {
                     .frame(width: 24)
                 Text(verbatim: category.title)
                 Spacer()
-                RedactedText(count: report?.summary(for: category).count)
+                RedactedText(count: log.report?.summary(for: category).count)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .frame(minWidth: RowSummary.countWidth, alignment: .trailing)
@@ -46,15 +46,8 @@ struct HomeLogSection: View {
         }
     }
 
-    private var report: LogReport? {
-        guard let series = try? log.result?.get() else {
-            return nil
-        }
-        return LogReport(
-            series: series,
-            visits: (try? devices.result?.get().visits) ?? [],
-            period: period
-        )
+    private var visits: [DeviceVisit] {
+        (try? devices.result?.get().visits) ?? []
     }
 }
 

--- a/Sources/ScoutUI/Home/Section/Log/LogReport.swift
+++ b/Sources/ScoutUI/Home/Section/Log/LogReport.swift
@@ -9,59 +9,47 @@ import Foundation
 import Scout
 
 struct LogReport {
-    let series: [MetricSeries]
-    let visits: [DeviceVisit]
-    let period: Period
+    private let summaries: [LogCategory: MetricSummary]
+
+    init(series: [MetricSeries], visits: [DeviceVisit], period: Period) {
+        summaries = Self.summaries(series: series, visits: visits, period: period)
+    }
 
     func summary(for category: LogCategory) -> MetricSummary {
-        let span = span
-
-        return switch category {
-        case .events:
-            MetricSummary(
-                points: span.points { $0 != CrashEntry.recordType && $0 != HangEntry.recordType }, period: period)
-        case .crashes:
-            MetricSummary(points: span.points { $0 == CrashEntry.recordType }, period: period)
-        case .hangs:
-            MetricSummary(points: span.points { $0 == HangEntry.recordType }, period: period)
-        case .network:
-            MetricSummary(points: span.points(inCategories: Set(StatusBuckets.categories)), period: period)
-        case .metrics:
-            metricsSummary
-        case .devices:
-            devicesSummary
-        }
+        summaries[category] ?? .loading
     }
 
-    private var window: Range<Date> {
-        period.previousRange.lowerBound..<period.initialRange.upperBound
-    }
+    private static func summaries(series: [MetricSeries], visits: [DeviceVisit], period: Period) -> [LogCategory:
+        MetricSummary]
+    {
+        let window = period.previousRange.lowerBound..<period.initialRange.upperBound
+        let span = SeriesSpan(series: series, range: window)
+        let slices = period.initialRange.slices(count: MiniChartSeries.sliceCount)
 
-    private var span: SeriesSpan {
-        SeriesSpan(series: series, range: window)
-    }
-
-    private var metricsSummary: MetricSummary {
-        func count(in range: Range<Date>) -> Int {
+        func metricCount(in range: Range<Date>) -> Int {
             SeriesSpan(series: series, range: range).metricCount
         }
 
-        return MetricSummary(
-            count: count(in: period.initialRange),
-            previous: count(in: period.previousRange),
-            values: slices.map(count)
+        let metrics = MetricSummary(
+            count: metricCount(in: period.initialRange),
+            previous: metricCount(in: period.previousRange),
+            values: slices.map(metricCount)
         )
-    }
 
-    private var devicesSummary: MetricSummary {
-        MetricSummary(
+        let devices = MetricSummary(
             count: visits.devices(in: period.initialRange),
             previous: visits.devices(in: period.previousRange),
             values: slices.map { visits.devices(in: $0) }
         )
-    }
 
-    private var slices: [Range<Date>] {
-        period.initialRange.slices(count: MiniChartSeries.sliceCount)
+        return [
+            .events: MetricSummary(
+                points: span.points { $0 != CrashEntry.recordType && $0 != HangEntry.recordType }, period: period),
+            .crashes: MetricSummary(points: span.points { $0 == CrashEntry.recordType }, period: period),
+            .hangs: MetricSummary(points: span.points { $0 == HangEntry.recordType }, period: period),
+            .network: MetricSummary(points: span.points(inCategories: Set(StatusBuckets.categories)), period: period),
+            .metrics: metrics,
+            .devices: devices,
+        ]
     }
 }

--- a/Sources/ScoutUI/Home/Section/Log/LogView.swift
+++ b/Sources/ScoutUI/Home/Section/Log/LogView.swift
@@ -34,7 +34,7 @@ struct LogView: View {
                             MetricCard(
                                 title: category.title,
                                 color: category.color,
-                                summary: report?.summary(for: category) ?? .loading
+                                summary: log.report?.summary(for: category) ?? .loading
                             )
                         }
                         .buttonStyle(.plain)
@@ -45,20 +45,15 @@ struct LogView: View {
         }
         .task(id: period) {
             log.period = period
+            log.visits = visits
             await log.fetchIfNeeded(in: database)
         }
+        .onChange(of: visits) { log.visits = $0 }
         .navigationTitle(en: "Log")
     }
 
-    private var report: LogReport? {
-        guard let series = try? log.result?.get() else {
-            return nil
-        }
-        return LogReport(
-            series: series,
-            visits: (try? devices.result?.get().visits) ?? [],
-            period: period
-        )
+    private var visits: [DeviceVisit] {
+        (try? devices.result?.get().visits) ?? []
     }
 }
 


### PR DESCRIPTION
The Home log section rebuilt a `LogReport` inside `body` and then called `summary(for:)` once per category, and each of those calls rebuilt its own `SeriesSpan` — so every render, including scroll and the rotating auto-refresh, repeated the per-category and per-slice passes and caused hitches.

`LogReport` now computes all six category summaries once in its initializer, so `summary(for:)` is a cache lookup. The report itself is derived once per data change in `HomeLogProvider` (following the `TimelineProvider.items` pattern) rather than on every body evaluation; the log views read `log.report` and feed the sibling device visits into the provider. Behavior is unchanged — `LogReportTests` still passes.