### PR TITLE
Raise the gate wait timeout to ride out runner queue backlogs

### DIFF
--- a/.github/scripts/wait-for-checks.sh
+++ b/.github/scripts/wait-for-checks.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 : "${SHAS:?SHAS is required}"
 : "${CHECKS:?CHECKS is required}"
-timeout="${TIMEOUT:-1200}"
+timeout="${TIMEOUT:-2400}"
 interval="${INTERVAL:-15}"
 
 read -ra shas <<< "$SHAS"

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -22,7 +22,7 @@ jobs:
   gate:
     name: gate
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     permissions:
       contents: read

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -87,7 +87,7 @@ jobs:
     name: gate
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     permissions:
       contents: read

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -54,7 +54,7 @@ jobs:
     name: gate
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     permissions:
       contents: read


### PR DESCRIPTION
The gate jobs wait for the fast cross-workflow checks with a 1200 s default in wait-for-checks.sh, but a macOS runner queue backlog can keep the Swift workflow (and its lint check) from even starting within that window, failing the gates on perfectly healthy PRs — as happened on #1061. The default wait is now 2400 s, and the gate jobs' timeout-minutes are raised from 25 to 45 to leave room for it.