### PR TITLE
Temporarily disable two flaky Cache-related CI tests

### DIFF
--- a/Tests/ScoutTests/Persistence/MergePolicyTests.swift
+++ b/Tests/ScoutTests/Persistence/MergePolicyTests.swift
@@ -18,7 +18,10 @@ struct MergePolicyTests {
     /// the duplicate) to prove the merge policy dedupes a colliding insert
     /// instead of throwing.
     ///
-    @Test("A duplicate insert on the same natural key dedupes instead of throwing")
+    @Test(
+        "A duplicate insert on the same natural key dedupes instead of throwing",
+        .disabled("Flakes in CI with a Core Data change-processing crash")
+    )
     func duplicateInsertDedupes() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/Tests/ScoutUITests/Cache/CachePerformanceTests.swift
+++ b/Tests/ScoutUITests/Cache/CachePerformanceTests.swift
@@ -72,6 +72,7 @@ final class RecordCachePerformanceTests: XCTestCase {
 @available(iOS 17, macOS 14, *)
 final class CachedDatabasePerformanceTests: XCTestCase {
     func testCachedSeriesReadPerformance() throws {
+        try XCTSkipIf(true, "Flakes in CI; temporarily disabled")
         let base = SpyDatabase()
         base.series = makeSeries(versions: 40, points: 800)
         let cutoff = Date(timeIntervalSince1970: 3_000_000)


### PR DESCRIPTION
MergePolicyTests.duplicateInsertDedupes intermittently crashes CI's test-ios-26 leg with a Core Data change-processing exception (it also failed on main yesterday), and CachedDatabasePerformanceTests.testCachedSeriesReadPerformance flakes on the same leg under measure. Both are disabled with an explanatory reason until the underlying instability is investigated; nothing about the code under test changes here.