### PR TITLE
Run the Swift matrix on pull requests stacked on other branches

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,11 +7,15 @@ name: Swift
 # Coverage is collected on the iOS 26 leg only — the reports differ between legs
 # by fractions of a percent, and that leg is the one where the snapshot suites
 # run. The stable iOS 18 / iOS 26 legs are the required checks on main.
+#
+# `pull_request` carries no base-branch filter on purpose. A PR stacked on
+# another PR's branch would otherwise skip this workflow entirely, and the gate
+# jobs in the sibling workflows — which wait for this workflow's `lint`
+# check-run — would hang until their timeout and fail the PR.
 on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
The Swift workflow only ran for pull requests targeting main, so a PR stacked on another PR's branch got no lint and no test matrix at all. That is worse than just missing coverage: the gate jobs in the API and Server workflows wait for this workflow's lint check-run before starting their expensive legs, and on a stacked PR that check-run never appears, so they hang until the 45-minute timeout and fail. Such a PR could not go green no matter what it contained.

Dropping the base-branch filter from the pull_request trigger fixes both. The push trigger still fires on main only, so nothing changes for branch pushes, and the concurrency group already cancels superseded runs on non-main refs.