### PR TITLE
Add a populated Home preview via a debug HomeList initializer

### DIFF
--- a/Sources/ScoutUI/Home/HomeList+Debug.swift
+++ b/Sources/ScoutUI/Home/HomeList+Debug.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+#if DEBUG
+    extension HomeList {
+        init(alerts: [AlertStatus]?, releases: [ReleaseHealth]?) {
+            self.init(
+                path: .constant([]),
+                activities: ActivityProvider(),
+                retention: RetentionProvider(),
+                sessions: StatProvider(eventName: "Session", periods: Period.summary),
+                releases: ReleaseHealthProvider(),
+                logs: HomeLogProvider(),
+                devices: DevicesProvider(),
+                alerts: AlertProvider()
+            )
+
+            activities.result = .success(.samples)
+            sessions.result = .success(.samples)
+            retention.result = .success(.samples)
+            devices.result = .success(.sample)
+
+            for period in Period.allCases {
+                logs.period = period
+                logs.result = .success(HomeLogProvider.sample(for: period))
+            }
+            logs.period = .today
+
+            self.alerts.result = alerts.map { .success($0) }
+            self.releases.result = releases.map { .success($0) }
+        }
+    }
+#endif

--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -81,51 +81,26 @@ struct HomeList: View {
     }
 }
 
-#Preview {
-    let activities = ActivityProvider()
-    activities.result = .success(.samples)
-
-    let sessions = StatProvider(eventName: "Session", periods: Period.summary)
-    sessions.result = .success(.samples)
-
-    let retention = RetentionProvider()
-    retention.result = .success(.samples)
-
-    let releases = ReleaseHealthProvider()
-    releases.result = .success(.samples)
-
-    @MainActor func makeLogs() -> HomeLogProvider {
-        let provider = HomeLogProvider()
-
-        for period in Period.allCases {
-            provider.period = period
-            provider.result = .success(HomeLogProvider.sample(for: period))
-        }
-
-        provider.period = .today
-        return provider
+#Preview("Populated") {
+    NavigationStack {
+        HomeList(alerts: [.firingSample, .armedSample], releases: .samples)
+            .navigationTitle(en: "Home")
     }
+    .environmentObject(Tint())
+}
 
-    let logs = makeLogs()
+#Preview("Skeletons") {
+    NavigationStack {
+        HomeList(alerts: nil, releases: nil)
+            .navigationTitle(en: "Home")
+    }
+    .environmentObject(Tint())
+}
 
-    let devices = DevicesProvider()
-    devices.result = .success(.sample)
-
-    let alerts = AlertProvider()
-    alerts.result = .success([.firingSample, .armedSample])
-
-    return NavigationStack {
-        HomeList(
-            path: .constant([]),
-            activities: activities,
-            retention: retention,
-            sessions: sessions,
-            releases: releases,
-            logs: logs,
-            devices: devices,
-            alerts: alerts
-        )
-        .navigationTitle(en: "Home")
+#Preview("Empty") {
+    NavigationStack {
+        HomeList(alerts: [], releases: [])
+            .navigationTitle(en: "Home")
     }
     .environmentObject(Tint())
 }

--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -81,25 +81,9 @@ struct HomeList: View {
     }
 }
 
-#Preview("Populated") {
+#Preview {
     NavigationStack {
         HomeList(alerts: [.firingSample, .armedSample], releases: .samples)
-            .navigationTitle(en: "Home")
-    }
-    .environmentObject(Tint())
-}
-
-#Preview("Skeletons") {
-    NavigationStack {
-        HomeList(alerts: nil, releases: nil)
-            .navigationTitle(en: "Home")
-    }
-    .environmentObject(Tint())
-}
-
-#Preview("Empty") {
-    NavigationStack {
-        HomeList(alerts: [], releases: [])
             .navigationTitle(en: "Home")
     }
     .environmentObject(Tint())


### PR DESCRIPTION
Adds a populated `HomeList` preview driven by a DEBUG-only convenience initializer that builds the screen with sample-primed providers, keeping the priming out of the main view file.

The initializer takes plain `[AlertStatus]?`/`[ReleaseHealth]?` arrays and maps them to provider results — `nil` leaves the result unset (the loading gate shows its ring), `[]` becomes an empty success, and a non-empty array a populated one — so loading/empty variants can be added back later without touching the initializer. It lives in a separate `HomeList+Debug.swift`.

Note: the providers are injected into `HomeList` (not left as defaults) so the `.result` assignments survive SwiftUI installing the view; priming default `@StateObject`s would be discarded on install.