### PR TITLE
Make Recorder and Meter searchable and keep zero gauges listed

### DIFF
--- a/Sources/ScoutUI/Home/Search/Detail/MetricSearchDetail.swift
+++ b/Sources/ScoutUI/Home/Search/Detail/MetricSearchDetail.swift
@@ -14,7 +14,7 @@ struct MetricSearchDetail: View {
 
     var body: some View {
         switch telemetry {
-        case .floatingCounter:
+        case .floatingCounter, .recorder, .meter:
             MetricSearchContent(name: name, telemetry: telemetry, formatter: \Double.decimal)
         case .timer:
             MetricSearchContent(name: name, telemetry: telemetry, formatter: \TimeInterval.duration)

--- a/Sources/ScoutUI/Home/Search/Index/GlobalSearchIndex.swift
+++ b/Sources/ScoutUI/Home/Search/Index/GlobalSearchIndex.swift
@@ -30,7 +30,7 @@ struct GlobalSearchIndex {
         self.hangs = hangs
     }
 
-    static let telemetries: [Telemetry.Export] = [.counter, .floatingCounter, .timer]
+    static let telemetries: [Telemetry.Export] = [.counter, .floatingCounter, .timer, .recorder, .meter]
 
     private static let endpointCategories = Set(LatencyBuckets.categories + StatusBuckets.categories)
 

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
@@ -25,7 +25,7 @@ struct MetricsContent<T: ChartNumeric>: View {
     var body: some View {
         ProviderView(provider: provider) { data in
             let groups: [PointGroup<T>] = data.pointGroups()
-            let ranked = groups.ranked(on: period)
+            let ranked = groups.ranked(on: period, by: summary)
 
             if ranked.isEmpty {
                 Placeholder(
@@ -87,11 +87,16 @@ struct MetricsContent<T: ChartNumeric>: View {
         .lineLimit(1)
     }
 
+    private var summary: SeriesSummary {
+        telemetry == .meter ? .latest : .total
+    }
+
     private func summary(of group: PointGroup<T>) -> T {
-        if telemetry == .meter {
-            group.points.latest(in: period.initialRange) ?? .zero
-        } else {
+        switch summary {
+        case .total:
             group.points.total
+        case .latest:
+            group.points.latest(in: period.initialRange) ?? .zero
         }
     }
 }

--- a/Sources/ScoutUI/Monitoring/Metrics/Series/PointSeries.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Series/PointSeries.swift
@@ -20,6 +20,11 @@ protocol PointSeries {
     init(name: String, points: [ChartPoint<T>])
 }
 
+enum SeriesSummary {
+    case total
+    case latest
+}
+
 extension PointSeries {
     var hasPoints: Bool {
         points.total > .zero
@@ -33,10 +38,22 @@ extension Collection where Element: PointSeries {
 }
 
 extension Collection where Element: PointSeries & Comparable {
-    func ranked(on period: Period) -> [Element] {
-        withPoints(in: period)
-            .filter(\.hasPoints)
-            .sorted()
+    func ranked(on period: Period, by summary: SeriesSummary = .total) -> [Element] {
+        let elements = withPoints(in: period)
+
+        switch summary {
+        case .total:
+            return elements.filter(\.hasPoints).sorted()
+        case .latest:
+            // A gauge reads zero or below just as meaningfully as it reads high, so any
+            // element carrying a point survives and ranks on its newest value.
+            return
+                elements
+                .filter { $0.points.count > 0 }
+                .map { ($0, $0.points.latest(in: period.initialRange) ?? .zero) }
+                .sorted { $0.1 > $1.1 }
+                .map(\.0)
+        }
     }
 
     private func withPoints(in period: Period) -> [Element] {

--- a/Tests/ScoutUITests/Home/Search/Index/GlobalSearchIndexTests.swift
+++ b/Tests/ScoutUITests/Home/Search/Index/GlobalSearchIndexTests.swift
@@ -69,12 +69,22 @@ struct GlobalSearchIndexTests {
         let index = makeIndex(series: [
             makeSeries("api_calls", category: Telemetry.Export.counter.rawValue),
             makeSeries("api_latency", category: Telemetry.Export.timer.rawValue),
+            makeSeries("api_payload", category: Telemetry.Export.recorder.rawValue),
             makeSeries("api_meter", category: Telemetry.Export.meter.rawValue),
         ])
         let hits = index.hits(matching: "api")
 
-        #expect(hits.map(\.title) == ["api_calls", "api_latency"])
+        #expect(Set(hits.map(\.title)) == ["api_calls", "api_latency", "api_payload", "api_meter"])
         #expect(hits.allSatisfy { $0.category == .metrics })
+    }
+
+    @Test("Reset and bucket categories stay out of the results") func auxiliaryCategoriesAreIgnored() {
+        let index = makeIndex(series: [
+            makeSeries("api_calls", category: ResetMarker.category),
+            makeSeries("api_calls", category: RecorderBuckets.categories[0]),
+        ])
+
+        #expect(index.hits(matching: "api").isEmpty)
     }
 
     @Test("Endpoint series match on status and latency categories") func endpointMatch() {

--- a/Tests/ScoutUITests/Monitoring/Metrics/Series/RankedSeriesTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Metrics/Series/RankedSeriesTests.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+@testable import ScoutUI
+@testable import Support
+
+@Suite("Ranked series")
+struct RankedSeriesTests {
+    private let period = Period.today
+
+    private func group(_ name: String, _ values: [Double]) -> PointGroup<Double> {
+        let start = period.initialRange.lowerBound
+        let points = values.enumerated().map { hour, value in
+            ChartPoint(date: start.addingTimeInterval(TimeInterval(hour) * .hour), count: value)
+        }
+        return PointGroup(name: name, points: points)
+    }
+
+    @Test("Totals rank by sum and drop the empty series")
+    func totalRanking() {
+        let ranked = [group("idle", [0, 0]), group("busy", [1, 2]), group("quiet", [1])]
+            .ranked(on: period, by: .total)
+
+        #expect(ranked.map(\.name) == ["busy", "quiet"])
+    }
+
+    @Test("Latest keeps a gauge that reads zero")
+    func latestKeepsZero() {
+        let ranked = [group("idle", [5, 0])].ranked(on: period, by: .latest)
+
+        #expect(ranked.map(\.name) == ["idle"])
+    }
+
+    @Test("Latest keeps a gauge that went negative")
+    func latestKeepsNegative() {
+        let ranked = [group("drained", [2, -3])].ranked(on: period, by: .latest)
+
+        #expect(ranked.map(\.name) == ["drained"])
+    }
+
+    @Test("Latest ranks on the newest value, not the sum")
+    func latestRanksOnNewestValue() {
+        let ranked = [group("spiky", [100, 1]), group("steady", [4, 5])]
+            .ranked(on: period, by: .latest)
+
+        #expect(ranked.map(\.name) == ["steady", "spiky"])
+    }
+
+    @Test("Latest still drops a series with no points in the period")
+    func latestDropsEmptySeries() {
+        let ranked = [group("absent", []), group("present", [0])]
+            .ranked(on: period, by: .latest)
+
+        #expect(ranked.map(\.name) == ["present"])
+    }
+}


### PR DESCRIPTION
Two loose ends from the Recorder, Meter and Gauge work. Global search only indexed counters and timers, so the newer metric kinds had list tabs but could not be found by name; they are registered now. Their detail route also fell through to the integer branch, which would have queried the wrong value flavor and shown nothing, since both are stored as doubles — recorder and meter now route to the double formatter alongside the floating-point counter.

Second, a gauge that reads zero across the window disappeared from the list. Zeros are deliberately preserved in storage and in both aggregation paths, but ranking still dropped any series whose points summed to zero, which also hid a meter that had been decremented below zero. Ranking now takes a summary mode: counters, timers and recorders keep the existing sum behavior, while gauges keep every series carrying a point and rank on the newest value instead — the same value the row already displays, so the list and its ordering finally agree.