### PR TITLE
Route Gauge through the last-value handler

### DIFF
--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryFactory.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryFactory.swift
@@ -21,11 +21,13 @@ struct TelemetryFactory: MetricsFactory {
     }
 
     func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
-        MeterHandlerImpl(label: label, sync: sync, session: session)
+        GaugeHandler(label: label, sync: sync, session: session)
     }
 
+    // A non-aggregating recorder is what `Gauge` asks for: each value replaces the last one.
     func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
-        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        guard aggregate else { return GaugeHandler(label: label, sync: sync, session: session) }
+        return TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
     }
 
     func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler.swift
@@ -62,7 +62,10 @@ extension TelemetryHandler: RecorderHandler {
     }
 }
 
-final class MeterHandlerImpl: NSObject, TelemetryPersisting {
+/// Backs both `Meter` and `Gauge`, which share point-in-time semantics: every operation resolves to an
+/// absolute value that the backend reads back with `SeriesQuery.Reduce.last`.
+///
+final class GaugeHandler: NSObject, TelemetryPersisting {
     let label: String
     let sync: Synchronize
     let session: Protected<UUID>
@@ -75,7 +78,7 @@ final class MeterHandlerImpl: NSObject, TelemetryPersisting {
     }
 }
 
-extension MeterHandlerImpl: MeterHandler {
+extension GaugeHandler: MeterHandler {
     func set(_ value: Int64) {
         set(Double(value))
     }
@@ -90,5 +93,15 @@ extension MeterHandlerImpl: MeterHandler {
 
     func decrement(by amount: Double) {
         logMeter(value: value.mutate { $0 -= amount })
+    }
+}
+
+extension GaugeHandler: RecorderHandler {
+    func record(_ value: Int64) {
+        set(value)
+    }
+
+    func record(_ value: Double) {
+        set(value)
     }
 }

--- a/Tests/ScoutTests/Diagnostics/Telemetry/TelemetryFactoryTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Telemetry/TelemetryFactoryTests.swift
@@ -32,16 +32,22 @@ struct TelemetryFactoryTests {
         #expect(handler is TelemetryHandler)
     }
 
-    @Test("makeMeter returns MeterHandlerImpl")
+    @Test("makeMeter returns GaugeHandler")
     func makeMeter() {
         let handler = factory.makeMeter(label: "test", dimensions: [])
-        #expect(handler is MeterHandlerImpl)
+        #expect(handler is GaugeHandler)
     }
 
-    @Test("makeRecorder returns TelemetryHandler")
-    func makeRecorder() {
-        let handler = factory.makeRecorder(label: "test", dimensions: [], aggregate: false)
+    @Test("An aggregating recorder returns TelemetryHandler")
+    func makeAggregatingRecorder() {
+        let handler = factory.makeRecorder(label: "test", dimensions: [], aggregate: true)
         #expect(handler is TelemetryHandler)
+    }
+
+    @Test("A non-aggregating recorder backs Gauge with GaugeHandler")
+    func makeNonAggregatingRecorder() {
+        let handler = factory.makeRecorder(label: "test", dimensions: [], aggregate: false)
+        #expect(handler is GaugeHandler)
     }
 
     @Test("makeCounter preserves label and dimensions")


### PR DESCRIPTION
`makeRecorder` ignored its `aggregate` flag and always returned the aggregating handler, so `Gauge` — which swift-metrics implements as `Recorder(aggregate: false)`, where each value replaces the previous one — was persisted as an accumulating distribution. Its totals and percentiles were therefore meaningless.

A non-aggregating recorder now returns the same point-in-time handler that backs `Meter`, so a gauge writes its absolute value and reads back through `SeriesQuery.Reduce.last`. Meter and Gauge are the same concept, so they share the handler, the `meter` category, and the existing Meter tab in the UI; the handler is renamed `GaugeHandler` to reflect that it serves both. This also stays correct if a future swift-metrics release re-backs `Gauge` onto `Meter`, since both routes land on the same handler.

Closes the last mishandled metric kind — all five swift-metrics handler types now persist with the right semantics.