### PR TITLE
Hide the top separator in the global search results list

### DIFF
--- a/Sources/ScoutUI/Search/Results/GlobalSearchList.swift
+++ b/Sources/ScoutUI/Search/Results/GlobalSearchList.swift
@@ -18,6 +18,7 @@ struct GlobalSearchList: View {
         if hits.count > 0 {
             List(hits) { hit in
                 GlobalSearchRow(hit: hit, query: query)
+                    .listRowSeparator(hit.id == hits.first?.id ? .hidden : .automatic, edges: .top)
             }
             .listStyle(.plain)
         } else {


### PR DESCRIPTION
The first row of the global search results list showed a redundant separator directly under the search bar. This hides just that top edge separator on the first row, leaving the separators between rows intact.