### PR TITLE
Fingerprint hangs by name and stack, excluding the per-occurrence reason

### DIFF
--- a/Sources/Scout/Diagnostics/Hang/Hang.swift
+++ b/Sources/Scout/Diagnostics/Hang/Hang.swift
@@ -49,7 +49,6 @@ extension Hang: RecordDecodable {
 
     package static let desiredKeys = [
         "name",
-        "fingerprint",
         "reason",
         "stack_trace",
         "duration",
@@ -77,8 +76,9 @@ extension Hang: RecordDecodable {
         } else {
             stackTrace = []
         }
-        fingerprint =
-            record["fingerprint"] ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value
+        // Stored fingerprints from older builds hashed the reason, which embeds
+        // the per-occurrence duration — recompute so legacy records group too.
+        fingerprint = CrashFingerprint(name: name, reason: nil, stackTrace: stackTrace).value
     }
 }
 

--- a/Sources/Scout/Diagnostics/Incident/LogIncident.swift
+++ b/Sources/Scout/Diagnostics/Incident/LogIncident.swift
@@ -11,6 +11,7 @@ protocol IncidentInfo {
     var name: String { get }
     var reason: String? { get }
     var stackTrace: [String] { get }
+    var fingerprint: String { get }
     var date: Date { get }
     var installID: UUID { get }
     var launchID: UUID { get }
@@ -18,8 +19,19 @@ protocol IncidentInfo {
     var appVersion: String? { get }
 }
 
-extension CrashInfo: IncidentInfo {}
-extension HangInfo: IncidentInfo {}
+extension CrashInfo: IncidentInfo {
+    var fingerprint: String {
+        CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value
+    }
+}
+
+extension HangInfo: IncidentInfo {
+    // A hang's reason embeds the per-occurrence duration, which would make
+    // every fingerprint unique — identity comes from the name and stack alone.
+    var fingerprint: String {
+        CrashFingerprint(name: name, reason: nil, stackTrace: stackTrace).value
+    }
+}
 
 func logIncident<Entry: IncidentEntry, Info: IncidentInfo>(
     _ info: Info, id: UUID, deviceID: UUID, entityName: String, idKey: String, markerName: String,
@@ -38,7 +50,7 @@ func logIncident<Entry: IncidentEntry, Info: IncidentInfo>(
     object.date = info.date
     object.appVersion = info.appVersion
     object.name = info.name
-    object.fingerprint = CrashFingerprint(name: info.name, reason: info.reason, stackTrace: info.stackTrace).value
+    object.fingerprint = info.fingerprint
     object.reason = info.reason
     object.stackTrace = try? JSONEncoder().encode(info.stackTrace)
 

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/Hang+Fixture.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/Hang+Fixture.swift
@@ -21,7 +21,7 @@ extension Hang: Fixture {
 
         return Hang(
             name: name,
-            fingerprint: CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value,
+            fingerprint: CrashFingerprint(name: name, reason: nil, stackTrace: stackTrace).value,
             reason: reason,
             stackTrace: stackTrace,
             duration: 6.4,

--- a/Tests/ScoutTests/Diagnostics/Hang/HangTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Hang/HangTests.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("Hang")
+struct HangTests {
+    @Test("Decoding recomputes the fingerprint, ignoring the stored one")
+    func decodingRecomputesFingerprint() throws {
+        var record = Record(recordType: Hang.recordType, recordID: "h-1")
+        record["name"] = "Main Thread Blocked"
+        record["reason"] = "Main thread unresponsive for 3.2s"
+        record["fingerprint"] = "stale-per-occurrence-fingerprint"
+        record["stack_trace"] = try JSONEncoder().encode(["frame0"])
+
+        let hang = try Hang(record: record)
+
+        let expected = CrashFingerprint(name: "Main Thread Blocked", reason: nil, stackTrace: ["frame0"]).value
+        #expect(hang.fingerprint == expected)
+    }
+
+    @Test("Decoded hangs with the same stack share a fingerprint despite differing reasons")
+    func decodedHangsShareFingerprint() throws {
+        func makeRecord(id: String, reason: String) throws -> Record {
+            var record = Record(recordType: Hang.recordType, recordID: id)
+            record["name"] = "Main Thread Blocked"
+            record["reason"] = reason
+            record["stack_trace"] = try JSONEncoder().encode(["frame0", "frame1"])
+            return record
+        }
+
+        let first = try Hang(record: makeRecord(id: "h-1", reason: "Main thread unresponsive for 3.2s"))
+        let second = try Hang(record: makeRecord(id: "h-2", reason: "Main thread unresponsive for 8.4s"))
+
+        #expect(first.fingerprint == second.fingerprint)
+    }
+}

--- a/Tests/ScoutTests/Diagnostics/Hang/LogHangTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Hang/LogHangTests.swift
@@ -35,8 +35,7 @@ struct LogHangTests {
         #expect(results.count == 1)
 
         let object = try #require(results.first)
-        let expectedFingerprint = CrashFingerprint(name: hang.name, reason: hang.reason, stackTrace: hang.stackTrace)
-            .value
+        let expectedFingerprint = CrashFingerprint(name: hang.name, reason: nil, stackTrace: hang.stackTrace).value
         #expect(object.name == "Main Thread Blocked")
         #expect(object.fingerprint == expectedFingerprint)
         #expect(object.reason == "Main thread unresponsive for 4.2s")
@@ -46,6 +45,23 @@ struct LogHangTests {
         #expect(object.launchID == hang.launchID)
         #expect(object.sessionID == hang.sessionID)
         #expect(object.appVersion == hang.appVersion)
+    }
+
+    @Test("Hangs with the same stack share a fingerprint despite differing durations")
+    func sharesFingerprintAcrossDurations() throws {
+        let first = makeHangInfo(
+            name: "Main Thread Blocked", reason: "Main thread unresponsive for 3.2s", stackTrace: ["frame0"],
+            duration: 3.2)
+        let second = makeHangInfo(
+            name: "Main Thread Blocked", reason: "Main thread unresponsive for 5.7s", stackTrace: ["frame0"],
+            duration: 5.7)
+
+        try logHang(first, deviceID: deviceID, context: context)
+        try logHang(second, deviceID: deviceID, context: context)
+
+        let fingerprints = try context.fetchAll(HangEntry.self).map(\.fingerprint)
+        #expect(fingerprints.count == 2)
+        #expect(Set(fingerprints).count == 1)
     }
 
     @Test("Preserves sessionID captured at hang time, not the recovery session")

--- a/Tests/ScoutUITests/Stubs/Hang+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Hang+Stub.swift
@@ -25,7 +25,7 @@ extension Hang {
     ) -> Hang {
         Hang(
             name: name,
-            fingerprint: fingerprint ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value,
+            fingerprint: fingerprint ?? CrashFingerprint(name: name, reason: nil, stackTrace: stackTrace).value,
             reason: reason,
             stackTrace: stackTrace,
             duration: duration,


### PR DESCRIPTION
The Hangs list never grouped anything: a hang's reason embeds the per-occurrence duration ("Main thread unresponsive for 3.2s") and was hashed into the fingerprint, so every record came out unique. Hang fingerprints are now computed from the name and stack trace only, both at capture time and on decode — decoding recomputes the fingerprint locally instead of trusting the stored one, so records logged by older builds group as well. The fingerprint field is dropped from Hang's desiredKeys since the client no longer reads it; the write path and server schema are unchanged. Crash fingerprinting is untouched.