### PR TITLE
Share one lifecycle-series name set across the stack

### DIFF
--- a/Sources/Scout/Diagnostics/Metrics/MetricSeries+Lifecycle.swift
+++ b/Sources/Scout/Diagnostics/Metrics/MetricSeries+Lifecycle.swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension MetricSeries {
+    /// The series names Scout reserves for its automatic lifecycle and service
+    /// records — devices, installs, launches, sessions, versions, and the
+    /// release-crash marker — rather than diagnostics or custom events.
+    ///
+    /// These records share the metric-series namespace with custom events, so
+    /// surfaces that list custom activity (such as the Home log) exclude them by
+    /// name. Owning the set here, in the same layer as the native aggregation
+    /// that emits these series, keeps its consumers from each carrying a private
+    /// copy that silently drifts as new lifecycle records are added.
+    ///
+    package static let lifecycleNames: Set<String> = [
+        DeviceEntry.recordType,
+        InstallEntry.recordType,
+        LaunchEntry.recordType,
+        SessionEntry.recordType,
+        VersionEntry.recordType,
+        MarkerEntry.crashName,
+    ]
+
+    /// A Boolean value indicating whether the series is one of Scout's reserved
+    /// lifecycle or service series rather than a diagnostic or custom event.
+    package var isLifecycle: Bool {
+        Self.lifecycleNames.contains(name)
+    }
+}

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
@@ -64,18 +64,9 @@ class HomeLogProvider: ObservableObject, Provider {
             throw CancellationError()
         }
 
-        return series.filter { !lifecycleNames.contains($0.name) }
+        return series.filter { !$0.isLifecycle }
     }
 }
-
-private let lifecycleNames: Set = [
-    DeviceEntry.recordType,
-    InstallEntry.recordType,
-    LaunchEntry.recordType,
-    MarkerEntry.crashName,
-    SessionEntry.recordType,
-    VersionEntry.recordType,
-]
 
 extension Period {
     fileprivate var logBucket: SeriesQuery.Bucket {

--- a/Tests/ScoutTests/Diagnostics/Metrics/MetricSeriesLifecycleTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Metrics/MetricSeriesLifecycleTests.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("MetricSeries lifecycle")
+struct MetricSeriesLifecycleTests {
+    @Test("Every reserved lifecycle record name is flagged as lifecycle")
+    func reservedNamesAreLifecycle() {
+        let reserved = [
+            DeviceEntry.recordType,
+            InstallEntry.recordType,
+            LaunchEntry.recordType,
+            SessionEntry.recordType,
+            VersionEntry.recordType,
+            MarkerEntry.crashName,
+        ]
+
+        #expect(MetricSeries.lifecycleNames == Set(reserved))
+
+        for name in reserved {
+            #expect(makeSeries(name: name).isLifecycle)
+        }
+    }
+
+    @Test("Diagnostics and custom events are not lifecycle")
+    func othersAreNotLifecycle() {
+        #expect(!makeSeries(name: CrashEntry.recordType).isLifecycle)
+        #expect(!makeSeries(name: HangEntry.recordType).isLifecycle)
+        #expect(!makeSeries(name: EventEntry.recordType).isLifecycle)
+        #expect(!makeSeries(name: "login").isLifecycle)
+    }
+
+    private func makeSeries(name: String) -> MetricSeries {
+        MetricSeries(name: name, category: nil, points: [])
+    }
+}


### PR DESCRIPTION
The Home log hid Scout's automatic lifecycle series (Device, Install, Launch, Session, Version, and the release-crash marker) with a private denylist inside `HomeLogProvider`, a client-side copy of the reserved-name convention the native series layer already encodes. The two ends could drift: a new lifecycle record type would surface in the log as a custom event until someone remembered to update the UI list, and a genuine custom event named after a lifecycle record would silently disappear.

This moves the reserved-name set into the series layer as `MetricSeries.lifecycleNames`, exposed through an `isLifecycle` predicate, and has `HomeLogProvider` filter on it instead of maintaining its own copy. The set is derived from the lifecycle entries' `recordType` constants, so it stays anchored to the types it names, and a new `ScoutTests` suite pins its membership.

This is the interim single-source-of-truth step. The ideal fix is a typed lifecycle-vs-custom discriminator carried by the series itself, which lands separately; this change removes the duplication hazard today and gives that later work a clean seam. UI/series-layer only, no wire-format impact.