### PR TITLE
Move the empty-retention separator under the header

### DIFF
--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -55,7 +55,7 @@ struct HomeRetentionSection: View {
                 .placeholderTextStyle()
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 20)
-                .listRowSeparator(.hidden, edges: .top)
+                .listRowSeparator(.hidden, edges: .bottom)
 
         default:
             HomeRetentionRow(series: .placeholder) {}


### PR DESCRIPTION
In the Home Retention section's empty state, the separator was drawn below the "No results" row, so the line ended up under the whole section. The row hid its top separator (`edges: .top`), leaving the bottom one visible.

This switches to `edges: .bottom`: the bottom separator is hidden and the top one stays, so the line is drawn on the boundary between the RETENTION header and the content — right under the header, as intended.