### PR TITLE
Give incident breakdown segments a typed kind for the aggregate bucket

### DIFF
--- a/Sources/ScoutUI/Insights/Chart/View/SegmentBar.swift
+++ b/Sources/ScoutUI/Insights/Chart/View/SegmentBar.swift
@@ -11,11 +11,45 @@ import Scout
 import SwiftUI
 
 struct Segment: Identifiable, Equatable {
-    let label: String
+    enum Kind: Equatable {
+        case value(String)
+        case other
+    }
+
     let count: Int
     let color: Color
+    let kind: Kind
 
-    var id: String { label }
+    init(label: String, count: Int, color: Color) {
+        self.init(count: count, color: color, kind: .value(label))
+    }
+
+    init(count: Int, color: Color, kind: Kind) {
+        self.count = count
+        self.color = color
+        self.kind = kind
+    }
+
+    var label: String {
+        switch kind {
+        case .value(let label): label
+        case .other: "Other"
+        }
+    }
+
+    var value: String? {
+        switch kind {
+        case .value(let label): label
+        case .other: nil
+        }
+    }
+
+    var id: String {
+        switch kind {
+        case .value(let label): "value:\(label)"
+        case .other: "other"
+        }
+    }
 }
 
 struct SegmentBar: View {

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
@@ -37,7 +37,7 @@ extension IncidentBreakdown {
 
         let other = ranked.count > top ? ranked[top...].reduce(0) { $0 + $1.value } : 0
         if other > 0 {
-            segments.append(Segment(label: "Other", count: other, color: .gray))
+            segments.append(Segment(count: other, color: .gray, kind: .other))
         }
 
         return segments
@@ -55,11 +55,11 @@ extension IncidentBreakdown {
     func records<Element: SessionContext>(from records: [Element], in dimension: Dimension, matching segment: Segment)
         -> [Element]
     {
-        guard segment.label == "Other" else {
-            return records.filter { label(of: $0, in: dimension) == segment.label }
+        guard segment.kind == .other else {
+            return records.filter { label(of: $0, in: dimension) == segment.value }
         }
 
-        let named = Set(segments(in: dimension).map(\.label))
+        let named = Set(segments(in: dimension).compactMap(\.value))
         return records.filter { record in
             guard let label = label(of: record, in: dimension) else { return false }
             return !named.contains(label)

--- a/Tests/ScoutUITests/Monitoring/Incident/Breakdown/IncidentBreakdownTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Incident/Breakdown/IncidentBreakdownTests.swift
@@ -127,10 +127,37 @@ extension IncidentBreakdownTests {
             makeContext(),
         ]
 
-        let other = try #require(breakdown.devices.first { $0.label == "Other" })
+        let other = try #require(breakdown.devices.first { $0.kind == .other })
         let matched = breakdown.records(from: records, in: .devices, matching: other)
 
         #expect(matched.count == 2)
         #expect(Set(matched.compactMap(\.deviceID)) == [deviceB, deviceC])
+    }
+
+    @Test("Keeps a real Other label separate from the aggregate segment")
+    func distinguishesRealOtherLabelFromAggregate() throws {
+        let deviceOther = UUID()
+        let deviceX = UUID()
+        let deviceY = UUID()
+        let breakdown = IncidentBreakdown(
+            devices: IncidentBreakdown.segments(from: ["Other", "Other", "X", "Y"], top: 1),
+            osVersions: [],
+            modelsByDevice: [deviceOther: "Other", deviceX: "X", deviceY: "Y"]
+        )
+        let records = [
+            makeContext(deviceID: deviceOther),
+            makeContext(deviceID: deviceOther),
+            makeContext(deviceID: deviceX),
+            makeContext(deviceID: deviceY),
+        ]
+
+        let value = try #require(breakdown.devices.first { $0.kind == .value("Other") })
+        let matchedValue = breakdown.records(from: records, in: .devices, matching: value)
+        #expect(matchedValue.count == 2)
+        #expect(matchedValue.allSatisfy { $0.deviceID == deviceOther })
+
+        let aggregate = try #require(breakdown.devices.first { $0.kind == .other })
+        let matchedAggregate = breakdown.records(from: records, in: .devices, matching: aggregate)
+        #expect(Set(matchedAggregate.compactMap(\.deviceID)) == [deviceX, deviceY])
     }
 }


### PR DESCRIPTION
The incident breakdown encoded its aggregate "everything else" bucket through a sentinel display string: the segment producer appended a `Segment` labelled "Other" and the record dispatch branched on `segment.label == "Other"`. A real data label equal to "Other" (a device model or OS string) collapsed into the aggregate, so tapping it showed all the others instead of its own records.

This moves the distinction into the model. `Segment` now carries a typed `kind` (`.value(String)` or `.other`), the label stays purely for display, and the filtering dispatch keys on the kind rather than the string. The aggregate's membership set is now built from the value segments' underlying values, so a real "Other" label and the aggregate bucket coexist correctly. Added a test covering that collision alongside the existing breakdown tests.