### PR TITLE
Record counter resets as markers and show them on the chart

### DIFF
--- a/Sources/Scout/Diagnostics/Telemetry/ResetMarker.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/ResetMarker.swift
@@ -1,0 +1,11 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+package enum ResetMarker {
+    package static let category = "counter_reset"
+}

--- a/Sources/Scout/Diagnostics/Telemetry/Telemetry.Export.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/Telemetry.Export.swift
@@ -14,6 +14,11 @@ extension Telemetry {
         case meter = "meter"
         case recorder = "recorder"
         case timer = "timer"
+
+        /// Whether the metric can be reset, which only counters can be.
+        package var hasResets: Bool {
+            self == .counter || self == .floatingCounter
+        }
     }
 
     enum ExportError: LocalizedError {

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler.swift
@@ -27,7 +27,12 @@ final class TelemetryHandler: NSObject, TelemetryPersisting {
         self.session = session
     }
 
-    func reset() {}
+    // Counters are stored as a stream of increments, so there is no running total to zero out.
+    // A reset is recorded as its own marker instead, leaving the increments that already
+    // happened intact and letting the charts show where the counter restarted.
+    func reset() {
+        logMetrics(category: ResetMarker.category, value: 1)
+    }
 }
 
 extension TelemetryHandler: CounterHandler {

--- a/Sources/ScoutUI/Home/Search/Detail/MetricSearchDetail.swift
+++ b/Sources/ScoutUI/Home/Search/Detail/MetricSearchDetail.swift
@@ -63,7 +63,8 @@ private struct MetricSearchContent<T: ChartNumeric>: View {
                         )
                     }
                 default:
-                    MetricsView(group: group, formatter: formatter, period: .today)
+                    MetricsView(
+                        group: group, formatter: formatter, period: .today, tracksResets: telemetry.hasResets)
                 }
             } else {
                 Placeholder(

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
@@ -71,7 +71,7 @@ struct MetricsContent<T: ChartNumeric>: View {
                 )
             }
         default:
-            MetricsView(group: group, formatter: formatter, period: period)
+            MetricsView(group: group, formatter: formatter, period: period, tracksResets: telemetry.hasResets)
         }
     }
 

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
@@ -18,14 +18,19 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
     @State private var isComparing = false
     @ViewBuilder let extra: (ChartExtent<Period>) -> Extra
 
+    @StateObject private var resets: ResetMarkerProvider
+    @Environment(\.database) var database
+
     init(
-        group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period,
+        group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period, tracksResets: Bool = false,
         @ViewBuilder extra: @escaping (ChartExtent<Period>) -> Extra
     ) {
         self.group = group
         self.formatter = formatter
         self.extra = extra
         self._extent = State(wrappedValue: ChartExtent(period: period))
+        self._resets = StateObject(
+            wrappedValue: ResetMarkerProvider(name: group.name, isEnabled: tracksResets))
     }
 
     var body: some View {
@@ -42,10 +47,14 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
                 points: group.points,
                 extent: extent,
                 color: .blue,
-                isComparing: isComparing
+                isComparing: isComparing,
+                markers: resets.dates(in: extent.domain)
             )
             .chartYAxis(content: { formattedMarks })
             .listRowSeparator(.hidden)
+            .autoRefresh {
+                await resets.fetchLatest(in: database)
+            }
 
             ComparisonToggle(isOn: $isComparing)
                 .disabled(!extent.canCompare(points: group.points, segment: segment))
@@ -77,8 +86,8 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
 }
 
 extension MetricsView where Extra == EmptyView {
-    init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period) {
-        self.init(group: group, formatter: formatter, period: period) { _ in EmptyView() }
+    init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period, tracksResets: Bool = false) {
+        self.init(group: group, formatter: formatter, period: period, tracksResets: tracksResets) { _ in EmptyView() }
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Metrics/ResetMarkerProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/ResetMarkerProvider.swift
@@ -1,0 +1,49 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Scout
+
+/// Loads the points where a counter was reset, so the chart can mark them.
+///
+/// Only counters carry resets, so a provider built for any other telemetry stays idle and
+/// resolves to no markers rather than querying a category that cannot match.
+///
+class ResetMarkerProvider: ObservableObject, Provider {
+    @Published var result: ProviderResult<[Date]>?
+
+    private let name: String
+    private let isEnabled: Bool
+
+    init(name: String, isEnabled: Bool) {
+        self.name = name
+        self.isEnabled = isEnabled
+    }
+
+    func fetch(in database: DatabaseReader) async throws -> [Date] {
+        guard isEnabled else { return [] }
+
+        let series = try await database.metricSeries(
+            Int.self,
+            category: ResetMarker.category,
+            in: Calendar.utc.defaultRange
+        )
+
+        return
+            series
+            .filter { $0.name == name }
+            .flatMap(\.points)
+            .map { Date(millisecondsSince1970: $0.date) }
+            .sorted()
+    }
+
+    func dates(in range: Range<Date>) -> [Date] {
+        guard case .success(let dates)? = result else { return [] }
+        return dates.filter(range.contains)
+    }
+}

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparableChart.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparableChart.swift
@@ -20,6 +20,7 @@ struct ComparableChart<T: ChartNumeric, S: ChartTimeScale>: View {
     let extent: ChartExtent<S>
     let color: Color
     let isComparing: Bool
+    var markers: [Date] = []
 
     var body: some View {
         if isComparing {
@@ -30,7 +31,7 @@ struct ComparableChart<T: ChartNumeric, S: ChartTimeScale>: View {
                 color: color
             )
         } else {
-            ChartView(segment: segment, timing: extent)
+            ChartView(segment: segment, timing: extent, markers: markers)
                 .foregroundStyle(color)
         }
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/View/ChartView.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/View/ChartView.swift
@@ -12,16 +12,25 @@ import SwiftUI
 struct ChartView<T: ChartNumeric>: View {
     let segment: [ChartPoint<T>]
     let timing: ChartTiming
+    var markers: [Date] = []
 
     var body: some View {
         let isEmpty = segment.total == .zero
 
-        Chart(segment, id: \.date) { point in
-            BarMark(
-                x: .value("X", point.date, unit: timing.unit),
-                y: .value("Y", point.count),
-                width: .ratio(ChartGeometry.barRatio)
-            )
+        Chart {
+            ForEach(segment, id: \.date) { point in
+                BarMark(
+                    x: .value("X", point.date, unit: timing.unit),
+                    y: .value("Y", point.count),
+                    width: .ratio(ChartGeometry.barRatio)
+                )
+            }
+
+            ForEach(markers, id: \.self) { marker in
+                RuleMark(x: .value("Reset", marker, unit: timing.unit))
+                    .foregroundStyle(Color.gray.opacity(0.55))
+                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+            }
         }
         .placeholderAxis(active: isEmpty)
         .chartXAxis {

--- a/Tests/ScoutUITests/Monitoring/Metrics/ResetMarkerProviderTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Metrics/ResetMarkerProviderTests.swift
@@ -1,0 +1,81 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+@testable import ScoutUI
+@testable import Support
+
+@MainActor
+struct ResetMarkerProviderTests {
+    private let first = Date(year: 2026, month: 6, day: 10, hour: 9)
+    private let second = Date(year: 2026, month: 6, day: 10, hour: 14)
+    private let foreign = Date(year: 2026, month: 6, day: 10, hour: 11)
+
+    private func markers() -> ServerStub {
+        ServerStub(metrics: [
+            MetricSeries(
+                name: "api_calls",
+                category: ResetMarker.category,
+                points: [
+                    MetricSeriesPoint(date: first.millisecondsSince1970, value: .int(1)),
+                    MetricSeriesPoint(date: second.millisecondsSince1970, value: .int(1)),
+                ]
+            ),
+            MetricSeries(
+                name: "errors",
+                category: ResetMarker.category,
+                points: [MetricSeriesPoint(date: foreign.millisecondsSince1970, value: .int(1))]
+            ),
+        ])
+    }
+
+    @Test("Markers resolve to the reset dates of the named counter only")
+    func fetchKeepsTheNamedCounter() async throws {
+        let provider = ResetMarkerProvider(name: "api_calls", isEnabled: true)
+        await provider.fetchIfNeeded(in: markers())
+
+        #expect(try provider.result?.get() == [first, second])
+    }
+
+    @Test("A disabled provider resolves to no markers")
+    func disabledProviderStaysEmpty() async throws {
+        let provider = ResetMarkerProvider(name: "api_calls", isEnabled: false)
+        await provider.fetchIfNeeded(in: markers())
+
+        #expect(try provider.result?.get() == [])
+    }
+
+    @Test("dates(in:) keeps only the markers inside the range")
+    func datesAreClippedToTheRange() async {
+        let provider = ResetMarkerProvider(name: "api_calls", isEnabled: true)
+        await provider.fetchIfNeeded(in: markers())
+
+        let from = Date(year: 2026, month: 6, day: 10, hour: 10)
+
+        #expect(provider.dates(in: from..<second.addingTimeInterval(1)) == [second])
+    }
+
+    @Test("dates(in:) is empty before the markers load")
+    func datesAreEmptyWithoutAResult() {
+        let provider = ResetMarkerProvider(name: "api_calls", isEnabled: true)
+
+        #expect(provider.dates(in: first..<second).isEmpty)
+    }
+
+    @Test("Only counters carry resets")
+    func onlyCountersHaveResets() {
+        #expect(Telemetry.Export.counter.hasResets)
+        #expect(Telemetry.Export.floatingCounter.hasResets)
+        #expect(!Telemetry.Export.timer.hasResets)
+        #expect(!Telemetry.Export.recorder.hasResets)
+        #expect(!Telemetry.Export.meter.hasResets)
+    }
+}


### PR DESCRIPTION
`CounterHandler.reset()` was an empty stub. Counters are stored as a stream of increments rather than a running total, so there is nothing to zero out — and writing a compensating negative row would corrupt the per-bucket view by hiding increments that really happened. A reset is recorded as its own marker instead, under a `counter_reset` category alongside the existing bucket categories, leaving the increment history intact.

The metric detail chart draws a dashed vertical rule wherever a counter was reset, so restarts are visible without distorting the bars. Markers are loaded by a small provider that stays idle for any telemetry that cannot be reset, so only counters and floating-point counters pay for the extra query. Comparison mode leaves the marks off to keep the overlay readable.