### PR TITLE
Escape the metric series key so a packed pipe can't corrupt the split

### DIFF
--- a/Sources/Scout/Connectors/Native/EntityCatalog.swift
+++ b/Sources/Scout/Connectors/Native/EntityCatalog.swift
@@ -28,7 +28,9 @@ enum EntityCatalog {
     }
 
     // Metric series are grouped by a single grid key, so the category and name
-    // are packed into one pipe-separated field on write and split on read.
+    // are packed into one field on write and split on read. Each component is
+    // backslash-escaped so a "|" (or "\") inside a category or name can't be
+    // mistaken for the separator and scatter points across the wrong series.
     static func seriesKey(for record: Record) -> ScoutDB.RecordValue? {
         guard record.recordType == IntMetricsEntry.recordType || record.recordType == DoubleMetricsEntry.recordType
         else {
@@ -36,7 +38,57 @@ enum EntityCatalog {
         }
         let category: String? = record["category"]
         let name: String? = record["name"]
-        return .string((category ?? "") + "|" + (name ?? ""))
+        return .string(encodeSeriesKey(category: category ?? "", name: name ?? ""))
+    }
+
+    static func encodeSeriesKey(category: String, name: String) -> String {
+        escape(category) + "|" + escape(name)
+    }
+
+    // Splits a series key at its unescaped separator and unescapes both halves.
+    // Legacy keys carry no escape sequences, so a value without a "|" or "\" in
+    // either component decodes identically to the old first-separator split.
+    static func decodeSeriesKey(_ key: String) -> (category: String, name: String)? {
+        var isEscaped = false
+        var index = key.startIndex
+        while index < key.endIndex {
+            let character = key[index]
+            if isEscaped {
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else if character == "|" {
+                return (unescape(String(key[..<index])), unescape(String(key[key.index(after: index)...])))
+            }
+            index = key.index(after: index)
+        }
+        return nil
+    }
+
+    private static func escape(_ component: String) -> String {
+        component.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "|", with: "\\|")
+    }
+
+    private static func unescape(_ escaped: String) -> String {
+        var result = ""
+        var isEscaped = false
+        for character in escaped {
+            if isEscaped {
+                if character != "\\" && character != "|" {
+                    result.append("\\")
+                }
+                result.append(character)
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else {
+                result.append(character)
+            }
+        }
+        if isEscaped {
+            result.append("\\")
+        }
+        return result
     }
 
     private static let event = definition(

--- a/Sources/Scout/Connectors/Native/NativeSeries.swift
+++ b/Sources/Scout/Connectors/Native/NativeSeries.swift
@@ -92,9 +92,7 @@ struct NativeSeries {
             entity: entity, view: EntityCatalog.metricSeriesView, from: from, to: query.range.upperBound)
 
         for point in points where point.date >= from {
-            guard let separator = point.group.firstIndex(of: "|") else { continue }
-            let category = String(point.group[..<separator])
-            let metric = String(point.group[point.group.index(after: separator)...])
+            guard let (category, metric) = EntityCatalog.decodeSeriesKey(point.group) else { continue }
 
             guard query.name == nil || metric == query.name else { continue }
             guard query.category == nil || category == query.category else { continue }

--- a/Tests/ScoutTests/Connectors/Native/EntityCatalogTests.swift
+++ b/Tests/ScoutTests/Connectors/Native/EntityCatalogTests.swift
@@ -71,4 +71,37 @@ struct EntityCatalogTests {
         #expect(EntityCatalog.seriesKey(for: record) == .string("timer|checkout"))
         #expect(EntityCatalog.seriesKey(for: Record(recordType: EventEntry.recordType, recordID: "e-1")) == nil)
     }
+
+    @Test(
+        "Series key round-trips components containing the separator or escape char",
+        arguments: [
+            ("timer", "checkout"),
+            ("", ""),
+            ("a|b", "c|d"),
+            ("path\\to", "na|me"),
+            ("trailing\\", "\\leading"),
+            ("|", "\\"),
+        ]
+    )
+    func seriesKeyRoundTrip(category: String, name: String) throws {
+        let key = EntityCatalog.encodeSeriesKey(category: category, name: name)
+        let decoded = try #require(EntityCatalog.decodeSeriesKey(key))
+        #expect(decoded.category == category)
+        #expect(decoded.name == name)
+    }
+
+    @Test("A packed pipe no longer truncates the category")
+    func seriesKeyDoesNotSplitOnPackedPipe() throws {
+        let key = EntityCatalog.encodeSeriesKey(category: "billing|eu", name: "renew")
+        let decoded = try #require(EntityCatalog.decodeSeriesKey(key))
+        #expect(decoded.category == "billing|eu")
+        #expect(decoded.name == "renew")
+    }
+
+    @Test("Legacy separator-free keys decode unchanged")
+    func seriesKeyDecodesLegacyValues() throws {
+        let decoded = try #require(EntityCatalog.decodeSeriesKey("timer|checkout"))
+        #expect(decoded.category == "timer")
+        #expect(decoded.name == "checkout")
+    }
 }

--- a/Tests/ScoutTests/Connectors/Native/NativeSeriesTests.swift
+++ b/Tests/ScoutTests/Connectors/Native/NativeSeriesTests.swift
@@ -152,4 +152,21 @@ struct NativeSeriesTests {
         #expect(latency.category == "recorder")
         #expect(latency.points.map(\.value) == [.double(1.5)])
     }
+
+    @Test("A pipe in the category keeps the metric in its own series")
+    func pipeInCategory() async throws {
+        var record = Record(recordType: DoubleMetricsEntry.recordType, recordID: "m-1")
+        record["name"] = "renew"
+        record["category"] = "billing|eu"
+        record["value"] = 2.5
+        record["date"] = TestDate.reference.addingTimeInterval(10 * .hour)
+        record["session_id"] = "session-1"
+        try await database.write(record: record)
+
+        let series = try await database.series(matching: SeriesQuery(bucket: .hour, range: range))
+        let renew = try #require(series.first { $0.name == "renew" })
+
+        #expect(renew.category == "billing|eu")
+        #expect(renew.points.map(\.value) == [.double(2.5)])
+    }
 }


### PR DESCRIPTION
The native metric series key packs a metric's `category` and `name` into one grid field joined by a `|`, and `NativeSeries.collectMetrics` split it at the first `|`. A category or name that itself contained a `|` was truncated at that separator, so its points landed in the wrong series. This backslash-escapes each component before joining (`EntityCatalog.encodeSeriesKey`) and unescapes on parse (`decodeSeriesKey`), making the separator unambiguous while keeping the single-column grid `groupBy` that ScoutDB's `AggregateView` supports today.

The series key is a stored value: it is written onto each metric record and materialized as the `group_key` on the persisted aggregate grid rows, so this is a data-format change. It is deliberately backward-compatible rather than a migration. Escaping only touches `|` and `\`, so any legacy key whose category and name contain neither decodes byte-for-byte as the old first-separator split did; unescape leaves unknown sequences intact, so a legacy raw backslash elsewhere in a component is preserved. No store migration is performed and none is needed — existing rows keep their old keys, and only new writes gain the escaping. The one unrepresentable legacy case is a component that ends in a backslash immediately before the real separator, which never occurs for metric identifiers; such a metric with a raw pipe was already mis-split before this change. No scout-server companion is involved — this is entirely within the native store layer.

Covered by round-trip tests over separator/escape-bearing components, a legacy-key decode test, and an end-to-end `NativeSeries` test asserting a pipe-bearing category keeps its own series.