### PR TITLE
Inline the incident group detail sections into the list body

### DIFF
--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
@@ -27,9 +27,38 @@ struct CrashGroupDetailView: View {
 
     var body: some View {
         InsetList {
-            headerSection
-            breakdownSection
-            occurrencesSection
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 24) {
+                    Readout(title: "Occurrences", value: "\(group.count)")
+                    Readout(title: "Devices", value: "\(group.affectedDevices)")
+                    Readout(title: "Sessions", value: "\(group.affectedSessions)")
+                }
+
+                if let reason = group.representative.reason {
+                    Text(verbatim: "REASON:   ").fontWeight(.bold)
+                        + Text(reason).fontWeight(.bold).foregroundColor(.red)
+                }
+
+                if let first = group.firstDate, let last = group.lastDate {
+                    Text(verbatim: "First seen \(first.relativeString) · Last seen \(last.relativeString)")
+                        .font(.system(size: 14))
+                        .padding(.bottom)
+                        .foregroundStyle(Color.gray)
+                }
+            }
+            .padding(.vertical, 4)
+
+            if let value = try? breakdown.result?.get() {
+                IncidentBreakdownSection(
+                    breakdown: value,
+                    records: group.records,
+                    row: occurrenceRow
+                )
+            }
+
+            Header(title: "Occurrences")
+
+            ForEach(group.records, content: occurrenceRow)
         }
         .navigationTint(.red)
         .toolbar {
@@ -46,47 +75,6 @@ struct CrashGroupDetailView: View {
         .task {
             await breakdown.fetchIfNeeded(in: database)
         }
-    }
-
-    private var headerSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 24) {
-                Readout(title: "Occurrences", value: "\(group.count)")
-                Readout(title: "Devices", value: "\(group.affectedDevices)")
-                Readout(title: "Sessions", value: "\(group.affectedSessions)")
-            }
-
-            if let reason = group.representative.reason {
-                Text(verbatim: "REASON:   ").fontWeight(.bold)
-                    + Text(reason).fontWeight(.bold).foregroundColor(.red)
-            }
-
-            if let first = group.firstDate, let last = group.lastDate {
-                Text(verbatim: "First seen \(first.relativeString) · Last seen \(last.relativeString)")
-                    .font(.system(size: 14))
-                    .padding(.bottom)
-                    .foregroundStyle(Color.gray)
-            }
-        }
-        .padding(.vertical, 4)
-    }
-
-    @ViewBuilder
-    private var breakdownSection: some View {
-        if let value = try? breakdown.result?.get() {
-            IncidentBreakdownSection(
-                breakdown: value,
-                records: group.records,
-                row: occurrenceRow
-            )
-        }
-    }
-
-    @ViewBuilder
-    private var occurrencesSection: some View {
-        Header(title: "Occurrences")
-
-        ForEach(group.records, content: occurrenceRow)
     }
 
     private func occurrenceRow(_ crash: Crash) -> some View {

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
@@ -23,9 +23,29 @@ struct HangGroupDetailView: View {
 
     var body: some View {
         InsetList {
-            headerSection
-            breakdownSection
-            occurrencesSection
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 16) {
+                    Readout(title: "Duration", value: group.durationText, color: group.severity.color)
+                    Readout(title: "Occurrences", value: "\(group.count)")
+                    Readout(title: "Devices", value: "\(group.affectedDevices)")
+                    Readout(title: "Sessions", value: "\(group.affectedSessions)")
+                }
+
+                if let first = group.firstDate, let last = group.lastDate {
+                    Text(verbatim: "First seen \(first.relativeString) · Last seen \(last.relativeString)")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color.gray)
+                }
+            }
+            .padding(.bottom)
+
+            if let value = try? breakdown.result?.get() {
+                IncidentBreakdownSection(breakdown: value, records: group.records, row: occurrenceRow)
+            }
+
+            Header(title: "Occurrences")
+
+            ForEach(group.records, content: occurrenceRow)
         }
         .navigationTint(group.severity.color)
         .toolbar {
@@ -42,38 +62,6 @@ struct HangGroupDetailView: View {
         .task {
             await breakdown.fetchIfNeeded(in: database)
         }
-    }
-
-    private var headerSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 16) {
-                Readout(title: "Duration", value: group.durationText, color: group.severity.color)
-                Readout(title: "Occurrences", value: "\(group.count)")
-                Readout(title: "Devices", value: "\(group.affectedDevices)")
-                Readout(title: "Sessions", value: "\(group.affectedSessions)")
-            }
-
-            if let first = group.firstDate, let last = group.lastDate {
-                Text(verbatim: "First seen \(first.relativeString) · Last seen \(last.relativeString)")
-                    .font(.system(size: 14))
-                    .foregroundStyle(Color.gray)
-            }
-        }
-        .padding(.bottom)
-    }
-
-    @ViewBuilder
-    private var breakdownSection: some View {
-        if let value = try? breakdown.result?.get() {
-            IncidentBreakdownSection(breakdown: value, records: group.records, row: occurrenceRow)
-        }
-    }
-
-    @ViewBuilder
-    private var occurrencesSection: some View {
-        Header(title: "Occurrences")
-
-        ForEach(group.records, content: occurrenceRow)
     }
 
     private func occurrenceRow(_ hang: Hang) -> some View {


### PR DESCRIPTION
CrashGroupDetailView and HangGroupDetailView each split their body into three private computed properties that were referenced exactly once, so reading either screen meant jumping between four places to see one list. This folds headerSection, breakdownSection and occurrencesSection back into the InsetList body. Both @ViewBuilder annotations go away with them — the list body is already a builder, so the if let and the bare Header plus ForEach pair work there as they are.

occurrenceRow stays a method in both views, since the breakdown section and the occurrence list both call it. Stacked on #1068, which renames Metric to Readout in these same two files.