### PR TITLE
Show a type-specific swift-metrics snippet in the metrics placeholder

### DIFF
--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
@@ -32,7 +32,7 @@ struct MetricsContent<T: ChartNumeric>: View {
                     text: "No results",
                     systemImage: "chart.bar",
                     description: "Metrics will appear here once your app records data",
-                    code: "Counter(label: \"api_calls\").increment()"
+                    code: telemetry.snippet
                 )
             } else {
                 List(ranked) { group in
@@ -102,7 +102,7 @@ struct MetricsContent<T: ChartNumeric>: View {
             text: "No results",
             systemImage: "chart.bar",
             description: "Metrics will appear here once your app records data",
-            code: "Counter(label: \"api_calls\").increment()"
+            code: Telemetry.Export.timer.snippet
         )
         .navigationTitle(en: "Metrics")
     }

--- a/Sources/ScoutUI/Monitoring/Metrics/TelemetrySnippet.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/TelemetrySnippet.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+
+extension Telemetry.Export {
+    var snippet: String {
+        switch self {
+        case .counter:
+            """
+            Counter(
+                label: "api_calls"
+            )
+            .increment()
+            """
+        case .floatingCounter:
+            """
+            FloatingPointCounter(
+                label: "mb"
+            )
+            .increment(by: 1.5)
+            """
+        case .meter:
+            """
+            Meter(
+                label: "queue_depth"
+            )
+            .set(12)
+            """
+        case .recorder:
+            """
+            Recorder(
+                label: "payload_size"
+            )
+            .record(1024)
+            """
+        case .timer:
+            """
+            Timer(
+                label: "request_duration"
+            )
+            .recordSeconds(0.42)
+            """
+        }
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Metrics/TelemetrySnippet.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/TelemetrySnippet.swift
@@ -12,38 +12,28 @@ extension Telemetry.Export {
         switch self {
         case .counter:
             """
-            Counter(
-                label: "api_calls"
-            )
-            .increment()
+            Counter(label: "api_calls")
+                .increment()
             """
         case .floatingCounter:
             """
-            FloatingPointCounter(
-                label: "mb"
-            )
-            .increment(by: 1.5)
+            FloatingPointCounter(label: "mb")
+                .increment(by: 1.5)
             """
         case .meter:
             """
-            Meter(
-                label: "queue_depth"
-            )
-            .set(12)
+            Meter(label: "queue_depth")
+                .set(12)
             """
         case .recorder:
             """
-            Recorder(
-                label: "payload_size"
-            )
-            .record(1024)
+            Recorder(label: "payload_size")
+                .record(1024)
             """
         case .timer:
             """
-            Timer(
-                label: "request_duration"
-            )
-            .recordSeconds(0.42)
+            Timer(label: "request_duration")
+                .recordSeconds(0.42)
             """
         }
     }


### PR DESCRIPTION
The empty state on every metrics tab showed the same `Counter(label: "api_calls").increment()` example, which is wrong code for the Double, Timer, Recorder and Meter tabs. A new `Telemetry.Export.snippet` maps each export type to the matching swift-metrics call, and `MetricsContent` renders the snippet for the tab currently on screen.

Each snippet breaks over two lines with the call on the second one, because the code chip fits about 35 monospaced characters and the previous one-liners wrapped at arbitrary points — the Timer example left a lone closing paren on a third line. The longest line is now 33 characters, so nothing wraps on any screen size.