### PR TITLE
Fix the populated Home preview: prime providers before injecting

### DIFF
--- a/Sources/ScoutUI/Home/HomeList+Debug.swift
+++ b/Sources/ScoutUI/Home/HomeList+Debug.swift
@@ -11,30 +11,41 @@ import SwiftUI
 #if DEBUG
     extension HomeList {
         init(alerts: [AlertStatus]?, releases: [ReleaseHealth]?) {
-            self.init(
-                path: .constant([]),
-                activities: ActivityProvider(),
-                retention: RetentionProvider(),
-                sessions: StatProvider(eventName: "Session", periods: Period.summary),
-                releases: ReleaseHealthProvider(),
-                logs: HomeLogProvider(),
-                devices: DevicesProvider(),
-                alerts: AlertProvider()
-            )
-
+            let activities = ActivityProvider()
             activities.result = .success(.samples)
+
+            let sessions = StatProvider(eventName: "Session", periods: Period.summary)
             sessions.result = .success(.samples)
+
+            let retention = RetentionProvider()
             retention.result = .success(.samples)
+
+            let devices = DevicesProvider()
             devices.result = .success(.sample)
 
+            let logs = HomeLogProvider()
             for period in Period.allCases {
                 logs.period = period
                 logs.result = .success(HomeLogProvider.sample(for: period))
             }
             logs.period = .today
 
-            self.alerts.result = alerts.map { .success($0) }
-            self.releases.result = releases.map { .success($0) }
+            let alertProvider = AlertProvider()
+            alertProvider.result = alerts.map { .success($0) }
+
+            let releaseProvider = ReleaseHealthProvider()
+            releaseProvider.result = releases.map { .success($0) }
+
+            self.init(
+                path: .constant([]),
+                activities: activities,
+                retention: retention,
+                sessions: sessions,
+                releases: releaseProvider,
+                logs: logs,
+                devices: devices,
+                alerts: alertProvider
+            )
         }
     }
 #endif


### PR DESCRIPTION
Follow-up to #1074, which shipped the populated `HomeList` preview but rendered only the loading gate's spinner.

The debug initializer set each provider's `result` *after* passing the provider into `HomeList` — i.e. through the view's `@StateObject`. That assignment lands on a throwaway instance and is discarded when SwiftUI installs the view, so no section ever saw its sample data.

Fix: build and prime each provider locally, then inject the already-primed instances. The sample state now survives installation. Verified by rendering the preview — it shows the populated Alerts/Users/Sessions/Log sections instead of a spinner.