### PR TITLE
Declare derived fields on catalog entries, not in the generic writer

### DIFF
--- a/Sources/Scout/Connectors/Native/EntityCatalog.swift
+++ b/Sources/Scout/Connectors/Native/EntityCatalog.swift
@@ -9,6 +9,22 @@ import Foundation
 import Scout
 import ScoutDB
 
+// A scout-db `EntityDefinition` paired with the derivations scout applies on
+// write. Derived fields live here because they compute over scout's `Record`,
+// which the wire-format `EntityDefinition` cannot express.
+struct CatalogEntry {
+    let definition: EntityDefinition
+    let derive: @Sendable (Record) -> [String: ScoutDB.RecordValue]
+
+    init(
+        _ definition: EntityDefinition,
+        derive: @escaping @Sendable (Record) -> [String: ScoutDB.RecordValue] = { _ in [:] }
+    ) {
+        self.definition = definition
+        self.derive = derive
+    }
+}
+
 // Slot assignment follows declaration order, so the field lists below are part
 // of the stored-data contract: never reorder or retype existing fields — append
 // new ones in a new schema version instead.
@@ -17,26 +33,34 @@ enum EntityCatalog {
     static let metricSeriesView = "series"
     static let metricSeriesKey = "series_key"
 
-    static let definitions: [EntityDefinition] = [
-        event, session, visit, launch, install, device, version, crash, hang,
+    static let entries: [CatalogEntry] = [
+        CatalogEntry(event), CatalogEntry(session), CatalogEntry(visit), CatalogEntry(launch),
+        CatalogEntry(install), CatalogEntry(device), CatalogEntry(version), CatalogEntry(crash), CatalogEntry(hang),
         metric(entity: IntMetricsEntry.recordType, valueType: .int),
         metric(entity: DoubleMetricsEntry.recordType, valueType: .double),
     ]
 
+    static var definitions: [EntityDefinition] {
+        entries.map(\.definition)
+    }
+
     static func definition(for entity: String) -> EntityDefinition? {
-        definitions.first { $0.entity == entity }
+        entries.first { $0.definition.entity == entity }?.definition
+    }
+
+    // The writer applies every entity's declared derivations uniformly, so a new
+    // computed field is a per-entity `derive` closure here rather than a special
+    // case wired into the shared write path.
+    static func derivedValues(for record: Record) -> [String: ScoutDB.RecordValue] {
+        entries.first { $0.definition.entity == record.recordType }?.derive(record) ?? [:]
     }
 
     // Metric series are grouped by a single grid key, so the category and name
     // are packed into one pipe-separated field on write and split on read.
-    static func seriesKey(for record: Record) -> ScoutDB.RecordValue? {
-        guard record.recordType == IntMetricsEntry.recordType || record.recordType == DoubleMetricsEntry.recordType
-        else {
-            return nil
-        }
+    private static func seriesKey(for record: Record) -> [String: ScoutDB.RecordValue] {
         let category: String? = record["category"]
         let name: String? = record["name"]
-        return .string((category ?? "") + "|" + (name ?? ""))
+        return [metricSeriesKey: .string((category ?? "") + "|" + (name ?? ""))]
     }
 
     private static let event = definition(
@@ -130,18 +154,21 @@ enum EntityCatalog {
         ]
     )
 
-    private static func metric(entity: String, valueType: FieldType) -> EntityDefinition {
-        definition(
-            entity: entity,
-            fields: [
-                ("name", .text),
-                ("category", .string),
-                ("session_id", .string),
-                (metricSeriesKey, .string),
-                ("value", valueType),
-                ("date", .timestamp),
-            ],
-            views: [AggregateView(name: metricSeriesView, groupBy: metricSeriesKey, bucket: .hour, sum: "value")]
+    private static func metric(entity: String, valueType: FieldType) -> CatalogEntry {
+        CatalogEntry(
+            definition(
+                entity: entity,
+                fields: [
+                    ("name", .text),
+                    ("category", .string),
+                    ("session_id", .string),
+                    (metricSeriesKey, .string),
+                    ("value", valueType),
+                    ("date", .timestamp),
+                ],
+                views: [AggregateView(name: metricSeriesView, groupBy: metricSeriesKey, bucket: .hour, sum: "value")]
+            ),
+            derive: seriesKey
         )
     }
 

--- a/Sources/Scout/Connectors/Native/NativeDatabase.swift
+++ b/Sources/Scout/Connectors/Native/NativeDatabase.swift
@@ -36,7 +36,7 @@ extension NativeDatabase: DatabaseWriter {
 
     private static func values(for record: Record) -> [String: ScoutDB.RecordValue] {
         var values = record.storeValues
-        values[EntityCatalog.metricSeriesKey] = EntityCatalog.seriesKey(for: record)
+        values.merge(EntityCatalog.derivedValues(for: record)) { _, derived in derived }
         return values
     }
 }

--- a/Tests/ScoutTests/Connectors/Native/EntityCatalogTests.swift
+++ b/Tests/ScoutTests/Connectors/Native/EntityCatalogTests.swift
@@ -62,13 +62,19 @@ struct EntityCatalogTests {
         }
     }
 
-    @Test("Series key packs category and name")
-    func seriesKey() {
+    @Test("Metric entities derive the series key from their definition")
+    func derivedSeriesKey() {
         var record = Record(recordType: IntMetricsEntry.recordType, recordID: "m-1")
         record["name"] = "checkout"
         record["category"] = "timer"
 
-        #expect(EntityCatalog.seriesKey(for: record) == .string("timer|checkout"))
-        #expect(EntityCatalog.seriesKey(for: Record(recordType: EventEntry.recordType, recordID: "e-1")) == nil)
+        #expect(
+            EntityCatalog.derivedValues(for: record) == [EntityCatalog.metricSeriesKey: .string("timer|checkout")])
+    }
+
+    @Test("Entities without a declared derivation derive nothing")
+    func noDerivation() {
+        let record = Record(recordType: EventEntry.recordType, recordID: "e-1")
+        #expect(EntityCatalog.derivedValues(for: record).isEmpty)
     }
 }


### PR DESCRIPTION
The generic native write path derived the metric `series_key` by name-checking `recordType` against `IntMetricsEntry`/`DoubleMetricsEntry` from inside `NativeDatabase.values(for:)`. That baked a hook for one entity family into the shared writer, so every future entity with a computed field would add another special case, and a forgotten hook would silently yield an empty series key and gaps in aggregates.

Derivations now belong to the entity that owns them. A scout-side `CatalogEntry` pairs each scout-db `EntityDefinition` with an optional `derive` closure over a `Record`, and the writer applies whatever the matching entry declares without knowing anything about metrics. The metric entities carry the same category|name packing they always did, so the stored `series_key` is byte-for-byte identical. The wire-format `EntityDefinition` in scout-db is unchanged: it is Codable and can't hold a Swift closure over scout's `Record`, so the derivation lives on scout's own catalog entry.

The old `seriesKey` unit test becomes two tests that exercise the derivation through the catalog entry rather than a type name-check, and the existing end-to-end metric-series tests continue to guard the aggregate path. Local build and the full ScoutTests target pass.