### PR TITLE
Remove changelog-style comment from SeriesQuery.Source

### DIFF
--- a/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
+++ b/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
@@ -23,10 +23,6 @@ package struct SeriesQuery: Sendable {
         case hour, day, week
     }
 
-    // Picks the namespace a name resolves against so a custom event and a
-    // built-in counter can share a name (e.g. "Session") without one shadowing
-    // the other. When absent the backend infers the namespace from the name,
-    // preserving the original string-guess behavior for existing callers.
     package enum Source: String, Sendable {
         case event, lifecycle, metric
     }


### PR DESCRIPTION
## Summary
- Removes a comment on `SeriesQuery.Source` that narrated the PR history behind the field (added in #1012) instead of explaining a non-obvious invariant.
- Swept the rest of `Sources` for similarly styled comments; the others found all explain genuine invariants/workarounds and were left in place.

## Test plan
- [x] No code behavior changed; comment-only removal.
