### PR TITLE
Move the home rotation's initial load out of autoRefresh

### DIFF
--- a/Sources/ScoutUI/Home/RotatingProviders.swift
+++ b/Sources/ScoutUI/Home/RotatingProviders.swift
@@ -27,15 +27,15 @@ private struct RotatingProvidersModifier: ViewModifier {
                 }
             }
         } else {
-            content.autoRefresh(rotating: refreshers)
+            content
+                .task { await providers.fetchIfNeeded(in: database) }
+                .autoRefresh(rotating: refreshers, primesOnAppear: false)
         }
     }
 
     private var refreshers: [RefreshAction] {
-        var refreshers: [RefreshAction] = []
-        for provider in providers {
-            refreshers.append { await provider.fetchLatest(in: database) }
+        providers.map { provider in
+            { await provider.fetchLatest(in: database) }
         }
-        return refreshers
     }
 }

--- a/Sources/ScoutUI/Primitives/Refresh/AutoRefresh.swift
+++ b/Sources/ScoutUI/Primitives/Refresh/AutoRefresh.swift
@@ -12,15 +12,15 @@ typealias RefreshAction = @MainActor () async -> Bool
 
 extension View {
     func autoRefresh(_ refresh: @escaping RefreshAction) -> some View {
-        modifier(AutoRefreshModifier(token: 0, refreshers: [refresh]))
+        modifier(AutoRefreshModifier(token: 0, refreshers: [refresh], primesOnAppear: true))
     }
 
     func autoRefresh(on token: some Equatable, _ refresh: @escaping RefreshAction) -> some View {
-        modifier(AutoRefreshModifier(token: token, refreshers: [refresh]))
+        modifier(AutoRefreshModifier(token: token, refreshers: [refresh], primesOnAppear: true))
     }
 
-    func autoRefresh(rotating refreshers: [RefreshAction]) -> some View {
-        modifier(AutoRefreshModifier(token: 0, refreshers: refreshers))
+    func autoRefresh(rotating refreshers: [RefreshAction], primesOnAppear: Bool = true) -> some View {
+        modifier(AutoRefreshModifier(token: 0, refreshers: refreshers, primesOnAppear: primesOnAppear))
     }
 }
 
@@ -31,6 +31,7 @@ private struct AutoRefreshModifier<Token: Equatable>: ViewModifier {
 
     let token: Token
     let refreshers: [RefreshAction]
+    let primesOnAppear: Bool
 
     func body(content: Content) -> some View {
         content.onAppear {
@@ -55,6 +56,8 @@ private struct AutoRefreshModifier<Token: Equatable>: ViewModifier {
             return
         }
 
+        let isColdStart = lastToken == nil
+
         if token == lastToken {
             do {
                 try await Task.sleep(for: .milliseconds(700))
@@ -65,9 +68,13 @@ private struct AutoRefreshModifier<Token: Equatable>: ViewModifier {
 
         lastToken = token
 
-        await withTaskGroup(of: Void.self) { group in
-            for refresh in refreshers {
-                group.addTask { _ = await refresh() }
+        // Callers that load their own initial data (primesOnAppear == false) skip the cold-start
+        // pass; every later (re)trigger — foreground return, re-appear — still refreshes everything.
+        if primesOnAppear || !isColdStart {
+            await withTaskGroup(of: Void.self) { group in
+                for refresh in refreshers {
+                    group.addTask { _ = await refresh() }
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

The home screen gates on `alerts` and `releases` before revealing the list:

```swift
.rotatingProviders([sessions, activities, logs, releases, devices, alerts])
.loadingGate([alerts, releases])
```

While the ring is shown, `loadingGate` fetches `alerts` and `releases` via `fetchIfNeeded`. Once both have results, the gate reveals its content and `rotatingProviders` mounts. Its first `autoRefresh` pass ran `fetchLatest` on **all six** providers — re-fetching `alerts` and `releases` that the gate had just loaded. So on every cold start those two providers made two network requests instead of one.

## Fix

Extract the initial load out of `autoRefresh` and give `rotatingProviders` its own startup `.task` (mirroring how `loadingGate` loads its own providers):

```swift
content
    .task { await providers.fetchIfNeeded(in: database) }
    .autoRefresh(rotating: refreshers, primesOnAppear: false)
```

- The `.task` runs `fetchIfNeeded` on every rotating provider — a no-op for the ones `loadingGate` already loaded, and the initial load for the rest.
- `autoRefresh` now owns only the rotation. A new `primesOnAppear` flag (default `true`) lets a caller opt out of the eager cold-start pass. `rotatingProviders` passes `false`, so `autoRefresh` skips its first pass on cold start (`lastToken == nil`) but still refreshes immediately on every later re-trigger — foreground return, re-appear — and on the scheduled loop.

Result:

- **Cold start:** gate loads `alerts`/`releases` under the ring; the `.task` loads the other four; the rotation loop starts refreshing after its first delay. Nothing is fetched twice.
- **Foreground return / re-appear:** `autoRefresh` runs `fetchLatest` immediately → everything refreshes, no staleness.
- **Other `rotating` call sites** (`VersionDetailView`, `SessionInspector`) and the single-shot `autoRefresh` variants keep `primesOnAppear: true`, so their behavior is unchanged.

## Notes

`AutoRefreshModifier` is a `ViewModifier` with no existing unit test; behavior verified by reasoning through the `run()` cold-start vs. re-trigger paths. `ScoutUI` builds clean.