### PR TITLE
Exclude the alert background scheduler from the macOS build

### DIFF
--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#if canImport(BackgroundTasks)
+#if canImport(BackgroundTasks) && !os(macOS)
     import BackgroundTasks
     import Foundation
 

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#if canImport(BackgroundTasks)
+#if canImport(BackgroundTasks) && !os(macOS)
     import Foundation
     import Scout
 

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertRefreshSchedulerTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertRefreshSchedulerTests.swift
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#if canImport(BackgroundTasks)
+#if canImport(BackgroundTasks) && !os(macOS)
     import BackgroundTasks
     import Foundation
     import Testing


### PR DESCRIPTION
The alert background-refresh scheduler gates on canImport(BackgroundTasks), but that module ships on macOS while BGTaskScheduler/BGTask are unavailable there, so the macOS build of the package fails to compile. This stayed latent because only the Server contract job builds the package for macOS, and it runs solely on wire-surface changes. Narrow the gate to canImport(BackgroundTasks) && !os(macOS), which keeps iOS, tvOS, visionOS, and Mac Catalyst — where the API exists — and drops native macOS. Verified with a macOS build-for-testing of Scout-Package.