### PR TITLE
Deduplicate provider queries and unify provider declarations

### DIFF
--- a/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
+++ b/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
@@ -13,8 +13,30 @@ extension DatabaseReader {
     ) async throws -> [MetricSeries] {
         try await series(
             matching: SeriesQuery(
-                category: category, values: T.seriesValues, bucket: .hour, reduce: reduce, range: range)
+                category: category,
+                values: T.seriesValues,
+                bucket: .hour,
+                reduce: reduce,
+                range: range
+            )
         )
+    }
+
+    package func metricSeries<T: MetricScalar>(
+        _ valueType: T.Type, categories: [String], in range: Range<Date>
+    ) async throws -> [MetricSeries] {
+        try await withThrowingTaskGroup(of: [MetricSeries].self) { group in
+            for category in categories {
+                group.addTask {
+                    try await self.metricSeries(T.self, category: category, in: range)
+                }
+            }
+            var series: [MetricSeries] = []
+            for try await chunk in group {
+                series += chunk
+            }
+            return series
+        }
     }
 }
 
@@ -100,7 +122,11 @@ package enum MetricValue: Decodable, Equatable, Sendable {
             self = .double(value)
         } else {
             throw DecodingError.dataCorrupted(
-                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown metric value type"))
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unknown metric value type"
+                )
+            )
         }
     }
 }

--- a/Sources/ScoutUI/Analytics/Activity/ActivityProvider.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 import Scout
 
-class ActivityProvider: ObservableObject, Provider {
+@MainActor
+final class ActivityProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[ActivityPoint]>?
 
     func fetch(in database: DatabaseReader) async throws -> [ActivityPoint] {

--- a/Sources/ScoutUI/Analytics/Event/Param/ParamProvider.swift
+++ b/Sources/ScoutUI/Analytics/Event/Param/ParamProvider.swift
@@ -8,7 +8,8 @@
 import Scout
 import SwiftUI
 
-class ParamProvider: ObservableObject, Provider {
+@MainActor
+final class ParamProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[Item]>?
 
     private let recordID: String

--- a/Sources/ScoutUI/Analytics/Retention/RetentionProvider.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 import Scout
 
-class RetentionProvider: ObservableObject, Provider {
+@MainActor
+final class RetentionProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[RetentionCohort]>?
 
     func fetch(in database: DatabaseReader) async throws -> [RetentionCohort] {

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthProvider.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthProvider.swift
@@ -9,7 +9,7 @@ import Scout
 import SwiftUI
 
 @MainActor
-class ReleaseHealthProvider: ObservableObject, Provider {
+final class ReleaseHealthProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[ReleaseHealth]>?
 
     init(releases: [ReleaseHealth]? = nil) {

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionIncidentProvider.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionIncidentProvider.swift
@@ -9,41 +9,27 @@ import Scout
 import SwiftUI
 
 @MainActor
-class VersionIncidentProvider<Element: RecordDecodable & Incident>: ObservableObject {
-    @Published var records: [Element]?
-    @Published var message: Message?
-
+final class VersionIncidentProvider<Element: RecordDecodable & Incident>: FeedProvider<Element> {
     let version: String
 
     init(version: String, records: [Element]? = nil) {
         self.version = version
+        super.init()
         self.records = records
     }
 
     private var query: RecordQuery {
-        RecordQuery(
-            recordType: Element.self,
-            filters: Calendar.utc.defaultRange.dateFilters + [
-                RecordQuery.Filter(field: "app_version", op: .equals, value: .string(version))
-            ]
-        )
+        Element.query(filters: [
+            RecordQuery.Filter(
+                field: "app_version",
+                op: .equals,
+                value:
+                    .string(version))
+        ])
     }
 
     @discardableResult
     func fetchLatest(in database: DatabaseReader) async -> Bool {
-        do {
-            records = try await database.readAll(
-                matching: query,
-                fields: Element.desiredKeys
-            )
-            return true
-        } catch is CancellationError {
-            return true
-        } catch {
-            if records == nil {
-                message = Message(error.localizedDescription, level: .error)
-            }
-            return false
-        }
+        await fetchAll(matching: query, in: database)
     }
 }

--- a/Sources/ScoutUI/Home/Search/Index/IncidentGroupsProvider.swift
+++ b/Sources/ScoutUI/Home/Search/Index/IncidentGroupsProvider.swift
@@ -13,15 +13,10 @@ final class IncidentGroupsProvider<Element: RecordDecodable & Incident>: Observa
     @Published var result: ProviderResult<[IncidentGroup<Element>]>?
 
     func fetch(in database: DatabaseReader) async throws -> [IncidentGroup<Element>] {
-        let chunk = try await database.read(matching: query, fields: Element.desiredKeys)
-        return IncidentGroup.groups(from: try chunk.records.map(Element.init))
-    }
-
-    private var query: RecordQuery {
-        RecordQuery(
-            recordType: Element.self,
-            filters: Calendar.utc.defaultRange.dateFilters,
-            sort: [RecordQuery.Sort(field: "date", ascending: false)]
+        let chunk = try await database.read(
+            matching: Element.query(),
+            fields: Element.desiredKeys
         )
+        return IncidentGroup.groups(from: try chunk.records.map(Element.init))
     }
 }

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import Scout
 
 @MainActor
-class HomeLogProvider: ObservableObject, Provider {
+final class HomeLogProvider: ObservableObject, Provider {
     typealias Output = [MetricSeries]
 
     @Published var period: Period {

--- a/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
@@ -10,7 +10,7 @@ import Foundation
 import Scout
 
 @MainActor
-class BackendHealthProvider: ObservableObject {
+final class BackendHealthProvider: ObservableObject {
     @Published private(set) var backends: [BackendHealth]
 
     init(backends: [Backend]) {

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertBacktestProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertBacktestProvider.swift
@@ -9,7 +9,7 @@ import Scout
 import SwiftUI
 
 @MainActor
-class AlertBacktestProvider: ObservableObject, Provider {
+final class AlertBacktestProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<AlertBacktest>?
 
     var metric: AlertMetric

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
@@ -9,7 +9,7 @@ import Scout
 import SwiftUI
 
 @MainActor
-class AlertProvider: ObservableObject, Provider {
+final class AlertProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[AlertStatus]>?
 
     private let store: AlertStore

--- a/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentProvider.swift
@@ -14,16 +14,8 @@ final class IncidentProvider<Element: RecordDecodable & Incident>: FeedProvider<
         records.map(IncidentGroup.groups)
     }
 
-    private var query: RecordQuery {
-        RecordQuery(
-            recordType: Element.self,
-            filters: Calendar.utc.defaultRange.dateFilters,
-            sort: [RecordQuery.Sort(field: "date", ascending: false)]
-        )
-    }
-
     @discardableResult
     func fetchLatest(in database: DatabaseReader) async -> Bool {
-        await fetchLatest(matching: query, in: database)
+        await fetchLatest(matching: Element.query(), in: database)
     }
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentQuery.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentQuery.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+extension Incident where Self: RecordDecodable {
+    static func query(filters extra: [RecordQuery.Filter] = []) -> RecordQuery {
+        RecordQuery(
+            recordType: Self.self,
+            filters: Calendar.utc.defaultRange.dateFilters + extra,
+            sort: [RecordQuery.Sort(field: "date", ascending: false)]
+        )
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionProvider.swift
@@ -9,7 +9,8 @@
 import Foundation
 import Scout
 
-class MetricDistributionProvider<H: QuantileHistogram>: ObservableObject, Provider {
+@MainActor
+final class MetricDistributionProvider<H: QuantileHistogram>: ObservableObject, Provider {
     @Published var result: ProviderResult<MetricDistribution<H>>?
 
     private let name: String
@@ -21,22 +22,11 @@ class MetricDistributionProvider<H: QuantileHistogram>: ObservableObject, Provid
     }
 
     func fetch(in database: DatabaseReader) async throws -> MetricDistribution<H> {
-        let range = Calendar.utc.defaultRange
-        let name = self.name
-
-        let series = try await withThrowingTaskGroup(of: [MetricSeries].self) { group in
-            for category in categories {
-                group.addTask {
-                    try await database.metricSeries(Int.self, category: category, in: range)
-                }
-            }
-            var series: [MetricSeries] = []
-            for try await chunk in group {
-                series += chunk
-            }
-            return series
-        }
-
+        let series = try await database.metricSeries(
+            Int.self,
+            categories: categories,
+            in: Calendar.utc.defaultRange
+        )
         return MetricDistribution(series: series.filter { $0.name == name })
     }
 }

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 import Scout
 
-class MetricsProvider<T: ChartNumeric>: ObservableObject, Provider {
+@MainActor
+final class MetricsProvider<T: ChartNumeric>: ObservableObject, Provider {
     @Published var result: ProviderResult<[MetricSeries]>?
 
     private let telemetry: Telemetry.Export

--- a/Sources/ScoutUI/Monitoring/Metrics/ResetMarkerProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/ResetMarkerProvider.swift
@@ -9,7 +9,8 @@
 import Foundation
 import Scout
 
-class ResetMarkerProvider: ObservableObject, Provider {
+@MainActor
+final class ResetMarkerProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[Date]>?
 
     private let name: String

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkProvider.swift
@@ -10,27 +10,16 @@ import Foundation
 import Scout
 
 @MainActor
-class NetworkProvider: ObservableObject, Provider {
+final class NetworkProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<NetworkReport>?
 
     func fetch(in database: DatabaseReader) async throws -> NetworkReport {
-        let range = Calendar.utc.defaultRange
         let categories = LatencyBuckets.categories + StatusBuckets.categories
-
-        let series = try await withThrowingTaskGroup(of: [MetricSeries].self) { group in
-            for category in categories {
-                group.addTask {
-                    try await database.metricSeries(Int.self, category: category, in: range)
-                }
-            }
-
-            var series: [MetricSeries] = []
-            for try await chunk in group {
-                series += chunk
-            }
-            return series
-        }
-
+        let series = try await database.metricSeries(
+            Int.self,
+            categories: categories,
+            in: Calendar.utc.defaultRange
+        )
         return NetworkReport(series: series)
     }
 }

--- a/Sources/ScoutUI/Primitives/Indicators/StatProvider.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import Scout
 
 @MainActor
-class StatProvider: ObservableObject, Provider {
+final class StatProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[ChartPoint<Int>]>?
 
     let eventName: String

--- a/Sources/ScoutUI/Support/Provider/FeedProvider.swift
+++ b/Sources/ScoutUI/Support/Provider/FeedProvider.swift
@@ -34,6 +34,21 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
         }
     }
 
+    @discardableResult
+    func fetchAll(matching query: RecordQuery, in database: DatabaseReader) async -> Bool {
+        do {
+            records = try await database.readAll(matching: query, fields: Element.desiredKeys)
+            return true
+        } catch is CancellationError {
+            return true
+        } catch {
+            if records == nil {
+                message = Message(error.localizedDescription, level: .error)
+            }
+            return false
+        }
+    }
+
     func fetchAgain(matching query: RecordQuery, in database: DatabaseReader) async {
         do {
             let results = try await database.read(matching: query, fields: Element.desiredKeys)


### PR DESCRIPTION
Providers had grown three copies of the same incident query and two copies of the same metric-series fan-out, and their class declarations drifted between marked and inferred `@MainActor`. This pulls the shared pieces out and settles on one shape.

The incident query ("default range, newest first") is now a single `Incident.query(filters:)` factory used by `IncidentProvider`, `IncidentGroupsProvider` and `VersionIncidentProvider`. The category fan-out moves into `DatabaseReader.metricSeries(_:categories:in:)`, collapsing the identical task groups in `NetworkProvider` and `MetricDistributionProvider` to a single call. `VersionIncidentProvider` now subclasses `FeedProvider` and reuses a new `fetchAll(matching:in:)` (a `readAll` load with the same toast-on-empty error handling) instead of duplicating the records/message plumbing. Every provider is now `@MainActor final class`.

No behavior change intended. `VersionIncidentProvider` gains a newest-first sort from the shared factory, which is inert for its consumer since the view re-aggregates by day and by fingerprint. Test target builds and `VersionIncidentProviderTests` passes.