### PR TITLE
Model SeriesQuery.values as a typed enum instead of magic strings

### DIFF
--- a/Sources/Cache/CachedMetricSeries.swift
+++ b/Sources/Cache/CachedMetricSeries.swift
@@ -14,7 +14,7 @@ enum CachedMetricSeries {
             scope, "series",
             query.name ?? "*",
             query.category ?? "*",
-            query.values ?? "*",
+            query.values?.rawValue ?? "*",
             query.bucket.rawValue,
             query.byVersion ? "version" : "*",
         ].joined(separator: "|")

--- a/Sources/Scout/Connectors/Hosted/HostedReader.swift
+++ b/Sources/Scout/Connectors/Hosted/HostedReader.swift
@@ -73,7 +73,7 @@ extension HTTPDatabase: DatabaseReader {
             params.append("category=\(Self.encode(category))")
         }
         if let values = query.values {
-            params.append("values=\(Self.encode(values))")
+            params.append("values=\(Self.encode(values.rawValue))")
         }
         if query.byVersion {
             params.append("by=version")

--- a/Sources/Scout/Connectors/Native/NativeSeries.swift
+++ b/Sources/Scout/Connectors/Native/NativeSeries.swift
@@ -16,10 +16,13 @@ struct NativeSeries {
         var intTotals: [GroupKey: [Date: Double]] = [:]
         var doubleTotals: [GroupKey: [Date: Double]] = [:]
 
-        if query.values != "double" {
+        switch query.values {
+        case .int:
             try await collectInt(into: &intTotals, store: store)
-        }
-        if query.values != "int" {
+        case .double:
+            try await collectMetrics(entity: DoubleMetricsEntry.recordType, into: &doubleTotals, store: store)
+        case nil:
+            try await collectInt(into: &intTotals, store: store)
             try await collectMetrics(entity: DoubleMetricsEntry.recordType, into: &doubleTotals, store: store)
         }
 

--- a/Sources/Scout/Diagnostics/Metrics/MetricScalar.swift
+++ b/Sources/Scout/Diagnostics/Metrics/MetricScalar.swift
@@ -9,16 +9,16 @@ import CoreData
 
 package protocol MetricScalar: AdditiveArithmetic & Comparable & Hashable & Sendable & RecordValueConvertible {
     associatedtype Object: MetricsValued where Object.Value == Self
-    static var seriesValues: String { get }
+    static var seriesValues: SeriesQuery.Values { get }
     init(_ value: Double)
 }
 
 extension Int: MetricScalar {
     package typealias Object = IntMetricsEntry
-    static package var seriesValues: String { "int" }
+    static package var seriesValues: SeriesQuery.Values { .int }
 }
 
 extension Double: MetricScalar {
     package typealias Object = DoubleMetricsEntry
-    static package var seriesValues: String { "double" }
+    static package var seriesValues: SeriesQuery.Values { .double }
 }

--- a/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
+++ b/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
@@ -23,15 +23,19 @@ package struct SeriesQuery: Sendable {
         case hour, day, week
     }
 
+    package enum Values: String, Sendable {
+        case int, double
+    }
+
     package var name: String?
     package var category: String?
-    package var values: String?
+    package var values: Values?
     package var bucket: Bucket = .day
     package var byVersion = false
     package var range: Range<Date>
 
     package init(
-        name: String? = nil, category: String? = nil, values: String? = nil, bucket: Bucket = .day,
+        name: String? = nil, category: String? = nil, values: Values? = nil, bucket: Bucket = .day,
         byVersion: Bool = false, range: Range<Date>
     ) {
         self.name = name

--- a/Tests/ScoutTests/Connectors/Hosted/HostedQueryEncodingTests.swift
+++ b/Tests/ScoutTests/Connectors/Hosted/HostedQueryEncodingTests.swift
@@ -18,14 +18,13 @@ struct HostedQueryEncodingTests {
     private let database = HTTPDatabase(url: URL(string: "https://example.com/")!, apiKey: nil)
     private let day = Date(timeIntervalSince1970: 1_750_000_000).startOfDay
 
-    @Test("The series name, category, and values parameters are percent-encoded")
+    @Test("The series name and category parameters are percent-encoded")
     func seriesParametersAreEncoded() throws {
         let url = try #require(
             database.seriesEndpoint(
                 for: SeriesQuery(
                     name: "Save & Exit",
-                    category: "a=b/c?d",
-                    values: "int+long",
+                    category: "a=b/c?d+e",
                     range: day..<day.addingDay()
                 )
             )
@@ -33,13 +32,28 @@ struct HostedQueryEncodingTests {
         let items = queryItems(of: url)
 
         #expect(items["name"] == "Save & Exit")
-        #expect(items["category"] == "a=b/c?d")
-        #expect(items["values"] == "int+long")
+        #expect(items["category"] == "a=b/c?d+e")
 
         // URLComponents decodes reserved delimiters but reads a literal `+` as
         // itself, so assert on the raw encoding to guard against a server that
         // form-decodes `+` into a space.
-        #expect(try rawQuery(of: url).contains("int%2Blong"))
+        #expect(try rawQuery(of: url).contains("%2B"))
+    }
+
+    @Test(
+        "The values parameter emits the raw wire strings int and double",
+        arguments: [
+            (SeriesQuery.Values.int, "int"),
+            (SeriesQuery.Values.double, "double"),
+        ])
+    func valuesEmitsWireString(_ values: SeriesQuery.Values, _ expected: String) throws {
+        let url = try #require(
+            database.seriesEndpoint(for: SeriesQuery(values: values, range: day..<day.addingDay()))
+        )
+
+        #expect(values.rawValue == expected)
+        #expect(SeriesQuery.Values(rawValue: expected) == values)
+        #expect(queryItems(of: url)["values"] == expected)
     }
 
     @Test("The lookup field list is percent-encoded")


### PR DESCRIPTION
`SeriesQuery.values` was a `String?` carrying the magic strings "int"/"double", compared with raw `!=` checks in `NativeSeries` and produced as literals by `MetricScalar.seriesValues`. A typo or a new value like "float" slipped past the compiler, and both `!=` branches would pass so the query silently collected both value sets. This replaces it with a `SeriesQuery.Values` enum that mirrors the neighbouring `Bucket` enum, turning the collect branch into an exhaustive switch and letting the compiler catch bad value types.

The wire format is untouched. `Values` is `String`-backed, so the HTTP query coding still emits and decodes exactly "int"/"double" through `rawValue`/`init(rawValue:)`, and no scout-server change is needed. A parameterised test asserts that round-trip, and the existing percent-encoding test moves its `+` coverage onto the `category` parameter now that `values` can only be the two known strings.