### PR TITLE
Gate the home screen on alerts and releases before revealing the list

### DIFF
--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -77,6 +77,7 @@ struct HomeList: View {
             }
         }
         .rotatingProviders([sessions, activities, logs, releases, devices, alerts])
+        .loadingGate([alerts, releases])
     }
 }
 
@@ -110,6 +111,9 @@ struct HomeList: View {
     let devices = DevicesProvider()
     devices.result = .success(.sample)
 
+    let alerts = AlertProvider()
+    alerts.result = .success([.firingSample, .armedSample])
+
     return NavigationStack {
         HomeList(
             path: .constant([]),
@@ -118,7 +122,8 @@ struct HomeList: View {
             sessions: sessions,
             releases: releases,
             logs: logs,
-            devices: devices
+            devices: devices,
+            alerts: alerts
         )
         .navigationTitle(en: "Home")
     }

--- a/Sources/ScoutUI/Home/LoadingGate.swift
+++ b/Sources/ScoutUI/Home/LoadingGate.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+extension View {
+    func loadingGate(_ providers: [any Provider]) -> some View {
+        modifier(LoadingGateModifier(providers: providers))
+    }
+}
+
+private struct LoadingGateModifier: ViewModifier {
+    @Environment(\.database) private var database
+
+    let providers: [any Provider]
+
+    func body(content: Content) -> some View {
+        Group {
+            if providers.contains(where: \.isLoading) {
+                RingIndicator().frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                content
+            }
+        }
+        .task {
+            await withTaskGroup(of: Void.self) { group in
+                for fetch in fetchers {
+                    group.addTask { await fetch() }
+                }
+            }
+        }
+    }
+
+    private var fetchers: [@MainActor () async -> Void] {
+        providers.map { provider in
+            { await provider.fetchIfNeeded(in: database) }
+        }
+    }
+}
+
+extension Provider {
+    fileprivate var isLoading: Bool {
+        result == nil
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
@@ -8,6 +8,8 @@
 import Foundation
 import Scout
 
+typealias MetricReadings = [AlertMetric: MetricReading]
+
 @MainActor
 final class AlertEngine {
     private let registry: AlertRegistry
@@ -21,14 +23,36 @@ final class AlertEngine {
 
     func statuses(in database: DatabaseReader) async throws -> [AlertStatus] {
         let now = Date()
+        let readings = try await readings(for: Set(registry.rules.map(\.metric)), in: database)
 
-        var statuses: [AlertStatus] = []
-        for rule in registry.rules {
-            let reading = try await rule.metric.reading(in: database, period: AlertScale.trailing)
-            let outcome = evaluator.evaluate(rule, reading: reading, state: registry.state(for: rule), now: now)
-            statuses.append(AlertStatus(rule: rule, outcome: outcome, reading: reading))
+        return registry.rules.compactMap { rule in
+            guard let reading = readings[rule.metric] else {
+                return nil
+            }
+            let outcome = evaluator.evaluate(
+                rule,
+                reading: reading,
+                state: registry.state(for: rule),
+                now: now
+            )
+            return AlertStatus(rule: rule, outcome: outcome, reading: reading)
         }
-        return statuses
+    }
+
+    private func readings(for metrics: Set<AlertMetric>, in database: DatabaseReader) async throws -> MetricReadings {
+        try await withThrowingTaskGroup(of: (AlertMetric, MetricReading).self) { group in
+            for metric in metrics {
+                group.addTask {
+                    (metric, try await metric.reading(in: database, period: AlertScale.trailing))
+                }
+            }
+
+            var readings: MetricReadings = [:]
+            for try await (metric, reading) in group {
+                readings[metric] = reading
+            }
+            return readings
+        }
     }
 
     @discardableResult


### PR DESCRIPTION
The alerts and releases sections can't know how many rows they'll load, so their fixed-count placeholder skeletons render a misleading layout during the first fetch. The home screen now shows a single centered loader until both providers resolve and only then reveals the list; every other section keeps loading in the second phase through the existing rotatingProviders path, so nothing else regresses.

The gate lives in a reusable loadingGate(_:) view modifier (mirroring rotatingProviders), driven by a type-erased isLoading on Provider, and it fetches the gating providers concurrently. To keep that loader as short as possible, the alert engine now fetches one reading per unique metric through a task group instead of walking the rules sequentially — several rules on the same metric share a single fetch, and readings run in parallel. Status ordering and firing/healthy semantics are unchanged.

Full ScoutUITests bundle passes (490 tests).