### PR TITLE
Add a source discriminator to SeriesQuery instead of guessing from the name

### DIFF
--- a/Sources/Cache/CachedMetricSeries.swift
+++ b/Sources/Cache/CachedMetricSeries.swift
@@ -17,6 +17,7 @@ enum CachedMetricSeries {
             query.values ?? "*",
             query.bucket.rawValue,
             query.byVersion ? "version" : "*",
+            query.source?.rawValue ?? "*",
         ].joined(separator: "|")
     }
 

--- a/Sources/Scout/Connectors/Hosted/HostedReader.swift
+++ b/Sources/Scout/Connectors/Hosted/HostedReader.swift
@@ -75,6 +75,9 @@ extension HTTPDatabase: DatabaseReader {
         if let values = query.values {
             params.append("values=\(Self.encode(values))")
         }
+        if let source = query.source {
+            params.append("source=\(source.rawValue)")
+        }
         if query.byVersion {
             params.append("by=version")
         }

--- a/Sources/Scout/Connectors/Native/NativeSeries.swift
+++ b/Sources/Scout/Connectors/Native/NativeSeries.swift
@@ -19,7 +19,7 @@ struct NativeSeries {
         if query.values != "double" {
             try await collectInt(into: &intTotals, store: store)
         }
-        if query.values != "int" {
+        if query.values != "int" && collectsDoubleMetrics {
             try await collectMetrics(entity: DoubleMetricsEntry.recordType, into: &doubleTotals, store: store)
         }
 
@@ -49,28 +49,57 @@ struct NativeSeries {
         }
     }
 
+    private var collectsDoubleMetrics: Bool {
+        switch query.source {
+        case nil, .metric:
+            true
+        case .event, .lifecycle:
+            false
+        }
+    }
+
     private func collectInt(into totals: inout [GroupKey: [Date: Double]], store: EntityStore) async throws {
+        switch query.source {
+        case .event:
+            try await collectEvents(name: query.name, into: &totals, store: store)
+        case .lifecycle:
+            if let source = query.name.flatMap(Self.lifecycle(named:)) {
+                try await collectCounts(of: source, into: &totals, store: store)
+            }
+        case .metric:
+            try await collectMetrics(entity: IntMetricsEntry.recordType, into: &totals, store: store)
+        case nil:
+            try await collectGuessed(into: &totals, store: store)
+        }
+    }
+
+    private func collectGuessed(into totals: inout [GroupKey: [Date: Double]], store: EntityStore) async throws {
         switch (query.name, query.category) {
         case (nil, nil):
             try await collectEvents(name: nil, into: &totals, store: store)
             try await collectCounts(of: .crashes, into: &totals, store: store)
             try await collectCounts(of: .hangs, into: &totals, store: store)
             try await collectMetrics(entity: IntMetricsEntry.recordType, into: &totals, store: store)
-        case (SessionEntry.recordType, nil):
-            try await collectCounts(of: .sessions, into: &totals, store: store)
-        case (CrashEntry.recordType, nil):
-            try await collectCounts(of: .crashes, into: &totals, store: store)
-        case (HangEntry.recordType, nil):
-            try await collectCounts(of: .hangs, into: &totals, store: store)
-        case (VersionEntry.recordType, nil):
-            try await collectCounts(of: .installs, into: &totals, store: store)
-        case (MarkerEntry.crashName, nil):
-            try await collectCounts(of: .firstCrashes, into: &totals, store: store)
         case (let name?, nil):
-            try await collectEvents(name: name, into: &totals, store: store)
-            try await collectMetrics(entity: IntMetricsEntry.recordType, into: &totals, store: store)
+            if let source = Self.lifecycle(named: name) {
+                try await collectCounts(of: source, into: &totals, store: store)
+            } else {
+                try await collectEvents(name: name, into: &totals, store: store)
+                try await collectMetrics(entity: IntMetricsEntry.recordType, into: &totals, store: store)
+            }
         default:
             try await collectMetrics(entity: IntMetricsEntry.recordType, into: &totals, store: store)
+        }
+    }
+
+    private static func lifecycle(named name: String) -> Source? {
+        switch name {
+        case SessionEntry.recordType: .sessions
+        case CrashEntry.recordType: .crashes
+        case HangEntry.recordType: .hangs
+        case VersionEntry.recordType: .installs
+        case MarkerEntry.crashName: .firstCrashes
+        default: nil
         }
     }
 

--- a/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
+++ b/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
@@ -23,22 +23,32 @@ package struct SeriesQuery: Sendable {
         case hour, day, week
     }
 
+    // Picks the namespace a name resolves against so a custom event and a
+    // built-in counter can share a name (e.g. "Session") without one shadowing
+    // the other. When absent the backend infers the namespace from the name,
+    // preserving the original string-guess behavior for existing callers.
+    package enum Source: String, Sendable {
+        case event, lifecycle, metric
+    }
+
     package var name: String?
     package var category: String?
     package var values: String?
     package var bucket: Bucket = .day
     package var byVersion = false
+    package var source: Source?
     package var range: Range<Date>
 
     package init(
         name: String? = nil, category: String? = nil, values: String? = nil, bucket: Bucket = .day,
-        byVersion: Bool = false, range: Range<Date>
+        byVersion: Bool = false, source: Source? = nil, range: Range<Date>
     ) {
         self.name = name
         self.category = category
         self.values = values
         self.bucket = bucket
         self.byVersion = byVersion
+        self.source = source
         self.range = range
     }
 }

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthProvider.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthProvider.swift
@@ -36,6 +36,6 @@ class ReleaseHealthProvider: ObservableObject, Provider {
     }
 
     private func query(name: String, in range: Range<Date>) -> SeriesQuery {
-        SeriesQuery(name: name, bucket: .day, byVersion: true, range: range)
+        SeriesQuery(name: name, bucket: .day, byVersion: true, source: .lifecycle, range: range)
     }
 }

--- a/Tests/ScoutTests/Connectors/Hosted/HostedQueryEncodingTests.swift
+++ b/Tests/ScoutTests/Connectors/Hosted/HostedQueryEncodingTests.swift
@@ -42,6 +42,27 @@ struct HostedQueryEncodingTests {
         #expect(try rawQuery(of: url).contains("int%2Blong"))
     }
 
+    @Test("An explicit source is carried as a query parameter")
+    func seriesSourceIsEncoded() throws {
+        let url = try #require(
+            database.seriesEndpoint(
+                for: SeriesQuery(name: "Session", source: .event, range: day..<day.addingDay())
+            )
+        )
+
+        #expect(queryItems(of: url)["source"] == "event")
+        #expect(queryItems(of: url)["name"] == "Session")
+    }
+
+    @Test("An absent source omits the parameter")
+    func seriesSourceOmittedWhenNil() throws {
+        let url = try #require(
+            database.seriesEndpoint(for: SeriesQuery(name: "Session", range: day..<day.addingDay()))
+        )
+
+        #expect(queryItems(of: url)["source"] == nil)
+    }
+
     @Test("The lookup field list is percent-encoded")
     func lookupFieldsAreEncoded() throws {
         let url = try #require(database.recordEndpoint(recordName: "abc", fields: ["a b", "c+d"]))

--- a/Tests/ScoutTests/Connectors/Hosted/ServerContractTests.swift
+++ b/Tests/ScoutTests/Connectors/Hosted/ServerContractTests.swift
@@ -173,6 +173,36 @@ struct ServerContractTests {
         #expect(sessions.points.map(\.value.doubleValue).reduce(0, +) == 2)
     }
 
+    @Test("An event source reaches a custom event named like the Session counter")
+    func eventSourceUnshadowsSession() async throws {
+        let database = try makeDatabase()
+        // A unique version isolates both series from any shared server data.
+        let version = "contract-\(UUID().uuidString)"
+        let range = eventDate.startOfDay..<eventDate.startOfDay.addingDay()
+
+        var event = makeEvent(name: "Session", index: 0)
+        event["app_version"] = version
+        var session = makeSession(installID: UUID().uuidString, startDate: eventDate)
+        session["app_version"] = version
+        try await database.write(records: [event, session])
+
+        let events = try await database.series(
+            matching: SeriesQuery(name: "Session", byVersion: true, source: .event, range: range)
+        )
+        let sessions = try await database.series(
+            matching: SeriesQuery(name: "Session", byVersion: true, source: .lifecycle, range: range)
+        )
+
+        // The event source counts only the custom "Session" event, and the
+        // lifecycle source counts only the Session record — neither shadows the
+        // other, and neither is conflated into the other's total.
+        let eventSeries = try #require(events.first { $0.version == version })
+        #expect(eventSeries.points.map(\.value.doubleValue).reduce(0, +) == 1)
+
+        let sessionSeries = try #require(sessions.first { $0.version == version })
+        #expect(sessionSeries.points.map(\.value.doubleValue).reduce(0, +) == 1)
+    }
+
     @Test("First crashes per install aggregate under the VersionCrash series")
     func versionCrashSeries() async throws {
         let database = try makeDatabase()

--- a/Tests/ScoutTests/Connectors/Native/NativeSeriesTests.swift
+++ b/Tests/ScoutTests/Connectors/Native/NativeSeriesTests.swift
@@ -136,6 +136,39 @@ struct NativeSeriesTests {
         #expect(crashed.first?.version == "1.2.0")
     }
 
+    @Test("An explicit event source reaches a custom event named like a lifecycle counter")
+    func eventSourceUnshadowsLifecycleName() async throws {
+        try await database.write(record: makeEventRecord(id: "e-1", name: SessionEntry.recordType))
+        try await database.write(record: makeEventRecord(id: "e-2", name: SessionEntry.recordType))
+        try await database.write(record: makeSessionRecord(id: "s-1", device: "a", day: 0))
+
+        let series = try await database.series(
+            matching: SeriesQuery(name: SessionEntry.recordType, bucket: .hour, source: .event, range: range)
+        )
+
+        let event = try #require(series.first)
+        #expect(series.count == 1)
+        #expect(event.name == SessionEntry.recordType)
+        #expect(event.points.map(\.value) == [.int(2)])
+    }
+
+    @Test("An explicit lifecycle source ignores a same-named custom event")
+    func lifecycleSourceIgnoresEvents() async throws {
+        try await database.write(record: makeEventRecord(id: "e-1", name: SessionEntry.recordType))
+        try await database.write(record: makeSessionRecord(id: "s-1", device: "a", day: 0))
+        try await database.write(record: makeSessionRecord(id: "s-2", device: "b", day: 0))
+
+        let series = try await database.series(
+            matching: SeriesQuery(
+                name: SessionEntry.recordType, bucket: .day, byVersion: true, source: .lifecycle, range: range)
+        )
+
+        let sessions = try #require(series.first)
+        #expect(series.count == 1)
+        #expect(sessions.version == "1.2.0")
+        #expect(sessions.points.map(\.value) == [.int(2)])
+    }
+
     @Test("Double metric series carry name and category")
     func doubleMetricSeries() async throws {
         var record = Record(recordType: DoubleMetricsEntry.recordType, recordID: "m-1")


### PR DESCRIPTION
`NativeSeries` switched over `query.name` to special-case `"Session"`, `"Crash"`, `"Hang"`, `"Version"`, and the `"VersionCrash"` marker as lifecycle counters and treated any other string as a custom event name. Concrete record-type knowledge was baked into the generic series layer, so a custom event named `"Session"` was unreachable (the query silently returned the lifecycle counter) and each new lifecycle type needed another remembered `case`.

This adds an optional `source` (`event`/`lifecycle`/`metric`) to `SeriesQuery` that pins the namespace at the call site instead of guessing. When it is absent, both the native and hosted connectors fall back to the original string-guess, so every existing query behaves exactly as before. The native resolver, the hosted query encoding (`source=` param), and the `CachedMetricSeries` fingerprint all carry it, and `ReleaseHealthProvider` tags its counter queries `.lifecycle`.

The wire field is additive: an old client sends no `source` and the new server infers from the name as before, and a new client sending `source` to an old server degrades to the same inference — so both directions keep working. The new custom-event disambiguation is the one behavior that needs the new server.

Companion server PR: kasianov-mikhail/scout-server#47, which decodes `source` and keeps the default path. Merge the server PR first; this PR is a draft so it cannot land before the server understands the field. `ServerContractTests` gains a case proving a custom event named "Session" is no longer shadowed by the lifecycle counter.

Local: `Scout-Package` build-for-testing and `ScoutTests` are green (194 tests, 0 failures); the contract case runs in the Server workflow.