### PR TITLE
Replace negative bottom padding with shared side insets in HomeMetricSection

### DIFF
--- a/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
+++ b/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
@@ -41,7 +41,7 @@ struct HomeMetricSection: View {
             }
             .buttonStyle(.plain)
         }
-        .padding(.bottom, -11)
+        .listRowInsets(.sideInsets)
         .listRowSeparator(.hidden)
     }
 

--- a/Sources/ScoutUI/Primitives/Styles/EdgeInsets+Styles.swift
+++ b/Sources/ScoutUI/Primitives/Styles/EdgeInsets+Styles.swift
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+extension EdgeInsets {
+    static let sideInsets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+}


### PR DESCRIPTION
The metric row in the home list compensated the list's default vertical insets with a magic `.padding(.bottom, -11)`, which only overlapped the next row instead of removing the space. It now zeroes the row insets properly via `.listRowInsets`, keeping the standard 16pt side margins. The value lives in a new shared `EdgeInsets.sideInsets` constant in `Primitives/Styles`, next to `Font+Styles.swift`, so other rows can adopt it later.