### PR TITLE
Give screens pushed from a monospaced title a large title of their own

### DIFF
--- a/Sources/ScoutUI/Analytics/Event/Detail/EventView.Sections.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/EventView.Sections.swift
@@ -59,6 +59,7 @@ extension EventView {
                         stat: stat
                     )
                     .navigationTitle(en: "Stats")
+                    .largeNavigationTitle()
                 }
             }
         }

--- a/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
@@ -21,7 +21,7 @@ struct EventStatList: View {
                 .autoRefresh {
                     await provider.fetchLatest(for: query, in: database)
                 }
-                .navigationTitle(range.label(using: rangeDateFormatter))
+                .navigationTitle(en: range.label(using: rangeDateFormatter))
                 .font(.caption)
         }
     }

--- a/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
@@ -34,6 +34,7 @@ struct SessionInspector: View {
             { await info.fetchLatest(in: database) },
         ])
         .navigationTitle(en: "Session")
+        .largeNavigationTitle()
     }
 
     private var query: EventQuery {


### PR DESCRIPTION
A pushed screen that does not state a display mode inherits the previous one, so everything opened from an event, a crash or a hang came up with a small inline title even though it is a destination in its own right. Stats, Params and Session now ask for a large title explicitly, matching how the same screens look when they are reached from Home.

The date range title on the event stat list also moves to navigationTitle(en:), so every title in the module is declared the same way and a future literal cannot slip through the host app's string catalog.

Stacked on #1058, which adds the largeNavigationTitle helper.