### PR TITLE
Fix crash and hang chart and badge colors

### DIFF
--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -31,15 +31,17 @@ struct VersionDetailView: View {
 
             IncidentTrendSection(
                 title: "Crashes over time", records: crashes.records ?? [], color: .red)
-            IncidentIssuesSection(title: "Top crash issues", groups: IncidentGroup.groups(from: crashes.records ?? []))
-            { group in
+            IncidentIssuesSection(
+                title: "Top crash issues", groups: IncidentGroup.groups(from: crashes.records ?? []), color: .red
+            ) { group in
                 CrashGroupDetailView(group: group)
             }
 
             IncidentTrendSection(
                 title: "Hangs over time", records: hangs.records ?? [], color: .orange)
-            IncidentIssuesSection(title: "Top hang issues", groups: IncidentGroup.groups(from: hangs.records ?? [])) {
-                group in
+            IncidentIssuesSection(
+                title: "Top hang issues", groups: IncidentGroup.groups(from: hangs.records ?? []), color: .orange
+            ) { group in
                 HangGroupDetailView(group: group)
             }
         }
@@ -124,6 +126,7 @@ private struct IncidentTrendSection<Element: Incident>: View {
 private struct IncidentIssuesSection<Element: Incident, Destination: View>: View {
     let title: String
     let groups: [IncidentGroup<Element>]
+    let color: Color
     @ViewBuilder let destination: (IncidentGroup<Element>) -> Destination
 
     @ViewBuilder
@@ -140,7 +143,7 @@ private struct IncidentIssuesSection<Element: Incident, Destination: View>: View
 
                     Spacer()
 
-                    CountBadge(count: group.count)
+                    CountBadge(count: group.count, color: color)
                 } destination: {
                     destination(group)
                 }

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -30,14 +30,14 @@ struct VersionDetailView: View {
             headerSection
 
             IncidentTrendSection(
-                title: "Crashes over time", records: crashes.records ?? [], color: release.freeSessions.color)
+                title: "Crashes over time", records: crashes.records ?? [], color: .red)
             IncidentIssuesSection(title: "Top crash issues", groups: IncidentGroup.groups(from: crashes.records ?? []))
             { group in
                 CrashGroupDetailView(group: group)
             }
 
             IncidentTrendSection(
-                title: "Hangs over time", records: hangs.records ?? [], color: release.freeSessions.color)
+                title: "Hangs over time", records: hangs.records ?? [], color: .orange)
             IncidentIssuesSection(title: "Top hang issues", groups: IncidentGroup.groups(from: hangs.records ?? [])) {
                 group in
                 HangGroupDetailView(group: group)


### PR DESCRIPTION
The crashes and hangs sections both reused release.freeSessions.color, so their trend charts — and, by default, the top-issue count badges — took whatever tint the crash-free-session health bucket happened to be, which is why everything rendered orange. This pins each section to a stable, meaning-carrying color independent of release health: crashes are red (trend chart and count badges), hangs are orange (trend chart and count badges). The navbar toolbar tint still tracks freeSessions.color.