### PR TITLE
Add alert rules with local notifications and background refresh

### DIFF
--- a/Sources/ScoutUI/Home/Connection/Backend+Active.swift
+++ b/Sources/ScoutUI/Home/Connection/Backend+Active.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+extension [Backend] {
+    func active(id: String) -> Backend? {
+        first { $0.id == id } ?? first
+    }
+
+    var active: Backend? {
+        active(id: UserDefaults.standard.string(forKey: "scout_active_backend") ?? "")
+    }
+}

--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -19,6 +19,7 @@ struct HomeList: View {
     @StateObject var releases = ReleaseHealthProvider()
     @StateObject var logs = HomeLogProvider()
     @StateObject var devices = DevicesProvider()
+    @StateObject var alerts = AlertProvider(notifier: AlertNotifier())
 
     var body: some View {
         List {
@@ -30,6 +31,10 @@ struct HomeList: View {
             .padding(.top, 8)
             .listRowSeparator(.hidden)
 
+            HomeAlertSection(
+                alerts: alerts,
+                path: $path
+            )
             HomeMetricSection(
                 activities: activities,
                 sessions: sessions,
@@ -68,9 +73,11 @@ struct HomeList: View {
                 LogView(period: period, log: logs, devices: devices)
             case .releaseHealth:
                 ReleaseHealthView(provider: releases)
+            case .alerts:
+                AlertListView(provider: alerts)
             }
         }
-        .rotatingProviders([sessions, activities, logs, releases, devices])
+        .rotatingProviders([sessions, activities, logs, releases, devices, alerts])
     }
 }
 

--- a/Sources/ScoutUI/Home/HomeView.swift
+++ b/Sources/ScoutUI/Home/HomeView.swift
@@ -20,7 +20,7 @@ struct HomeView: View {
     }
 
     private var backend: Backend? {
-        backends.first { $0.id == activeID } ?? backends.first
+        backends.active(id: activeID)
     }
 
     private var active: Binding<String> {

--- a/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
+++ b/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
@@ -1,0 +1,62 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct HomeAlertSection: View {
+    @ObservedObject var alerts: AlertProvider
+
+    @Binding var path: [HomeDestination]
+
+    var body: some View {
+        Header(title: "Alerts") {
+            HStack(spacing: 8) {
+                if let statuses = try? alerts.result?.get() {
+                    FiringBadge(count: statuses.firingCount)
+                }
+
+                AllButton { path.append(.alerts) }
+            }
+        }
+
+        switch alerts.result {
+        case .success(let statuses) where statuses.count > 0:
+            ForEach(statuses.prefix(2), id: \.rule) { status in
+                AlertRow(status: status)
+            }
+
+        case .success:
+            Text(verbatim: "No alert rules")
+                .placeholderTextStyle()
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 20)
+                .listRowSeparator(.hidden)
+
+        default:
+            ForEach(0..<2, id: \.self) { _ in
+                AlertRowPlaceholder()
+            }
+        }
+    }
+}
+
+#Preview {
+    let alerts = AlertProvider()
+    alerts.result = .success([.firingSample, .armedSample])
+
+    let empty = AlertProvider()
+    empty.result = .success([])
+
+    return NavigationStack {
+        List {
+            HomeAlertSection(alerts: alerts, path: .constant([]))
+            HomeAlertSection(alerts: empty, path: .constant([]))
+        }
+        .listStyle(.plain)
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Concepts/AlertDesignConcepts.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Concepts/AlertDesignConcepts.swift
@@ -1,0 +1,288 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Charts
+import SwiftUI
+
+private struct ConceptAlert: Identifiable {
+    let id = UUID()
+    let color: Color
+    let title: String
+    let detail: String
+    let time: String
+    let values: [Int]
+}
+
+extension ConceptAlert {
+    static let crashFree = ConceptAlert(
+        color: .red,
+        title: "Crash-free sessions",
+        detail: "98.2% — below 99.5% for 2h",
+        time: "14:20",
+        values: [12, 11, 12, 10, 8, 6, 5]
+    )
+
+    static let latency = ConceptAlert(
+        color: .orange,
+        title: "POST /v1/records p99",
+        detail: "412 ms — 2.3× above baseline",
+        time: "11:05",
+        values: [3, 3, 4, 3, 5, 9, 14]
+    )
+
+    static let errors = ConceptAlert(
+        color: .orange,
+        title: "Error logs",
+        detail: "148/h — spike over 3× median",
+        time: "21:47",
+        values: [2, 3, 2, 2, 3, 11, 4]
+    )
+
+    static let adoption = ConceptAlert(
+        color: .blue,
+        title: "Release 3.4.0 adoption",
+        detail: "Reached 50% of sessions",
+        time: "09:30",
+        values: [1, 2, 4, 7, 11, 14, 16]
+    )
+}
+
+private struct AlertInboxRow: View {
+    let alert: ConceptAlert
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(alert.color)
+                .frame(width: 8, height: 8)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: alert.title)
+                    .font(.body.weight(.medium))
+                Text(verbatim: alert.detail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(verbatim: alert.time)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                MiniChart(series: MiniChartSeries(values: alert.values), color: alert.color)
+            }
+        }
+        .padding(.vertical, 4)
+        .trailingRowSeparator()
+    }
+}
+
+#Preview("1 · Inbox — лента алертов") {
+    NavigationStack {
+        List {
+            Header(title: "Today")
+            AlertInboxRow(alert: .crashFree)
+            AlertInboxRow(alert: .latency)
+            Header(title: "Yesterday")
+            AlertInboxRow(alert: .errors)
+            AlertInboxRow(alert: .adoption)
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: "Alerts")
+    }
+}
+
+private struct ThresholdChartConcept: View {
+    let values: [Double] = [99.8, 99.7, 99.8, 99.6, 99.4, 98.9, 98.2]
+    let threshold = 99.5
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(verbatim: "CRASH-FREE SESSIONS")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.secondary)
+                    Text(verbatim: "98.2%")
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                        .foregroundStyle(.red)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Label("Fired 14:20", systemImage: "bell.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.red)
+                    Text(verbatim: "below 99.5% for 2h")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Chart {
+                ForEach(Array(values.enumerated()), id: \.offset) { index, value in
+                    AreaMark(x: .value("Hour", index), yStart: .value("Bottom", 98.0), yEnd: .value("Value", value))
+                        .interpolationMethod(.catmullRom)
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: [.red.opacity(0.25), .red.opacity(0.03)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+
+                    LineMark(x: .value("Hour", index), y: .value("Value", value))
+                        .interpolationMethod(.catmullRom)
+                        .foregroundStyle(.red)
+                        .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round))
+                }
+
+                RuleMark(y: .value("Threshold", threshold))
+                    .foregroundStyle(.red.opacity(0.6))
+                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                    .annotation(position: .topTrailing) {
+                        Text(verbatim: "99.5%")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.red)
+                    }
+
+                PointMark(x: .value("Hour", 5), y: .value("Value", 98.9))
+                    .foregroundStyle(.red)
+                    .symbolSize(80)
+            }
+            .chartYScale(domain: 98.0...100.0)
+            .chartXAxis(.hidden)
+            .frame(height: 180)
+
+            HStack(spacing: 12) {
+                Button {
+                } label: {
+                    Text(verbatim: "Open Sessions")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button {
+                } label: {
+                    Text(verbatim: "Mute 24h")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview("3 · Threshold — график с порогом") {
+    ThresholdChartConcept()
+}
+
+private struct AlertBanner: View {
+    let alert: ConceptAlert
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "bell.badge.fill")
+                .font(.title3)
+                .foregroundStyle(alert.color)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: alert.title)
+                    .font(.subheadline.weight(.semibold))
+                Text(verbatim: alert.detail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            MiniChart(series: MiniChartSeries(values: alert.values), color: alert.color)
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+        .background(alert.color.opacity(0.12))
+        .background()
+        .cornerRadius(16)
+        .overlay {
+            RoundedRectangle(cornerRadius: 16).stroke(alert.color.opacity(0.6), lineWidth: 1)
+        }
+        .padding(.horizontal)
+    }
+}
+
+#Preview("5 · Banner — richer in-app тост") {
+    VStack(spacing: 12) {
+        AlertBanner(alert: .crashFree)
+        AlertBanner(alert: .latency)
+        AlertBanner(alert: .adoption)
+    }
+}
+
+private struct StatusChip: View {
+    let icon: String
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Label(text, systemImage: icon)
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 13)
+            .padding(.vertical, 8)
+            .background(color.opacity(0.12), in: Capsule())
+    }
+}
+
+private struct StatusStripConcept: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        StatusChip(icon: "exclamationmark.triangle.fill", text: "Crash-free 98.2%", color: .red)
+                        StatusChip(icon: "clock.fill", text: "p99 ×2.3", color: .orange)
+                        StatusChip(icon: "checkmark.circle.fill", text: "Errors OK", color: .green)
+                        StatusChip(icon: "checkmark.circle.fill", text: "Sessions OK", color: .green)
+                    }
+                }
+                .listRowSeparator(.hidden)
+
+                Header(title: "Alerts") {
+                    Text(verbatim: "2")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 2)
+                        .background(.red, in: Capsule())
+                }
+                AlertInboxRow(alert: .crashFree)
+                AlertInboxRow(alert: .latency)
+
+                Header(title: "Metrics")
+                HStack {
+                    Text(verbatim: "Sessions")
+                    Spacer()
+                    MiniChart(series: MiniChartSeries(values: [7, 8, 8, 9, 8, 9, 10]), color: .purple)
+                }
+                .trailingRowSeparator()
+            }
+            .listStyle(.plain)
+            .navigationTitle(en: "Scout")
+        }
+    }
+}
+
+#Preview("7 · Status Strip — статус на Home") {
+    StatusStripConcept()
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertMessage.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertMessage.swift
@@ -1,0 +1,78 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct AlertMessage: Equatable {
+    let title: String
+    let body: String
+}
+
+extension AlertMessage {
+    init?(status: AlertStatus) {
+        guard status.outcome.shouldNotify, status.rule.notifies, let detail = status.detail else { return nil }
+
+        title = status.rule.metric.title
+        body = detail
+    }
+}
+
+extension AlertMetric {
+    var title: String {
+        switch self {
+        case .eventCount(let name):
+            name
+        case .crashFreeSessions:
+            "Crash-free sessions"
+        }
+    }
+
+    func format(_ value: Double) -> String {
+        switch self {
+        case .eventCount:
+            String(Int(value))
+        case .crashFreeSessions:
+            Stability(value).formatted
+        }
+    }
+}
+
+extension AlertCondition {
+    func summary(format: (Double) -> String) -> String {
+        "\(comparison.summary) \(reference.summary(format: format))"
+    }
+}
+
+extension AlertCondition.Comparison {
+    fileprivate var summary: String {
+        switch self {
+        case .below:
+            "below"
+        case .above:
+            "above"
+        }
+    }
+}
+
+extension AlertCondition.Reference {
+    fileprivate func summary(format: (Double) -> String) -> String {
+        switch self {
+        case .constant(let value):
+            format(value)
+        case .baselineFactor(let factor):
+            "\(factor.formattedFactor) baseline"
+        case .medianFactor(let factor):
+            "\(factor.formattedFactor) median"
+        }
+    }
+}
+
+extension Double {
+    fileprivate var formattedFactor: String {
+        String(format: "%g×", self)
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
@@ -1,0 +1,48 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import UserNotifications
+
+protocol AlertNotificationCenter: Sendable {
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
+    func add(_ request: UNNotificationRequest) async throws
+}
+
+// UNUserNotificationCenter is documented thread-safe but not annotated Sendable in the SDK.
+extension UNUserNotificationCenter: @retroactive @unchecked Sendable {}
+
+extension UNUserNotificationCenter: AlertNotificationCenter {}
+
+struct AlertNotifier {
+    let center: AlertNotificationCenter
+
+    init(center: AlertNotificationCenter = UNUserNotificationCenter.current()) {
+        self.center = center
+    }
+
+    func requestAuthorization() async -> Bool {
+        (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+    }
+
+    func deliver(_ statuses: [AlertStatus]) async {
+        for status in statuses {
+            guard let message = AlertMessage(status: status) else { continue }
+
+            let content = UNMutableNotificationContent()
+            content.title = message.title
+            content.body = message.body
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: UUID().uuidString,
+                content: content,
+                trigger: nil
+            )
+            try? await center.add(request)
+        }
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#if canImport(BackgroundTasks)
+    import BackgroundTasks
+    import Foundation
+
+    protocol AlertTaskScheduler: Sendable {
+        func register(
+            forTaskWithIdentifier identifier: String, using queue: DispatchQueue?,
+            launchHandler: @escaping @Sendable (BGTask) -> Void
+        ) -> Bool
+        func submit(_ taskRequest: BGTaskRequest) throws
+    }
+
+    // BGTaskScheduler and BGTask are thread-safe but not annotated Sendable in the SDK.
+    extension BGTaskScheduler: @retroactive @unchecked Sendable {}
+    extension BGTask: @retroactive @unchecked Sendable {}
+
+    extension BGTaskScheduler: AlertTaskScheduler {}
+
+    @MainActor
+    final class AlertRefreshScheduler {
+        static let taskIdentifier = "scout.alert.refresh"
+
+        private let scheduler: AlertTaskScheduler
+        private let interval: TimeInterval
+        private let refresh: @Sendable () async -> Void
+
+        init(
+            scheduler: AlertTaskScheduler = BGTaskScheduler.shared, interval: TimeInterval = 1800,
+            refresh: @escaping @Sendable () async -> Void
+        ) {
+            self.scheduler = scheduler
+            self.interval = interval
+            self.refresh = refresh
+        }
+
+        @discardableResult
+        func register() -> Bool {
+            scheduler.register(forTaskWithIdentifier: Self.taskIdentifier, using: nil) { [refresh, weak self] task in
+                let work = Task {
+                    await refresh()
+                    await self?.schedule()
+                    task.setTaskCompleted(success: true)
+                }
+                task.expirationHandler = { work.cancel() }
+            }
+        }
+
+        func schedule() {
+            let request = BGAppRefreshTaskRequest(identifier: Self.taskIdentifier)
+            request.earliestBeginDate = Date(timeIntervalSinceNow: interval)
+            try? scheduler.submit(request)
+        }
+    }
+#endif

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#if canImport(BackgroundTasks)
+    import Foundation
+    import Scout
+
+    /// Host-app entry point for background alert evaluation.
+    ///
+    /// Call ``registerBackgroundRefresh(backends:)`` before the app finishes
+    /// launching and ``scheduleBackgroundRefresh()`` whenever the app moves to
+    /// the background. The host's Info.plist must list ``taskIdentifier`` under
+    /// `BGTaskSchedulerPermittedIdentifiers` and include the `fetch` background
+    /// mode.
+    ///
+    @MainActor
+    public enum ScoutAlerts {
+        /// The background task identifier host apps whitelist in their Info.plist.
+        public static var taskIdentifier: String {
+            AlertRefreshScheduler.taskIdentifier
+        }
+
+        private static var scheduler: AlertRefreshScheduler?
+
+        /// Hooks alert evaluation into the background task scheduler.
+        ///
+        /// Must be called before the app finishes launching; the system rejects
+        /// later registrations.
+        ///
+        public static func registerBackgroundRefresh(backends: [Backend]) {
+            let provider = AlertProvider(notifier: AlertNotifier())
+            let refresher = AlertRefreshScheduler {
+                await refresh(provider: provider, backends: backends)
+            }
+
+            refresher.register()
+            scheduler = refresher
+        }
+
+        /// Requests a background refresh, skipped while no alert rules exist.
+        public static func scheduleBackgroundRefresh() {
+            guard AlertStore().rules.count > 0 else { return }
+            scheduler?.schedule()
+        }
+
+        private static func refresh(provider: AlertProvider, backends: [Backend]) async {
+            guard let backend = backends.active else { return }
+            _ = try? await provider.fetch(in: backend.cachedDatabase)
+        }
+    }
+#endif

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertBacktest.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertBacktest.swift
@@ -1,0 +1,51 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct AlertBacktest: Equatable {
+    static let windowBuckets = 24
+
+    let values: [Double]
+
+    func fireCount(for rule: AlertRule) -> Int {
+        let window = Self.windowBuckets
+        let evaluator = AlertEvaluator()
+
+        guard values.count >= window * 2 else { return 0 }
+
+        var state = AlertState.armed
+        var fires = 0
+
+        for end in (window * 2)...values.count {
+            let reading = MetricReading(
+                baseline: Array(values[(end - window * 2)..<(end - window)]).median ?? 0,
+                recent: Array(values[(end - window)..<end])
+            )
+            let outcome = evaluator.evaluate(rule, reading: reading, state: state, now: Date(timeIntervalSince1970: 0))
+
+            state = outcome.state
+
+            if outcome.shouldNotify {
+                fires += 1
+            }
+        }
+
+        return fires
+    }
+
+    func summary(for rule: AlertRule) -> String {
+        switch fireCount(for: rule) {
+        case 0:
+            "Would not have fired in the past week"
+        case 1:
+            "Would have fired once in the past week"
+        case let count:
+            "Would have fired \(count) times in the past week"
+        }
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEvaluator.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEvaluator.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct AlertOutcome: Equatable {
+    let state: AlertState
+    let shouldNotify: Bool
+}
+
+struct AlertEvaluator {
+    func evaluate(_ rule: AlertRule, reading: MetricReading, state: AlertState, now: Date) -> AlertOutcome {
+        if case .muted(let until) = state, now < until {
+            return AlertOutcome(state: state, shouldNotify: false)
+        }
+
+        guard rule.isSustained(in: reading) else {
+            return AlertOutcome(state: .armed, shouldNotify: false)
+        }
+
+        if case .firing(let since) = state {
+            return AlertOutcome(state: .firing(since: since), shouldNotify: false)
+        }
+
+        return AlertOutcome(state: .firing(since: now), shouldNotify: true)
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertStore.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertStore.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+@MainActor
+final class AlertStore {
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var rules: [AlertRule] {
+        get {
+            decode([AlertRule].self, forKey: "scout_alert_rules") ?? []
+        }
+        set {
+            encode(newValue, forKey: "scout_alert_rules")
+            states = states.filter { newValue.contains($0.key) }
+        }
+    }
+
+    func state(for rule: AlertRule) -> AlertState {
+        states[rule] ?? .armed
+    }
+
+    func setState(_ state: AlertState, for rule: AlertRule) {
+        var updated = states
+        updated[rule] = state
+        states = updated
+    }
+
+    private var states: [AlertRule: AlertState] {
+        get { decode([AlertRule: AlertState].self, forKey: "scout_alert_states") ?? [:] }
+        set { encode(newValue, forKey: "scout_alert_states") }
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+        defaults.data(forKey: key).flatMap { try? JSONDecoder().decode(type, from: $0) }
+    }
+
+    private func encode(_ value: some Encodable, forKey key: String) {
+        defaults.set(try? JSONEncoder().encode(value), forKey: key)
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertCondition.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertCondition.swift
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct AlertCondition: Hashable, Codable {
+    let comparison: Comparison
+    let reference: Reference
+}
+
+extension AlertCondition {
+    enum Comparison: Hashable, Codable {
+        case below
+        case above
+    }
+
+    enum Reference: Hashable, Codable {
+        case constant(Double)
+        case baselineFactor(Double)
+        case medianFactor(Double)
+    }
+}
+
+extension AlertCondition {
+    func isBreached(by value: Double, in reading: MetricReading) -> Bool {
+        guard let reference = reading.reference(for: reference) else { return false }
+
+        switch comparison {
+        case .below:
+            return value < reference
+        case .above:
+            return value > reference
+        }
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertDraft.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertDraft.swift
@@ -1,0 +1,149 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct AlertDraft: Equatable {
+    var choice = MetricChoice.crashFreeSessions
+    var eventName = ""
+    var kind = Kind.fallsBelow
+    var stabilityThreshold = 0.995
+    var countThreshold = 100.0
+    var factor = 2.0
+    var hold = Hold.oneHour
+    var notifies = true
+}
+
+extension AlertDraft {
+    enum MetricChoice: CaseIterable {
+        case crashFreeSessions
+        case eventCount
+
+        var label: String {
+            switch self {
+            case .crashFreeSessions:
+                "Crash-free sessions"
+            case .eventCount:
+                "Event count"
+            }
+        }
+    }
+
+    enum Kind: CaseIterable {
+        case fallsBelow
+        case risesAbove
+        case spikes
+
+        var label: String {
+            switch self {
+            case .fallsBelow:
+                "Falls below"
+            case .risesAbove:
+                "Rises above"
+            case .spikes:
+                "Spikes"
+            }
+        }
+    }
+
+    enum Hold: CaseIterable {
+        case oneHour
+        case twoHours
+        case sixHours
+        case day
+
+        var buckets: Int {
+            switch self {
+            case .oneHour:
+                1
+            case .twoHours:
+                2
+            case .sixHours:
+                6
+            case .day:
+                24
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .oneHour:
+                "1h"
+            case .twoHours:
+                "2h"
+            case .sixHours:
+                "6h"
+            case .day:
+                "24h"
+            }
+        }
+    }
+}
+
+extension AlertDraft {
+    var metric: AlertMetric {
+        switch choice {
+        case .crashFreeSessions:
+            .crashFreeSessions
+        case .eventCount:
+            .eventCount(name: eventName)
+        }
+    }
+
+    var rule: AlertRule {
+        AlertRule(metric: metric, condition: condition, holdBuckets: hold.buckets, notifies: notifies)
+    }
+
+    var isValid: Bool {
+        choice == .crashFreeSessions || eventName.count > 0
+    }
+
+    private var condition: AlertCondition {
+        switch kind {
+        case .fallsBelow:
+            AlertCondition(comparison: .below, reference: .constant(constant))
+        case .risesAbove:
+            AlertCondition(comparison: .above, reference: .baselineFactor(factor))
+        case .spikes:
+            AlertCondition(comparison: .above, reference: .medianFactor(factor))
+        }
+    }
+
+    private var constant: Double {
+        choice == .crashFreeSessions ? stabilityThreshold : countThreshold
+    }
+}
+
+extension AlertDraft {
+    var valueText: String {
+        switch kind {
+        case .fallsBelow:
+            choice == .crashFreeSessions ? Stability(stabilityThreshold).formatted : String(Int(countThreshold))
+        case .risesAbove, .spikes:
+            String(format: "%g×", factor)
+        }
+    }
+
+    mutating func increment() {
+        step(1)
+    }
+
+    mutating func decrement() {
+        step(-1)
+    }
+
+    private mutating func step(_ direction: Double) {
+        switch kind {
+        case .fallsBelow where choice == .crashFreeSessions:
+            stabilityThreshold = min(0.9999, max(0.9, stabilityThreshold + direction * 0.001))
+        case .fallsBelow:
+            countThreshold = min(100_000, max(1, countThreshold + direction * 10))
+        case .risesAbove, .spikes:
+            factor = min(10, max(1.5, factor + direction * 0.5))
+        }
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertMetric.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertMetric.swift
@@ -1,0 +1,67 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+enum AlertMetric: Hashable, Codable {
+    case eventCount(name: String)
+    case crashFreeSessions
+}
+
+extension AlertMetric {
+    func reading(in database: DatabaseReader, period: some ChartTimeScale) async throws -> MetricReading {
+        let range = period.previousRange.lowerBound..<period.initialRange.upperBound
+
+        switch self {
+        case .eventCount:
+            return MetricReading(points: try await eventPoints(in: database, range: range), period: period)
+        case .crashFreeSessions:
+            let (sessions, crashes) = try await lifecyclePoints(in: database, range: range)
+            return MetricReading(sessions: sessions, crashes: crashes, period: period)
+        }
+    }
+
+    func values(in database: DatabaseReader, range: Range<Date>) async throws -> [Double] {
+        switch self {
+        case .eventCount:
+            return try await eventPoints(in: database, range: range)
+                .bucket(in: range, component: .hour)
+                .reversed()
+                .map { Double($0.count) }
+
+        case .crashFreeSessions:
+            let (sessions, crashes) = try await lifecyclePoints(in: database, range: range)
+            return MetricReading.stabilities(sessions: sessions, crashes: crashes, in: range, component: .hour)
+        }
+    }
+
+    private func eventPoints(in database: DatabaseReader, range: Range<Date>) async throws -> [ChartPoint<Int>] {
+        guard case .eventCount(let name) = self else { return [] }
+
+        let series = try await database.series(
+            matching: SeriesQuery(name: name, bucket: .hour, range: range)
+        )
+        return series.flatMap { $0.chartPoints() }
+    }
+
+    private func lifecyclePoints(in database: DatabaseReader, range: Range<Date>) async throws -> (
+        sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>]
+    ) {
+        async let sessions = database.series(
+            matching: SeriesQuery(name: SessionEntry.recordType, bucket: .hour, source: .lifecycle, range: range)
+        )
+        async let crashes = database.series(
+            matching: SeriesQuery(name: CrashEntry.recordType, bucket: .hour, source: .lifecycle, range: range)
+        )
+
+        return (
+            sessions: try await sessions.flatMap { $0.chartPoints() },
+            crashes: try await crashes.flatMap { $0.chartPoints() }
+        )
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertRule.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertRule.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct AlertRule: Hashable, Codable {
+    let metric: AlertMetric
+    let condition: AlertCondition
+    let holdBuckets: Int
+    let notifies: Bool
+
+    init(metric: AlertMetric, condition: AlertCondition, holdBuckets: Int = 1, notifies: Bool = true) {
+        self.metric = metric
+        self.condition = condition
+        self.holdBuckets = holdBuckets
+        self.notifies = notifies
+    }
+}
+
+extension AlertRule {
+    func isSustained(in reading: MetricReading) -> Bool {
+        let window = reading.recent.suffix(holdBuckets)
+
+        return window.count == holdBuckets
+            && window.allSatisfy { condition.isBreached(by: $0, in: reading) }
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertScale.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertScale.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct AlertScale: ChartTimeScale {
+    let horizonDate: Date
+
+    var id: Date { horizonDate }
+    var rangeComponent: Calendar.Component { .day }
+    var pointComponent: Calendar.Component { .hour }
+}
+
+extension AlertScale {
+    static var trailing: AlertScale {
+        AlertScale(horizonDate: Date().startOfHour)
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertState.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertState.swift
@@ -6,13 +6,9 @@
 // https://opensource.org/licenses/MIT.
 
 import Foundation
-import Scout
 
-enum HomeDestination: Hashable {
-    case activity
-    case retention
-    case sessions
-    case log
-    case releaseHealth
-    case alerts
+enum AlertState: Equatable, Codable {
+    case armed
+    case firing(since: Date)
+    case muted(until: Date)
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertStatus.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertStatus.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct AlertStatus: Equatable {
+    let rule: AlertRule
+    let outcome: AlertOutcome
+    let reading: MetricReading
+}
+
+extension AlertStatus {
+    var detail: String? {
+        guard let current = reading.recent.last else { return nil }
+        return "\(rule.metric.format(current)) — \(rule.condition.summary(format: rule.metric.format))"
+    }
+
+    var series: MiniChartSeries {
+        MiniChartSeries(values: reading.recent.map { Int($0 * 1000) })
+    }
+}
+
+extension [AlertStatus] {
+    var firingCount: Int {
+        count { if case .firing = $0.outcome.state { true } else { false } }
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading+ChartPoints.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading+ChartPoints.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+extension MetricReading {
+    init(points: [ChartPoint<Int>], period: some ChartTimeScale) {
+        let previous = points.bucket(in: period.previousRange, component: period.pointComponent)
+        let current = points.bucket(on: period)
+
+        self.init(
+            baseline: previous.map { Double($0.count) }.median ?? 0,
+            recent: current.reversed().map { Double($0.count) }
+        )
+    }
+
+    init(sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], period: some ChartTimeScale) {
+        let previous = Self.stabilities(
+            sessions: sessions, crashes: crashes, in: period.previousRange, component: period.pointComponent)
+        let current = Self.stabilities(
+            sessions: sessions, crashes: crashes, in: period.initialRange, component: period.pointComponent)
+
+        self.init(baseline: previous.median ?? 0, recent: current)
+    }
+
+    static func stabilities(
+        sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], in range: Range<Date>, component: Calendar.Component
+    ) -> [Double] {
+        zip(
+            sessions.bucket(in: range, component: component).reversed(),
+            crashes.bucket(in: range, component: component).reversed()
+        )
+        .map { Stability(of: $1.count, in: $0.count).value }
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct MetricReading: Equatable {
+    let baseline: Double
+    let recent: [Double]
+}
+
+extension MetricReading {
+    func reference(for reference: AlertCondition.Reference) -> Double? {
+        switch reference {
+        case .constant(let value):
+            value
+        case .baselineFactor(let factor):
+            baseline > 0 ? baseline * factor : nil
+        case .medianFactor(let factor):
+            recent.median.map { $0 * factor }
+        }
+    }
+}
+
+extension [Double] {
+    var median: Double? {
+        guard count > 0 else { return nil }
+
+        let sorted = sorted()
+        let middle = count / 2
+
+        guard count.isMultiple(of: 2) else {
+            return sorted[middle]
+        }
+        return (sorted[middle - 1] + sorted[middle]) / 2
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertBacktestProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertBacktestProvider.swift
@@ -1,0 +1,26 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+@MainActor
+class AlertBacktestProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<AlertBacktest>?
+
+    var metric: AlertMetric
+
+    init(metric: AlertMetric) {
+        self.metric = metric
+    }
+
+    func fetch(in database: DatabaseReader) async throws -> AlertBacktest {
+        let horizon = Date().startOfHour
+        let values = try await metric.values(in: database, range: horizon.addingDay(-9)..<horizon)
+        return AlertBacktest(values: values)
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
@@ -1,0 +1,168 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct AlertEditorView: View {
+    @ObservedObject var provider: AlertProvider
+
+    @StateObject private var backtest = AlertBacktestProvider(metric: .crashFreeSessions)
+    @State private var draft = AlertDraft()
+
+    @Environment(\.database) private var database
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            Header(title: "Metric")
+            metricRow
+
+            if draft.choice == .eventCount {
+                eventNameRow
+            }
+
+            Header(title: "Condition")
+            PillRow(options: AlertDraft.Kind.allCases, selection: $draft.kind) { $0.label }
+            valueRow
+
+            Header(title: "For at least")
+            PillRow(options: AlertDraft.Hold.allCases, selection: $draft.hold) { $0.label }
+
+            Header(title: "Delivery")
+            Toggle(isOn: $draft.notifies) {
+                Text(verbatim: "Notify on this device")
+            }
+            .trailingRowSeparator()
+
+            backtestRow
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: "New Rule")
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button {
+                    Task {
+                        await provider.add(draft.rule)
+                        dismiss()
+                    }
+                } label: {
+                    Text(verbatim: "Save")
+                }
+                .disabled(!draft.isValid)
+            }
+        }
+        .task(id: draft.metric) {
+            guard draft.isValid else { return }
+            guard (try? await Task.sleep(nanoseconds: 300_000_000)) != nil else { return }
+
+            backtest.metric = draft.metric
+            await backtest.fetchAgain(in: database)
+        }
+    }
+
+    private var metricRow: some View {
+        Menu {
+            ForEach(AlertDraft.MetricChoice.allCases, id: \.self) { choice in
+                Button {
+                    draft.choice = choice
+                } label: {
+                    Text(verbatim: choice.label)
+                }
+            }
+        } label: {
+            HStack {
+                Text(verbatim: draft.choice.label)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .buttonStyle(.plain)
+        .trailingRowSeparator()
+    }
+
+    private var eventNameRow: some View {
+        TextField(text: $draft.eventName, prompt: Text(verbatim: "Event name")) {
+            Text(verbatim: "Event name")
+        }
+        .autocorrectionDisabled()
+        .trailingRowSeparator()
+    }
+
+    private var valueRow: some View {
+        HStack {
+            Text(verbatim: draft.valueText)
+                .font(.system(size: 34, weight: .bold, design: .rounded))
+                .monospacedDigit()
+
+            Spacer()
+
+            Stepper {
+                EmptyView()
+            } onIncrement: {
+                draft.increment()
+            } onDecrement: {
+                draft.decrement()
+            }
+            .labelsHidden()
+        }
+        .trailingRowSeparator()
+    }
+
+    @ViewBuilder private var backtestRow: some View {
+        if draft.isValid, case .success(let test) = backtest.result {
+            Label {
+                Text(verbatim: test.summary(for: draft.rule))
+            } icon: {
+                Image(systemName: "clock.arrow.circlepath")
+            }
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .listRowSeparator(.hidden)
+            .padding(.top, 8)
+        }
+    }
+}
+
+private struct PillRow<Option: Hashable>: View {
+    let options: [Option]
+    @Binding var selection: Option
+    let label: (Option) -> String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(options, id: \.self) { option in
+                Button {
+                    selection = option
+                } label: {
+                    Text(verbatim: label(option))
+                        .font(.subheadline.weight(option == selection ? .semibold : .regular))
+                        .padding(.horizontal, 13)
+                        .padding(.vertical, 8)
+                        .background(
+                            option == selection ? Color.accentColor.opacity(0.15) : Color(.systemGray6),
+                            in: Capsule()
+                        )
+                        .foregroundStyle(option == selection ? Color.accentColor : .primary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .listRowSeparator(.hidden)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AlertEditorView(provider: AlertProvider())
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -1,0 +1,185 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct AlertListView: View {
+    @ObservedObject var provider: AlertProvider
+
+    @Environment(\.database) private var database
+    @State private var isEditorPresented = false
+
+    var body: some View {
+        List {
+            content
+        }
+        .listStyle(.plain)
+        .navigationTitle(en: "Alerts")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    isEditorPresented = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $isEditorPresented) {
+            Task { await provider.fetchAgain(in: database) }
+        } content: {
+            NavigationStack {
+                AlertEditorView(provider: provider)
+            }
+        }
+        .task { await provider.fetchIfNeeded(in: database) }
+        .refreshable { await provider.fetchAgain(in: database) }
+    }
+
+    @ViewBuilder private var content: some View {
+        switch provider.result {
+        case .success(let statuses) where statuses.count > 0:
+            chips(statuses)
+
+            Header(title: "Rules") {
+                FiringBadge(count: statuses.firingCount)
+            }
+
+            ForEach(statuses, id: \.rule) { status in
+                AlertRow(status: status)
+                    .swipeActions {
+                        Button(role: .destructive) {
+                            provider.remove(status.rule)
+                            Task { await provider.fetchAgain(in: database) }
+                        } label: {
+                            Text(verbatim: "Delete")
+                        }
+                    }
+            }
+
+        case .success:
+            Placeholder(
+                text: "No alert rules",
+                systemImage: "bell.badge",
+                description: "Add a rule to get notified when a metric misbehaves."
+            )
+            .frame(maxWidth: .infinity)
+            .padding(.top, 80)
+            .listRowSeparator(.hidden)
+
+        case .failure(let error):
+            ErrorView(description: error.localizedDescription) {
+                await provider.fetchAgain(in: database)
+            }
+            .listRowSeparator(.hidden)
+
+        case nil:
+            Header(title: "Rules")
+
+            ForEach(0..<3, id: \.self) { _ in
+                AlertRowPlaceholder()
+            }
+        }
+    }
+
+    private func chips(_ statuses: [AlertStatus]) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(statuses, id: \.rule) { status in
+                    AlertChip(status: status)
+                }
+            }
+        }
+        .listRowSeparator(.hidden)
+    }
+}
+
+private struct AlertChip: View {
+    let status: AlertStatus
+
+    var body: some View {
+        Label {
+            Text(verbatim: text)
+        } icon: {
+            Image(systemName: status.outcome.state.icon)
+        }
+        .font(.footnote.weight(.semibold))
+        .foregroundStyle(status.outcome.state.color)
+        .padding(.horizontal, 13)
+        .padding(.vertical, 8)
+        .background(status.outcome.state.color.opacity(0.12), in: Capsule())
+    }
+
+    private var text: String {
+        guard let current = status.reading.recent.last else { return status.rule.metric.title }
+        return "\(status.rule.metric.title) \(status.rule.metric.format(current))"
+    }
+}
+
+struct FiringBadge: View {
+    let count: Int
+
+    var body: some View {
+        if count > 0 {
+            Text(verbatim: String(count))
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 2)
+                .background(.red, in: Capsule())
+        }
+    }
+}
+
+#Preview {
+    let provider = AlertProvider()
+    provider.result = .success([.firingSample, .armedSample])
+
+    return NavigationStack {
+        AlertListView(provider: provider)
+    }
+}
+
+#Preview("Empty") {
+    let provider = AlertProvider()
+    provider.result = .success([])
+
+    return NavigationStack {
+        AlertListView(provider: provider)
+    }
+}
+
+extension AlertStatus {
+    static var firingSample: AlertStatus {
+        AlertStatus(
+            rule: AlertRule(
+                metric: .crashFreeSessions,
+                condition: AlertCondition(comparison: .below, reference: .constant(0.995)),
+                holdBuckets: 2
+            ),
+            outcome: AlertOutcome(
+                state: .firing(since: Date(timeIntervalSinceReferenceDate: 803_500_000)),
+                shouldNotify: false
+            ),
+            reading: MetricReading(
+                baseline: 0.998,
+                recent: [0.998, 0.998, 0.997, 0.996, 0.994, 0.989, 0.982]
+            )
+        )
+    }
+
+    static var armedSample: AlertStatus {
+        AlertStatus(
+            rule: AlertRule(
+                metric: .eventCount(name: "Error"),
+                condition: AlertCondition(comparison: .above, reference: .medianFactor(3))
+            ),
+            outcome: AlertOutcome(state: .armed, shouldNotify: false),
+            reading: MetricReading(baseline: 4, recent: [4, 3, 4, 5, 3, 4, 5])
+        )
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
@@ -1,0 +1,58 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+@MainActor
+class AlertProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<[AlertStatus]>?
+
+    private let store: AlertStore
+    private let notifier: AlertNotifier?
+    private let evaluator = AlertEvaluator()
+
+    init(store: AlertStore = AlertStore(), notifier: AlertNotifier? = nil) {
+        self.store = store
+        self.notifier = notifier
+    }
+
+    var rules: [AlertRule] {
+        store.rules
+    }
+
+    func add(_ rule: AlertRule) async {
+        let isFirst = store.rules.count == 0
+        store.rules.append(rule)
+
+        if isFirst, let notifier {
+            _ = await notifier.requestAuthorization()
+        }
+    }
+
+    func remove(_ rule: AlertRule) {
+        store.rules.removeAll { $0 == rule }
+    }
+
+    func fetch(in database: DatabaseReader) async throws -> [AlertStatus] {
+        let period = AlertScale.trailing
+        let now = Date()
+
+        var statuses: [AlertStatus] = []
+
+        for rule in store.rules {
+            let reading = try await rule.metric.reading(in: database, period: period)
+            let outcome = evaluator.evaluate(rule, reading: reading, state: store.state(for: rule), now: now)
+
+            store.setState(outcome.state, for: rule)
+            statuses.append(AlertStatus(rule: rule, outcome: outcome, reading: reading))
+        }
+
+        await notifier?.deliver(statuses)
+        return statuses
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertRow.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertRow.swift
@@ -1,0 +1,94 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct AlertRow: View {
+    let status: AlertStatus
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(status.outcome.state.color)
+                .frame(width: 8, height: 8)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: status.rule.metric.title)
+                    .font(.body.weight(.medium))
+
+                if let detail = status.detail {
+                    Text(verbatim: detail)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 4) {
+                if case .firing(let since) = status.outcome.state {
+                    Text(verbatim: since.formatted(date: .omitted, time: .shortened))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                MiniChart(series: status.series, color: status.outcome.state.color)
+            }
+        }
+        .padding(.vertical, 4)
+        .trailingRowSeparator()
+    }
+}
+
+struct AlertRowPlaceholder: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(.gray)
+                .frame(width: 8, height: 8)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: "Crash-free sessions")
+                    .font(.body.weight(.medium))
+                Text(verbatim: "99.50% — below 99.50%")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            MiniChart(series: nil, color: .gray)
+        }
+        .padding(.vertical, 4)
+        .redacted(reason: .placeholder)
+        .trailingRowSeparator()
+    }
+}
+
+extension AlertState {
+    var color: Color {
+        switch self {
+        case .armed:
+            .green
+        case .firing:
+            .red
+        case .muted:
+            .gray
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .armed:
+            "checkmark.circle.fill"
+        case .firing:
+            "exclamationmark.triangle.fill"
+        case .muted:
+            "bell.slash.fill"
+        }
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertMessageTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertMessageTests.swift
@@ -1,0 +1,106 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+struct AlertMessageTests {
+    @Test("A crash-free breach reads as percentages against the threshold")
+    func crashFree() throws {
+        let message = try #require(
+            AlertMessage(
+                status: makeStatus(
+                    metric: .crashFreeSessions,
+                    condition: AlertCondition(comparison: .below, reference: .constant(0.995)),
+                    recent: [0.998, 0.9]
+                )
+            )
+        )
+
+        #expect(message.title == "Crash-free sessions")
+        #expect(message.body == "90.00% — below 99.50%")
+    }
+
+    @Test("An event spike over the baseline reads as counts against the factor")
+    func baseline() throws {
+        let message = try #require(
+            AlertMessage(
+                status: makeStatus(
+                    metric: .eventCount(name: "Error"),
+                    condition: AlertCondition(comparison: .above, reference: .baselineFactor(2)),
+                    recent: [4, 20]
+                )
+            )
+        )
+
+        #expect(message.title == "Error")
+        #expect(message.body == "20 — above 2× baseline")
+    }
+
+    @Test("A spike over the median names the median factor")
+    func median() throws {
+        let message = try #require(
+            AlertMessage(
+                status: makeStatus(
+                    metric: .eventCount(name: "Error"),
+                    condition: AlertCondition(comparison: .above, reference: .medianFactor(3)),
+                    recent: [4, 148]
+                )
+            )
+        )
+
+        #expect(message.body == "148 — above 3× median")
+    }
+
+    @Test("A silent outcome carries no message")
+    func silent() {
+        let status = makeStatus(
+            metric: .crashFreeSessions,
+            condition: AlertCondition(comparison: .below, reference: .constant(0.995)),
+            recent: [0.9],
+            shouldNotify: false
+        )
+
+        #expect(AlertMessage(status: status) == nil)
+    }
+
+    @Test("An empty reading carries no message")
+    func empty() {
+        let status = makeStatus(
+            metric: .crashFreeSessions,
+            condition: AlertCondition(comparison: .below, reference: .constant(0.995)),
+            recent: []
+        )
+
+        #expect(AlertMessage(status: status) == nil)
+    }
+
+    @Test("A rule with delivery switched off carries no message")
+    func deliveryOff() {
+        let status = makeStatus(
+            metric: .crashFreeSessions,
+            condition: AlertCondition(comparison: .below, reference: .constant(0.995)),
+            recent: [0.9],
+            notifies: false
+        )
+
+        #expect(AlertMessage(status: status) == nil)
+    }
+
+    private func makeStatus(
+        metric: AlertMetric, condition: AlertCondition, recent: [Double], shouldNotify: Bool = true,
+        notifies: Bool = true
+    ) -> AlertStatus {
+        AlertStatus(
+            rule: AlertRule(metric: metric, condition: condition, notifies: notifies),
+            outcome: AlertOutcome(state: .firing(since: Date(timeIntervalSince1970: 0)), shouldNotify: shouldNotify),
+            reading: MetricReading(baseline: 0, recent: recent)
+        )
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+struct AlertNotifierTests {
+    @Test("Only notifying statuses become notifications")
+    func delivers() async throws {
+        let center = NotificationCenterStub()
+        let notifier = AlertNotifier(center: center)
+
+        await notifier.deliver([
+            makeStatus(shouldNotify: true),
+            makeStatus(shouldNotify: false),
+        ])
+
+        let request = try #require(center.requests.first)
+
+        #expect(center.requests.count == 1)
+        #expect(request.content.title == "Crash-free sessions")
+        #expect(request.content.body == "90.00% — below 99.50%")
+        #expect(request.trigger == nil)
+    }
+
+    @Test("Authorization passes the center's grant through")
+    func authorization() async {
+        let center = NotificationCenterStub()
+        center.granted = false
+
+        let notifier = AlertNotifier(center: center)
+        let granted = await notifier.requestAuthorization()
+
+        #expect(!granted)
+        #expect(center.authorizationRequests == 1)
+    }
+
+    private func makeStatus(shouldNotify: Bool) -> AlertStatus {
+        AlertStatus(
+            rule: AlertRule(
+                metric: .crashFreeSessions,
+                condition: AlertCondition(comparison: .below, reference: .constant(0.995))
+            ),
+            outcome: AlertOutcome(state: .firing(since: Date(timeIntervalSince1970: 0)), shouldNotify: shouldNotify),
+            reading: MetricReading(baseline: 0, recent: [0.9])
+        )
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertRefreshSchedulerTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertRefreshSchedulerTests.swift
@@ -1,0 +1,73 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#if canImport(BackgroundTasks)
+    import BackgroundTasks
+    import Foundation
+    import Testing
+
+    @testable import ScoutUI
+
+    @MainActor
+    struct AlertRefreshSchedulerTests {
+        @Test("Registering hooks the alert task identifier")
+        func register() {
+            let stub = TaskSchedulerStub()
+            let scheduler = AlertRefreshScheduler(scheduler: stub) {}
+
+            #expect(scheduler.register())
+            #expect(stub.registered == [AlertRefreshScheduler.taskIdentifier])
+        }
+
+        @Test("Scheduling submits an app-refresh request no earlier than the interval")
+        func schedule() throws {
+            let stub = TaskSchedulerStub()
+            let scheduler = AlertRefreshScheduler(scheduler: stub, interval: 1800) {}
+
+            scheduler.schedule()
+
+            let request = try #require(stub.submitted.first as? BGAppRefreshTaskRequest)
+
+            #expect(request.identifier == AlertRefreshScheduler.taskIdentifier)
+            #expect(try #require(request.earliestBeginDate).timeIntervalSinceNow > 1700)
+        }
+    }
+
+    private final class TaskSchedulerStub: AlertTaskScheduler, @unchecked Sendable {
+        private let lock = NSLock()
+        private var registeredStorage: [String] = []
+        private var submittedStorage: [BGTaskRequest] = []
+
+        var registered: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return registeredStorage
+        }
+
+        var submitted: [BGTaskRequest] {
+            lock.lock()
+            defer { lock.unlock() }
+            return submittedStorage
+        }
+
+        func register(
+            forTaskWithIdentifier identifier: String, using queue: DispatchQueue?,
+            launchHandler: @escaping @Sendable (BGTask) -> Void
+        ) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            registeredStorage.append(identifier)
+            return true
+        }
+
+        func submit(_ taskRequest: BGTaskRequest) throws {
+            lock.lock()
+            defer { lock.unlock() }
+            submittedStorage.append(taskRequest)
+        }
+    }
+#endif

--- a/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertBacktestTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertBacktestTests.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+struct AlertBacktestTests {
+    private let dropRule = AlertRule(
+        metric: .eventCount(name: "Session"),
+        condition: AlertCondition(comparison: .below, reference: .constant(5))
+    )
+
+    @Test("A history shorter than two windows never fires")
+    func shortHistory() {
+        let backtest = AlertBacktest(values: Array(repeating: 1, count: 47))
+
+        #expect(backtest.fireCount(for: dropRule) == 0)
+    }
+
+    @Test("A healthy history never fires")
+    func healthy() {
+        let backtest = AlertBacktest(values: Array(repeating: 10, count: 96))
+
+        #expect(backtest.fireCount(for: dropRule) == 0)
+    }
+
+    @Test("A single drop fires once")
+    func singleDrop() {
+        let backtest = AlertBacktest(values: Array(repeating: 10, count: 48) + [1])
+
+        #expect(backtest.fireCount(for: dropRule) == 1)
+    }
+
+    @Test("A long-lasting drop still counts as one fire")
+    func longDrop() {
+        let backtest = AlertBacktest(values: Array(repeating: 10, count: 48) + Array(repeating: 1, count: 5))
+
+        #expect(backtest.fireCount(for: dropRule) == 1)
+    }
+
+    @Test("A recovery between drops re-arms and counts a second fire")
+    func twoDrops() {
+        let backtest = AlertBacktest(values: Array(repeating: 10, count: 48) + [1, 10, 1])
+
+        #expect(backtest.fireCount(for: dropRule) == 2)
+    }
+
+    @Test("A spike over the trailing baseline fires")
+    func baselineSpike() {
+        let rule = AlertRule(
+            metric: .eventCount(name: "Error"),
+            condition: AlertCondition(comparison: .above, reference: .baselineFactor(2))
+        )
+        let backtest = AlertBacktest(values: Array(repeating: 4, count: 48) + [20])
+
+        #expect(backtest.fireCount(for: rule) == 1)
+    }
+
+    @Test("Summaries phrase zero, one, and many fires")
+    func summaries() {
+        let none = AlertBacktest(values: Array(repeating: 10, count: 96))
+        let once = AlertBacktest(values: Array(repeating: 10, count: 48) + [1])
+        let twice = AlertBacktest(values: Array(repeating: 10, count: 48) + [1, 10, 1])
+
+        #expect(none.summary(for: dropRule) == "Would not have fired in the past week")
+        #expect(once.summary(for: dropRule) == "Would have fired once in the past week")
+        #expect(twice.summary(for: dropRule) == "Would have fired 2 times in the past week")
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertEvaluatorTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertEvaluatorTests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+@testable import Support
+
+struct AlertEvaluatorTests {
+    private let evaluator = AlertEvaluator()
+    private let now = Date(year: 2026, month: 7, day: 20, hour: 14)
+
+    private let rule = AlertRule(
+        metric: .crashFreeSessions,
+        condition: AlertCondition(comparison: .below, reference: .constant(0.995)),
+        holdBuckets: 2
+    )
+
+    private let breached = MetricReading(baseline: 0, recent: [0.998, 0.996, 0.994, 0.993])
+    private let healthy = MetricReading(baseline: 0, recent: [0.998, 0.996, 0.997, 0.998])
+
+    @Test("An armed rule fires and notifies when the breach sustains")
+    func fires() {
+        let outcome = evaluator.evaluate(rule, reading: breached, state: .armed, now: now)
+
+        #expect(outcome == AlertOutcome(state: .firing(since: now), shouldNotify: true))
+    }
+
+    @Test("An armed rule stays quiet while the metric is healthy")
+    func staysArmed() {
+        let outcome = evaluator.evaluate(rule, reading: healthy, state: .armed, now: now)
+
+        #expect(outcome == AlertOutcome(state: .armed, shouldNotify: false))
+    }
+
+    @Test("A firing rule keeps its start date and does not notify again")
+    func keepsFiring() {
+        let since = Date(year: 2026, month: 7, day: 20, hour: 12)
+        let outcome = evaluator.evaluate(rule, reading: breached, state: .firing(since: since), now: now)
+
+        #expect(outcome == AlertOutcome(state: .firing(since: since), shouldNotify: false))
+    }
+
+    @Test("A firing rule re-arms silently once the breach clears")
+    func recovers() {
+        let since = Date(year: 2026, month: 7, day: 20, hour: 12)
+        let outcome = evaluator.evaluate(rule, reading: healthy, state: .firing(since: since), now: now)
+
+        #expect(outcome == AlertOutcome(state: .armed, shouldNotify: false))
+    }
+
+    @Test("A muted rule suppresses a sustained breach until the mute expires")
+    func muted() {
+        let until = Date(year: 2026, month: 7, day: 20, hour: 16)
+        let outcome = evaluator.evaluate(rule, reading: breached, state: .muted(until: until), now: now)
+
+        #expect(outcome == AlertOutcome(state: .muted(until: until), shouldNotify: false))
+    }
+
+    @Test("An expired mute evaluates again and fires anew")
+    func muteExpired() {
+        let until = Date(year: 2026, month: 7, day: 20, hour: 13)
+        let outcome = evaluator.evaluate(rule, reading: breached, state: .muted(until: until), now: now)
+
+        #expect(outcome == AlertOutcome(state: .firing(since: now), shouldNotify: true))
+    }
+
+    @Test("An expired mute re-arms silently when the metric is healthy")
+    func muteExpiredHealthy() {
+        let until = Date(year: 2026, month: 7, day: 20, hour: 13)
+        let outcome = evaluator.evaluate(rule, reading: healthy, state: .muted(until: until), now: now)
+
+        #expect(outcome == AlertOutcome(state: .armed, shouldNotify: false))
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertStoreTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertStoreTests.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+@MainActor
+struct AlertStoreTests {
+    private let defaults = UserDefaults(suiteName: "AlertStoreTests-\(UUID().uuidString)")!
+
+    private let rule = AlertRule(
+        metric: .crashFreeSessions,
+        condition: AlertCondition(comparison: .below, reference: .constant(0.995)),
+        holdBuckets: 2
+    )
+
+    @Test("Rules survive a new store instance")
+    func rulesPersist() {
+        let store = AlertStore(defaults: defaults)
+        store.rules = [rule]
+
+        #expect(AlertStore(defaults: defaults).rules == [rule])
+    }
+
+    @Test("States survive a new store instance")
+    func statesPersist() {
+        let since = Date(timeIntervalSince1970: 1_000_000)
+        let store = AlertStore(defaults: defaults)
+        store.rules = [rule]
+        store.setState(.firing(since: since), for: rule)
+
+        #expect(AlertStore(defaults: defaults).state(for: rule) == .firing(since: since))
+    }
+
+    @Test("An unknown rule reads as armed")
+    func unknownRule() {
+        #expect(AlertStore(defaults: defaults).state(for: rule) == .armed)
+    }
+
+    @Test("Removing a rule clears its state")
+    func removalClearsState() {
+        let store = AlertStore(defaults: defaults)
+        store.rules = [rule]
+        store.setState(.firing(since: Date(timeIntervalSince1970: 0)), for: rule)
+
+        store.rules = []
+        store.rules = [rule]
+
+        #expect(store.state(for: rule) == .armed)
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Model/AlertConditionTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Model/AlertConditionTests.swift
@@ -1,0 +1,48 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+struct AlertConditionTests {
+    private let reading = MetricReading(baseline: 100, recent: [])
+
+    @Test("Falling below the reference is a breach")
+    func below() {
+        let condition = AlertCondition(comparison: .below, reference: .constant(0.995))
+
+        #expect(condition.isBreached(by: 0.99, in: reading))
+        #expect(!condition.isBreached(by: 0.998, in: reading))
+    }
+
+    @Test("Rising above the reference is a breach")
+    func above() {
+        let condition = AlertCondition(comparison: .above, reference: .baselineFactor(2))
+
+        #expect(condition.isBreached(by: 230, in: reading))
+        #expect(!condition.isBreached(by: 180, in: reading))
+    }
+
+    @Test("Sitting exactly on the reference is not a breach")
+    func equal() {
+        let below = AlertCondition(comparison: .below, reference: .constant(0.995))
+        let above = AlertCondition(comparison: .above, reference: .constant(0.995))
+
+        #expect(!below.isBreached(by: 0.995, in: reading))
+        #expect(!above.isBreached(by: 0.995, in: reading))
+    }
+
+    @Test("An unresolvable reference never breaches")
+    func unresolvable() {
+        let empty = MetricReading(baseline: 0, recent: [])
+        let condition = AlertCondition(comparison: .above, reference: .baselineFactor(2))
+
+        #expect(!condition.isBreached(by: 1000, in: empty))
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Model/AlertDraftTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Model/AlertDraftTests.swift
@@ -1,0 +1,112 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+struct AlertDraftTests {
+    @Test("The default draft is a crash-free threshold rule")
+    func defaults() {
+        let rule = AlertDraft().rule
+
+        #expect(rule.metric == .crashFreeSessions)
+        #expect(rule.condition == AlertCondition(comparison: .below, reference: .constant(0.995)))
+        #expect(rule.holdBuckets == 1)
+        #expect(rule.notifies)
+    }
+
+    @Test("Rising above maps to a baseline factor")
+    func risesAbove() {
+        var draft = AlertDraft()
+        draft.kind = .risesAbove
+
+        #expect(draft.rule.condition == AlertCondition(comparison: .above, reference: .baselineFactor(2)))
+    }
+
+    @Test("Spiking maps to a median factor")
+    func spikes() {
+        var draft = AlertDraft()
+        draft.kind = .spikes
+        draft.factor = 3
+
+        #expect(draft.rule.condition == AlertCondition(comparison: .above, reference: .medianFactor(3)))
+    }
+
+    @Test("An event draft carries its name and count threshold")
+    func event() {
+        var draft = AlertDraft()
+        draft.choice = .eventCount
+        draft.eventName = "Error"
+        draft.countThreshold = 50
+
+        #expect(draft.rule.metric == .eventCount(name: "Error"))
+        #expect(draft.rule.condition == AlertCondition(comparison: .below, reference: .constant(50)))
+    }
+
+    @Test("An event draft without a name is invalid")
+    func invalid() {
+        var draft = AlertDraft()
+        draft.choice = .eventCount
+
+        #expect(!draft.isValid)
+
+        draft.eventName = "Error"
+
+        #expect(draft.isValid)
+    }
+
+    @Test("The hold pills map to hourly buckets")
+    func hold() {
+        #expect(AlertDraft.Hold.allCases.map(\.buckets) == [1, 2, 6, 24])
+    }
+
+    @Test("Values format per metric and kind")
+    func valueText() {
+        var draft = AlertDraft()
+
+        #expect(draft.valueText == "99.50%")
+
+        draft.kind = .risesAbove
+
+        #expect(draft.valueText == "2×")
+
+        draft.kind = .fallsBelow
+        draft.choice = .eventCount
+
+        #expect(draft.valueText == "100")
+    }
+
+    @Test("Stepping the stability threshold respects its bounds")
+    func stabilityBounds() {
+        var draft = AlertDraft()
+        draft.stabilityThreshold = 0.9995
+
+        for _ in 0..<10 { draft.increment() }
+
+        #expect(draft.stabilityThreshold == 0.9999)
+
+        for _ in 0..<200 { draft.decrement() }
+
+        #expect(draft.stabilityThreshold == 0.9)
+    }
+
+    @Test("Stepping the factor respects its bounds")
+    func factorBounds() {
+        var draft = AlertDraft()
+        draft.kind = .spikes
+
+        for _ in 0..<30 { draft.increment() }
+
+        #expect(draft.factor == 10)
+
+        for _ in 0..<30 { draft.decrement() }
+
+        #expect(draft.factor == 1.5)
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Model/AlertRuleTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Model/AlertRuleTests.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+struct AlertRuleTests {
+    @Test("The default hold fires on the last bucket alone")
+    func defaultHold() {
+        let rule = makeRule()
+        let reading = MetricReading(baseline: 0, recent: [0.998, 0.997, 0.99])
+
+        #expect(rule.isSustained(in: reading))
+    }
+
+    @Test("A breach in only the last of three held buckets does not sustain")
+    func partialHold() {
+        let rule = makeRule(holdBuckets: 3)
+        let reading = MetricReading(baseline: 0, recent: [0.998, 0.997, 0.99])
+
+        #expect(!rule.isSustained(in: reading))
+    }
+
+    @Test("A breach across the full hold window sustains")
+    func fullHold() {
+        let rule = makeRule(holdBuckets: 3)
+        let reading = MetricReading(baseline: 0, recent: [0.998, 0.994, 0.993, 0.99])
+
+        #expect(rule.isSustained(in: reading))
+    }
+
+    @Test("A history shorter than the hold window cannot sustain")
+    func shortHistory() {
+        let rule = makeRule(holdBuckets: 3)
+        let reading = MetricReading(baseline: 0, recent: [0.99, 0.99])
+
+        #expect(!rule.isSustained(in: reading))
+    }
+
+    @Test("A spike over the median of a flat history sustains")
+    func spike() {
+        let rule = AlertRule(
+            metric: .eventCount(name: "Error"),
+            condition: AlertCondition(comparison: .above, reference: .medianFactor(3))
+        )
+        let reading = MetricReading(baseline: 0, recent: [4, 3, 4, 5, 3, 4, 14])
+
+        #expect(rule.isSustained(in: reading))
+    }
+
+    @Test("A flat history without a spike stays quiet")
+    func flat() {
+        let rule = AlertRule(
+            metric: .eventCount(name: "Error"),
+            condition: AlertCondition(comparison: .above, reference: .medianFactor(3))
+        )
+        let reading = MetricReading(baseline: 0, recent: [4, 3, 4, 5, 3, 4, 5])
+
+        #expect(!rule.isSustained(in: reading))
+    }
+
+    private func makeRule(holdBuckets: Int = 1) -> AlertRule {
+        AlertRule(
+            metric: .crashFreeSessions,
+            condition: AlertCondition(comparison: .below, reference: .constant(0.995)),
+            holdBuckets: holdBuckets
+        )
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Model/AlertStatusTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Model/AlertStatusTests.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+struct AlertStatusTests {
+    @Test("Detail pairs the current value with the condition")
+    func detail() {
+        let status = makeStatus(recent: [0.998, 0.9], state: .armed)
+
+        #expect(status.detail == "90.00% — below 99.50%")
+    }
+
+    @Test("An empty reading carries no detail")
+    func emptyDetail() {
+        let status = makeStatus(recent: [], state: .armed)
+
+        #expect(status.detail == nil)
+    }
+
+    @Test("The chart series preserves the shape of ratio readings")
+    func series() {
+        let status = makeStatus(recent: [0.998, 0.9], state: .armed)
+
+        #expect(status.series.values == [998, 900])
+    }
+
+    @Test("Only firing statuses count toward the badge")
+    func firingCount() {
+        let statuses = [
+            makeStatus(recent: [0.9], state: .firing(since: Date(timeIntervalSince1970: 0))),
+            makeStatus(recent: [0.998], state: .armed),
+            makeStatus(recent: [0.998], state: .muted(until: Date(timeIntervalSince1970: 0))),
+        ]
+
+        #expect(statuses.firingCount == 1)
+    }
+
+    private func makeStatus(recent: [Double], state: AlertState) -> AlertStatus {
+        AlertStatus(
+            rule: AlertRule(
+                metric: .crashFreeSessions,
+                condition: AlertCondition(comparison: .below, reference: .constant(0.995))
+            ),
+            outcome: AlertOutcome(state: state, shouldNotify: false),
+            reading: MetricReading(baseline: 0.998, recent: recent)
+        )
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Model/MetricReadingChartPointsTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Model/MetricReadingChartPointsTests.swift
@@ -1,0 +1,97 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+@testable import ScoutUI
+@testable import Support
+
+struct MetricReadingChartPointsTests {
+    private let scale = AlertScale(horizonDate: Date(year: 2026, month: 6, day: 8))
+
+    @Test("Hourly buckets land oldest first in the recent window")
+    func recentOrder() {
+        let reading = MetricReading(
+            points: [
+                makePoint(day: 7, hour: 0, count: 5),
+                makePoint(day: 7, hour: 23, count: 9),
+            ],
+            period: scale
+        )
+
+        #expect(reading.recent.count == 24)
+        #expect(reading.recent.first == 5)
+        #expect(reading.recent.last == 9)
+    }
+
+    @Test("Points within the same hour sum into one bucket")
+    func sameHour() {
+        let reading = MetricReading(
+            points: [
+                makePoint(day: 7, hour: 3, count: 2),
+                makePoint(day: 7, hour: 3, count: 3),
+            ],
+            period: scale
+        )
+
+        #expect(reading.recent[3] == 5)
+    }
+
+    @Test("Baseline is the median hourly bucket of the previous window")
+    func baseline() {
+        let points = (0..<24).map { makePoint(day: 6, hour: $0, count: 4) }
+        let reading = MetricReading(points: points, period: scale)
+
+        #expect(reading.baseline == 4)
+    }
+
+    @Test("An empty previous window carries no baseline to compare against")
+    func emptyPrevious() {
+        let reading = MetricReading(points: [makePoint(day: 7, hour: 1, count: 8)], period: scale)
+
+        #expect(reading.baseline == 0)
+        #expect(reading.reference(for: .baselineFactor(2)) == nil)
+    }
+
+    @Test("Crash-free stability is computed per hour")
+    func stability() {
+        let sessions = (0..<24).map { makePoint(day: 7, hour: $0, count: 10) }
+        let reading = MetricReading(
+            sessions: sessions,
+            crashes: [makePoint(day: 7, hour: 5, count: 1)],
+            period: scale
+        )
+
+        #expect(reading.recent[5] == 0.9)
+        #expect(reading.recent[6] == 1)
+    }
+
+    @Test("An idle hour reads as fully stable")
+    func idle() {
+        let reading = MetricReading(sessions: [], crashes: [], period: scale)
+
+        #expect(reading.recent.allSatisfy { $0 == 1 })
+        #expect(reading.baseline == 1)
+    }
+
+    @Test("A crashing hour with no sessions reads as fully unstable")
+    func crashesWithoutSessions() {
+        let reading = MetricReading(
+            sessions: [],
+            crashes: [makePoint(day: 7, hour: 3, count: 2)],
+            period: scale
+        )
+
+        #expect(reading.recent[3] == 0)
+    }
+
+    private func makePoint(day: Int, hour: Int, count: Int) -> ChartPoint<Int> {
+        ChartPoint(date: Date(year: 2026, month: 6, day: day, hour: hour), count: count)
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Model/MetricReadingTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Model/MetricReadingTests.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+struct MetricReadingTests {
+    @Test("A constant reference passes through untouched")
+    func constant() {
+        let reading = MetricReading(baseline: 100, recent: [])
+
+        #expect(reading.reference(for: .constant(0.995)) == 0.995)
+    }
+
+    @Test("A baseline factor scales the previous window's value")
+    func baselineFactor() {
+        let reading = MetricReading(baseline: 200, recent: [])
+
+        #expect(reading.reference(for: .baselineFactor(2)) == 400)
+    }
+
+    @Test("An empty baseline has nothing to compare against")
+    func emptyBaseline() {
+        let reading = MetricReading(baseline: 0, recent: [])
+
+        #expect(reading.reference(for: .baselineFactor(2)) == nil)
+    }
+
+    @Test("A median factor scales the middle of an odd-count history")
+    func medianFactorOdd() {
+        let reading = MetricReading(baseline: 0, recent: [8, 2, 4])
+
+        #expect(reading.reference(for: .medianFactor(3)) == 12)
+    }
+
+    @Test("A median factor averages the middle pair of an even-count history")
+    func medianFactorEven() {
+        let reading = MetricReading(baseline: 0, recent: [8, 2, 4, 6])
+
+        #expect(reading.reference(for: .medianFactor(2)) == 10)
+    }
+
+    @Test("An empty history has no median to scale")
+    func emptyHistory() {
+        let reading = MetricReading(baseline: 100, recent: [])
+
+        #expect(reading.reference(for: .medianFactor(3)) == nil)
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/View/AlertProviderTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/View/AlertProviderTests.swift
@@ -1,0 +1,158 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+@testable import ScoutUI
+@testable import Support
+
+@MainActor
+struct AlertProviderTests {
+    private let defaults = UserDefaults(suiteName: "AlertProviderTests-\(UUID().uuidString)")!
+
+    @Test("An error spike over the baseline fires once and stays firing on the next refresh")
+    func firesOnce() async throws {
+        let database = DatabaseStub()
+        database.add(series: makeSeries(name: "Error", counts: errorCounts))
+
+        let provider = makeProvider(rules: [errorRule])
+
+        let first = try await provider.fetch(in: database)
+
+        #expect(first.count == 1)
+        #expect(first[0].outcome.shouldNotify)
+
+        let second = try await provider.fetch(in: database)
+
+        #expect(!second[0].outcome.shouldNotify)
+        #expect(second[0].outcome.state == first[0].outcome.state)
+    }
+
+    @Test("A crash-free dip below the threshold fires")
+    func crashFree() async throws {
+        let database = DatabaseStub()
+        database.add(
+            series: makeSeries(
+                name: SessionEntry.recordType, counts: [(hoursAgo: 1, count: 10), (hoursAgo: 2, count: 10)]),
+            makeSeries(name: CrashEntry.recordType, counts: [(hoursAgo: 1, count: 1), (hoursAgo: 2, count: 1)])
+        )
+
+        let provider = makeProvider(rules: [crashFreeRule])
+        let statuses = try await provider.fetch(in: database)
+
+        #expect(statuses[0].outcome.shouldNotify)
+    }
+
+    @Test("A firing refresh posts one notification and the next refresh stays silent")
+    func deliversOnce() async throws {
+        let database = DatabaseStub()
+        database.add(series: makeSeries(name: "Error", counts: errorCounts))
+
+        let center = NotificationCenterStub()
+        let provider = makeProvider(rules: [errorRule], center: center)
+
+        _ = try await provider.fetch(in: database)
+
+        #expect(center.requests.count == 1)
+        #expect(center.requests.first?.content.title == "Error")
+
+        _ = try await provider.fetch(in: database)
+
+        #expect(center.requests.count == 1)
+    }
+
+    @Test("A firing state survives into a new provider instance")
+    func statePersists() async throws {
+        let database = DatabaseStub()
+        database.add(series: makeSeries(name: "Error", counts: errorCounts))
+
+        let center = NotificationCenterStub()
+
+        _ = try await makeProvider(rules: [errorRule], center: center).fetch(in: database)
+        _ = try await makeProvider(rules: [errorRule], center: center).fetch(in: database)
+
+        #expect(center.requests.count == 1)
+    }
+
+    @Test("A healthy metric stays armed")
+    func healthy() async throws {
+        let database = DatabaseStub()
+        database.add(series: makeSeries(name: SessionEntry.recordType, counts: [(hoursAgo: 1, count: 10)]))
+
+        let provider = makeProvider(rules: [crashFreeRule])
+        let statuses = try await provider.fetch(in: database)
+
+        #expect(statuses[0].outcome == AlertOutcome(state: .armed, shouldNotify: false))
+    }
+
+    @Test("Adding the first rule requests notification authorization once")
+    func firstRuleAuthorization() async {
+        let center = NotificationCenterStub()
+        let provider = makeProvider(rules: [], center: center)
+
+        await provider.add(errorRule)
+
+        #expect(center.authorizationRequests == 1)
+        #expect(provider.rules == [errorRule])
+
+        await provider.add(crashFreeRule)
+
+        #expect(center.authorizationRequests == 1)
+        #expect(provider.rules.count == 2)
+    }
+
+    @Test("Removing a rule leaves the others in place")
+    func remove() async {
+        let provider = makeProvider(rules: [errorRule, crashFreeRule])
+
+        provider.remove(errorRule)
+
+        #expect(provider.rules == [crashFreeRule])
+    }
+
+    private var errorRule: AlertRule {
+        AlertRule(
+            metric: .eventCount(name: "Error"),
+            condition: AlertCondition(comparison: .above, reference: .baselineFactor(2))
+        )
+    }
+
+    private var crashFreeRule: AlertRule {
+        AlertRule(
+            metric: .crashFreeSessions,
+            condition: AlertCondition(comparison: .below, reference: .constant(0.995)),
+            holdBuckets: 2
+        )
+    }
+
+    private var errorCounts: [(hoursAgo: Int, count: Int)] {
+        (25...48).map { (hoursAgo: $0, count: 4) } + [(hoursAgo: 1, count: 20)]
+    }
+
+    private func makeProvider(rules: [AlertRule], center: NotificationCenterStub? = nil) -> AlertProvider {
+        let store = AlertStore(defaults: defaults)
+        store.rules = rules
+        return AlertProvider(store: store, notifier: center.map { AlertNotifier(center: $0) })
+    }
+
+    private func makeSeries(name: String, counts: [(hoursAgo: Int, count: Int)]) -> MetricSeries {
+        let horizon = Date().startOfHour
+
+        return MetricSeries(
+            name: name,
+            category: nil,
+            points: counts.map {
+                MetricSeriesPoint(
+                    date: horizon.addingHour(-$0.hoursAgo).millisecondsSince1970,
+                    value: .int($0.count)
+                )
+            }
+        )
+    }
+}

--- a/Tests/ScoutUITests/Stubs/NotificationCenterStub.swift
+++ b/Tests/ScoutUITests/Stubs/NotificationCenterStub.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import UserNotifications
+
+@testable import ScoutUI
+
+final class NotificationCenterStub: AlertNotificationCenter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var grantedStorage = true
+    private var authorizationStorage = 0
+    private var requestStorage: [UNNotificationRequest] = []
+
+    var granted: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return grantedStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            grantedStorage = newValue
+        }
+    }
+
+    var authorizationRequests: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return authorizationStorage
+    }
+
+    var requests: [UNNotificationRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestStorage
+    }
+
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool {
+        recordAuthorization()
+    }
+
+    func add(_ request: UNNotificationRequest) async throws {
+        record(request)
+    }
+
+    private func recordAuthorization() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        authorizationStorage += 1
+        return grantedStorage
+    }
+
+    private func record(_ request: UNNotificationRequest) {
+        lock.lock()
+        defer { lock.unlock() }
+        requestStorage.append(request)
+    }
+}


### PR DESCRIPTION
Adds an alert engine to ScoutUI: user-defined rules watch a metric (crash-free sessions or an event count) and fire when it falls below a threshold, rises above a multiple of the previous day's baseline, or spikes over the trailing median, after holding for a configurable window. A firing rule posts a local notification once per incident, auto-resolves, and its armed/firing state persists in UserDefaults across launches. Home gains an Alerts section leading to a status list with an editor that backtests the drafted rule against the past week. The public ScoutAlerts facade lets host apps register a BGAppRefreshTask so rules are evaluated in the background; the companion wiring lives in kasianov-mikhail/scout-ip#638.