### PR TITLE
Let containers own component spacing instead of the components

### DIFF
--- a/Sources/ScoutUI/Home/Settings/GlanceHero.swift
+++ b/Sources/ScoutUI/Home/Settings/GlanceHero.swift
@@ -21,7 +21,9 @@ struct GlanceSummary {
         averageLatency = latencies.count > 0 ? latencies.reduce(0, +) / latencies.count : nil
     }
 
-    var allOperational: Bool { reachable == total }
+    var allOperational: Bool {
+        reachable == total
+    }
 
     var title: String {
         allOperational ? "All Systems Operational" : "\(reachable) of \(total) Backends Reachable"
@@ -32,9 +34,13 @@ struct GlanceSummary {
         return averageLatency.map { "\(count) · \($0) ms average latency" } ?? count
     }
 
-    var color: Color { allOperational ? .green : .orange }
+    var color: Color {
+        allOperational ? .green : .orange
+    }
 
-    var icon: String { allOperational ? "checkmark.seal.fill" : "exclamationmark.triangle.fill" }
+    var icon: String {
+        allOperational ? "checkmark.seal.fill" : "exclamationmark.triangle.fill"
+    }
 }
 
 struct GlanceHero: View {

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownProvider.swift
@@ -25,39 +25,62 @@ final class IncidentBreakdownProvider: ObservableObject, Provider {
         async let models = deviceModels(in: database)
         async let versions = osVersions(in: database)
 
-        return IncidentBreakdown(
-            devices: IncidentBreakdown.segments(from: Array(try await models.values)),
-            osVersions: IncidentBreakdown.segments(from: Array(try await versions.values)),
+        return try await IncidentBreakdown(
+            devices: IncidentBreakdown.segments(from: Array(models.values)),
+            osVersions: IncidentBreakdown.segments(from: Array(versions.values)),
             modelsByDevice: try await models,
             versionsBySession: try await versions
         )
     }
 
     private func deviceModels(in database: DatabaseReader) async throws -> [UUID: String] {
-        guard deviceIDs.count > 0 else { return [:] }
+        guard deviceIDs.count > 0 else {
+            return [:]
+        }
 
         let query = RecordQuery(
             recordType: Device.self,
-            filters: [RecordQuery.Filter(field: "device_id", op: .in, value: .strings(deviceIDs.map(\.uuidString)))]
+            filters: [
+                RecordQuery.Filter(
+                    field: "device_id",
+                    op: .in,
+                    value: .strings(deviceIDs.map(\.uuidString))
+                )
+            ]
         )
         let records: [Record] = try await database.readAll(matching: query, fields: ["device_id", "model"])
         return dictionary(from: records, key: "device_id", value: "model")
     }
 
     private func osVersions(in database: DatabaseReader) async throws -> [UUID: String] {
-        guard sessionIDs.count > 0 else { return [:] }
+        guard sessionIDs.count > 0 else {
+            return [:]
+        }
 
         let query = RecordQuery(
             recordType: Session.self,
-            filters: [RecordQuery.Filter(field: "session_id", op: .in, value: .strings(sessionIDs.map(\.uuidString)))]
+            filters: [
+                RecordQuery.Filter(
+                    field: "session_id",
+                    op: .in,
+                    value: .strings(sessionIDs.map(\.uuidString))
+                )
+            ]
         )
-        let records: [Record] = try await database.readAll(matching: query, fields: ["session_id", "os_version"])
+
+        let records: [Record] = try await database.readAll(
+            matching: query,
+            fields: ["session_id", "os_version"]
+        )
+
         return dictionary(from: records, key: "session_id", value: "os_version")
     }
 
     private func dictionary(from records: [Record], key: String, value: String) -> [UUID: String] {
         let pairs = records.compactMap { (record: Record) -> (UUID, String)? in
-            guard let id = record[key].flatMap(UUID.init), let label: String = record[value] else { return nil }
+            guard let id = record[key].flatMap(UUID.init), let label: String = record[value] else {
+                return nil
+            }
             return (id, label)
         }
         return Dictionary(pairs, uniquingKeysWith: { first, _ in first })

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionView.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionView.swift
@@ -33,7 +33,6 @@ struct MetricDistributionView: View {
 
             PercentileTrendChart(trend: trend, unit: unit, formatter: formatter)
         }
-        .padding(.vertical)
     }
 }
 

--- a/Sources/ScoutUI/Primitives/Calendar/RangeControl.swift
+++ b/Sources/ScoutUI/Primitives/Calendar/RangeControl.swift
@@ -36,8 +36,6 @@ struct RangeControl<T: ChartTimeScale>: View {
             .disabled(!extent.isRightEnabled)
         }
         .frame(height: 44)
-        .padding(.top)
-        .padding(.horizontal)
         .hapticFeedback(.selection, trigger: extent.domain)
     }
 

--- a/Sources/ScoutUI/Primitives/Calendar/RangeSheet.swift
+++ b/Sources/ScoutUI/Primitives/Calendar/RangeSheet.swift
@@ -28,8 +28,6 @@ struct RangeSheet: View {
             footer
         }
         .padding(.horizontal, 20)
-        .padding(.top, 32)
-        .padding(.bottom, 20)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.white)
     }
@@ -114,7 +112,7 @@ private struct RangeSheetPreviewHost: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .padding()
+        .padding(.horizontal)
         .sheet(item: $activeStyle) { style in
             RangeSheet(style: style, selection: $selection)
                 .presentationDetents([.height(540)])

--- a/Sources/ScoutUI/Primitives/Calendar/WeekStripCalendar.swift
+++ b/Sources/ScoutUI/Primitives/Calendar/WeekStripCalendar.swift
@@ -39,7 +39,7 @@ struct WeekStripCalendar: View {
                     .transition(.scale(scale: 0.92, anchor: .top).combined(with: .opacity))
             }
         }
-        .padding()
+        .padding(.horizontal)
     }
 
     private var control: some View {

--- a/Sources/ScoutUI/Primitives/Indicators/InfoChip.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/InfoChip.swift
@@ -21,7 +21,7 @@ struct InfoChip: View {
         }
         .font(.footnote)
         .padding(.horizontal, 10)
-        .padding(.vertical, 5)
+        .frame(height: 28)
         .background {
             ZStack(alignment: .leading) {
                 Color.gray.opacity(0.12)

--- a/Sources/ScoutUI/Primitives/Indicators/Metric.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/Metric.swift
@@ -23,6 +23,7 @@ struct Metric: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(Color.gray)
         }
+        .frame(height: 70)
     }
 }
 

--- a/Sources/ScoutUI/Primitives/States/ErrorView.swift
+++ b/Sources/ScoutUI/Primitives/States/ErrorView.swift
@@ -43,7 +43,7 @@ struct ErrorView: View {
             Spacer()
         }
         .lineSpacing(4)
-        .padding()
+        .padding(.horizontal)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 

--- a/Sources/ScoutUI/Primitives/States/Placeholder.swift
+++ b/Sources/ScoutUI/Primitives/States/Placeholder.swift
@@ -38,7 +38,7 @@ struct Placeholder: View {
                 Text(code.swiftSyntax).codeChipStyle()
             }
         }
-        .padding()
+        .padding(.horizontal)
         .frame(maxHeight: .infinity)
     }
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparableChart.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparableChart.swift
@@ -8,12 +8,6 @@
 import Scout
 import SwiftUI
 
-/// Chart row that switches between the plain bar chart and the comparison
-/// overlay; pairs with `ComparisonToggle` driving `isComparing`.
-///
-/// `points` is the full data set the reference segment is bucketed from,
-/// while `segment` is the already-computed current-window slice of it.
-///
 struct ComparableChart<T: ChartNumeric, S: ChartTimeScale>: View {
     let segment: [ChartPoint<T>]
     let points: [ChartPoint<T>]

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonChartView.swift
@@ -9,22 +9,6 @@ import Charts
 import Scout
 import SwiftUI
 
-/// A bar chart of the current period with the previous period's per-bucket
-/// levels drawn on top of it.
-///
-/// - where the value grew, a white dashed line marks the previous level and
-///   the slice of the bar above it is lightened;
-/// - where the value dropped, a dashed contour rises above the bar to the
-///   previous level and the missing slice is tinted.
-///
-/// `reference` is expected to sit on the same bucket dates as `segment`
-/// (see `ChartExtent.referenceSegment(from:alignedTo:)`); buckets missing
-/// from it have no comparison data and draw no reference marks.
-///
-/// The y scale covers both periods, rounded up to a nice axis value the same
-/// way plain bar charts round their maximum — so reference contours always
-/// fit and the axis keeps regular tick values.
-///
 struct ComparisonChartView<T: ChartNumeric>: View {
     let segment: [ChartPoint<T>]
     let reference: [ChartPoint<T>]
@@ -59,9 +43,7 @@ struct ComparisonChartView<T: ChartNumeric>: View {
             }
         }
         .aspectRatio(4 / 3, contentMode: .fit)
-        .padding()
-        .padding(.bottom)
-        .listRowInsets(EdgeInsets())
+        .padding(.horizontal)
         .environment(\.calendar, .utc)
         .environment(\.timeZone, Calendar.utc.timeZone)
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Picker/PeriodPicker.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Picker/PeriodPicker.swift
@@ -20,7 +20,6 @@ struct PeriodPicker<T: PickerCompatible & ChartTimeScale & CaseIterable>: View {
             distribution: .justified,
             title: title
         )
-        .padding(.horizontal)
     }
 
     private func title(period: T) -> String {

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/View/ChartView.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/View/ChartView.swift
@@ -42,9 +42,6 @@ struct ChartView<T: ChartNumeric>: View {
             }
         }
         .aspectRatio(4 / 3, contentMode: .fit)
-        .padding()
-        .padding(.bottom)
-        .listRowInsets(EdgeInsets())
         .environment(\.calendar, .utc)
         .environment(\.timeZone, Calendar.utc.timeZone)
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Heatmap/HeatmapView.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Heatmap/HeatmapView.swift
@@ -40,6 +40,7 @@ struct HeatmapView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity)
     }
 
     private func cell(day: Int, block: Int, maxBlock: Int) -> some View {

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/View/TimelineSegment.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/View/TimelineSegment.swift
@@ -23,8 +23,6 @@ struct TimelineSegment: View {
         )
         .fill(color.opacity(isActive ? 1 : 0.08))
         .frame(width: 8)
-        .padding(.top, topRadius > 0 ? 2 : 0)
-        .padding(.bottom, bottomRadius > 0 ? 2 : 0)
         .frame(width: 16)
     }
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/View/TimelineSegment.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/View/TimelineSegment.swift
@@ -23,6 +23,8 @@ struct TimelineSegment: View {
         )
         .fill(color.opacity(isActive ? 1 : 0.08))
         .frame(width: 8)
+        .padding(.top, topRadius > 0 ? 2 : 0)
+        .padding(.bottom, bottomRadius > 0 ? 2 : 0)
         .frame(width: 16)
     }
 }


### PR DESCRIPTION
Components carried their own outer spacing, so the same gap was expressed in two places and drifted: a row of chips padded itself vertically while the list row it sat in also reserved height, and charts and pickers padded themselves horizontally on top of the inset their row already had. Each component now renders its own content and leaves the surrounding space to whoever places it, which is the container that actually knows the layout.

Padding that defines a shape rather than a gap stays, so pills and badges keep their capsule proportions, and the placeholders and sheets that are not list rows keep the margins that centre them. The timeline segment keeps its two points as well: they form the seam between adjacent rail segments and shape the rounded joint, which the snapshot suite caught as soon as they were dropped. Where a component only ever painted all four edges, the horizontal half is preserved and only the vertical part is dropped.

This pairs with the InsetList change in #1058, which is where the row inset now comes from.