### PR TITLE
Fold segment bar legend labels into Other so they fit one line

### DIFF
--- a/Sources/ScoutUI/Primitives/Visualization/Chart/View/SegmentBar.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/View/SegmentBar.swift
@@ -52,10 +52,63 @@ struct Segment: Identifiable, Equatable {
     }
 }
 
+extension String {
+    var captionWidth: CGFloat {
+        #if os(iOS)
+            let font = UIFont.preferredFont(forTextStyle: .caption1)
+        #else
+            let font = NSFont.preferredFont(forTextStyle: .caption1)
+        #endif
+        return (self as NSString).size(withAttributes: [.font: font]).width
+    }
+}
+
+extension [Segment] {
+    func fittingLegend(width: CGFloat, spacing: CGFloat, chipWidth: (Segment) -> CGFloat) -> [Segment] {
+        var named = filter { $0.kind != .other }
+        var otherCount = first { $0.kind == .other }?.count ?? 0
+
+        func candidate() -> [Segment] {
+            otherCount > 0 ? named + [Segment(count: otherCount, color: .gray, kind: .other)] : named
+        }
+
+        while named.count > 1 {
+            let current = candidate()
+            let chips = current.reduce(0) { $0 + chipWidth($1) }
+            let gaps = spacing * CGFloat(Swift.max(current.count - 1, 0))
+
+            if chips + gaps <= width {
+                break
+            }
+            otherCount += named.removeLast().count
+        }
+
+        return candidate()
+    }
+}
+
 struct SegmentBar: View {
     let segments: [Segment]
 
+    private static let legendSpacing: CGFloat = 16
+    private static let dotWidth: CGFloat = 7
+    private static let dotSpacing: CGFloat = 5
+
     var body: some View {
+        GeometryReader { proxy in
+            content(fitted: fitted(in: proxy.size.width))
+                .frame(maxHeight: .infinity)
+        }
+        .frame(height: 78)
+    }
+
+    private func fitted(in width: CGFloat) -> [Segment] {
+        segments.fittingLegend(width: width, spacing: Self.legendSpacing) { segment in
+            Self.dotWidth + Self.dotSpacing + segment.label.captionWidth
+        }
+    }
+
+    private func content(fitted segments: [Segment]) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Chart(segments) { segment in
                 BarMark(
@@ -69,13 +122,15 @@ struct SegmentBar: View {
             .frame(height: 18)
             .clipShape(Capsule())
 
-            HStack(spacing: 16) {
+            HStack(spacing: Self.legendSpacing) {
                 ForEach(segments) { segment in
-                    HStack(spacing: 5) {
-                        Circle().fill(segment.color).frame(width: 7, height: 7)
+                    HStack(spacing: Self.dotSpacing) {
+                        Circle().fill(segment.color).frame(width: Self.dotWidth, height: Self.dotWidth)
                         Text(verbatim: segment.label)
                             .font(.caption)
                             .foregroundStyle(.gray)
+                            .lineLimit(1)
+                            .fixedSize()
                     }
                 }
             }

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/View/SegmentBarTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/View/SegmentBarTests.swift
@@ -1,0 +1,86 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Scout
+@testable import ScoutUI
+
+@Suite("SegmentBar legend fitting")
+struct SegmentBarTests {
+    private func makeSegments(_ counts: [Int], other: Int? = nil) -> [Segment] {
+        var segments = counts.enumerated().map { index, count in
+            Segment(label: "L\(index)", count: count, color: .blue)
+        }
+        if let other {
+            segments.append(Segment(count: other, color: .gray, kind: .other))
+        }
+        return segments
+    }
+
+    private let chip: (Segment) -> CGFloat = { $0.kind == .other ? 4 : 10 }
+
+    @Test("Keeps every segment when the legend already fits")
+    func keepsFittingSegments() {
+        let segments = makeSegments([5, 4, 3])
+
+        let fitted = segments.fittingLegend(width: 100, spacing: 2, chipWidth: chip)
+
+        #expect(fitted.map(\.label) == ["L0", "L1", "L2"])
+    }
+
+    @Test("Folds the overflowing tail into a single other segment")
+    func foldsOverflowIntoOther() {
+        let segments = makeSegments([5, 4, 3])
+
+        let fitted = segments.fittingLegend(width: 30, spacing: 2, chipWidth: chip)
+
+        #expect(fitted.map(\.label) == ["L0", "L1", "Other"])
+        #expect(fitted.last?.count == 3)
+    }
+
+    @Test("Adds the folded counts to an existing other segment")
+    func mergesIntoExistingOther() {
+        let segments = makeSegments([5, 4], other: 6)
+
+        let fitted = segments.fittingLegend(width: 20, spacing: 2, chipWidth: chip)
+
+        #expect(fitted.map(\.label) == ["L0", "Other"])
+        #expect(fitted.last?.count == 10)
+    }
+
+    @Test("Never folds away the last named segment")
+    func keepsOneNamedSegment() {
+        let segments = makeSegments([5, 4, 3])
+
+        let fitted = segments.fittingLegend(width: 0, spacing: 2, chipWidth: chip)
+
+        #expect(fitted.map(\.label) == ["L0", "Other"])
+        #expect(fitted.last?.count == 7)
+    }
+
+    @Test("Leaves a lone segment untouched")
+    func keepsLoneSegment() {
+        let segments = makeSegments([5])
+
+        let fitted = segments.fittingLegend(width: 0, spacing: 2, chipWidth: chip)
+
+        #expect(fitted.map(\.label) == ["L0"])
+    }
+
+    @Test("Preserves the total count while folding")
+    func preservesTotal() {
+        let segments = makeSegments([9, 7, 5, 3], other: 1)
+
+        let fitted = segments.fittingLegend(width: 24, spacing: 2, chipWidth: chip)
+
+        #expect(fitted.reduce(0) { $0 + $1.count } == 25)
+    }
+}


### PR DESCRIPTION
The segment bar legend wrapped long device names onto a second line because the breakdown always kept a fixed top four segments regardless of how wide their labels were. The legend now measures the rendered caption width against the space actually available and folds the overflowing tail into the existing Other segment, so labels always stay on one line. Folding happens on the segments themselves rather than only on the legend, which keeps the bar and its labels in agreement, and one named segment is always preserved so the bar stays meaningful. The fitting logic lives in an array extension with the widths passed in, and is covered by unit tests.