### PR TITLE
Introduce InsetList so every list shares one row inset

### DIFF
--- a/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
@@ -35,7 +35,7 @@ struct ActivityView: View {
                 RangeControl(extent: $extent)
                     .padding(.vertical)
 
-                PlainList {
+                InsetList {
                     let points = data.points(on: extent.period)
                     let segment = extent.segment(from: points)
                     let canCompare = extent.canCompare(points: points, segment: segment)

--- a/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
@@ -29,13 +29,16 @@ struct ActivityView: View {
     var body: some View {
         VStack(spacing: 0) {
             PeriodPicker(extent: $extent, periods: ActivityPeriod.allCases)
+                .padding(.top)
 
             ProviderView(provider: activity) { data in
                 RangeControl(extent: $extent)
+                    .padding(.vertical)
 
-                List {
+                PlainList {
                     let points = data.points(on: extent.period)
                     let segment = extent.segment(from: points)
+                    let canCompare = extent.canCompare(points: points, segment: segment)
 
                     ComparableChart(
                         segment: segment,
@@ -45,19 +48,22 @@ struct ActivityView: View {
                         isComparing: isComparing
                     )
                     .listRowSeparator(.hidden)
+                    .padding(.bottom)
 
-                    ComparisonToggle(isOn: $isComparing)
-                        .disabled(!extent.canCompare(points: points, segment: segment))
+                    ComparisonToggle(isOn: $isComparing).disabled(!canCompare)
                 }
-                .listStyle(.plain)
                 .scrollDisabled(true)
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
                         ChartExportButton(
-                            title: "Active Users", rangeLabel: extent.domain.label(using: rangeDateFormatter)
+                            title: "Active Users",
+                            rangeLabel: extent.domain.label(using: rangeDateFormatter)
                         ) {
-                            ChartView(segment: extent.segment(from: data.points(on: extent.period)), timing: extent)
-                                .foregroundStyle(.green)
+                            ChartView(
+                                segment: extent.segment(from: data.points(on: extent.period)),
+                                timing: extent
+                            )
+                            .foregroundStyle(.green)
                         }
                     }
                 }
@@ -70,6 +76,7 @@ struct ActivityView: View {
 #Preview("ActivityView") {
     let activity = ActivityProvider()
     activity.result = .success([])
+
     return NavigationStack {
         ActivityView(activity: activity, period: .daily)
     }

--- a/Sources/ScoutUI/Analytics/Event/Detail/EventView.Sections.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/EventView.Sections.swift
@@ -59,6 +59,7 @@ extension EventView {
                         stat: stat
                     )
                     .navigationTitle(en: "Stats")
+                    .largeNavigationTitle()
                 }
             }
         }

--- a/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
@@ -25,7 +25,7 @@ struct EventView: View {
     var body: some View {
         let color = event.level?.color
 
-        PlainList {
+        InsetList {
             EventHeader(event: event)
 
             if let paramCount = event.paramCount, paramCount > 0 {

--- a/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
@@ -25,7 +25,7 @@ struct EventView: View {
     var body: some View {
         let color = event.level?.color
 
-        List {
+        PlainList {
             EventHeader(event: event)
 
             if let paramCount = event.paramCount, paramCount > 0 {
@@ -39,7 +39,6 @@ struct EventView: View {
             StatSection(stat: stat)
             HistorySection(event: event)
         }
-        .listStyle(.plain)
         .navigationTint(color)
         .monospacedNavigationTitle(en: event.name)
         .navigationDestination(isPresented: $isParamPresented) {
@@ -61,19 +60,17 @@ extension EventView {
         let event: Event
 
         var body: some View {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 10) {
                 if let date = event.date {
                     UTCTimestampText(date: date)
                 }
-
-                Spacer().frame(height: 10)
 
                 if let level = event.level {
                     (Text(verbatim: "LEVEL:   ") + level.descriptionText)
                         .fontWeight(.bold)
                 }
             }
-            .padding(.vertical, 4)
+            .frame(height: 90)
         }
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/Detail/StatRow.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/StatRow.swift
@@ -47,7 +47,7 @@ struct StatRow<Destination: View>: View {
 
 #Preview {
     NavigationStack {
-        List {
+        PlainList {
             StatRow(
                 color: .blue,
                 period: .today,
@@ -56,6 +56,5 @@ struct StatRow<Destination: View>: View {
                 Text(verbatim: "Detail")
             }
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/Detail/StatRow.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/StatRow.swift
@@ -47,7 +47,7 @@ struct StatRow<Destination: View>: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             StatRow(
                 color: .blue,
                 period: .today,

--- a/Sources/ScoutUI/Analytics/Event/List/EventList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventList.swift
@@ -25,7 +25,7 @@ struct EventList<Header: View>: View {
                     code: "logger.info(\"button_tapped\")"
                 )
             } else {
-                PlainList {
+                InsetList {
                     header()
                     rows(for: events)
                 }

--- a/Sources/ScoutUI/Analytics/Event/List/EventList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventList.swift
@@ -25,11 +25,10 @@ struct EventList<Header: View>: View {
                     code: "logger.info(\"button_tapped\")"
                 )
             } else {
-                List {
+                PlainList {
                     header()
                     rows(for: events)
                 }
-                .listStyle(.plain)
                 .animation(nil, value: UUID())
             }
         } else {

--- a/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
@@ -21,7 +21,7 @@ struct EventStatList: View {
                 .autoRefresh {
                     await provider.fetchLatest(for: query, in: database)
                 }
-                .navigationTitle(range.label(using: rangeDateFormatter))
+                .navigationTitle(en: range.label(using: rangeDateFormatter))
                 .font(.caption)
         }
     }

--- a/Sources/ScoutUI/Analytics/Event/Param/ParamList.swift
+++ b/Sources/ScoutUI/Analytics/Event/Param/ParamList.swift
@@ -17,7 +17,7 @@ struct ParamList: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             ForEach(items) { item in
                 ParamRow(item: item)
             }

--- a/Sources/ScoutUI/Analytics/Event/Param/ParamList.swift
+++ b/Sources/ScoutUI/Analytics/Event/Param/ParamList.swift
@@ -17,13 +17,13 @@ struct ParamList: View {
     }
 
     var body: some View {
-        List {
+        PlainList {
             ForEach(items) { item in
                 ParamRow(item: item)
             }
         }
-        .listStyle(.plain)
         .navigationTitle(en: "Params")
+        .largeNavigationTitle()
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
                 ShareLink(item: text)

--- a/Sources/ScoutUI/Analytics/Event/Param/ParamView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Param/ParamView.swift
@@ -30,7 +30,7 @@ struct ParamView: View {
     var body: some View {
         Group {
             if value.isContainer {
-                PlainList {
+                InsetList {
                     ForEach(value.nodes) { node in
                         Row {
                             ParamValueRow(node: node)

--- a/Sources/ScoutUI/Analytics/Event/Param/ParamView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Param/ParamView.swift
@@ -30,14 +30,15 @@ struct ParamView: View {
     var body: some View {
         Group {
             if value.isContainer {
-                List(value.nodes) { node in
-                    Row {
-                        ParamValueRow(node: node)
-                    } destination: {
-                        ParamView(node: node)
+                PlainList {
+                    ForEach(value.nodes) { node in
+                        Row {
+                            ParamValueRow(node: node)
+                        } destination: {
+                            ParamView(node: node)
+                        }
                     }
                 }
-                .listStyle(.plain)
             } else {
                 ParamScalarView(raw: raw, value: value)
             }

--- a/Sources/ScoutUI/Analytics/Retention/RetentionCohortDetailView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionCohortDetailView.swift
@@ -19,7 +19,7 @@ struct RetentionCohortDetailView: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             VStack(alignment: .leading, spacing: 4) {
                 Text(verbatim: "\(cohort.size) installs").font(.caption).foregroundStyle(.secondary)
 

--- a/Sources/ScoutUI/Analytics/Retention/RetentionCohortDetailView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionCohortDetailView.swift
@@ -19,7 +19,7 @@ struct RetentionCohortDetailView: View {
     }
 
     var body: some View {
-        List {
+        PlainList {
             VStack(alignment: .leading, spacing: 4) {
                 Text(verbatim: "\(cohort.size) installs").font(.caption).foregroundStyle(.secondary)
 
@@ -69,27 +69,25 @@ struct RetentionCohortDetailView: View {
 
                 legend
             }
+            .padding(.top)
             .listRowSeparator(.hidden)
 
             Header(title: "By OS Version")
 
             ForEach(cohort.segments) { segment in
-                NavigationLink {
-                    RetentionSegmentDetailView(segment: segment, cohort: cohort)
-                } label: {
-                    HStack {
-                        Text(verbatim: segment.name).font(.subheadline)
-                        Spacer()
+                Row {
+                    Text(verbatim: segment.name).font(.subheadline)
+                    Spacer()
 
-                        HStack(spacing: 14) {
-                            stat(day: 7, retention: segment.retention)
-                            stat(day: 30, retention: segment.retention)
-                        }
+                    HStack(spacing: 14) {
+                        stat(day: 7, retention: segment.retention)
+                        stat(day: 30, retention: segment.retention)
                     }
+                } destination: {
+                    RetentionSegmentDetailView(segment: segment, cohort: cohort)
                 }
             }
         }
-        .listStyle(.plain)
         .navigationTitle(en: "Week of \(cohort.label)")
     }
 

--- a/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
@@ -37,7 +37,7 @@ private struct RetentionHeroChart: View {
     }
 
     var body: some View {
-        List {
+        PlainList {
             VStack(alignment: .leading, spacing: 4) {
                 Text(verbatim: "Average Retention").font(.headline)
                 Text(verbatim: "Across \(cohorts.count) weekly cohorts").font(.caption).foregroundStyle(.secondary)
@@ -78,38 +78,36 @@ private struct RetentionHeroChart: View {
                 .aspectRatio(1.618, contentMode: .fit)
                 .padding(.top, 8)
             }
+            .padding(.top)
             .listRowSeparator(.hidden)
 
             Header(title: "By Cohort")
 
             ForEach(cohorts.reversed()) { cohort in
-                NavigationLink {
-                    RetentionCohortDetailView(cohort: cohort, cohorts: cohorts)
-                } label: {
-                    HStack {
-                        Text(verbatim: "Week of \(cohort.label)").font(.subheadline)
-                        Spacer()
-                        Text(verbatim: "\(cohort.size)").font(.caption).foregroundStyle(.secondary)
+                Row {
+                    Text(verbatim: "Week of \(cohort.label)").font(.subheadline)
+                    Spacer()
+                    Text(verbatim: "\(cohort.size)").font(.caption).foregroundStyle(.secondary)
 
-                        if let day7 = RetentionCohort.rate(cohort.retention, onDay: 7) {
-                            Text(
-                                verbatim:
-                                    "D7 \(day7.formatted(.retentionRate))"
-                            )
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.green)
+                    if let day7 = RetentionCohort.rate(cohort.retention, onDay: 7) {
+                        Text(
+                            verbatim:
+                                "D7 \(day7.formatted(.retentionRate))"
+                        )
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.green)
+                        .frame(width: 72, alignment: .trailing)
+                    } else {
+                        Text(verbatim: "—")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
                             .frame(width: 72, alignment: .trailing)
-                        } else {
-                            Text(verbatim: "—")
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
-                                .frame(width: 72, alignment: .trailing)
-                        }
                     }
+                } destination: {
+                    RetentionCohortDetailView(cohort: cohort, cohorts: cohorts)
                 }
             }
         }
-        .listStyle(.plain)
     }
 }
 

--- a/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
@@ -37,7 +37,7 @@ private struct RetentionHeroChart: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             VStack(alignment: .leading, spacing: 4) {
                 Text(verbatim: "Average Retention").font(.headline)
                 Text(verbatim: "Across \(cohorts.count) weekly cohorts").font(.caption).foregroundStyle(.secondary)

--- a/Sources/ScoutUI/Analytics/Retention/RetentionSegmentDetailView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionSegmentDetailView.swift
@@ -22,7 +22,7 @@ struct RetentionSegmentDetailView: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             VStack(alignment: .leading, spacing: 4) {
                 Text(verbatim: "Week of \(cohort.label)").font(.caption).foregroundStyle(.secondary)
 

--- a/Sources/ScoutUI/Analytics/Retention/RetentionSegmentDetailView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionSegmentDetailView.swift
@@ -22,7 +22,7 @@ struct RetentionSegmentDetailView: View {
     }
 
     var body: some View {
-        List {
+        PlainList {
             VStack(alignment: .leading, spacing: 4) {
                 Text(verbatim: "Week of \(cohort.label)").font(.caption).foregroundStyle(.secondary)
 
@@ -74,6 +74,7 @@ struct RetentionSegmentDetailView: View {
 
                 legend
             }
+            .padding(.top)
             .listRowSeparator(.hidden)
 
             Header(title: "Stability")
@@ -82,7 +83,6 @@ struct RetentionSegmentDetailView: View {
                 stabilityStat(title: "Crashes", value: segment.crashRate, color: .red)
                 stabilityStat(title: "Hangs", value: segment.hangRate, color: .orange)
             }
-            .listRowSeparator(.hidden)
 
             if crashMultiplier > 1.2 {
                 Text(
@@ -91,10 +91,9 @@ struct RetentionSegmentDetailView: View {
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
-                .listRowSeparator(.hidden)
+                .listRowSeparator(.hidden, edges: .bottom)
             }
         }
-        .listStyle(.plain)
         .navigationTitle(en: segment.name)
     }
 
@@ -113,6 +112,7 @@ struct RetentionSegmentDetailView: View {
                 .foregroundStyle(color)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: 70)
     }
 }
 

--- a/Sources/ScoutUI/Analytics/Session/SessionHeader.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionHeader.swift
@@ -51,8 +51,7 @@ struct SessionHeader: View {
 }
 
 #Preview {
-    List {
+    PlainList {
         SessionHeader(info: .sample)
     }
-    .listStyle(.plain)
 }

--- a/Sources/ScoutUI/Analytics/Session/SessionHeader.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionHeader.swift
@@ -51,7 +51,7 @@ struct SessionHeader: View {
 }
 
 #Preview {
-    PlainList {
+    InsetList {
         SessionHeader(info: .sample)
     }
 }

--- a/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
@@ -34,6 +34,7 @@ struct SessionInspector: View {
             { await info.fetchLatest(in: database) },
         ])
         .navigationTitle(en: "Session")
+        .largeNavigationTitle()
     }
 
     private var query: EventQuery {

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
@@ -20,20 +20,20 @@ struct DeviceDetailView: View {
     }
 
     var body: some View {
-        List {
+        PlainList {
             FlowLayout(spacing: 6) {
                 InfoChip(systemImage: device.symbol, text: device.modelName, color: .blue)
                 InfoChip(systemImage: "gearshape", text: device.osVersion, color: .indigo)
                 InfoChip(systemImage: "clock", text: "seen \(device.lastSeen.relativeString)", color: .teal)
             }
             .listRowSeparator(.hidden)
+            .padding(.vertical)
 
             HStack(spacing: 28) {
                 Metric(title: "Sessions", value: device.sessions.plain, color: .primary)
                 Metric(title: "Crashes", value: device.crashes.plain, color: device.crashes > 0 ? .red : .primary)
                 Spacer()
             }
-            .listRowSeparator(.hidden)
 
             if crashes.count > 0 {
                 Header(title: "Recent Crashes")
@@ -69,7 +69,6 @@ struct DeviceDetailView: View {
                 }
             }
         }
-        .listStyle(.plain)
         .navigationTitle(en: device.modelName)
         .autoRefresh {
             await incidents.fetchLatest(in: database)

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
@@ -20,7 +20,7 @@ struct DeviceDetailView: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             FlowLayout(spacing: 6) {
                 InfoChip(systemImage: device.symbol, text: device.modelName, color: .blue)
                 InfoChip(systemImage: "gearshape", text: device.osVersion, color: .indigo)

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceRow.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceRow.swift
@@ -53,7 +53,7 @@ struct DeviceRow: View {
 }
 
 #Preview("DeviceRow") {
-    PlainList {
+    InsetList {
         ForEach(DeviceSummary.samples) { device in
             DeviceRow(device: device)
         }

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceRow.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceRow.swift
@@ -48,13 +48,14 @@ struct DeviceRow: View {
                 .foregroundStyle(.secondary)
                 .frame(minWidth: 64, alignment: .trailing)
         }
-        .frame(height: 44)
+        .frame(height: 70)
     }
 }
 
 #Preview("DeviceRow") {
-    List(DeviceSummary.samples) { device in
-        DeviceRow(device: device)
+    PlainList {
+        ForEach(DeviceSummary.samples) { device in
+            DeviceRow(device: device)
+        }
     }
-    .listStyle(.plain)
 }

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesListView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesListView.swift
@@ -20,12 +20,11 @@ struct DevicesListView: View {
                     description: "Devices appear here once your app reports sessions"
                 )
             } else {
-                List {
+                PlainList {
                     ForEach(devices.sorted { $0.lastSeen > $1.lastSeen }) { device in
                         DeviceLink(device: device)
                     }
                 }
-                .listStyle(.plain)
             }
         }
         .navigationTitle(en: "Devices")

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesListView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesListView.swift
@@ -20,7 +20,7 @@ struct DevicesListView: View {
                     description: "Devices appear here once your app reports sessions"
                 )
             } else {
-                PlainList {
+                InsetList {
                     ForEach(devices.sorted { $0.lastSeen > $1.lastSeen }) { device in
                         DeviceLink(device: device)
                     }

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
@@ -35,7 +35,7 @@ struct DevicesView: View {
         let modelBreakdown = IncidentBreakdown.segments(from: devices.map(\.modelName))
         let osBreakdown = IncidentBreakdown.segments(from: devices.map(\.osVersion))
 
-        return List {
+        return PlainList {
             HStack(spacing: 28) {
                 Metric(title: "Devices", value: devices.count.plain, color: .primary)
                 Metric(title: "Active 7d", value: activeCount.plain, color: .blue)
@@ -56,7 +56,6 @@ struct DevicesView: View {
                 DeviceLink(device: device)
             }
         }
-        .listStyle(.plain)
         .navigationDestination(isPresented: $showAllDevices) {
             DevicesListView(devices: devices)
         }

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
@@ -35,7 +35,7 @@ struct DevicesView: View {
         let modelBreakdown = IncidentBreakdown.segments(from: devices.map(\.modelName))
         let osBreakdown = IncidentBreakdown.segments(from: devices.map(\.osVersion))
 
-        return PlainList {
+        return InsetList {
             HStack(spacing: 28) {
                 Metric(title: "Devices", value: devices.count.plain, color: .primary)
                 Metric(title: "Active 7d", value: activeCount.plain, color: .blue)

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthView.swift
@@ -20,7 +20,7 @@ struct ReleaseHealthView: View {
                     description: "Release health appears once your app reports versions"
                 )
             } else {
-                PlainList {
+                InsetList {
                     ForEach(releases) { release in
                         ReleaseRow(release: release)
                     }

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthView.swift
@@ -20,12 +20,11 @@ struct ReleaseHealthView: View {
                     description: "Release health appears once your app reports versions"
                 )
             } else {
-                List {
+                PlainList {
                     ForEach(releases) { release in
                         ReleaseRow(release: release)
                     }
                 }
-                .listStyle(.plain)
             }
         }
         .navigationTitle(en: "Releases")

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseRow.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseRow.swift
@@ -91,7 +91,7 @@ private struct ReleasePercent: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             ForEach([ReleaseHealth].samples) { release in
                 ReleaseRow(release: release)
             }

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseRow.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseRow.swift
@@ -91,14 +91,13 @@ private struct ReleasePercent: View {
 
 #Preview {
     NavigationStack {
-        List {
+        PlainList {
             ForEach([ReleaseHealth].samples) { release in
                 ReleaseRow(release: release)
             }
             ReleaseRowPlaceholder()
             ReleaseRowPlaceholder()
         }
-        .listStyle(.plain)
         .navigationTitle(en: "Releases")
     }
 }

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -29,7 +29,7 @@ struct VersionDetailView: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             VStack(alignment: .leading, spacing: -8) {
                 HStack(spacing: 24) {
                     Metric(title: "Crash-free sessions", stability: release.freeSessions)
@@ -110,7 +110,7 @@ private struct VersionIncidentsView<Element: Incident, Destination: View>: View 
     @ViewBuilder let destination: (IncidentGroup<Element>) -> Destination
 
     var body: some View {
-        PlainList {
+        InsetList {
             IncidentTrendChart(records: records, color: color)
                 .padding(.top)
 

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -16,6 +16,9 @@ struct VersionDetailView: View {
     @StateObject var crashes: VersionIncidentProvider<Crash>
     @StateObject var hangs: VersionIncidentProvider<Hang>
 
+    @State private var showAllCrashes = false
+    @State private var showAllHangs = false
+
     init(
         release: ReleaseHealth, crashes: VersionIncidentProvider<Crash>? = nil,
         hangs: VersionIncidentProvider<Hang>? = nil
@@ -26,26 +29,58 @@ struct VersionDetailView: View {
     }
 
     var body: some View {
-        List {
-            headerSection
+        PlainList {
+            VStack(alignment: .leading, spacing: -8) {
+                HStack(spacing: 24) {
+                    Metric(title: "Crash-free sessions", stability: release.freeSessions)
+                    if let freeUsers = release.freeUsers {
+                        Metric(title: "Crash-free users", stability: freeUsers)
+                    }
+                }
 
-            IncidentTrendSection(
-                title: "Crashes over time", records: crashes.records ?? [], color: .red)
-            IncidentIssuesSection(
-                title: "Top crash issues", groups: IncidentGroup.groups(from: crashes.records ?? []), color: .red
+                HStack(spacing: 24) {
+                    Metric(title: "Crashes", value: "\(release.crashes)")
+                    Metric(title: "Hangs", value: "\(release.hangs)")
+                    Metric(title: "Sessions", value: release.sessions.compact)
+                    Metric(title: "Adoption", value: release.adoption.formatted)
+                }
+            }
+            .padding(.top)
+            .padding(.bottom, 4)
+            .listRowSeparator(.hidden, edges: .top)
+
+            IncidentTrendSection(title: "Crashes", records: crashRecords, color: .red) {
+                if crashRecords.count > 0 {
+                    AllButton { showAllCrashes = true }
+                }
+            }
+
+            IncidentTrendSection(title: "Hangs", records: hangRecords, color: .orange) {
+                if hangRecords.count > 0 {
+                    AllButton { showAllHangs = true }
+                }
+            }
+        }
+        .navigationDestination(isPresented: $showAllCrashes) {
+            VersionIncidentsView(
+                title: "Crashes",
+                issuesTitle: "Top crash issues",
+                records: crashRecords,
+                color: .red
             ) { group in
                 CrashGroupDetailView(group: group)
             }
-
-            IncidentTrendSection(
-                title: "Hangs over time", records: hangs.records ?? [], color: .orange)
-            IncidentIssuesSection(
-                title: "Top hang issues", groups: IncidentGroup.groups(from: hangs.records ?? []), color: .orange
+        }
+        .navigationDestination(isPresented: $showAllHangs) {
+            VersionIncidentsView(
+                title: "Hangs",
+                issuesTitle: "Top hang issues",
+                records: hangRecords,
+                color: .orange
             ) { group in
                 HangGroupDetailView(group: group)
             }
         }
-        .listStyle(.plain)
         .toolbarBackground(release.freeSessions.color.opacity(0.12), for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .monospacedNavigationTitle(en: release.id)
@@ -57,29 +92,55 @@ struct VersionDetailView: View {
         ])
     }
 
-    private var headerSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 24) {
-                Metric(title: "Crash-free sessions", stability: release.freeSessions)
-                if let freeUsers = release.freeUsers {
-                    Metric(title: "Crash-free users", stability: freeUsers)
-                }
-            }
+    private var crashRecords: [Crash] {
+        crashes.records ?? []
+    }
 
-            HStack(spacing: 24) {
-                Metric(title: "Crashes", value: "\(release.crashes)")
-                Metric(title: "Hangs", value: "\(release.hangs)")
-                Metric(title: "Sessions", value: release.sessions.compact)
-                Metric(title: "Adoption", value: release.adoption.formatted)
-            }
-        }
-        .padding(.vertical, 4)
-        .listRowSeparator(.hidden)
+    private var hangRecords: [Hang] {
+        hangs.records ?? []
     }
 }
 
-private struct IncidentTrendSection<Element: Incident>: View {
+private struct VersionIncidentsView<Element: Incident, Destination: View>: View {
     let title: String
+    let issuesTitle: String
+    let records: [Element]
+    let color: Color
+
+    @ViewBuilder let destination: (IncidentGroup<Element>) -> Destination
+
+    var body: some View {
+        PlainList {
+            IncidentTrendChart(records: records, color: color)
+                .padding(.top)
+
+            IncidentIssuesSection(
+                title: issuesTitle,
+                groups: IncidentGroup.groups(from: records),
+                color: color,
+                destination: destination
+            )
+        }
+        .navigationTitle(en: title)
+        .largeNavigationTitle()
+    }
+}
+
+private struct IncidentTrendSection<Element: Incident, Trailing: View>: View {
+    let title: String
+    let records: [Element]
+    let color: Color
+
+    @ViewBuilder let trailing: () -> Trailing
+
+    var body: some View {
+        Header(title: title, trailing: trailing)
+
+        IncidentTrendChart(records: records, color: color)
+    }
+}
+
+private struct IncidentTrendChart<Element: Incident>: View {
     let records: [Element]
     let color: Color
 
@@ -89,8 +150,6 @@ private struct IncidentTrendSection<Element: Incident>: View {
 
     var body: some View {
         let isEmpty = !days.contains(where: { $0.count > 0 })
-
-        Header(title: title)
 
         Chart(days, id: \.date) { day in
             BarMark(
@@ -118,7 +177,6 @@ private struct IncidentTrendSection<Element: Incident>: View {
             }
         }
         .frame(height: 170)
-        .padding(.vertical, 8)
         .listRowSeparator(.hidden)
     }
 }
@@ -160,7 +218,11 @@ private struct IncidentIssuesSection<Element: Incident, Destination: View>: View
     hangs.records = .samples
 
     return NavigationStack {
-        VersionDetailView(release: [ReleaseHealth].samples[0], crashes: crashes, hangs: hangs)
+        VersionDetailView(
+            release: [ReleaseHealth].samples[0],
+            crashes: crashes,
+            hangs: hangs
+        )
     }
     .environmentObject(Tint())
 }

--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -22,7 +22,7 @@ struct HomeList: View {
     @StateObject var alerts = AlertProvider(notifier: AlertNotifier())
 
     var body: some View {
-        PlainList {
+        InsetList {
             SegmentStrip(
                 selection: $period,
                 distribution: .justified,

--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -22,7 +22,7 @@ struct HomeList: View {
     @StateObject var alerts = AlertProvider(notifier: AlertNotifier())
 
     var body: some View {
-        List {
+        PlainList {
             SegmentStrip(
                 selection: $period,
                 distribution: .justified,
@@ -56,7 +56,6 @@ struct HomeList: View {
                 path: $path
             )
         }
-        .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .globalSearch()
         .navigationDestination(for: HomeDestination.self) { destination in

--- a/Sources/ScoutUI/Home/Search/Results/GlobalSearchList.swift
+++ b/Sources/ScoutUI/Home/Search/Results/GlobalSearchList.swift
@@ -16,7 +16,7 @@ struct GlobalSearchList: View {
         let hits = index.hits(matching: query)
 
         if hits.count > 0 {
-            PlainList {
+            InsetList {
                 ForEach(hits) { hit in
                     GlobalSearchRow(hit: hit, query: query)
                         .listRowSeparator(hit.id == hits.first?.id ? .hidden : .automatic, edges: .top)

--- a/Sources/ScoutUI/Home/Search/Results/GlobalSearchList.swift
+++ b/Sources/ScoutUI/Home/Search/Results/GlobalSearchList.swift
@@ -16,11 +16,12 @@ struct GlobalSearchList: View {
         let hits = index.hits(matching: query)
 
         if hits.count > 0 {
-            List(hits) { hit in
-                GlobalSearchRow(hit: hit, query: query)
-                    .listRowSeparator(hit.id == hits.first?.id ? .hidden : .automatic, edges: .top)
+            PlainList {
+                ForEach(hits) { hit in
+                    GlobalSearchRow(hit: hit, query: query)
+                        .listRowSeparator(hit.id == hits.first?.id ? .hidden : .automatic, edges: .top)
+                }
             }
-            .listStyle(.plain)
         } else {
             Placeholder(
                 text: "No results",

--- a/Sources/ScoutUI/Home/Search/Results/GlobalSearchRow.swift
+++ b/Sources/ScoutUI/Home/Search/Results/GlobalSearchRow.swift
@@ -72,7 +72,7 @@ struct GlobalSearchBadge: View {
 
 #Preview {
     NavigationStack {
-        List {
+        PlainList {
             GlobalSearchRow(hit: .event(name: "session_start"), query: "ses")
             GlobalSearchRow(hit: .metric(name: "session_duration", telemetry: .timer), query: "ses")
             GlobalSearchRow(hit: .endpoint(name: "GET /v1/sessions"), query: "ses")
@@ -90,7 +90,6 @@ struct GlobalSearchBadge: View {
                 GlobalSearchRow(hit: .hang(group), query: "main")
             }
         }
-        .listStyle(.plain)
         .environmentObject(Tint())
     }
 }

--- a/Sources/ScoutUI/Home/Search/Results/GlobalSearchRow.swift
+++ b/Sources/ScoutUI/Home/Search/Results/GlobalSearchRow.swift
@@ -72,7 +72,7 @@ struct GlobalSearchBadge: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             GlobalSearchRow(hit: .event(name: "session_start"), query: "ses")
             GlobalSearchRow(hit: .metric(name: "session_duration", telemetry: .timer), query: "ses")
             GlobalSearchRow(hit: .endpoint(name: "GET /v1/sessions"), query: "ses")

--- a/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
+++ b/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
@@ -42,7 +42,7 @@ struct HomeAlertSection: View {
 
         switch alerts.result {
         case .success(let statuses) where statuses.allHealthy:
-            placeholderText("All healthy", color: .green).listRowInsets(.sideInsets)
+            placeholderText("All healthy", color: .green)
 
         case .success(let statuses) where statuses.count > 0:
             ForEach(statuses.prefix(2), id: \.rule) { status in
@@ -56,7 +56,6 @@ struct HomeAlertSection: View {
                 placeholderText("New rule", color: .blue)
             }
             .buttonStyle(.plain)
-            .listRowInsets(.sideInsets)
 
         default:
             ForEach(0..<2, id: \.self) { _ in
@@ -87,11 +86,10 @@ struct HomeAlertSection: View {
     empty.result = .success([])
 
     return NavigationStack {
-        List {
+        PlainList {
             HomeAlertSection(alerts: firing, path: .constant([]))
             HomeAlertSection(alerts: healthy, path: .constant([]))
             HomeAlertSection(alerts: empty, path: .constant([]))
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
+++ b/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
@@ -86,7 +86,7 @@ struct HomeAlertSection: View {
     empty.result = .success([])
 
     return NavigationStack {
-        PlainList {
+        InsetList {
             HomeAlertSection(alerts: firing, path: .constant([]))
             HomeAlertSection(alerts: healthy, path: .constant([]))
             HomeAlertSection(alerts: empty, path: .constant([]))

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogRow.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogRow.swift
@@ -34,7 +34,7 @@ struct HomeLogRow<Destination: View>: View {
 
 #Preview {
     NavigationStack {
-        List {
+        PlainList {
             HomeLogRow(title: "Events", image: "list.bullet", color: .blue, count: 42) {
                 Text(verbatim: "Detail")
             }
@@ -42,6 +42,5 @@ struct HomeLogRow<Destination: View>: View {
                 Text(verbatim: "Detail")
             }
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogRow.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogRow.swift
@@ -34,7 +34,7 @@ struct HomeLogRow<Destination: View>: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             HomeLogRow(title: "Events", image: "list.bullet", color: .blue, count: 42) {
                 Text(verbatim: "Detail")
             }

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
@@ -68,7 +68,7 @@ struct HomeLogSection: View {
     devices.result = .success(.sample)
 
     return NavigationStack {
-        PlainList {
+        InsetList {
             HomeLogSection(
                 period: .today,
                 log: makeLog(),

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
@@ -68,7 +68,7 @@ struct HomeLogSection: View {
     devices.result = .success(.sample)
 
     return NavigationStack {
-        List {
+        PlainList {
             HomeLogSection(
                 period: .today,
                 log: makeLog(),
@@ -76,6 +76,5 @@ struct HomeLogSection: View {
                 path: .constant([])
             )
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
+++ b/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
@@ -40,7 +40,6 @@ struct HomeMetricSection: View {
             }
             .buttonStyle(.plain)
         }
-        .listRowInsets(.sideInsets)
         .listRowSeparator(.hidden)
     }
 
@@ -70,7 +69,7 @@ struct HomeMetricSection: View {
     sessions.result = .success(.samples)
 
     return NavigationStack {
-        List {
+        PlainList {
             HomeMetricSection(
                 activities: activities,
                 sessions: sessions,
@@ -78,6 +77,5 @@ struct HomeMetricSection: View {
                 path: .constant([])
             )
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
+++ b/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
@@ -69,7 +69,7 @@ struct HomeMetricSection: View {
     sessions.result = .success(.samples)
 
     return NavigationStack {
-        PlainList {
+        InsetList {
             HomeMetricSection(
                 activities: activities,
                 sessions: sessions,

--- a/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
@@ -49,10 +49,9 @@ struct HomeReleaseSection: View {
     let empty = ReleaseHealthProvider(releases: [])
 
     return NavigationStack {
-        List {
+        PlainList {
             HomeReleaseSection(releases: releases, path: .constant([]))
             HomeReleaseSection(releases: empty, path: .constant([]))
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
@@ -49,7 +49,7 @@ struct HomeReleaseSection: View {
     let empty = ReleaseHealthProvider(releases: [])
 
     return NavigationStack {
-        PlainList {
+        InsetList {
             HomeReleaseSection(releases: releases, path: .constant([]))
             HomeReleaseSection(releases: empty, path: .constant([]))
         }

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionRow.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionRow.swift
@@ -25,7 +25,7 @@ struct HomeRetentionRow: View {
 }
 
 #Preview {
-    PlainList {
+    InsetList {
         HomeRetentionRow(series: MiniChartSeries(values: [100, 42, 28, 19, 13, 8])) {}
     }
 }

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionRow.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionRow.swift
@@ -21,13 +21,11 @@ struct HomeRetentionRow: View {
         }
         .buttonStyle(.plain)
         .listRowSeparator(.hidden)
-        .listRowInsets(EdgeInsets())
     }
 }
 
 #Preview {
-    List {
+    PlainList {
         HomeRetentionRow(series: MiniChartSeries(values: [100, 42, 28, 19, 13, 8])) {}
     }
-    .listStyle(.plain)
 }

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -86,7 +86,7 @@ struct HomeRetentionSection: View {
     retention.result = .success(.samples)
 
     return NavigationStack {
-        PlainList {
+        InsetList {
             HomeRetentionSection(retention: retention, path: .constant([]))
             HomeRetentionSection(retention: RetentionProvider(), path: .constant([]))
         }

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -86,10 +86,9 @@ struct HomeRetentionSection: View {
     retention.result = .success(.samples)
 
     return NavigationStack {
-        List {
+        PlainList {
             HomeRetentionSection(retention: retention, path: .constant([]))
             HomeRetentionSection(retention: RetentionProvider(), path: .constant([]))
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Home/Settings/BackendDetailView.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendDetailView.swift
@@ -33,7 +33,7 @@ struct BackendDetailView: View {
     }
 
     private func content(for backend: BackendHealth) -> some View {
-        List {
+        PlainList {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 10) {
                     Image(systemName: backend.status.healthIcon)
@@ -111,7 +111,6 @@ struct BackendDetailView: View {
             }
             .disabled(isChecking)
         }
-        .listStyle(.plain)
     }
 }
 

--- a/Sources/ScoutUI/Home/Settings/BackendDetailView.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendDetailView.swift
@@ -33,7 +33,7 @@ struct BackendDetailView: View {
     }
 
     private func content(for backend: BackendHealth) -> some View {
-        PlainList {
+        InsetList {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 10) {
                     Image(systemName: backend.status.healthIcon)

--- a/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
+++ b/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
@@ -19,7 +19,7 @@ struct SettingsOverviewView: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             GlanceHero(summary: GlanceSummary(backends: provider.backends))
                 .padding(.vertical, 6)
                 .padding(.top)

--- a/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
+++ b/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
@@ -19,9 +19,10 @@ struct SettingsOverviewView: View {
     }
 
     var body: some View {
-        List {
+        PlainList {
             GlanceHero(summary: GlanceSummary(backends: provider.backends))
                 .padding(.vertical, 6)
+                .padding(.top)
                 .listRowSeparator(.hidden)
 
             Header(title: "Backends")
@@ -39,11 +40,9 @@ struct SettingsOverviewView: View {
             Button {
                 Task { await provider.refreshAll() }
             } label: {
-                Text(verbatim: "Check All Backends")
-                    .foregroundStyle(.tint)
+                Text(verbatim: "Check All Backends").foregroundStyle(.tint)
             }
         }
-        .listStyle(.plain)
         .navigationTitle(en: "Settings")
         .dismissable()
         .opaquePresentation()

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
@@ -18,7 +18,7 @@ struct AlertEditorView: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        List {
+        PlainList {
             Header(title: "Metric")
             metricRow
 
@@ -27,13 +27,21 @@ struct AlertEditorView: View {
             }
 
             Header(title: "Condition")
-            PillRow(options: AlertDraft.Kind.allCases, selection: $draft.kind) { $0.label }
+            PillRow(
+                options: AlertDraft.Kind.allCases,
+                selection: $draft.kind
+            ) { $0.label }
+
             valueRow
 
             Header(title: "For at least")
-            PillRow(options: AlertDraft.Hold.allCases, selection: $draft.hold) { $0.label }
+            PillRow(
+                options: AlertDraft.Hold.allCases,
+                selection: $draft.hold
+            ) { $0.label }
 
             Header(title: "Delivery")
+
             Toggle(isOn: $draft.notifies) {
                 Text(verbatim: "Notify on this device")
             }
@@ -41,7 +49,6 @@ struct AlertEditorView: View {
 
             backtestRow
         }
-        .listStyle(.plain)
         .navigationTitle(en: "New Rule")
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
@@ -18,7 +18,7 @@ struct AlertEditorView: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        PlainList {
+        InsetList {
             Header(title: "Metric")
             metricRow
 

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -45,7 +45,7 @@ struct AlertListView: View {
     @ViewBuilder private var content: some View {
         switch provider.result {
         case .success(let statuses) where statuses.count > 0:
-            PlainList {
+            InsetList {
                 chips(statuses)
 
                 Header(title: "Rules") {
@@ -81,7 +81,7 @@ struct AlertListView: View {
             }
 
         case nil:
-            PlainList {
+            InsetList {
                 Header(title: "Rules")
 
                 ForEach(0..<3, id: \.self) { _ in

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -34,14 +34,18 @@ struct AlertListView: View {
                 }
             }
             .opaquePresentation()
-            .task { await provider.fetchIfNeeded(in: database) }
-            .refreshable { await provider.fetchAgain(in: database) }
+            .task {
+                await provider.fetchIfNeeded(in: database)
+            }
+            .refreshable {
+                await provider.fetchAgain(in: database)
+            }
     }
 
     @ViewBuilder private var content: some View {
         switch provider.result {
         case .success(let statuses) where statuses.count > 0:
-            List {
+            PlainList {
                 chips(statuses)
 
                 Header(title: "Rules") {
@@ -62,7 +66,7 @@ struct AlertListView: View {
                         }
                 }
             }
-            .listStyle(.plain)
+            .environment(\.defaultMinListRowHeight, 34)
 
         case .success:
             Placeholder(
@@ -77,14 +81,13 @@ struct AlertListView: View {
             }
 
         case nil:
-            List {
+            PlainList {
                 Header(title: "Rules")
 
                 ForEach(0..<3, id: \.self) { _ in
                     AlertRowPlaceholder()
                 }
             }
-            .listStyle(.plain)
         }
     }
 

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertRow.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertRow.swift
@@ -31,7 +31,6 @@ struct AlertRow: View {
             MiniChart(series: status.series, color: status.outcome.state.color)
         }
         .frame(height: 68)
-        .listRowInsets(.sideInsets)
     }
 }
 
@@ -54,7 +53,6 @@ struct AlertRowPlaceholder: View {
 
             MiniChart(series: nil, color: .gray)
         }
-        .padding(.vertical, 4)
         .redacted(reason: .placeholder)
         .trailingRowSeparator()
     }

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownSection.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownSection.swift
@@ -17,14 +17,22 @@ struct IncidentBreakdownSection<Element: Incident, RowContent: View>: View {
     var body: some View {
         if breakdown.devices.count > 0 {
             Header(title: "Top Devices")
-            chart(for: .devices, segments: breakdown.devices, caption: "devices")
-                .listRowSeparator(.hidden, edges: .bottom)
+
+            chart(
+                for: .devices,
+                segments: breakdown.devices,
+                caption: "devices"
+            )
         }
 
         if breakdown.osVersions.count > 0 {
             Header(title: "OS Versions")
-            chart(for: .osVersions, segments: breakdown.osVersions, caption: "sessions")
-                .listRowSeparator(.hidden, edges: .bottom)
+
+            chart(
+                for: .osVersions,
+                segments: breakdown.osVersions,
+                caption: "sessions"
+            )
         }
     }
 
@@ -40,6 +48,11 @@ struct IncidentBreakdownSection<Element: Incident, RowContent: View>: View {
                     row: row
                 )
             }
+            .listRowSeparator(.hidden, edges: .top)
+            .alignmentGuide(.listRowSeparatorLeading) { dimension in
+                dimension[.leading]
+            }
+            .padding(.bottom)
         } else {
             SegmentBar(segments: segments)
         }
@@ -52,7 +65,7 @@ struct IncidentBreakdownSection<Element: Incident, RowContent: View>: View {
 
 #Preview {
     NavigationStack {
-        List {
+        PlainList {
             IncidentBreakdownSection(breakdown: .sample, records: [Crash].samples) { crash in
                 Row {
                     if let date = crash.date {
@@ -63,7 +76,6 @@ struct IncidentBreakdownSection<Element: Incident, RowContent: View>: View {
                 }
             }
         }
-        .listStyle(.plain)
     }
     .environmentObject(Tint())
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownSection.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownSection.swift
@@ -65,7 +65,7 @@ struct IncidentBreakdownSection<Element: Incident, RowContent: View>: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             IncidentBreakdownSection(breakdown: .sample, records: [Crash].samples) { crash in
                 Row {
                     if let date = crash.date {

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/SegmentOccurrenceList.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/SegmentOccurrenceList.swift
@@ -15,10 +15,9 @@ struct SegmentOccurrenceList<Element: Incident, RowContent: View>: View {
     @ViewBuilder let row: (Element) -> RowContent
 
     var body: some View {
-        List {
+        PlainList {
             ForEach(records, content: row)
         }
-        .listStyle(.plain)
         .monospacedNavigationTitle(en: title)
     }
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/SegmentOccurrenceList.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/SegmentOccurrenceList.swift
@@ -15,7 +15,7 @@ struct SegmentOccurrenceList<Element: Incident, RowContent: View>: View {
     @ViewBuilder let row: (Element) -> RowContent
 
     var body: some View {
-        PlainList {
+        InsetList {
             ForEach(records, content: row)
         }
         .monospacedNavigationTitle(en: title)

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashDetailView.swift
@@ -12,7 +12,7 @@ struct CrashDetailView: View {
     let crash: Crash
 
     var body: some View {
-        PlainList {
+        InsetList {
             VStack(alignment: .leading, spacing: 10) {
                 if let date = crash.date {
                     UTCTimestampText(date: date)

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashDetailView.swift
@@ -12,7 +12,7 @@ struct CrashDetailView: View {
     let crash: Crash
 
     var body: some View {
-        List {
+        PlainList {
             VStack(alignment: .leading, spacing: 10) {
                 if let date = crash.date {
                     UTCTimestampText(date: date)
@@ -24,13 +24,12 @@ struct CrashDetailView: View {
                         .fontWeight(.bold)
                 }
             }
-            .padding(.vertical, 4)
+            .padding(.vertical)
 
             ContextSection(context: crash, timelineHighlight: .red)
 
             StackTraceSection(frames: crash.stackTrace)
         }
-        .listStyle(.plain)
         .navigationTint(.red)
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
@@ -26,7 +26,7 @@ struct CrashGroupDetailView: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             headerSection
             breakdownSection
             occurrencesSection

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
@@ -18,16 +18,19 @@ struct CrashGroupDetailView: View {
         self.group = group
         self._breakdown = StateObject(
             wrappedValue: breakdown
-                ?? IncidentBreakdownProvider(deviceIDs: group.deviceIDs, sessionIDs: group.sessionIDs))
+                ?? IncidentBreakdownProvider(
+                    deviceIDs: group.deviceIDs,
+                    sessionIDs: group.sessionIDs
+                )
+        )
     }
 
     var body: some View {
-        List {
+        PlainList {
             headerSection
             breakdownSection
             occurrencesSection
         }
-        .listStyle(.plain)
         .navigationTint(.red)
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
@@ -61,6 +64,7 @@ struct CrashGroupDetailView: View {
             if let first = group.firstDate, let last = group.lastDate {
                 Text(verbatim: "First seen \(first.relativeString) · Last seen \(last.relativeString)")
                     .font(.system(size: 14))
+                    .padding(.bottom)
                     .foregroundStyle(Color.gray)
             }
         }
@@ -70,7 +74,11 @@ struct CrashGroupDetailView: View {
     @ViewBuilder
     private var breakdownSection: some View {
         if let value = try? breakdown.result?.get() {
-            IncidentBreakdownSection(breakdown: value, records: group.records, row: occurrenceRow)
+            IncidentBreakdownSection(
+                breakdown: value,
+                records: group.records,
+                row: occurrenceRow
+            )
         }
     }
 

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
@@ -22,7 +22,7 @@ struct CrashListView: View {
                         description: "No crash reports have been recorded"
                     )
                 } else {
-                    List {
+                    PlainList {
                         ForEach(groups, content: row)
 
                         if let cursor = provider.cursor {
@@ -31,7 +31,6 @@ struct CrashListView: View {
                             }
                         }
                     }
-                    .listStyle(.plain)
                     .animation(nil, value: groups)
                 }
             } else {

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
@@ -22,7 +22,7 @@ struct CrashListView: View {
                         description: "No crash reports have been recorded"
                     )
                 } else {
-                    PlainList {
+                    InsetList {
                         ForEach(groups, content: row)
 
                         if let cursor = provider.cursor {

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangDetailView.swift
@@ -12,7 +12,7 @@ struct HangDetailView: View {
     let hang: Hang
 
     var body: some View {
-        PlainList {
+        InsetList {
             VStack(alignment: .leading, spacing: 0) {
                 if let date = hang.date {
                     UTCTimestampText(date: date)

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangDetailView.swift
@@ -12,10 +12,11 @@ struct HangDetailView: View {
     let hang: Hang
 
     var body: some View {
-        List {
-            VStack(alignment: .leading, spacing: 10) {
+        PlainList {
+            VStack(alignment: .leading, spacing: 0) {
                 if let date = hang.date {
                     UTCTimestampText(date: date)
+                        .frame(height: 44)
                 }
 
                 HStack(spacing: 6) {
@@ -25,9 +26,9 @@ struct HangDetailView: View {
                         .fontWeight(.bold)
                         .foregroundStyle(hang.severity.color)
                 }
-
+                Divider().padding(.vertical)
                 if let reason = hang.reason {
-                    VStack(alignment: .leading, spacing: 4) {
+                    VStack(alignment: .leading, spacing: 8) {
                         Text(verbatim: "BLOCKED ON:")
                         Text(reason)
                             .foregroundColor(hang.severity.color)
@@ -35,13 +36,13 @@ struct HangDetailView: View {
                     .fontWeight(.bold)
                 }
             }
-            .padding(.vertical, 4)
+            .listRowSeparator(.hidden, edges: .top)
+            .padding(.bottom)
 
             ContextSection(context: hang, timelineHighlight: hang.severity.color)
 
             StackTraceSection(frames: hang.stackTrace)
         }
-        .listStyle(.plain)
         .navigationTint(hang.severity.color)
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
@@ -22,12 +22,11 @@ struct HangGroupDetailView: View {
     }
 
     var body: some View {
-        List {
+        PlainList {
             headerSection
             breakdownSection
             occurrencesSection
         }
-        .listStyle(.plain)
         .navigationTint(group.severity.color)
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
@@ -60,7 +59,7 @@ struct HangGroupDetailView: View {
                     .foregroundStyle(Color.gray)
             }
         }
-        .padding(.vertical, 4)
+        .padding(.bottom)
     }
 
     @ViewBuilder

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
@@ -22,7 +22,7 @@ struct HangGroupDetailView: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             headerSection
             breakdownSection
             occurrencesSection

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
@@ -22,7 +22,7 @@ struct HangListView: View {
                         description: "No unresponsive main thread has been recorded"
                     )
                 } else {
-                    List {
+                    PlainList {
                         ForEach(groups) { group in
                             HangRow(group: group)
                         }
@@ -33,7 +33,6 @@ struct HangListView: View {
                             }
                         }
                     }
-                    .listStyle(.plain)
                     .animation(nil, value: groups)
                 }
             } else {

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
@@ -22,7 +22,7 @@ struct HangListView: View {
                         description: "No unresponsive main thread has been recorded"
                     )
                 } else {
-                    PlainList {
+                    InsetList {
                         ForEach(groups) { group in
                             HangRow(group: group)
                         }

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangRow.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangRow.swift
@@ -23,7 +23,7 @@ struct HangRow: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             ForEach(IncidentGroup.groups(from: [Hang].samples)) { group in
                 HangRow(group: group)
             }

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangRow.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangRow.swift
@@ -23,12 +23,11 @@ struct HangRow: View {
 
 #Preview {
     NavigationStack {
-        List {
+        PlainList {
             ForEach(IncidentGroup.groups(from: [Hang].samples)) { group in
                 HangRow(group: group)
             }
         }
-        .listStyle(.plain)
         .navigationTitle(en: "Hangs")
     }
     .environmentObject(Tint())

--- a/Sources/ScoutUI/Monitoring/Incident/Section/ContextSection.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Section/ContextSection.swift
@@ -63,7 +63,7 @@ struct ContextSection<Context: SessionContext>: View {
     }
 
     return NavigationStack {
-        PlainList {
+        InsetList {
             ContextSection(context: Sample(sessionID: UUID(), deviceID: UUID()), timelineHighlight: .red)
         }
     }

--- a/Sources/ScoutUI/Monitoring/Incident/Section/ContextSection.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Section/ContextSection.swift
@@ -63,9 +63,8 @@ struct ContextSection<Context: SessionContext>: View {
     }
 
     return NavigationStack {
-        List {
+        PlainList {
             ContextSection(context: Sample(sessionID: UUID(), deviceID: UUID()), timelineHighlight: .red)
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Section/StackTraceSection.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Section/StackTraceSection.swift
@@ -26,11 +26,10 @@ struct StackTraceSection: View {
 }
 
 #Preview {
-    List {
+    PlainList {
         StackTraceSection(frames: [
             "0   CoreFoundation        0x0 __exceptionPreprocess + 164",
             "1   libobjc.A.dylib       0x0 objc_exception_throw + 60",
         ])
     }
-    .listStyle(.plain)
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Section/StackTraceSection.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Section/StackTraceSection.swift
@@ -26,7 +26,7 @@ struct StackTraceSection: View {
 }
 
 #Preview {
-    PlainList {
+    InsetList {
         StackTraceSection(frames: [
             "0   CoreFoundation        0x0 __exceptionPreprocess + 164",
             "1   libobjc.A.dylib       0x0 objc_exception_throw + 60",

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
@@ -54,7 +54,7 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
     provider.result = .success(.sample)
 
     return NavigationStack {
-        List {
+        PlainList {
             MetricDistributionSection(
                 name: "http_request",
                 categories: [],
@@ -63,7 +63,6 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
                 provider: provider
             )
         }
-        .listStyle(.plain)
         .monospacedNavigationTitle(en: "http_request")
     }
 }
@@ -73,7 +72,7 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
     provider.result = .success(.sample)
 
     return NavigationStack {
-        List {
+        PlainList {
             MetricDistributionSection(
                 name: "payload_size",
                 categories: [],
@@ -82,7 +81,6 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
                 provider: provider
             )
         }
-        .listStyle(.plain)
         .monospacedNavigationTitle(en: "payload_size")
     }
 }

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
@@ -54,7 +54,7 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
     provider.result = .success(.sample)
 
     return NavigationStack {
-        PlainList {
+        InsetList {
             MetricDistributionSection(
                 name: "http_request",
                 categories: [],
@@ -72,7 +72,7 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
     provider.result = .success(.sample)
 
     return NavigationStack {
-        PlainList {
+        InsetList {
             MetricDistributionSection(
                 name: "payload_size",
                 categories: [],

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
@@ -35,16 +35,17 @@ struct MetricsContent<T: ChartNumeric>: View {
                     code: telemetry.snippet
                 )
             } else {
-                List(ranked) { group in
-                    Row {
-                        row(group: group)
-                    } destination: {
-                        if let named = groups.named(group.name) {
-                            destination(group: named)
+                PlainList {
+                    ForEach(ranked) { group in
+                        Row {
+                            row(group: group)
+                        } destination: {
+                            if let named = groups.named(group.name) {
+                                destination(group: named)
+                            }
                         }
                     }
                 }
-                .listStyle(.plain)
             }
         }
     }

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
@@ -35,7 +35,7 @@ struct MetricsContent<T: ChartNumeric>: View {
                     code: telemetry.snippet
                 )
             } else {
-                PlainList {
+                InsetList {
                     ForEach(ranked) { group in
                         Row {
                             row(group: group)

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
@@ -34,13 +34,20 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
     }
 
     var body: some View {
-        SegmentStrip(selection: $extent.period, distribution: .justified, title: \.shortTitle)
-            .padding(.horizontal)
+        PlainList {
+            SegmentStrip(
+                selection: $extent.period,
+                distribution: .justified,
+                title: \.shortTitle
+            )
+            .listRowSeparator(.hidden)
 
-        RangeControl(extent: $extent)
+            RangeControl(extent: $extent)
+                .padding(.bottom)
+                .listRowSeparator(.hidden)
 
-        List {
             let segment = extent.segment(from: group.points)
+            let canCompare = extent.canCompare(points: group.points, segment: segment)
 
             ComparableChart(
                 segment: segment,
@@ -50,18 +57,19 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
                 isComparing: isComparing,
                 markers: resets.dates(in: extent.domain)
             )
-            .chartYAxis(content: { formattedMarks })
+            .chartYAxis {
+                formattedMarks
+            }
             .listRowSeparator(.hidden)
             .autoRefresh {
                 await resets.fetchLatest(in: database)
             }
+            .padding(.bottom)
 
-            ComparisonToggle(isOn: $isComparing)
-                .disabled(!extent.canCompare(points: group.points, segment: segment))
+            ComparisonToggle(isOn: $isComparing).disabled(!canCompare)
 
             extra(extent)
         }
-        .listStyle(.plain)
         .monospacedNavigationTitle(en: group.name)
         .scrollDisabled(Extra.self == EmptyView.self)
         .toolbar {
@@ -87,7 +95,12 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
 
 extension MetricsView where Extra == EmptyView {
     init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period, tracksResets: Bool = false) {
-        self.init(group: group, formatter: formatter, period: period, tracksResets: tracksResets) { _ in EmptyView() }
+        self.init(
+            group: group,
+            formatter: formatter,
+            period: period,
+            tracksResets: tracksResets
+        ) { _ in EmptyView() }
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
@@ -34,7 +34,7 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
     }
 
     var body: some View {
-        PlainList {
+        InsetList {
             SegmentStrip(
                 selection: $extent.period,
                 distribution: .justified,

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointDetailView.swift
@@ -16,7 +16,7 @@ struct NetworkEndpointDetailView: View {
     var unit: Calendar.Component = .hour
 
     var body: some View {
-        List {
+        PlainList {
             HStack(spacing: 28) {
                 Metric(
                     title: "Method",
@@ -35,7 +35,7 @@ struct NetworkEndpointDetailView: View {
                 )
                 Spacer()
             }
-            .listRowSeparator(.hidden)
+            .listRowSeparator(.hidden, edges: .top)
 
             let distribution = report.distributions[endpoint.name]
             let statuses = report.statuses[endpoint.name]
@@ -43,7 +43,6 @@ struct NetworkEndpointDetailView: View {
             if let percentiles = distribution?.summary(in: range) {
                 Header(title: "Latency")
                 PercentileRow(percentiles: percentiles, formatter: \TimeInterval.duration)
-                    .listRowSeparator(.hidden, edges: .bottom)
             }
 
             if let trend = distribution?.trend(in: range, component: unit), trend.count > 0 {
@@ -58,7 +57,6 @@ struct NetworkEndpointDetailView: View {
                     .listRowSeparator(.hidden, edges: .bottom)
             }
         }
-        .listStyle(.plain)
         .monospacedNavigationTitle(en: endpoint.path)
     }
 }

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointDetailView.swift
@@ -16,7 +16,7 @@ struct NetworkEndpointDetailView: View {
     var unit: Calendar.Component = .hour
 
     var body: some View {
-        PlainList {
+        InsetList {
             HStack(spacing: 28) {
                 Metric(
                     title: "Method",

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointRow.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointRow.swift
@@ -52,7 +52,7 @@ struct NetworkEndpointRow: View {
     let range = Period.today.initialRange
 
     NavigationStack {
-        PlainList {
+        InsetList {
             ForEach(report.endpoints(in: range)) { endpoint in
                 NetworkEndpointRow(endpoint: endpoint, report: report, range: range)
             }

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointRow.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointRow.swift
@@ -40,7 +40,7 @@ struct NetworkEndpointRow: View {
                         .foregroundStyle(.gray)
                 }
             }
-            .frame(height: 44)
+            .frame(height: 70)
         } destination: {
             NetworkEndpointDetailView(endpoint: endpoint, report: report, range: range)
         }
@@ -52,9 +52,10 @@ struct NetworkEndpointRow: View {
     let range = Period.today.initialRange
 
     NavigationStack {
-        List(report.endpoints(in: range)) { endpoint in
-            NetworkEndpointRow(endpoint: endpoint, report: report, range: range)
+        PlainList {
+            ForEach(report.endpoints(in: range)) { endpoint in
+                NetworkEndpointRow(endpoint: endpoint, report: report, range: range)
+            }
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointsView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointsView.swift
@@ -18,21 +18,36 @@ struct NetworkEndpointsView: View {
         let breakdown = report.summary(in: range)
         let worstP99 = endpoints.compactMap(\.p99).max()
 
-        List {
+        PlainList {
             HStack(spacing: 28) {
-                Metric(title: "Requests", value: breakdown.total.plain, color: .primary)
-                Metric(title: "Success", value: breakdown.successRate.formatted, color: breakdown.successRate.color)
-                Metric(title: "Worst P99", value: worstP99?.duration ?? "—", color: .orange)
+                Metric(
+                    title: "Requests",
+                    value: breakdown.total.plain,
+                    color: .primary
+                )
+                Metric(
+                    title: "Success",
+                    value: breakdown.successRate.formatted,
+                    color: breakdown.successRate.color
+                )
+                Metric(
+                    title: "Worst P99",
+                    value: worstP99?.duration ?? "—",
+                    color: .orange
+                )
                 Spacer()
             }
-            .listRowSeparator(.hidden)
 
             Header(title: "Endpoints")
             ForEach(endpoints) { endpoint in
-                NetworkEndpointRow(endpoint: endpoint, report: report, range: range)
+                NetworkEndpointRow(
+                    endpoint: endpoint,
+                    report: report,
+                    range: range
+                )
+                .frame(height: 70)
             }
         }
-        .listStyle(.plain)
         .navigationTitle(en: "Endpoints")
     }
 }

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointsView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointsView.swift
@@ -18,7 +18,7 @@ struct NetworkEndpointsView: View {
         let breakdown = report.summary(in: range)
         let worstP99 = endpoints.compactMap(\.p99).max()
 
-        PlainList {
+        InsetList {
             HStack(spacing: 28) {
                 Metric(
                     title: "Requests",

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
@@ -35,7 +35,7 @@ struct NetworkView: View {
         let successRate = breakdown.total > 0 ? breakdown.successRate : nil
         let trend = report.trend(in: range, component: .hour)
 
-        return PlainList {
+        return InsetList {
             HStack(spacing: 28) {
                 Metric(title: "P99", value: report.percentiles(in: range)?.p99.duration ?? "—", color: .orange)
                 Metric(title: "Success", value: successRate?.formatted ?? "—", color: successRate?.color ?? .primary)

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
@@ -35,14 +35,13 @@ struct NetworkView: View {
         let successRate = breakdown.total > 0 ? breakdown.successRate : nil
         let trend = report.trend(in: range, component: .hour)
 
-        return List {
+        return PlainList {
             HStack(spacing: 28) {
                 Metric(title: "P99", value: report.percentiles(in: range)?.p99.duration ?? "—", color: .orange)
                 Metric(title: "Success", value: successRate?.formatted ?? "—", color: successRate?.color ?? .primary)
                 Metric(title: "Req/min", value: report.requestsPerMinute(endpoints, in: range).plain, color: .primary)
                 Spacer()
             }
-            .listRowSeparator(.hidden)
 
             if trend.count > 0 {
                 Header(title: "Latency P99")
@@ -52,16 +51,18 @@ struct NetworkView: View {
 
             Header(title: "Status codes")
             SegmentBar(segments: breakdown.segments)
-                .listRowSeparator(.hidden)
 
             Header(title: "Top endpoints") {
                 AllButton { showAllEndpoints = true }
             }
             ForEach(endpoints.prefix(3)) { endpoint in
-                NetworkEndpointRow(endpoint: endpoint, report: report, range: range)
+                NetworkEndpointRow(
+                    endpoint: endpoint,
+                    report: report,
+                    range: range
+                )
             }
         }
-        .listStyle(.plain)
         .navigationDestination(isPresented: $showAllEndpoints) {
             NetworkEndpointsView(report: report, range: range)
         }

--- a/Sources/ScoutUI/Primitives/Indicators/StatView.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatView.swift
@@ -22,7 +22,7 @@ struct StatView: View {
             let segment = extent.segment(from: points)
             let canCompare = extent.canCompare(points: points, segment: segment)
 
-            PlainList {
+            InsetList {
                 PeriodPicker(extent: $extent, periods: stat.periods)
                     .listRowInsets(EdgeInsets())
                     .listRowSeparator(.hidden)

--- a/Sources/ScoutUI/Primitives/Indicators/StatView.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatView.swift
@@ -20,27 +20,40 @@ struct StatView: View {
     var body: some View {
         ProviderView(provider: stat) { points in
             let segment = extent.segment(from: points)
+            let canCompare = extent.canCompare(points: points, segment: segment)
 
-            List {
+            PlainList {
                 PeriodPicker(extent: $extent, periods: stat.periods)
                     .listRowInsets(EdgeInsets())
                     .listRowSeparator(.hidden)
 
                 RangeControl(extent: $extent)
+                    .padding(.bottom)
                     .listRowInsets(EdgeInsets())
                     .listRowSeparator(.hidden)
 
                 ComparableChart(
-                    segment: segment, points: points, extent: extent, color: color, isComparing: isComparing
+                    segment: segment,
+                    points: points,
+                    extent: extent,
+                    color: color,
+                    isComparing: isComparing
                 )
-                .listRowSeparator(.hidden, edges: .top)
-                .listRowSeparator(showList ? .visible : .hidden, edges: .bottom)
+                .listRowSeparator(.hidden)
+                .padding(.bottom)
 
                 ComparisonToggle(isOn: $isComparing)
-                    .disabled(!extent.canCompare(points: points, segment: segment))
+                    .disabled(!canCompare)
 
                 if showList {
-                    total(count: segment.total)
+                    Row {
+                        Text(verbatim: "Events")
+                        Spacer()
+                        RedactedText(count: segment.count)
+                    } destination: {
+                        EventStatList(eventName: stat.eventName, range: extent.domain)
+                    }
+                    .foregroundColor(.blue)
                 }
 
                 Header(title: "Weekly Pattern") {
@@ -48,7 +61,7 @@ struct StatView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
-                .listRowSeparator(.hidden)
+                .listRowSeparator(.hidden, edges: .bottom)
 
                 HeatmapView(
                     grid: HeatmapGrid(
@@ -59,11 +72,11 @@ struct StatView: View {
                 )
                 .listRowSeparator(.hidden)
             }
-            .listStyle(.plain)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     ChartExportButton(
-                        title: stat.eventName, rangeLabel: extent.domain.label(using: rangeDateFormatter)
+                        title: stat.eventName,
+                        rangeLabel: extent.domain.label(using: rangeDateFormatter)
                     ) {
                         ChartView(segment: segment, timing: extent)
                             .foregroundStyle(color)
@@ -72,17 +85,6 @@ struct StatView: View {
             }
         }
         .resetsTint()
-    }
-
-    func total(count: Int) -> some View {
-        Row {
-            Text(verbatim: "Events")
-            Spacer()
-            RedactedText(count: count)
-        } destination: {
-            EventStatList(eventName: stat.eventName, range: extent.domain)
-        }
-        .foregroundColor(.blue)
     }
 }
 

--- a/Sources/ScoutUI/Primitives/Rows/AllButton.swift
+++ b/Sources/ScoutUI/Primitives/Rows/AllButton.swift
@@ -22,7 +22,7 @@ struct AllButton: View {
 }
 
 #Preview {
-    PlainList {
+    InsetList {
         Header(title: "Section Title") {
             AllButton {}
         }

--- a/Sources/ScoutUI/Primitives/Rows/AllButton.swift
+++ b/Sources/ScoutUI/Primitives/Rows/AllButton.swift
@@ -22,10 +22,9 @@ struct AllButton: View {
 }
 
 #Preview {
-    List {
+    PlainList {
         Header(title: "Section Title") {
             AllButton {}
         }
     }
-    .listStyle(.plain)
 }

--- a/Sources/ScoutUI/Primitives/Rows/Header.swift
+++ b/Sources/ScoutUI/Primitives/Rows/Header.swift
@@ -26,17 +26,16 @@ struct Header<Trailing: View>: View {
 
             trailing()
         }
-        .padding(.top, 16)
-        .padding(.bottom, 4)
+        .padding(.top, 12)
+        .frame(height: 70)
     }
 }
 
 #Preview {
-    List {
+    PlainList {
         Header(title: "Section Title")
         Header(title: "Section Title") {
             AllButton {}
         }
     }
-    .listStyle(.plain)
 }

--- a/Sources/ScoutUI/Primitives/Rows/Header.swift
+++ b/Sources/ScoutUI/Primitives/Rows/Header.swift
@@ -32,7 +32,7 @@ struct Header<Trailing: View>: View {
 }
 
 #Preview {
-    PlainList {
+    InsetList {
         Header(title: "Section Title")
         Header(title: "Section Title") {
             AllButton {}

--- a/Sources/ScoutUI/Primitives/Rows/InsetList.swift
+++ b/Sources/ScoutUI/Primitives/Rows/InsetList.swift
@@ -12,7 +12,7 @@ extension EdgeInsets {
     static let sideInsets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
 }
 
-struct PlainList<Content: View>: View {
+struct InsetList<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -25,7 +25,7 @@ struct PlainList<Content: View>: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             Header(title: "Section Title")
 
             Row {

--- a/Sources/ScoutUI/Primitives/Rows/PlainList.swift
+++ b/Sources/ScoutUI/Primitives/Rows/PlainList.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Mikhail Kasianov
+// Copyright 2026 Mikhail Kasianov
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
@@ -8,30 +8,26 @@
 import Scout
 import SwiftUI
 
-struct Row<Content: View, Destination: View>: View {
+extension EdgeInsets {
+    static let sideInsets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+}
+
+struct PlainList<Content: View>: View {
     @ViewBuilder let content: () -> Content
-    @ViewBuilder let destination: () -> Destination
 
     var body: some View {
-        ZStack {
-            HStack {
-                content()
-            }
-
-            NavigationLink {
-                destination()
-            } label: {
-                EmptyView()
-            }
-            .opacity(0)
+        List {
+            content().listRowInsets(.sideInsets)
         }
-        .trailingRowSeparator()
+        .listStyle(.plain)
     }
 }
 
 #Preview {
     NavigationStack {
         PlainList {
+            Header(title: "Section Title")
+
             Row {
                 Text(verbatim: "Label")
                 Spacer()
@@ -39,6 +35,10 @@ struct Row<Content: View, Destination: View>: View {
             } destination: {
                 Text(verbatim: "Detail")
             }
+
+            Text(verbatim: "Full width")
+                .frame(maxWidth: .infinity)
+                .background(.blue.opacity(0.1))
         }
     }
 }

--- a/Sources/ScoutUI/Primitives/Rows/Row.swift
+++ b/Sources/ScoutUI/Primitives/Rows/Row.swift
@@ -31,7 +31,7 @@ struct Row<Content: View, Destination: View>: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             Row {
                 Text(verbatim: "Label")
                 Spacer()

--- a/Sources/ScoutUI/Primitives/Rows/RowSummary.swift
+++ b/Sources/ScoutUI/Primitives/Rows/RowSummary.swift
@@ -28,7 +28,7 @@ struct RowSummary: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             HStack {
                 Text(verbatim: "Loaded")
                 Spacer()

--- a/Sources/ScoutUI/Primitives/Rows/RowSummary.swift
+++ b/Sources/ScoutUI/Primitives/Rows/RowSummary.swift
@@ -20,7 +20,7 @@ struct RowSummary: View {
         HStack(spacing: 8) {
             MiniChart(series: series, color: color)
             RedactedText(count: count)
-                .foregroundColor(color)
+                .foregroundColor(.primary)
                 .frame(minWidth: Self.countWidth, alignment: .trailing)
         }
     }
@@ -28,7 +28,7 @@ struct RowSummary: View {
 
 #Preview {
     NavigationStack {
-        List {
+        PlainList {
             HStack {
                 Text(verbatim: "Loaded")
                 Spacer()
@@ -52,6 +52,5 @@ struct RowSummary: View {
                     color: .blue)
             }
         }
-        .listStyle(.plain)
     }
 }

--- a/Sources/ScoutUI/Primitives/States/RedactedText.swift
+++ b/Sources/ScoutUI/Primitives/States/RedactedText.swift
@@ -30,10 +30,9 @@ struct Redacted: View {
 }
 
 #Preview {
-    List {
+    PlainList {
         Redacted(length: 3)
         Redacted(length: 5)
         Redacted(length: 8)
     }
-    .listStyle(.plain)
 }

--- a/Sources/ScoutUI/Primitives/States/RedactedText.swift
+++ b/Sources/ScoutUI/Primitives/States/RedactedText.swift
@@ -30,7 +30,7 @@ struct Redacted: View {
 }
 
 #Preview {
-    PlainList {
+    InsetList {
         Redacted(length: 3)
         Redacted(length: 5)
         Redacted(length: 8)

--- a/Sources/ScoutUI/Primitives/Styles/View+LargeTitle.swift
+++ b/Sources/ScoutUI/Primitives/Styles/View+LargeTitle.swift
@@ -8,6 +8,12 @@
 import Scout
 import SwiftUI
 
-extension EdgeInsets {
-    static let sideInsets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+extension View {
+    func largeNavigationTitle() -> some View {
+        #if os(iOS)
+            navigationBarTitleDisplayMode(.large)
+        #else
+            self
+        #endif
+    }
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonToggle.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonToggle.swift
@@ -8,7 +8,6 @@
 import Scout
 import SwiftUI
 
-/// List row with the switch that turns the previous-period overlay on.
 struct ComparisonToggle: View {
     @Binding var isOn: Bool
 
@@ -16,17 +15,16 @@ struct ComparisonToggle: View {
         Toggle(isOn: $isOn) {
             Text(verbatim: "Compare with previous period")
         }
-        .listRowSeparator(.hidden)
+        .listRowSeparator(.hidden, edges: .top)
         .hapticFeedback(.selection, trigger: isOn)
     }
 }
 
 #Preview("ComparisonToggle") {
-    List {
+    PlainList {
         ComparisonToggle(isOn: .constant(true))
         ComparisonToggle(isOn: .constant(false))
         ComparisonToggle(isOn: .constant(false))
             .disabled(true)
     }
-    .listStyle(.plain)
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonToggle.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonToggle.swift
@@ -21,7 +21,7 @@ struct ComparisonToggle: View {
 }
 
 #Preview("ComparisonToggle") {
-    PlainList {
+    InsetList {
         ComparisonToggle(isOn: .constant(true))
         ComparisonToggle(isOn: .constant(false))
         ComparisonToggle(isOn: .constant(false))

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportSheet.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportSheet.swift
@@ -22,7 +22,7 @@ struct ChartExportSheet<ChartContent: View>: View {
     @Environment(\.displayScale) private var displayScale
 
     var body: some View {
-        PlainList {
+        InsetList {
             ChartSnapshot(
                 title: title,
                 rangeLabel: rangeLabel,

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportSheet.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportSheet.swift
@@ -22,7 +22,7 @@ struct ChartExportSheet<ChartContent: View>: View {
     @Environment(\.displayScale) private var displayScale
 
     var body: some View {
-        List {
+        PlainList {
             ChartSnapshot(
                 title: title,
                 rangeLabel: rangeLabel,
@@ -32,7 +32,6 @@ struct ChartExportSheet<ChartContent: View>: View {
                 chart: chart
             )
             .listRowSeparator(.hidden)
-            .listRowInsets(EdgeInsets())
 
             Header(title: "Format")
                 .listRowSeparator(.hidden, edges: .top)
@@ -78,7 +77,6 @@ struct ChartExportSheet<ChartContent: View>: View {
                 Text(verbatim: "Period Label")
             }
         }
-        .listStyle(.plain)
         .disabledBounce()
         .scrollContentBackground(.hidden)
         .background(.background)

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/View/MiniChart.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/View/MiniChart.swift
@@ -37,7 +37,7 @@ struct MiniChart: View {
 
 #Preview {
     NavigationStack {
-        PlainList {
+        InsetList {
             HStack {
                 Text(verbatim: "Loaded")
                 Spacer()

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/View/MiniChart.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/View/MiniChart.swift
@@ -37,7 +37,7 @@ struct MiniChart: View {
 
 #Preview {
     NavigationStack {
-        List {
+        PlainList {
             HStack {
                 Text(verbatim: "Loaded")
                 Spacer()
@@ -56,6 +56,5 @@ struct MiniChart: View {
                 )
             }
         }
-        .listStyle(.plain)
     }
 }


### PR DESCRIPTION
Row insets were applied ad hoc: sideInsets appeared at fifteen call sites while the remaining rows relied on whatever the plain list style defaults to, and every list repeated listStyle(.plain) even though the project only ever uses that style. InsetList wraps both, so a screen declares its rows and the container decides how they are inset, and a row that needs to bleed full width still overrides it with its own listRowInsets because the modifier closer to the row wins.

The name points at the inset rather than the style, since the plain style is already the only one the project uses and the shared row inset is the part that is not obvious from the call site.

Every list in the module moves over, including the five that used the List(collection:) initializer and now nest a ForEach. The duplicated sideInsets on individual rows are gone, and the constant itself moved next to the container since that is now its only use, which empties EdgeInsets+Styles.swift. StatRow moves next to EventView.Sections, the only place that builds it.

Rows that deliberately zero their insets keep doing so, so charts and pickers stay full width rather than picking up the container inset on top of their own padding. Screens pushed from a monospaced title also gain a large title of their own, which arrived here from #1060.