### PR TITLE
Render monospaced navigation titles as a reliable inline principal title

### DIFF
--- a/Sources/ScoutUI/Primitives/Styles/View+MonospacedNavigationTitle.swift
+++ b/Sources/ScoutUI/Primitives/Styles/View+MonospacedNavigationTitle.swift
@@ -11,70 +11,15 @@ import SwiftUI
 
 extension View {
     func monospacedNavigationTitle(en title: String) -> some View {
-        #if canImport(UIKit)
-            navigationTitle(en: title)
-                .navigationBarTitleDisplayMode(.large)
-                .background(MonospacedNavigationBar())
-        #else
-            navigationTitle(en: title)
-        #endif
-    }
-}
-
-#if canImport(UIKit)
-    private struct MonospacedNavigationBar: UIViewControllerRepresentable {
-        func makeUIViewController(context: Context) -> Controller {
-            Controller()
-        }
-
-        func updateUIViewController(_ controller: Controller, context: Context) {}
-
-        final class Controller: UIViewController {
-            private var originals: [TitleFonts] = []
-
-            override func viewWillAppear(_ animated: Bool) {
-                super.viewWillAppear(animated)
-
-                guard let bar = navigationController?.navigationBar else { return }
-
-                originals = bar.allAppearances.map(TitleFonts.init)
-
-                for appearance in bar.allAppearances {
-                    appearance.largeTitleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 24, weight: .bold)
-                    appearance.titleTextAttributes[.font] = UIFont.monospacedSystemFont(ofSize: 17, weight: .semibold)
+        navigationTitle(en: title)
+            .inlineNavigationTitle()
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text(verbatim: title)
+                        .font(.system(.headline, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
                 }
             }
-
-            override func viewWillDisappear(_ animated: Bool) {
-                super.viewWillDisappear(animated)
-                originals.forEach { $0.restore() }
-            }
-        }
     }
-
-    @MainActor
-    private struct TitleFonts {
-        let appearance: UINavigationBarAppearance
-        let largeTitle: UIFont?
-        let title: UIFont?
-
-        init(_ appearance: UINavigationBarAppearance) {
-            self.appearance = appearance
-            self.largeTitle = appearance.largeTitleTextAttributes[.font] as? UIFont
-            self.title = appearance.titleTextAttributes[.font] as? UIFont
-        }
-
-        func restore() {
-            appearance.largeTitleTextAttributes[.font] = largeTitle
-            appearance.titleTextAttributes[.font] = title
-        }
-    }
-
-    extension UINavigationBar {
-        fileprivate var allAppearances: [UINavigationBarAppearance] {
-            [standardAppearance, compactAppearance, scrollEdgeAppearance, compactScrollEdgeAppearance].compactMap(
-                \.self)
-        }
-    }
-
-#endif
+}


### PR DESCRIPTION
The `.monospacedNavigationTitle(en:)` modifier used to force a monospaced large title by mutating `UINavigationBarAppearance` fonts, but iOS 26 renders the large navigation title with its own SwiftUI view and ignores those appearance fonts, so event/crash/endpoint names showed up in the proportional system font on device (it only looked right in a static hosted snapshot).

This drops the `UINavigationBarAppearance` representable and instead renders the title as an inline `.principal` toolbar item, which is a plain SwiftUI view that honours `.font(.system(.headline, design: .monospaced))` — so the monospaced rendering is reliable on device. The visible large title becomes a smaller inline title (chosen tradeoff, since a reliably monospaced large title isn't achievable on iOS 26). The modifier signature is unchanged, so all fourteen call sites are unaffected; `navigationTitle(en:)` stays for the back-button label and accessibility, and long titles truncate in the middle.