### PR TITLE
Gate expensive CI jobs on the fast PR checks

### DIFF
--- a/.github/scripts/wait-for-checks.sh
+++ b/.github/scripts/wait-for-checks.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Hold an expensive job until the cheap PR checks it should never outrun have
+# finished. A failing fast check — lint, the Core Data model-version rules, the
+# wire-change probe — already red-flags the PR, so there is no point spending
+# 20–30 minutes of macOS runner time on the long job behind it. This gate fails
+# the instant any awaited check concludes in failure (which skips the dependent
+# long job) and passes once they are all green (which lets it proceed).
+#
+# CHECKS holds check-run names, i.e. bare job names — "lint", "model-versions",
+# "changes" — not the "Workflow / job" label the UI shows. A pull_request run
+# attaches its check-runs to the head commit, but the merge commit is queried
+# too so the lookup is robust to either association. SHAS and CHECKS are
+# supplied by the workflow; TIMEOUT/INTERVAL fall back to sensible defaults.
+set -euo pipefail
+
+: "${SHAS:?SHAS is required}"
+: "${CHECKS:?CHECKS is required}"
+timeout="${TIMEOUT:-1200}"
+interval="${INTERVAL:-15}"
+
+read -ra shas <<< "$SHAS"
+read -ra names <<< "$CHECKS"
+
+deadline=$(( SECONDS + timeout ))
+while :; do
+  runs="$(
+    for sha in "${shas[@]}"; do
+      [ -n "$sha" ] || continue
+      gh api --paginate \
+        "repos/$GITHUB_REPOSITORY/commits/$sha/check-runs" \
+        --jq '.check_runs[] | {name, status, conclusion, started_at}'
+    done | jq -s '.'
+  )"
+
+  pending=()
+  for name in "${names[@]}"; do
+    # Reruns leave older entries behind, so pick the most recently started run.
+    run="$(echo "$runs" | jq -c --arg n "$name" \
+      '[.[] | select(.name == $n)] | sort_by(.started_at) | last')"
+    if [ -z "$run" ] || [ "$run" = "null" ]; then
+      pending+=("$name(absent)")
+      continue
+    fi
+    status="$(echo "$run" | jq -r '.status')"
+    conclusion="$(echo "$run" | jq -r '.conclusion')"
+    if [ "$status" != "completed" ]; then
+      pending+=("$name($status)")
+      continue
+    fi
+    case "$conclusion" in
+      success | skipped | neutral) ;;
+      *)
+        echo "::error::Fast check '$name' concluded '$conclusion'; skipping the long job."
+        exit 1
+        ;;
+    esac
+  done
+
+  if [ "${#pending[@]}" -eq 0 ]; then
+    echo "All fast checks passed: ${names[*]}"
+    exit 0
+  fi
+
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "::error::Timed out after ${timeout}s still waiting on: ${pending[*]}"
+    exit 1
+  fi
+
+  echo "Waiting on: ${pending[*]}"
+  sleep "$interval"
+done

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -15,7 +15,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The fast PR checks (lint, the Core Data model rules, the wire-change probe)
+  # live in sibling workflows, out of `needs` reach. This cheap ubuntu job waits
+  # for their check-runs and fails if any fails, so the 30-minute macOS diff
+  # below never starts behind an already-red fast check.
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+      checks: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
+      - name: Wait for the fast checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHAS: ${{ github.event.pull_request.head.sha }} ${{ github.sha }}
+          CHECKS: lint model-versions changes
+        run: .github/scripts/wait-for-checks.sh
+
   api-breakage:
+    needs: gate
     runs-on: macos-26
     timeout-minutes: 30
 

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -77,9 +77,45 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: .github/scripts/detect-wire-changes.sh
 
+  # This workflow's own fast check is `changes` (gated below via `needs`); the
+  # other fast checks (lint, the Core Data model rules) live in sibling
+  # workflows out of `needs` reach. This cheap ubuntu job waits for their
+  # check-runs and fails if either fails, so the 30-minute contract run never
+  # starts behind an already-red fast check. It runs only on PRs — on
+  # push/schedule/dispatch those sibling checks do not run.
+  gate:
+    name: gate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+      checks: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
+      - name: Wait for the fast cross-workflow checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHAS: ${{ github.event.pull_request.head.sha }} ${{ github.sha }}
+          CHECKS: lint model-versions
+        run: .github/scripts/wait-for-checks.sh
+
   contract:
-    needs: changes
-    if: needs.changes.outputs.backend == 'true'
+    needs: [changes, gate]
+    # Run when the wire surface changed and the fast checks passed. On a PR that
+    # leaves the wire surface untouched, backend is 'false' and this skips; on
+    # push/schedule/dispatch `gate` is skipped (PR-only) and backend is 'true',
+    # so a skipped gate is allowed through while a failed one blocks.
+    if: >-
+      ${{ always()
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.backend == 'true'
+      && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: macos-26
     timeout-minutes: 30
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -37,9 +37,40 @@ jobs:
             exit 1
           fi
 
+  # `needs: lint` gates the matrix on this workflow's own fast check; the other
+  # fast checks (Core Data model rules, the wire-change probe) live in sibling
+  # workflows where `needs` cannot reach them. This cheap ubuntu job waits for
+  # their check-runs on the PR and fails if either fails, so the expensive macOS
+  # matrix below never starts behind an already-red fast check. It runs only on
+  # PRs — on a push to main those sibling checks do not run.
+  gate:
+    name: gate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    permissions:
+      contents: read
+      checks: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
+      - name: Wait for the fast cross-workflow checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHAS: ${{ github.event.pull_request.head.sha }} ${{ github.sha }}
+          CHECKS: model-versions changes
+        run: .github/scripts/wait-for-checks.sh
+
   tests:
     name: test-ios-${{ matrix.ios }}
-    needs: lint
+    needs: [lint, gate]
+    # On a push to main `gate` is skipped (it is PR-only); require lint and let
+    # a skipped gate through, but block on a gate that actually failed.
+    if: ${{ always() && needs.lint.result == 'success' && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 


### PR DESCRIPTION
The Swift test matrix, api-breakage, and the server contract run each burn 20–30 minutes of macOS runner time even when a cheap check has already failed the PR. Until now only `Swift / tests` waited for a fast check (`needs: lint`), and `needs` can't reach across workflow files to the other fast checks. This adds a cheap ubuntu `gate` job to each long workflow that polls the Checks API (new `.github/scripts/wait-for-checks.sh`) for the sibling fast checks and fails the instant one fails; the expensive macOS job then hangs off `needs: gate`, so it never starts behind an already-red fast check.

Coverage: `swift / tests` waits for `model-versions` and `changes` (keeps `needs: lint` natively); `api / api-breakage` waits for `lint`, `model-versions`, `changes`; `server / contract` waits for `lint` and `model-versions` (keeps `needs: changes`). Gates run only on `pull_request`, so push/schedule/dispatch are untouched, and the long jobs' `if:` lets a skipped gate through while blocking on a failed one. No workflows are merged and no check names change, so branch protection needs no edits; `contract-gate` is unchanged and still passes when `contract` is skipped (the PR stays blocked by the actually-red fast check).

One thing to know: checks are matched by check-run name — the bare job name (`lint`, `model-versions`, `changes`), not the `Swift / lint` UI label — so renaming any of those jobs means updating `CHECKS` in the three workflows. Three new non-required checks (`Swift / gate`, `API / gate`, `Server / gate`) will appear on PRs. The polling logic only really exercises on GitHub, so the first PR run is worth a look.