### PR TITLE
Let the period picker and range control take the shared row inset

### DIFF
--- a/Sources/ScoutUI/Primitives/Indicators/StatView.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatView.swift
@@ -24,12 +24,10 @@ struct StatView: View {
 
             InsetList {
                 PeriodPicker(extent: $extent, periods: stat.periods)
-                    .listRowInsets(EdgeInsets())
                     .listRowSeparator(.hidden)
 
                 RangeControl(extent: $extent)
                     .padding(.bottom)
-                    .listRowInsets(EdgeInsets())
                     .listRowSeparator(.hidden)
 
                 ComparableChart(


### PR DESCRIPTION
The period picker and the range control zeroed their row insets back when they supplied their own horizontal padding, so the two cancelled out and the rows lined up with everything else. #1059 moved that padding to the container, but the zeroed insets stayed behind, which left both rows flush against the screen edge.

Dropping the override lets InsetList inset them like every other row. No row in the module zeroes its insets any more, so the horizontal inset now comes from exactly one place.