### PR TITLE
Group cached and fetched series points in a SeriesGroups struct

### DIFF
--- a/Sources/LookupIndex/CachedMetricSeries.swift
+++ b/Sources/LookupIndex/CachedMetricSeries.swift
@@ -18,7 +18,8 @@ enum CachedMetricSeries {
             query.bucket.rawValue,
             query.byVersion ? "version" : "*",
             query.source?.rawValue ?? "*",
-        ].joined(separator: "|")
+        ]
+        .joined(separator: "|")
     }
 
     static func records(from series: [MetricSeries]) -> [Record] {
@@ -36,7 +37,7 @@ enum CachedMetricSeries {
     }
 
     static func series(cached: [Record], fetched: [MetricSeries]) -> [MetricSeries] {
-        var points: [SeriesKey: [MetricSeriesPoint]] = [:]
+        var groups = SeriesGroups()
 
         for record in cached {
             guard case .date(let date)? = record.fields["date"] else { continue }
@@ -47,35 +48,15 @@ enum CachedMetricSeries {
                 if case .string(let category)? = record.fields["category"] { category } else { nil }
             let version: String? =
                 if case .string(let version)? = record.fields["app_version"] { version } else { nil }
-            let point = MetricSeriesPoint(date: date.millisecondsSince1970, value: value)
-            points[SeriesKey(name: name, category: category, version: version), default: []].append(point)
+            let key = SeriesKey(name: name, category: category, version: version)
+            groups.append(MetricSeriesPoint(date: date.millisecondsSince1970, value: value), to: key)
         }
 
         for series in fetched {
-            points[SeriesKey(name: series.name, category: series.category, version: series.version), default: []] +=
-                series.points
+            groups.append(series)
         }
 
-        return
-            points
-            .sorted {
-                ($0.key.name, $0.key.category ?? "", $0.key.version ?? "")
-                    < ($1.key.name, $1.key.category ?? "", $1.key.version ?? "")
-            }
-            .map { key, points in
-                MetricSeries(
-                    name: key.name,
-                    category: key.category,
-                    version: key.version,
-                    points: points.sorted { $0.date < $1.date }
-                )
-            }
-    }
-
-    private struct SeriesKey: Hashable {
-        let name: String
-        let category: String?
-        let version: String?
+        return groups.series
     }
 
     private static func recordValue(_ value: MetricValue) -> RecordValue {

--- a/Sources/LookupIndex/SeriesGroups.swift
+++ b/Sources/LookupIndex/SeriesGroups.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct SeriesKey: Hashable, Comparable {
+    let name: String
+    let category: String?
+    let version: String?
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        (lhs.name, lhs.category ?? "", lhs.version ?? "") < (rhs.name, rhs.category ?? "", rhs.version ?? "")
+    }
+}
+
+struct SeriesGroups {
+    private var points: [SeriesKey: [MetricSeriesPoint]] = [:]
+
+    mutating func append(_ point: MetricSeriesPoint, to key: SeriesKey) {
+        points[key, default: []].append(point)
+    }
+
+    mutating func append(_ series: MetricSeries) {
+        let key = SeriesKey(
+            name: series.name,
+            category: series.category,
+            version: series.version
+        )
+        points[key, default: []] += series.points
+    }
+
+    var series: [MetricSeries] {
+        points.sorted(by: \.key).map { key, points in
+            MetricSeries(
+                name: key.name,
+                category: key.category,
+                version: key.version,
+                points: points.sorted { $0.date < $1.date }
+            )
+        }
+    }
+}
+
+extension Sequence {
+    fileprivate func sorted<Value: Comparable>(by keyPath: KeyPath<Element, Value>) -> [Element] {
+        sorted { $0[keyPath: keyPath] < $1[keyPath: keyPath] }
+    }
+}

--- a/Tests/LookupIndexTests/SeriesGroupsTests.swift
+++ b/Tests/LookupIndexTests/SeriesGroupsTests.swift
@@ -1,0 +1,73 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import LookupIndex
+@testable import Scout
+
+struct SeriesGroupsTests {
+    @Test func mergesPointsUnderTheSameKey() {
+        var groups = SeriesGroups()
+        groups.append(makePoint(date: 2), to: makeKey())
+        groups.append(makeSeries(points: [makePoint(date: 1)]))
+
+        let series = groups.series
+        #expect(series.count == 1)
+        #expect(series.first?.points.map(\.date) == [1, 2])
+    }
+
+    @Test func keepsSeriesWithDifferentKeysApart() {
+        var groups = SeriesGroups()
+        groups.append(makePoint(date: 1), to: makeKey(version: "1.0"))
+        groups.append(makePoint(date: 1), to: makeKey(version: "1.1"))
+        groups.append(makePoint(date: 1), to: makeKey(category: "billing"))
+
+        #expect(groups.series.count == 3)
+    }
+
+    @Test func sortsSeriesByNameThenCategoryThenVersion() {
+        var groups = SeriesGroups()
+        groups.append(makePoint(date: 1), to: makeKey(name: "Session", version: "1.1"))
+        groups.append(makePoint(date: 1), to: makeKey(name: "Session", version: "1.0"))
+        groups.append(makePoint(date: 1), to: makeKey(name: "Session", category: "billing"))
+        groups.append(makePoint(date: 1), to: makeKey(name: "Crash"))
+
+        let keys = groups.series.map { [$0.name, $0.category ?? "", $0.version ?? ""] }
+        #expect(
+            keys == [
+                ["Crash", "", ""],
+                ["Session", "", "1.0"],
+                ["Session", "", "1.1"],
+                ["Session", "billing", ""],
+            ]
+        )
+    }
+
+    @Test func treatsMissingCategoryAndVersionAsEmpty() {
+        #expect(makeKey(category: nil) < makeKey(category: "billing"))
+        #expect(makeKey(version: nil) < makeKey(version: "1.0"))
+        #expect(makeKey(name: "Crash") < makeKey(name: "Session", category: nil, version: nil))
+    }
+
+    @Test func hasNoSeriesWhenNothingAppended() {
+        #expect(SeriesGroups().series.count == 0)
+    }
+
+    private func makeKey(name: String = "Session", category: String? = nil, version: String? = nil) -> SeriesKey {
+        SeriesKey(name: name, category: category, version: version)
+    }
+
+    private func makePoint(date: Int64) -> MetricSeriesPoint {
+        MetricSeriesPoint(date: date, value: .int(1))
+    }
+
+    private func makeSeries(points: [MetricSeriesPoint]) -> MetricSeries {
+        MetricSeries(name: "Session", category: nil, version: nil, points: points)
+    }
+}


### PR DESCRIPTION
`CachedMetricSeries.series(cached:fetched:)` merged cached records and fetched series inline — a local `[SeriesKey: [MetricSeriesPoint]]` dictionary, an ad-hoc tuple comparison for ordering, and the final map into `MetricSeries`, all interleaved with `Record` field decoding. The grouping now lives in a `SeriesGroups` struct that owns the dictionary and exposes `append(_:to:)` for a point decoded from a cached record, `append(_:)` for an already fetched series, and `series` for the merged, sorted result.

`SeriesKey` gained `Comparable` — ordering by name, then category, then version, with `nil` compared as an empty string — so the sort reads `sorted(by: \.key)` through a small key-path overload instead of an inline tuple comparison. Both types moved to their own file, leaving `CachedMetricSeries` with just the `Record` encoding and decoding. Behavior is unchanged.

`SeriesGroupsTests` now covers what was previously reachable only through `CachedMetricSeries.series`: merging points under one key with points sorted by date, keeping distinct versions and categories apart, series ordering, `nil` category and version sorting first, and the empty case. Test target builds; all 27 `LookupIndexTests` pass.