### PR TITLE
Destroy an unrecognizable RecordCache store before opening it

### DIFF
--- a/Sources/Cache/RecordCacheStore.swift
+++ b/Sources/Cache/RecordCacheStore.swift
@@ -87,7 +87,7 @@ enum RecordCacheStore {
 
     // The cache is disposable: any schema mismatch destroys the store instead of migrating.
     static func container<Row: CacheRow>(for row: Row.Type, at url: URL, defaults: UserDefaults) -> ModelContainer? {
-        if defaults.integer(forKey: versionKey) != Row.schemaVersion {
+        if defaults.integer(forKey: versionKey) != Row.schemaVersion || !storeHasSQLiteHeader(at: url) {
             destroyStore(at: url)
         }
         if let container = openContainer(for: row, at: url) {
@@ -98,6 +98,18 @@ enum RecordCacheStore {
         guard let container = openContainer(for: row, at: url) else { return nil }
         defaults.set(Row.schemaVersion, forKey: versionKey)
         return container
+    }
+
+    // SwiftData can add the store asynchronously, so a corrupt file surfaces its SQLite
+    // "file is not a database" failure on a background queue that escapes `try?` and lets Core
+    // Data abort the process. Destroy anything without a valid SQLite header up front so only an
+    // openable (or absent) store ever reaches ModelContainer; a valid store keeps its bytes.
+    private static func storeHasSQLiteHeader(at url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return true }
+        defer { try? handle.close() }
+        let header = (try? handle.read(upToCount: 16)) ?? Data()
+        if header.isEmpty { return true }
+        return header.elementsEqual(Array("SQLite format 3\u{0}".utf8))
     }
 
     static func destroyStore(at url: URL) {


### PR DESCRIPTION
iOS test legs have been intermittently dying with `CoreData: error: (26) Fatal error. The database at .../data/tmp/.../RecordCache.store is corrupted. SQLite error code:26, 'file is not a database'` followed by `** TEST EXECUTE FAILED **`, on random legs and on PRs that never touch the Cache module. The path is the one `RecordCacheStoreTests` builds in `temporaryDirectory`, and that suite deliberately writes a corrupt store to check that `RecordCacheStore` recovers. The trouble is that when the recorded schema version matches, `container(for:)` handed the on-disk file straight to a SwiftData `ModelContainer`; SwiftData can add the store asynchronously, so the "file is not a database" failure surfaced on a background queue that escapes the `try?` guarding the open, and Core Data aborted the whole process after the test's synchronous assertions had already passed. Whether the load stayed synchronous (caught, benign) or went async (uncatchable, fatal) came down to timing, which is why reruns rarely swept clean and different iOS versions flaked differently.

The fix adds a cheap SQLite-header pre-check so anything that is not a recognizable store is destroyed before any `ModelContainer` touches it, leaving only an openable or absent store to load. A store with a valid header keeps its bytes, so real user caches are never wiped, and this also closes a genuine production gap where a corrupt on-device cache would have crashed the app on launch instead of being recreated. Looping `RecordCacheStoreTests` reproduced the corruption log on every run and an abort roughly one run in six before the change; after it, twelve loops show zero corruption lines and the full CacheTests suite passes.