### PR TITLE
Derive the Devices list from sessions instead of Device records

### DIFF
--- a/Sources/ScoutUI/Delivery/Devices/Model/DeviceSummary.swift
+++ b/Sources/ScoutUI/Delivery/Devices/Model/DeviceSummary.swift
@@ -31,20 +31,22 @@ extension DeviceSummary {
         let crashCounts = Dictionary(
             crashes.compactMap { (record: Record) -> String? in record["device_id"] }.map { ($0, 1) },
             uniquingKeysWith: +)
-
-        return devices.compactMap { device -> DeviceSummary? in
-            guard let deviceID: String = device["device_id"], let uuid = UUID(uuidString: deviceID) else { return nil }
-
-            guard let latest = (sessionsByDevice[deviceID] ?? []).max(by: { $0.startDate < $1.startDate }) else {
-                return nil
+        let models: [String: String] = devices.reduce(into: [:]) { models, device in
+            if let deviceID: String = device["device_id"], let model: String = device["model"] {
+                models[deviceID] = model
             }
+        }
+
+        return sessionsByDevice.compactMap { deviceID, sessions -> DeviceSummary? in
+            guard let uuid = UUID(uuidString: deviceID) else { return nil }
+            guard let latest = sessions.max(by: { $0.startDate < $1.startDate }) else { return nil }
 
             return DeviceSummary(
                 id: uuid,
-                model: device["model"],
+                model: models[deviceID],
                 osVersion: latest.osVersion,
                 lastSeen: latest.startDate,
-                sessions: sessionsByDevice[deviceID]?.count ?? 0,
+                sessions: sessions.count,
                 crashes: crashCounts[deviceID] ?? 0
             )
         }

--- a/Tests/ScoutUITests/Delivery/Devices/Model/DeviceSummaryTests.swift
+++ b/Tests/ScoutUITests/Delivery/Devices/Model/DeviceSummaryTests.swift
@@ -54,6 +54,31 @@ struct DeviceSummaryTests {
         #expect(summaries.isEmpty)
     }
 
+    @Test("Lists devices from sessions alone, without a Device record")
+    func summariesListSessionOnlyDevices() throws {
+        let deviceID = UUID()
+        let date = Date()
+
+        let summaries = DeviceSummary.summaries(
+            devices: [],
+            sessions: [
+                .sessionStub(
+                    sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: date, osVersion: "iOS 17.4",
+                    deviceID: deviceID)
+            ],
+            crashes: []
+        )
+
+        let summary = try #require(summaries.first)
+        #expect(summaries.count == 1)
+        #expect(summary.id == deviceID)
+        #expect(summary.model == nil)
+        #expect(summary.modelName == "Unknown")
+        #expect(summary.osVersion == "iOS 17.4")
+        #expect(summary.lastSeen == date)
+        #expect(summary.sessions == 1)
+    }
+
     @Test("Keeps devices with no model, naming them Unknown")
     func summariesKeepModellessDevices() throws {
         let deviceID = UUID()


### PR DESCRIPTION
The Devices screen built its list solely from Device records, while the Home row counts devices from session visits. A Device record is delivered to a backend only once, so a backend added or cleared after the first sync never receives it while sessions keep arriving — the screen showed the empty placeholder even though the Home row counted a device. Summaries are now built from sessions grouped by device_id, with Device records only supplying the model name (Unknown when absent). Devices without sessions stay hidden, as before. Covered by a new DeviceSummary test for a device that has sessions but no Device record.