### PR TITLE
Track scout-db's main branch instead of a released version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
-        .package(url: "https://github.com/kasianov-mikhail/scout-db.git", from: "0.10.0"),
+        .package(url: "https://github.com/kasianov-mikhail/scout-db.git", branch: "main"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),
     ],


### PR DESCRIPTION
Switches the scout-db dependency from `from: "0.10.0"` to `branch: "main"` so scout builds against the latest scout-db work instead of the last tagged release. Resolving picks up scout-db main at 9653454, and the test target builds clean against it, so no source changes were needed on this side. Note that this is a floating pin — CI will pull whatever main holds at build time, and `Package.resolved` is gitignored here, so nothing locks the revision; worth reverting to a version pin before a release.