### PR TITLE
Add a global search across the app

### DIFF
--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -51,6 +51,9 @@ struct HomeList: View {
                 path: $path
             )
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .globalSearch()
         .navigationDestination(for: HomeDestination.self) { destination in
             switch destination {
             case .activity:
@@ -67,8 +70,6 @@ struct HomeList: View {
                 ReleaseHealthView(provider: releases)
             }
         }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
         .rotatingProviders([sessions, activities, logs, releases, devices])
     }
 }

--- a/Sources/ScoutUI/Provider/Provider+Fetch.swift
+++ b/Sources/ScoutUI/Provider/Provider+Fetch.swift
@@ -48,3 +48,18 @@ extension Provider {
         }
     }
 }
+
+@MainActor
+extension Sequence where Element == any Provider {
+    func fetchIfNeeded(in database: DatabaseReader) async {
+        for provider in self {
+            await provider.fetchIfNeeded(in: database)
+        }
+    }
+
+    func fetchIfFailed(in database: DatabaseReader) async {
+        for provider in self {
+            await provider.fetchIfFailed(in: database)
+        }
+    }
+}

--- a/Sources/ScoutUI/Search/Detail/EndpointSearchDetail.swift
+++ b/Sources/ScoutUI/Search/Detail/EndpointSearchDetail.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct EndpointSearchDetail: View {
+    let name: String
+
+    @StateObject var provider = NetworkProvider()
+
+    var body: some View {
+        ProviderView(provider: provider) { report in
+            let range = Period.today.initialRange
+
+            if let endpoint = report.endpoints(in: range).first(where: { $0.name == name }) {
+                NetworkEndpointDetailView(endpoint: endpoint, report: report, range: range)
+            } else {
+                Placeholder(
+                    text: "No requests",
+                    systemImage: "network",
+                    description: "No requests have been recorded for this endpoint today"
+                )
+            }
+        }
+    }
+}

--- a/Sources/ScoutUI/Search/Detail/MetricSearchDetail.swift
+++ b/Sources/ScoutUI/Search/Detail/MetricSearchDetail.swift
@@ -1,0 +1,62 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct MetricSearchDetail: View {
+    let name: String
+    let telemetry: Telemetry.Export
+
+    var body: some View {
+        switch telemetry {
+        case .floatingCounter:
+            MetricSearchContent(name: name, telemetry: telemetry, formatter: \Double.decimal)
+        case .timer:
+            MetricSearchContent(name: name, telemetry: telemetry, formatter: \TimeInterval.duration)
+        default:
+            MetricSearchContent(name: name, telemetry: telemetry, formatter: \Int.plain)
+        }
+    }
+}
+
+private struct MetricSearchContent<T: ChartNumeric>: View {
+    let name: String
+    let telemetry: Telemetry.Export
+    let formatter: KeyPath<T, String>
+
+    @StateObject var provider: MetricsProvider<T>
+
+    init(name: String, telemetry: Telemetry.Export, formatter: KeyPath<T, String>) {
+        self.name = name
+        self.telemetry = telemetry
+        self.formatter = formatter
+        self._provider = StateObject(wrappedValue: MetricsProvider(telemetry: telemetry))
+    }
+
+    var body: some View {
+        ProviderView(provider: provider) { data in
+            let groups: [PointGroup<T>] = data.pointGroups()
+
+            if let group = groups.named(name) {
+                if telemetry == .timer {
+                    MetricsView(group: group, formatter: formatter, period: .today) { extent in
+                        TimerDistributionSection(name: group.name, extent: extent)
+                    }
+                } else {
+                    MetricsView(group: group, formatter: formatter, period: .today)
+                }
+            } else {
+                Placeholder(
+                    text: "No data",
+                    systemImage: "chart.bar",
+                    description: "No values have been recorded for this metric in the current period"
+                )
+            }
+        }
+    }
+}

--- a/Sources/ScoutUI/Search/Index/GlobalSearch.swift
+++ b/Sources/ScoutUI/Search/Index/GlobalSearch.swift
@@ -1,0 +1,102 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+extension View {
+    func globalSearch() -> some View {
+        modifier(GlobalSearchModifier())
+    }
+}
+
+private struct GlobalSearchModifier: ViewModifier {
+    enum LoadState {
+        case loading
+        case ready(GlobalSearchIndex)
+        case failed(Error)
+    }
+
+    @State private var query = ""
+
+    @StateObject private var names = SearchSeriesProvider()
+    @StateObject private var devices = DevicesProvider()
+    @StateObject private var releases = ReleaseHealthProvider()
+    @StateObject private var crashes = IncidentGroupsProvider<Crash>()
+    @StateObject private var hangs = IncidentGroupsProvider<Hang>()
+
+    @Environment(\.database) private var database
+
+    private var providers: [any Provider] {
+        [names, devices, releases, crashes, hangs]
+    }
+
+    func body(content: Content) -> some View {
+        Group {
+            if query.trimmingCharacters(in: .whitespaces).isEmpty {
+                content
+            } else {
+                results
+            }
+        }
+        .searchable(text: $query, placement: .navigationBar, prompt: Text(verbatim: "Search"))
+        .autocorrectionDisabled(true)
+        .onChange(of: query) { text in
+            if !text.trimmingCharacters(in: .whitespaces).isEmpty {
+                Task {
+                    await providers.fetchIfNeeded(in: database)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var results: some View {
+        switch state {
+        case .ready(let index):
+            GlobalSearchList(query: query, index: index)
+        case .loading:
+            RingIndicator().frame(maxHeight: .infinity)
+        case .failed(let error):
+            ErrorView(description: Text(verbatim: error.localizedDescription)) {
+                await providers.fetchIfFailed(in: database)
+            }
+        }
+    }
+
+    private var state: LoadState {
+        do {
+            guard let index = try index else {
+                return .loading
+            }
+            return .ready(index)
+        } catch {
+            return .failed(error)
+        }
+    }
+
+    private var index: GlobalSearchIndex? {
+        get throws {
+            try GlobalSearchIndex(
+                series: names.result?.get(),
+                devices: devices.result?.get().summaries,
+                releases: releases.result?.get(),
+                crashes: crashes.result?.get(),
+                hangs: hangs.result?.get()
+            )
+        }
+    }
+}
+
+extension SearchFieldPlacement {
+    fileprivate static var navigationBar: SearchFieldPlacement {
+        #if os(iOS)
+            .navigationBarDrawer(displayMode: .always)
+        #else
+            .automatic
+        #endif
+    }
+}

--- a/Sources/ScoutUI/Search/Index/GlobalSearchCategory.swift
+++ b/Sources/ScoutUI/Search/Index/GlobalSearchCategory.swift
@@ -1,0 +1,52 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+enum GlobalSearchCategory: String, CaseIterable, Identifiable {
+    case events
+    case metrics
+    case network
+    case devices
+    case releases
+    case crashes
+    case hangs
+
+    var id: Self { self }
+
+    var title: String {
+        rawValue.capitalized
+    }
+
+    var color: Color {
+        switch self {
+        case .events:
+            .blue
+        case .metrics:
+            .purple
+        case .network:
+            .teal
+        case .devices:
+            .cyan
+        case .releases:
+            .green
+        case .crashes:
+            .red
+        case .hangs:
+            .orange
+        }
+    }
+
+    var isMonospaced: Bool {
+        switch self {
+        case .network, .crashes, .hangs:
+            true
+        default:
+            false
+        }
+    }
+}

--- a/Sources/ScoutUI/Search/Index/GlobalSearchHit.swift
+++ b/Sources/ScoutUI/Search/Index/GlobalSearchHit.swift
@@ -1,0 +1,66 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+enum GlobalSearchHit: Identifiable {
+    case event(name: String)
+    case metric(name: String, telemetry: Telemetry.Export)
+    case endpoint(name: String)
+    case device(DeviceSummary)
+    case release(ReleaseHealth)
+    case crash(IncidentGroup<Crash>)
+    case hang(IncidentGroup<Hang>)
+
+    var category: GlobalSearchCategory {
+        switch self {
+        case .event:
+            .events
+        case .metric:
+            .metrics
+        case .endpoint:
+            .network
+        case .device:
+            .devices
+        case .release:
+            .releases
+        case .crash:
+            .crashes
+        case .hang:
+            .hangs
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .event(let name), .metric(let name, _), .endpoint(let name):
+            name
+        case .device(let device):
+            device.modelName
+        case .release(let release):
+            release.id
+        case .crash(let group):
+            group.name
+        case .hang(let group):
+            group.name
+        }
+    }
+
+    var id: String {
+        switch self {
+        case .device(let device):
+            "\(category.rawValue):\(device.id)"
+        case .crash(let group):
+            "\(category.rawValue):\(group.id)"
+        case .hang(let group):
+            "\(category.rawValue):\(group.id)"
+        default:
+            "\(category.rawValue):\(title)"
+        }
+    }
+}

--- a/Sources/ScoutUI/Search/Index/GlobalSearchIndex.swift
+++ b/Sources/ScoutUI/Search/Index/GlobalSearchIndex.swift
@@ -1,0 +1,90 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct GlobalSearchIndex {
+    let series: [MetricSeries]
+    let devices: [DeviceSummary]
+    let releases: [ReleaseHealth]
+    let crashes: [IncidentGroup<Crash>]
+    let hangs: [IncidentGroup<Hang>]
+
+    init?(
+        series: [MetricSeries]?, devices: [DeviceSummary]?, releases: [ReleaseHealth]?,
+        crashes: [IncidentGroup<Crash>]?, hangs: [IncidentGroup<Hang>]?
+    ) {
+        guard let series, let devices, let releases, let crashes, let hangs else {
+            return nil
+        }
+
+        self.series = series
+        self.devices = devices
+        self.releases = releases
+        self.crashes = crashes
+        self.hangs = hangs
+    }
+
+    static let telemetries: [Telemetry.Export] = [.counter, .floatingCounter, .timer]
+
+    private static let endpointCategories = Set(LatencyBuckets.categories + StatusBuckets.categories)
+
+    private static let reservedNames = MetricSeries.lifecycleNames.union([
+        CrashEntry.recordType,
+        HangEntry.recordType,
+    ])
+
+    func hits(matching query: String) -> [GlobalSearchHit] {
+        let text = query.trimmingCharacters(in: .whitespaces)
+
+        guard !text.isEmpty else {
+            return []
+        }
+
+        func matches(_ name: String) -> Bool {
+            name.localizedCaseInsensitiveContains(text)
+        }
+
+        func names(where predicate: (MetricSeries) -> Bool) -> [String] {
+            Set(series.filter(predicate).map(\.name)).filter(matches).sorted()
+        }
+
+        let events = names { $0.category == nil && !Self.reservedNames.contains($0.name) }
+            .map { GlobalSearchHit.event(name: $0) }
+
+        let metrics = Self.telemetries.flatMap { telemetry in
+            names { $0.category == telemetry.rawValue }
+                .map { GlobalSearchHit.metric(name: $0, telemetry: telemetry) }
+        }
+
+        let endpoints = names { Self.endpointCategories.contains($0.category ?? "") }
+            .map { GlobalSearchHit.endpoint(name: $0) }
+
+        let devices =
+            devices
+            .filter { matches($0.modelName) }
+            .map { GlobalSearchHit.device($0) }
+
+        let releases =
+            releases
+            .filter { matches($0.id) }
+            .map { GlobalSearchHit.release($0) }
+
+        let crashes =
+            crashes
+            .filter { matches($0.name) }
+            .map { GlobalSearchHit.crash($0) }
+
+        let hangs =
+            hangs
+            .filter { matches($0.name) }
+            .map { GlobalSearchHit.hang($0) }
+
+        return events + metrics + endpoints + devices + releases + crashes + hangs
+    }
+}

--- a/Sources/ScoutUI/Search/Index/IncidentGroupsProvider.swift
+++ b/Sources/ScoutUI/Search/Index/IncidentGroupsProvider.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+@MainActor
+final class IncidentGroupsProvider<Element: RecordDecodable & Incident>: ObservableObject, Provider {
+    @Published var result: ProviderResult<[IncidentGroup<Element>]>?
+
+    func fetch(in database: DatabaseReader) async throws -> [IncidentGroup<Element>] {
+        let chunk = try await database.read(matching: query, fields: Element.desiredKeys)
+        return IncidentGroup.groups(from: try chunk.records.map(Element.init))
+    }
+
+    private var query: RecordQuery {
+        RecordQuery(
+            recordType: Element.self,
+            filters: Calendar.utc.defaultRange.dateFilters,
+            sort: [RecordQuery.Sort(field: "date", ascending: false)]
+        )
+    }
+}

--- a/Sources/ScoutUI/Search/Index/SearchSeriesProvider.swift
+++ b/Sources/ScoutUI/Search/Index/SearchSeriesProvider.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+@MainActor
+final class SearchSeriesProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<[MetricSeries]>?
+
+    func fetch(in database: DatabaseReader) async throws -> [MetricSeries] {
+        try await database.series(
+            matching: SeriesQuery(bucket: .week, range: Calendar.utc.defaultRange)
+        )
+    }
+}

--- a/Sources/ScoutUI/Search/Results/GlobalSearchList.swift
+++ b/Sources/ScoutUI/Search/Results/GlobalSearchList.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct GlobalSearchList: View {
+    let query: String
+    let index: GlobalSearchIndex
+
+    var body: some View {
+        let hits = index.hits(matching: query)
+
+        if hits.count > 0 {
+            List(hits) { hit in
+                GlobalSearchRow(hit: hit, query: query)
+            }
+            .listStyle(.plain)
+        } else {
+            Placeholder(
+                text: "No results",
+                systemImage: "magnifyingglass",
+                description: "Nothing matches “\(query)”"
+            )
+        }
+    }
+}
+
+#Preview {
+    let index = GlobalSearchIndex(
+        series: [
+            MetricSeries(name: "session_start", category: nil, points: []),
+            MetricSeries(name: "session_end", category: nil, points: []),
+            MetricSeries(name: "session_duration", category: Telemetry.Export.timer.rawValue, points: []),
+            MetricSeries(name: "GET /v1/sessions", category: StatusBuckets.categories[0], points: []),
+        ],
+        devices: .samples,
+        releases: .samples,
+        crashes: IncidentGroup.groups(from: .samples),
+        hangs: IncidentGroup.groups(from: .samples)
+    )
+
+    return NavigationStack {
+        if let index {
+            GlobalSearchList(query: "ses", index: index)
+        }
+    }
+    .environmentObject(Tint())
+}

--- a/Sources/ScoutUI/Search/Results/GlobalSearchRow.swift
+++ b/Sources/ScoutUI/Search/Results/GlobalSearchRow.swift
@@ -1,0 +1,96 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct GlobalSearchRow: View {
+    let hit: GlobalSearchHit
+    let query: String
+
+    var body: some View {
+        Row {
+            Text(highlightedTitle)
+            Spacer()
+            GlobalSearchBadge(category: hit.category)
+        } destination: {
+            destination
+        }
+    }
+
+    private var highlightedTitle: AttributedString {
+        let font: Font = hit.category.isMonospaced ? .codeChip : .body
+
+        var string = AttributedString(hit.title)
+        string.font = font
+
+        let text = query.trimmingCharacters(in: .whitespaces)
+        if !text.isEmpty, let range = string.range(of: text, options: .caseInsensitive) {
+            string[range].font = font.weight(.bold)
+            string[range].foregroundColor = .blue
+        }
+
+        return string
+    }
+
+    @ViewBuilder private var destination: some View {
+        switch hit {
+        case .event(let name):
+            EventStatList(eventName: name, range: Calendar.utc.defaultRange)
+        case .metric(let name, let telemetry):
+            MetricSearchDetail(name: name, telemetry: telemetry)
+        case .endpoint(let name):
+            EndpointSearchDetail(name: name)
+        case .device(let device):
+            DeviceDetailView(device: device)
+        case .release(let release):
+            VersionDetailView(release: release)
+        case .crash(let group):
+            CrashGroupDetailView(group: group)
+        case .hang(let group):
+            HangGroupDetailView(group: group)
+        }
+    }
+}
+
+struct GlobalSearchBadge: View {
+    let category: GlobalSearchCategory
+
+    var body: some View {
+        Text(verbatim: category.title.uppercased())
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(category.color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(category.color.opacity(0.14)))
+    }
+}
+
+#Preview {
+    NavigationStack {
+        List {
+            GlobalSearchRow(hit: .event(name: "session_start"), query: "ses")
+            GlobalSearchRow(hit: .metric(name: "session_duration", telemetry: .timer), query: "ses")
+            GlobalSearchRow(hit: .endpoint(name: "GET /v1/sessions"), query: "ses")
+
+            if let device = [DeviceSummary].samples.first {
+                GlobalSearchRow(hit: .device(device), query: "iphone")
+            }
+            if let release = [ReleaseHealth].samples.first {
+                GlobalSearchRow(hit: .release(release), query: "3.2")
+            }
+            if let group = IncidentGroup.groups(from: [Crash].samples).first {
+                GlobalSearchRow(hit: .crash(group), query: "range")
+            }
+            if let group = IncidentGroup.groups(from: [Hang].samples).first {
+                GlobalSearchRow(hit: .hang(group), query: "main")
+            }
+        }
+        .listStyle(.plain)
+        .environmentObject(Tint())
+    }
+}

--- a/Tests/ScoutUITests/Search/Index/GlobalSearchIndexTests.swift
+++ b/Tests/ScoutUITests/Search/Index/GlobalSearchIndexTests.swift
@@ -1,0 +1,148 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+@testable import ScoutUI
+
+struct GlobalSearchIndexTests {
+    private func makeIndex(
+        series: [MetricSeries] = [], devices: [DeviceSummary] = [], releases: [ReleaseHealth] = [],
+        crashes: [IncidentGroup<Crash>] = [], hangs: [IncidentGroup<Hang>] = []
+    ) -> GlobalSearchIndex {
+        GlobalSearchIndex(series: series, devices: devices, releases: releases, crashes: crashes, hangs: hangs)!
+    }
+
+    private func makeSeries(_ name: String, category: String? = nil) -> MetricSeries {
+        MetricSeries(name: name, category: category, points: [])
+    }
+
+    private func makeDevice(model: String) -> DeviceSummary {
+        DeviceSummary(id: UUID(), model: model, osVersion: "18.0", lastSeen: Date(), sessions: 1, crashes: 0)
+    }
+
+    private func makeRelease(_ version: String) -> ReleaseHealth {
+        ReleaseHealth(
+            id: version,
+            freeSessions: 1.0,
+            freeUsers: nil,
+            crashes: 0,
+            hangs: 0,
+            sessions: 1,
+            adoption: 1.0,
+            trend: []
+        )
+    }
+
+    @Test("Empty query produces no hits") func emptyQuery() {
+        let index = makeIndex(series: [makeSeries("session_start")])
+
+        #expect(index.hits(matching: "").isEmpty)
+        #expect(index.hits(matching: "   ").isEmpty)
+    }
+
+    @Test("Event names match case-insensitively") func eventMatch() {
+        let index = makeIndex(series: [makeSeries("Session_Start"), makeSeries("purchase")])
+        let hits = index.hits(matching: "session")
+
+        #expect(hits.map(\.title) == ["Session_Start"])
+        #expect(hits.map(\.category) == [.events])
+    }
+
+    @Test("Lifecycle and incident series are not events") func reservedNames() {
+        let index = makeIndex(series: [
+            makeSeries(SessionEntry.recordType),
+            makeSeries(CrashEntry.recordType),
+            makeSeries(HangEntry.recordType),
+        ])
+
+        #expect(index.hits(matching: "s").isEmpty)
+    }
+
+    @Test("Metric series match by telemetry category") func metricMatch() {
+        let index = makeIndex(series: [
+            makeSeries("api_calls", category: Telemetry.Export.counter.rawValue),
+            makeSeries("api_latency", category: Telemetry.Export.timer.rawValue),
+            makeSeries("api_meter", category: Telemetry.Export.meterSet.rawValue),
+        ])
+        let hits = index.hits(matching: "api")
+
+        #expect(hits.map(\.title) == ["api_calls", "api_latency"])
+        #expect(hits.allSatisfy { $0.category == .metrics })
+    }
+
+    @Test("Endpoint series match on status and latency categories") func endpointMatch() {
+        let index = makeIndex(series: [
+            makeSeries("GET /v1/sessions", category: StatusBuckets.categories[0]),
+            makeSeries("GET /v1/sessions", category: LatencyBuckets.categories[0]),
+            makeSeries("POST /v1/metrics", category: StatusBuckets.categories[1]),
+        ])
+        let hits = index.hits(matching: "sessions")
+
+        #expect(hits.map(\.title) == ["GET /v1/sessions"])
+        #expect(hits.map(\.category) == [.network])
+    }
+
+    @Test("Devices match on model name") func deviceMatch() {
+        let index = makeIndex(devices: [makeDevice(model: "iPhone14,6"), makeDevice(model: "iPad13,1")])
+        let hits = index.hits(matching: "iphone")
+
+        #expect(hits.count == 1)
+        #expect(hits.allSatisfy { $0.category == .devices })
+    }
+
+    @Test("Releases match on version") func releaseMatch() {
+        let index = makeIndex(releases: [makeRelease("3.2.0"), makeRelease("2.9.9")])
+        let hits = index.hits(matching: "3.2")
+
+        #expect(hits.map(\.title) == ["3.2.0"])
+        #expect(hits.map(\.category) == [.releases])
+    }
+
+    @Test("Crash groups match on name") func crashMatch() {
+        let crashes = [Crash.stub(name: "NSRangeException"), Crash.stub(name: "SIGSEGV")]
+        let index = makeIndex(crashes: IncidentGroup.groups(from: crashes))
+        let hits = index.hits(matching: "range")
+
+        #expect(hits.map(\.title) == ["NSRangeException"])
+        #expect(hits.map(\.category) == [.crashes])
+    }
+
+    @Test("Hang groups match on name") func hangMatch() {
+        let hangs = [Hang.stub(name: "MainThreadStall"), Hang.stub(name: "DiskWriteStall")]
+        let index = makeIndex(hangs: IncidentGroup.groups(from: hangs))
+        let hits = index.hits(matching: "mainthread")
+
+        #expect(hits.map(\.title) == ["MainThreadStall"])
+        #expect(hits.map(\.category) == [.hangs])
+    }
+
+    @Test("Categories keep a stable order") func categoryOrder() {
+        let index = makeIndex(
+            series: [
+                makeSeries("session_start"),
+                makeSeries("sessions_per_user", category: Telemetry.Export.counter.rawValue),
+                makeSeries("GET /v1/sessions", category: StatusBuckets.categories[0]),
+            ],
+            devices: [makeDevice(model: "iPhone SE")],
+            releases: [makeRelease("1.0-session")],
+            crashes: IncidentGroup.groups(from: [Crash.stub(name: "SessionStoreCrash")]),
+            hangs: IncidentGroup.groups(from: [Hang.stub(name: "SessionSaveStall")])
+        )
+        let hits = index.hits(matching: "se")
+
+        #expect(hits.map(\.category) == [.events, .metrics, .network, .devices, .releases, .crashes, .hangs])
+    }
+
+    @Test("Hits are unique per name within a category") func deduplication() {
+        let index = makeIndex(series: [makeSeries("session_start"), makeSeries("session_start")])
+
+        #expect(index.hits(matching: "session").count == 1)
+    }
+}


### PR DESCRIPTION
Adds a single search layer over the whole app, reachable from the Home screen's navigation-bar search field. Typing a query surfaces matching events, metrics, network endpoints, devices, releases, crash fingerprints, and hang fingerprints, grouped by kind with the match highlighted, and each result navigates straight into its existing detail screen. Matching is pure and unit-tested in GlobalSearchIndex; the four providers behind it load lazily on the first query and share a common error and retry path.