### PR TITLE
Document the remaining workflows with header comments

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,10 @@
 name: CodeQL
 
+# GitHub's CodeQL static analysis for Swift, uploading results to the
+# security-events dashboard. Analysis needs a full manual build, so this runs
+# nightly on a schedule (and on demand) rather than per-PR: tracing slows
+# compilation down severalfold, so it builds a single architecture of the Scout
+# scheme only.
 on:
   schedule:
     - cron: "33 2 * * *"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,9 @@
 name: Docs
 
+# Builds the Scout DocC documentation and publishes it to GitHub Pages. Runs on
+# every push to main (and on demand) so the hosted docs track the shipped API;
+# the two jobs split generation (macOS, needs the Swift toolchain) from
+# deployment (ubuntu, just uploads the artifact to Pages).
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,5 +1,9 @@
 name: Notify
 
+# Fans a green main out to the downstream scout-ip repository. When the Swift
+# workflow completes successfully on main, this fires a repository_dispatch so
+# scout-ip can pick up the new Scout revision. It keys off workflow_run (not
+# push) so the notification only goes out once CI has actually passed.
 on:
   workflow_run:
     workflows: [Swift]

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,9 @@
 name: Stale
 
+# Housekeeping for inactive issues and pull requests. Runs daily on a schedule
+# (and on demand): anything untouched for 60 days is marked stale, then closed
+# 14 days later unless activity resumes. Items labelled pinned or security are
+# exempt.
 on:
   schedule:
     - cron: "17 3 * * *"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,5 +1,12 @@
 name: Swift
 
+# The primary CI: lints with swift-format, then builds and tests the package
+# across a matrix of iOS versions. The matrix spans the package's minimum
+# deployment target (iOS 16) up to the latest public-preview toolchain
+# (xcode-27), so both old-SDK breakage and new-SDK regressions surface here.
+# Coverage is collected on the iOS 26 leg only — the reports differ between legs
+# by fractions of a percent, and that leg is the one where the snapshot suites
+# run. The stable iOS 18 / iOS 26 legs are the required checks on main.
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Adds a descriptive header comment after the name: line in the Swift, CodeQL, Docs, Notify, and Stale workflows, explaining what each does and the non-obvious rationale behind it. This matches the style already established in server.yml, api.yml, and coredata.yml, so every workflow now carries an at-a-glance description.