### PR TITLE
Refresh the whole rotating set each cycle instead of one provider

### DIFF
--- a/Sources/ScoutUI/Primitives/Refresh/AutoRefresh.swift
+++ b/Sources/ScoutUI/Primitives/Refresh/AutoRefresh.swift
@@ -81,9 +81,11 @@ private struct AutoRefreshModifier<Token: Equatable>: ViewModifier {
             }
 
             var isSuccess = true
+
             for refresh in refreshers {
-                guard !Task.isCancelled else { return }
-                if await refresh() == false {
+                if Task.isCancelled {
+                    return
+                } else if await refresh() == false {
                     isSuccess = false
                 }
             }

--- a/Sources/ScoutUI/Primitives/Refresh/AutoRefresh.swift
+++ b/Sources/ScoutUI/Primitives/Refresh/AutoRefresh.swift
@@ -72,7 +72,6 @@ private struct AutoRefreshModifier<Token: Equatable>: ViewModifier {
         }
 
         var schedule = RefreshSchedule()
-        var index = 0
 
         while !Task.isCancelled {
             do {
@@ -80,12 +79,20 @@ private struct AutoRefreshModifier<Token: Equatable>: ViewModifier {
             } catch {
                 break
             }
-            if await refreshers[index % refreshers.count]() {
+
+            var isSuccess = true
+            for refresh in refreshers {
+                guard !Task.isCancelled else { return }
+                if await refresh() == false {
+                    isSuccess = false
+                }
+            }
+
+            if isSuccess {
                 schedule.recordSuccess()
             } else {
                 schedule.recordFailure()
             }
-            index += 1
         }
     }
 }


### PR DESCRIPTION
The auto-refresh loop used to wake up every schedule tick and refresh a single provider from the rotating set, so a set of N providers took N ticks to fully update. Now each cycle runs the entire set sequentially with no pauses in between, then waits out the schedule delay (same 3 s seed with the existing failure backoff) and repeats. A failure anywhere in the set records a failure for the cycle.

Since fetchLatest deliberately swallows CancellationError, the sequential run also checks Task.isCancelled between requests — leaving the screen cancels the task and stops the sequence immediately instead of starting the next request.