### PR TITLE
Tighten the filter sheet layout and switch its toolbar to symbols

### DIFF
--- a/Sources/ScoutUI/Analytics/Event/Filter/FilterContextView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Filter/FilterContextView.swift
@@ -11,11 +11,21 @@ struct FilterContextView: View {
     @ObservedObject var draft: FilterDraft
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: 16) {
             Header(title: "Context")
 
-            IDField(title: "Session ID", text: $draft.sessionText, isValid: draft.isSessionValid)
-            IDField(title: "Device ID", text: $draft.deviceText, isValid: draft.isDeviceValid)
+            VStack(alignment: .leading, spacing: 10) {
+                IDField(
+                    title: "Session ID",
+                    text: $draft.sessionText,
+                    isValid: draft.isSessionValid
+                )
+                IDField(
+                    title: "Device ID",
+                    text: $draft.deviceText,
+                    isValid: draft.isDeviceValid
+                )
+            }
         }
     }
 }
@@ -54,7 +64,6 @@ private struct IDField: View {
                 .buttonStyle(.plain)
             }
         }
-        .padding(14)
         .softCell()
     }
 

--- a/Sources/ScoutUI/Analytics/Event/Filter/FilterLevelsView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Filter/FilterLevelsView.swift
@@ -11,13 +11,16 @@ import SwiftUI
 struct FilterLevelsView: View {
     @ObservedObject var draft: FilterDraft
 
-    private let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
+    private static let columns = [
+        GridItem(.flexible(), spacing: 10),
+        GridItem(.flexible(), spacing: 10),
+    ]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: 16) {
             Header(title: "Levels")
 
-            LazyVGrid(columns: columns, spacing: 10) {
+            LazyVGrid(columns: Self.columns, spacing: 10) {
                 ForEach(EventLevel.allCases, id: \.rawValue) { level in
                     let tint = level.color ?? .blue
                     HStack {
@@ -31,7 +34,6 @@ struct FilterLevelsView: View {
                         Text(level.description).font(.callout)
                         Spacer()
                     }
-                    .padding(12)
                     .softCell(selected: draft.isSelected(level), tint: tint)
                     .contentShape(Rectangle())
                     .onTapGesture {

--- a/Sources/ScoutUI/Analytics/Event/Filter/FilterPeriodView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Filter/FilterPeriodView.swift
@@ -12,19 +12,20 @@ struct FilterPeriodView: View {
     @ObservedObject var draft: FilterDraft
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: 16) {
             Header(title: "Period")
 
-            Toggle(isOn: $draft.isDateRangeEnabled.animation()) {
-                Text(verbatim: "Date range").font(.callout)
-            }
-            .padding(14)
-            .softCell()
+            VStack(alignment: .leading, spacing: 10) {
+                Toggle(isOn: $draft.isDateRangeEnabled.animation()) {
+                    Text(verbatim: "Date range").font(.callout)
+                }
+                .softCell()
 
-            if draft.isDateRangeEnabled {
-                HStack(spacing: 10) {
-                    dateBox("From", selection: $draft.startDate)
-                    dateBox("To", selection: $draft.endDate)
+                if draft.isDateRangeEnabled {
+                    HStack(spacing: 10) {
+                        dateBox("From", selection: $draft.startDate)
+                        dateBox("To", selection: $draft.endDate)
+                    }
                 }
             }
         }
@@ -33,15 +34,30 @@ struct FilterPeriodView: View {
     private func dateBox(_ title: String, selection: Binding<Date>) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(verbatim: title).font(.caption).foregroundStyle(.secondary)
-            DatePicker(selection: selection, displayedComponents: .date) {
-                Text(verbatim: title)
-            }
-            .labelsHidden()
-            .environment(\.calendar, Calendar.utc)
-            .environment(\.timeZone, Calendar.utc.timeZone)
+
+            Text(verbatim: dateBoxFormatter.string(from: selection.wrappedValue))
+                .font(.callout)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .overlay {
+                    DatePicker(selection: selection, displayedComponents: .date) {
+                        Text(verbatim: title)
+                    }
+                    .labelsHidden()
+                    .blendMode(.destinationOver)
+                    .environment(\.calendar, Calendar.utc)
+                    .environment(\.timeZone, Calendar.utc.timeZone)
+                }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
         .softCell()
     }
 }
+
+private let dateBoxFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US")
+    formatter.calendar = .utc
+    formatter.timeZone = Calendar.utc.timeZone
+    formatter.dateFormat = "d MMM yyyy"
+    return formatter
+}()

--- a/Sources/ScoutUI/Analytics/Event/Filter/FilterView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Filter/FilterView.swift
@@ -31,59 +31,53 @@ struct FilterView: View {
                     Button {
                         dismiss()
                     } label: {
-                        Text(verbatim: "Cancel")
+                        Image(systemName: "xmark")
                     }
+                    .accessibilityLabel(Text(verbatim: "Cancel"))
                 }
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Button {
                         draft.reset()
                     } label: {
-                        Text(verbatim: "Reset")
+                        Image(systemName: "arrow.counterclockwise")
                     }
+                    .tint(.red)
                     .disabled(!draft.isResetEnabled)
+                    .accessibilityLabel(Text(verbatim: "Reset"))
                     Button {
                         draft.apply()
                         dismiss()
                     } label: {
-                        Text(verbatim: "Apply")
+                        Image(systemName: "checkmark")
                     }
+                    .tint(.green)
                     .disabled(!draft.isApplyEnabled)
                     .fontWeight(.semibold)
+                    .accessibilityLabel(Text(verbatim: "Apply"))
                 }
             }
             .navigationTitle(en: "Filter")
             .inlineNavigationTitle()
         }
-        .modalFrame(height: draft.isDateRangeEnabled ? 720 : 600)
     }
 }
 
 extension View {
     func softCell(selected: Bool = false, tint: Color = .blue) -> some View {
-        background(tint.opacity(selected ? 0.1 : 0.04), in: RoundedRectangle(cornerRadius: 12))
-    }
-}
-
-extension View {
-    @ViewBuilder
-    fileprivate func modalFrame(height: CGFloat) -> some View {
-        #if os(iOS)
-            self
-        #else
-            frame(width: height / 1.618, height: height)
-        #endif
+        padding(12).background(
+            tint.opacity(selected ? 0.1 : 0.04),
+            in: RoundedRectangle(cornerRadius: 12)
+        )
     }
 }
 
 #Preview("Filter Form") {
-    Color.clear.sheet(isPresented: .constant(true)) {
-        FilterView(
-            query: .constant(
-                EventQuery(
-                    levels: [.error, .critical],
-                    dates: Date().startOfDay.addingDay(-7)..<Date().startOfDay
-                )
+    FilterView(
+        query: .constant(
+            EventQuery(
+                levels: [.error, .critical],
+                dates: Date().startOfDay.addingDay(-7)..<Date().startOfDay
             )
         )
-    }
+    )
 }


### PR DESCRIPTION
The filter sheet had drifted: cells padded themselves inconsistently at 12 and 14 points, and the spacing that separated a section header from its content was also used between the cells, so rows sat twice as far apart as the level grid. The cell padding now lives inside softCell so it cannot diverge again, and each section nests its cells in their own tighter stack while the header keeps its original distance.

Cancel, Reset and Apply became symbols with Reset and Apply tinted red and green, each carrying an accessibility label so the icons stay meaningful without their text. The date boxes render the selected day themselves in a UTC formatter, keeping the compact DatePicker only as the tap target, which drops the grey capsule it draws around the value. The fixed sheet size is gone, so the sheet no longer jumps between two heights when the date range is toggled.