### PR TITLE
Fix the Core Data queue-confinement violation behind the MergePolicyTests flake

### DIFF
--- a/Tests/ScoutTests/Persistence/MergePolicyTests.swift
+++ b/Tests/ScoutTests/Persistence/MergePolicyTests.swift
@@ -11,6 +11,7 @@ import Testing
 @testable import Scout
 @testable import Support
 
+@MainActor
 @Suite("Merge policy")
 struct MergePolicyTests {
     /// Uniqueness constraints are only enforced by the SQLite store, so this
@@ -18,10 +19,7 @@ struct MergePolicyTests {
     /// the duplicate) to prove the merge policy dedupes a colliding insert
     /// instead of throwing.
     ///
-    @Test(
-        "A duplicate insert on the same natural key dedupes instead of throwing",
-        .disabled("Flakes in CI with a Core Data change-processing crash")
-    )
+    @Test("A duplicate insert on the same natural key dedupes instead of throwing")
     func duplicateInsertDedupes() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/Tests/Support/Transient/InMemoryContext.swift
+++ b/Tests/Support/Transient/InMemoryContext.swift
@@ -11,8 +11,6 @@ import Testing
 @testable import Scout
 
 extension NSManagedObjectContext {
-    // Returns the container's main-queue viewContext, so callers must be
-    // @MainActor-isolated — the annotation makes the compiler enforce it.
     @MainActor
     static func inMemoryContext() -> NSManagedObjectContext {
         let container = NSPersistentContainer(named: "ScoutModel")

--- a/Tests/Support/Transient/InMemoryContext.swift
+++ b/Tests/Support/Transient/InMemoryContext.swift
@@ -11,6 +11,9 @@ import Testing
 @testable import Scout
 
 extension NSManagedObjectContext {
+    // Returns the container's main-queue viewContext, so callers must be
+    // @MainActor-isolated — the annotation makes the compiler enforce it.
+    @MainActor
     static func inMemoryContext() -> NSManagedObjectContext {
         let container = NSPersistentContainer(named: "ScoutModel")
 


### PR DESCRIPTION
MergePolicyTests was the only Core Data test suite not isolated to the main actor, so its body mutated a main-queue viewContext from Swift Testing's background threads — the source of the intermittent change-processing crash (`-[NSManagedObjectContext _processPendingUpdates:]`) on the test-ios-26 CI leg that led to disabling `duplicateInsertDedupes` in #1036. This isolates the suite with `@MainActor` and re-enables the test.

`NSManagedObjectContext.inMemoryContext()` is now also annotated `@MainActor`: it hands out a main-queue viewContext, and the annotation makes the compiler reject any future suite that consumes it without main-actor isolation. All 26 existing call sites are already `@MainActor` suites, so no call-site changes were needed — switching the helper to a background context was considered and rejected, since it would force `perform` wrapping across all those files with no safety gain.