### PR TITLE
Show a bottom separator under the Retention empty state

### DIFF
--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -55,7 +55,7 @@ struct HomeRetentionSection: View {
                 .placeholderTextStyle()
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 20)
-                .listRowSeparator(.hidden)
+                .listRowSeparator(.hidden, edges: .top)
 
         default:
             HomeRetentionRow(series: .placeholder) {}


### PR DESCRIPTION
The Retention section on Home hid all row separators in its empty state, so the "No results" placeholder sat without a bottom divider closing off the section. Since Retention is the last section, this left the list trailing off without a rule. Hiding only the top edge lets the default bottom separator render, matching the divider the section shows when it has data.