### PR TITLE
Plan deliveries per backend and keep one-shot entries past cleanup

### DIFF
--- a/Sources/Scout/Lifecycle/Device/DeviceEntry.swift
+++ b/Sources/Scout/Lifecycle/Device/DeviceEntry.swift
@@ -18,6 +18,10 @@ package final class DeviceEntry: SyncableEntry {
     override var references: Set<DateEntry> {
         Set(Array(installs))
     }
+
+    override var isPurgeable: Bool {
+        false
+    }
 }
 
 extension DeviceEntry: RecordEncodable {

--- a/Sources/Scout/Lifecycle/Install/InstallEntry.swift
+++ b/Sources/Scout/Lifecycle/Install/InstallEntry.swift
@@ -19,6 +19,10 @@ package final class InstallEntry: SyncableEntry, HasDevice {
     override var references: Set<DateEntry> {
         Set(Array(launches) + Array(markers))
     }
+
+    override var isPurgeable: Bool {
+        false
+    }
 }
 
 extension InstallEntry: RecordEncodable {

--- a/Sources/Scout/Lifecycle/Version/VersionEntry.swift
+++ b/Sources/Scout/Lifecycle/Version/VersionEntry.swift
@@ -14,6 +14,10 @@ package final class VersionEntry: SyncableEntry, HasLaunch {
     @NSManaged var appVersion: String?
     @NSManaged var buildNumber: String?
     @NSManaged var launch: LaunchEntry?
+
+    override var isPurgeable: Bool {
+        false
+    }
 }
 
 extension VersionEntry: RecordEncodable {

--- a/Sources/Scout/Sync/DateEntry+Cleanup.swift
+++ b/Sources/Scout/Sync/DateEntry+Cleanup.swift
@@ -17,7 +17,7 @@ extension DateEntry {
         request.predicate = NSPredicate(format: "datePrimitive < %@", cutoff as NSDate)
 
         for object in try context.fetch(request)
-        where object.references.count == 0 && !retained.contains(object.objectID) {
+        where object.isPurgeable && object.references.count == 0 && !retained.contains(object.objectID) {
             context.delete(object)
         }
 

--- a/Sources/Scout/Sync/SyncableEntry+Plan.swift
+++ b/Sources/Scout/Sync/SyncableEntry+Plan.swift
@@ -9,11 +9,14 @@ import CoreData
 
 extension SyncableEntry {
     static func plan(backends: [Backend], in context: NSManagedObjectContext) throws {
-        let request = NSFetchRequest<SyncableEntry>(entityName: "SyncableEntry")
-        request.predicate = NSPredicate(format: "deliveries.@count == 0")
+        for backend in backends {
+            let request = NSFetchRequest<SyncableEntry>(entityName: "SyncableEntry")
+            request.predicate = NSPredicate(
+                format: "SUBQUERY(deliveries, $d, $d.backendID == %@).@count == 0",
+                backend.id
+            )
 
-        for object in try context.fetch(request) {
-            for backend in backends {
+            for object in try context.fetch(request) {
                 let row = context.insert(DeliveryEntry.self)
                 row.backendID = backend.id
                 row.object = object

--- a/Sources/Scout/Utilities/Date/DateEntry.swift
+++ b/Sources/Scout/Utilities/Date/DateEntry.swift
@@ -21,6 +21,12 @@ package class DateEntry: NSManagedObject {
         []
     }
 
+    // One-shot entries (device, install, version) are created once and never
+    // re-created, so cleanup must keep them for backends configured later.
+    var isPurgeable: Bool {
+        true
+    }
+
     var inferred: Date? {
         (references.map(\.datePrimitive) + [datePrimitive]).compactMap(\.self).max()
     }

--- a/Tests/ScoutTests/Sync/DateEntryCleanupTests.swift
+++ b/Tests/ScoutTests/Sync/DateEntryCleanupTests.swift
@@ -38,6 +38,21 @@ struct DateEntryCleanupTests {
         #expect(try context.fetchAll(LaunchEntry.self).isEmpty)
     }
 
+    @Test("Keeps delivered one-shot entries regardless of age")
+    func keepsOneShotEntries() throws {
+        let old = Date(timeIntervalSinceNow: -8 * 86400)
+        DeviceEntry.stub(date: old, synced: true, in: context)
+        InstallEntry.stub(date: old, synced: true, in: context)
+        VersionEntry.stub(date: old, synced: true, in: context)
+        try context.save()
+
+        try DateEntry.cleanup(backends: [], in: context)
+
+        #expect(try context.fetchAll(DeviceEntry.self).count == 1)
+        #expect(try context.fetchAll(InstallEntry.self).count == 1)
+        #expect(try context.fetchAll(VersionEntry.self).count == 1)
+    }
+
     @Test("Keeps synced objects newer than 7 days")
     func keepsSyncedRecent() throws {
         let recent = Date(timeIntervalSinceNow: -6 * 86400)

--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -200,6 +200,26 @@ struct DeliverTests {
         #expect(server.records.count(of: "Event") == 0)
     }
 
+    @Test("A backend added after the first sync still receives one-shot records")
+    func lateAddedBackendReceivesOneShots() async throws {
+        let old = Date(timeIntervalSinceNow: -8 * 86400)
+        DeviceEntry.stub(date: old, in: context)
+        try context.save()
+
+        // First cycle: only the cloud is configured; the record delivers and
+        // ages past the cleanup window.
+        try SyncableEntry.plan(backends: [cloudBackend], in: context)
+        try await deliver(DeviceEntry.self, to: cloudBackend)
+        try DateEntry.cleanup(backends: [cloudBackend], in: context)
+
+        // Second cycle: the server joins and receives the same record.
+        try SyncableEntry.plan(backends: backends, in: context)
+        try await deliver(DeviceEntry.self, to: serverBackend)
+
+        #expect(cloud.records.count(of: "Device") == 1)
+        #expect(server.records.count(of: "Device") == 1)
+    }
+
     @Test("Dropping a never-reached backend lets cleanup reclaim the record")
     func droppingBackendUnblocks() async throws {
         let old = Date(timeIntervalSinceNow: -8 * 86400)

--- a/Tests/ScoutTests/Sync/SyncableEntryPlanTests.swift
+++ b/Tests/ScoutTests/Sync/SyncableEntryPlanTests.swift
@@ -28,6 +28,42 @@ struct SyncableEntryPlanTests {
         #expect(event.delivery(for: "server")?.isPending == true)
     }
 
+    @Test("Seeds only the missing backend for an already-delivered record")
+    func seedsLateAddedBackend() throws {
+        let event = EventEntry.stub(name: "login", in: context)
+        event.seedDelivery(pending: false, for: "cloud", in: context)
+        try context.save()
+
+        try SyncableEntry.plan(backends: [makeBackend(id: "cloud"), makeBackend(id: "server")], in: context)
+
+        #expect(event.deliveries.count == 2)
+        #expect(event.delivery(for: "cloud")?.isDelivered == true)
+        #expect(event.delivery(for: "server")?.isPending == true)
+    }
+
+    @Test("Replanning does not duplicate delivery rows")
+    func replanningIsIdempotent() throws {
+        let event = EventEntry.stub(name: "login", in: context)
+        try context.save()
+
+        try SyncableEntry.plan(backends: [makeBackend(id: "cloud")], in: context)
+        try SyncableEntry.plan(backends: [makeBackend(id: "cloud")], in: context)
+
+        #expect(event.deliveries.count == 1)
+    }
+
+    @Test("An abandoned backend row is not reseeded")
+    func abandonedRowIsNotReseeded() throws {
+        let event = EventEntry.stub(name: "login", in: context)
+        event.seedDelivery(attempts: Int16(DeliveryEntry.maxAttempts), for: "cloud", in: context)
+        try context.save()
+
+        try SyncableEntry.plan(backends: [makeBackend(id: "cloud")], in: context)
+
+        #expect(event.deliveries.count == 1)
+        #expect(event.delivery(for: "cloud")?.isAbandoned == true)
+    }
+
     @Test("Ignores local-only objects")
     func skipsLocalOnly() throws {
         let marker = context.insert(MarkerEntry.self)


### PR DESCRIPTION
A backend added after the first sync (or one whose storage was cleared) never received Device, Install, or Version records: plan only seeded delivery rows for entries with no deliveries at all, and cleanup deleted delivered entries after 7 days, so device models showed as Unknown on the late backend. Plan now seeds a pending row for every configured backend an entry has no delivery for, without touching delivered or abandoned rows, and one-shot entries (device, install, version) override the new `DateEntry.isPurgeable` to survive cleanup so a late-added backend still receives them on its first sync. Stream entries are cleaned up as before, and the wire format is unchanged, so no scout-server change is needed. Covered by new plan, cleanup, and end-to-end delivery tests.