### PR TITLE
Drop the comments added with the metrics handlers

### DIFF
--- a/Sources/Scout/Diagnostics/Telemetry/Telemetry.Export.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/Telemetry.Export.swift
@@ -15,7 +15,6 @@ extension Telemetry {
         case recorder = "recorder"
         case timer = "timer"
 
-        /// Whether the metric can be reset, which only counters can be.
         package var hasResets: Bool {
             self == .counter || self == .floatingCounter
         }

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryFactory.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryFactory.swift
@@ -24,7 +24,6 @@ struct TelemetryFactory: MetricsFactory {
         GaugeHandler(label: label, sync: sync, session: session)
     }
 
-    // A non-aggregating recorder is what `Gauge` asks for: each value replaces the last one.
     func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
         guard aggregate else { return GaugeHandler(label: label, sync: sync, session: session) }
         return TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler.swift
@@ -27,9 +27,6 @@ final class TelemetryHandler: NSObject, TelemetryPersisting {
         self.session = session
     }
 
-    // Counters are stored as a stream of increments, so there is no running total to zero out.
-    // A reset is recorded as its own marker instead, leaving the increments that already
-    // happened intact and letting the charts show where the counter restarted.
     func reset() {
         logMetrics(category: ResetMarker.category, value: 1)
     }
@@ -67,9 +64,6 @@ extension TelemetryHandler: RecorderHandler {
     }
 }
 
-/// Backs both `Meter` and `Gauge`, which share point-in-time semantics: every operation resolves to an
-/// absolute value that the backend reads back with `SeriesQuery.Reduce.last`.
-///
 final class GaugeHandler: NSObject, TelemetryPersisting {
     let label: String
     let sync: Synchronize

--- a/Sources/ScoutUI/Monitoring/Metrics/ResetMarkerProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/ResetMarkerProvider.swift
@@ -9,11 +9,6 @@
 import Foundation
 import Scout
 
-/// Loads the points where a counter was reset, so the chart can mark them.
-///
-/// Only counters carry resets, so a provider built for any other telemetry stays idle and
-/// resolves to no markers rather than querying a category that cannot match.
-///
 class ResetMarkerProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[Date]>?
 


### PR DESCRIPTION
The Recorder, Meter, Gauge and counter-reset work left behind comments the codebase does not want: doc comments on `GaugeHandler`, `ResetMarkerProvider` and `hasResets`, which are internal or package rather than public API, plus inline notes on `reset()` and `makeRecorder`. Removing them; only the license headers and the comments that predate this work remain.