### PR TITLE
Re-enable the two flaky CI tests with their root causes fixed

### DIFF
--- a/Tests/ScoutTests/Persistence/MergePolicyTests.swift
+++ b/Tests/ScoutTests/Persistence/MergePolicyTests.swift
@@ -18,10 +18,7 @@ struct MergePolicyTests {
     /// the duplicate) to prove the merge policy dedupes a colliding insert
     /// instead of throwing.
     ///
-    @Test(
-        "A duplicate insert on the same natural key dedupes instead of throwing",
-        .disabled("Flakes in CI with a Core Data change-processing crash")
-    )
+    @Test("A duplicate insert on the same natural key dedupes instead of throwing")
     func duplicateInsertDedupes() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -33,19 +30,27 @@ struct MergePolicyTests {
         ]
         try container.loadStore()
 
-        let context = container.viewContext
+        // The main-queue viewContext is off-limits here: Swift Testing runs on a
+        // background thread, and mutating it there races the main run loop's own
+        // change processing — an intermittent CI crash in
+        // -[NSManagedObjectContext _processPendingUpdates:]. A private-queue
+        // context confines every mutation to performAndWait instead.
+        let context = container.newBackgroundContext()
+        context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+
         let eventID = UUID()
+        let events = try context.performAndWait {
+            let first = EventEntry.stub(name: "first", in: context)
+            first.eventID = eventID
+            try context.save()
 
-        let first = EventEntry.stub(name: "first", in: context)
-        first.eventID = eventID
-        try context.save()
+            let second = EventEntry.stub(name: "second", in: context)
+            second.eventID = eventID
+            try context.save()
 
-        let second = EventEntry.stub(name: "second", in: context)
-        second.eventID = eventID
-        try context.save()
-
-        let request = NSFetchRequest<EventEntry>(entityName: "EventEntry")
-        let events = try context.fetch(request)
+            let request = NSFetchRequest<EventEntry>(entityName: "EventEntry")
+            return try context.fetch(request)
+        }
         #expect(events.count == 1)
     }
 }

--- a/Tests/ScoutUITests/Cache/CachePerformanceTests.swift
+++ b/Tests/ScoutUITests/Cache/CachePerformanceTests.swift
@@ -72,9 +72,10 @@ final class RecordCachePerformanceTests: XCTestCase {
 @available(iOS 17, macOS 14, *)
 final class CachedDatabasePerformanceTests: XCTestCase {
     func testCachedSeriesReadPerformance() throws {
-        try XCTSkipIf(true, "Flakes in CI; temporarily disabled")
         let base = SpyDatabase()
-        base.series = makeSeries(versions: 40, points: 800)
+        // Sized so the warm-up store finishes well inside runBlocking's timeout:
+        // at 40×800 the 32k-row SwiftData insert alone brushed 60s on CI runners.
+        base.series = makeSeries(versions: 10, points: 400)
         let cutoff = Date(timeIntervalSince1970: 3_000_000)
         let database = CachedDatabase(
             base: base,


### PR DESCRIPTION
Re-enables the two tests disabled in #1036. MergePolicyTests.duplicateInsertDedupes crashed because it mutated the main-queue viewContext from Swift Testing's background thread, racing the main run loop's Core Data change processing (the CI stack shows save: → _processRecentChanges → _processPendingUpdates hitting a nil in the context's internal set); it now runs on a private-queue context via performAndWait. testCachedSeriesReadPerformance wasn't a measure failure at all — the CI log shows the 60-second runBlocking timeout on the warm-up store of 32,000 SwiftData rows on a debug x86_64 runner — so the dataset shrinks to 4,000 points, in line with the neighboring 5,000-record perf tests that never flaked. Verified locally by running the full Scout-Package bundle (build-for-testing / test-without-building); both tests execute and pass.