### PR TITLE
Present the event filter as a full-screen modal

### DIFF
--- a/Sources/ScoutUI/Analytics/Event/Filter/FilterButton.swift
+++ b/Sources/ScoutUI/Analytics/Event/Filter/FilterButton.swift
@@ -18,10 +18,17 @@ struct FilterButton: View {
         } label: {
             Text(verbatim: "Filter")
         }
-        .sheet(isPresented: $isFilterPresented) {
-            FilterView(query: $query)
+        #if os(iOS)
+            .fullScreenCover(isPresented: $isFilterPresented) {
+                FilterView(query: $query)
                 .opaquePresentation()
-        }
+            }
+        #else
+            .sheet(isPresented: $isFilterPresented) {
+                FilterView(query: $query)
+                .opaquePresentation()
+            }
+        #endif
         .tint(.primary)
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/Filter/FilterView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Filter/FilterView.swift
@@ -29,13 +29,18 @@ struct FilterView: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button {
+                        dismiss()
+                    } label: {
+                        Text(verbatim: "Cancel")
+                    }
+                }
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button {
                         draft.reset()
                     } label: {
                         Text(verbatim: "Reset")
                     }
                     .disabled(!draft.isResetEnabled)
-                }
-                ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         draft.apply()
                         dismiss()
@@ -49,7 +54,7 @@ struct FilterView: View {
             .navigationTitle(en: "Filter")
             .inlineNavigationTitle()
         }
-        .presentationHeight(draft.isDateRangeEnabled ? 720 : 600)
+        .modalFrame(height: draft.isDateRangeEnabled ? 720 : 600)
     }
 }
 
@@ -61,13 +66,9 @@ extension View {
 
 extension View {
     @ViewBuilder
-    fileprivate func presentationHeight(_ height: CGFloat) -> some View {
+    fileprivate func modalFrame(height: CGFloat) -> some View {
         #if os(iOS)
-            if #available(iOS 16.4, *) {
-                presentationDetents([.height(height)])
-            } else {
-                self
-            }
+            self
         #else
             frame(width: height / 1.618, height: height)
         #endif


### PR DESCRIPTION
Opens the events Filter modal in a full-screen cover on iOS instead of a fixed-height sheet, so the levels, period, and context sections get the whole screen. Since full-screen presentation drops the swipe-to-dismiss gesture, the toolbar now carries a Cancel button on the left with Reset and Apply grouped on the right. Non-iOS platforms keep the sheet with its golden-ratio frame.