### PR TITLE
Tint level filter chips with their level color

### DIFF
--- a/Sources/ScoutUI/Analytics/Event/Filter/FilterLevelsView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Filter/FilterLevelsView.swift
@@ -27,7 +27,7 @@ struct FilterLevelsView: View {
                         Spacer()
                     }
                     .padding(12)
-                    .softCell(selected: on)
+                    .softCell(selected: on, tint: level.color ?? .blue)
                     .contentShape(Rectangle())
                     .onTapGesture {
                         draft.toggle(level)

--- a/Sources/ScoutUI/Analytics/Event/Filter/FilterLevelsView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Filter/FilterLevelsView.swift
@@ -19,15 +19,20 @@ struct FilterLevelsView: View {
 
             LazyVGrid(columns: columns, spacing: 10) {
                 ForEach(EventLevel.allCases, id: \.rawValue) { level in
-                    let on = draft.isSelected(level)
+                    let tint = level.color ?? .blue
                     HStack {
-                        Image(systemName: on ? "checkmark.circle.fill" : "circle")
-                            .foregroundStyle(on ? (level.color ?? .blue) : Color(.systemGray3))
+                        if draft.isSelected(level) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(tint)
+                        } else {
+                            Image(systemName: "circle")
+                                .foregroundStyle(Color(.systemGray3))
+                        }
                         Text(level.description).font(.callout)
                         Spacer()
                     }
                     .padding(12)
-                    .softCell(selected: on, tint: level.color ?? .blue)
+                    .softCell(selected: draft.isSelected(level), tint: tint)
                     .contentShape(Rectangle())
                     .onTapGesture {
                         draft.toggle(level)

--- a/Sources/ScoutUI/Analytics/Event/Filter/FilterView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Filter/FilterView.swift
@@ -54,8 +54,8 @@ struct FilterView: View {
 }
 
 extension View {
-    func softCell(selected: Bool = false) -> some View {
-        background(.blue.opacity(selected ? 0.1 : 0.04), in: RoundedRectangle(cornerRadius: 12))
+    func softCell(selected: Bool = false, tint: Color = .blue) -> some View {
+        background(tint.opacity(selected ? 0.1 : 0.04), in: RoundedRectangle(cornerRadius: 12))
     }
 }
 


### PR DESCRIPTION
The Warning/Error and Critical filter chips now fill with yellow and red backgrounds at the same opacity as the blue chips, instead of always using a blue tint. The soft-cell background takes an optional tint that defaults to blue, and the levels grid passes each level's own color.