### PR TITLE
Ungate the debug HomeList initializer so release builds compile

### DIFF
--- a/Sources/ScoutUI/Home/HomeList+Debug.swift
+++ b/Sources/ScoutUI/Home/HomeList+Debug.swift
@@ -8,44 +8,42 @@
 import Scout
 import SwiftUI
 
-#if DEBUG
-    extension HomeList {
-        init(alerts: [AlertStatus]?, releases: [ReleaseHealth]?) {
-            let activities = ActivityProvider()
-            activities.result = .success(.samples)
+extension HomeList {
+    init(alerts: [AlertStatus]?, releases: [ReleaseHealth]?) {
+        let activities = ActivityProvider()
+        activities.result = .success(.samples)
 
-            let sessions = StatProvider(eventName: "Session", periods: Period.summary)
-            sessions.result = .success(.samples)
+        let sessions = StatProvider(eventName: "Session", periods: Period.summary)
+        sessions.result = .success(.samples)
 
-            let retention = RetentionProvider()
-            retention.result = .success(.samples)
+        let retention = RetentionProvider()
+        retention.result = .success(.samples)
 
-            let devices = DevicesProvider()
-            devices.result = .success(.sample)
+        let devices = DevicesProvider()
+        devices.result = .success(.sample)
 
-            let logs = HomeLogProvider()
-            for period in Period.allCases {
-                logs.period = period
-                logs.result = .success(HomeLogProvider.sample(for: period))
-            }
-            logs.period = .today
-
-            let alertProvider = AlertProvider()
-            alertProvider.result = alerts.map { .success($0) }
-
-            let releaseProvider = ReleaseHealthProvider()
-            releaseProvider.result = releases.map { .success($0) }
-
-            self.init(
-                path: .constant([]),
-                activities: activities,
-                retention: retention,
-                sessions: sessions,
-                releases: releaseProvider,
-                logs: logs,
-                devices: devices,
-                alerts: alertProvider
-            )
+        let logs = HomeLogProvider()
+        for period in Period.allCases {
+            logs.period = period
+            logs.result = .success(HomeLogProvider.sample(for: period))
         }
+        logs.period = .today
+
+        let alertProvider = AlertProvider()
+        alertProvider.result = alerts.map { .success($0) }
+
+        let releaseProvider = ReleaseHealthProvider()
+        releaseProvider.result = releases.map { .success($0) }
+
+        self.init(
+            path: .constant([]),
+            activities: activities,
+            retention: retention,
+            sessions: sessions,
+            releases: releaseProvider,
+            logs: logs,
+            devices: devices,
+            alerts: alertProvider
+        )
     }
-#endif
+}


### PR DESCRIPTION
## Summary

The scout-ip TestFlight archive ([run 30021582828](https://github.com/kasianov-mikhail/scout-ip/actions/runs/30021582828)) fails compiling ScoutUI at the pinned revision 59dc131: the `#Preview` in `HomeList.swift` calls the debug initializer `HomeList(alerts:releases:)`, but that initializer is wrapped in `#if DEBUG` while `#Preview` bodies are compiled in release configurations too. In an archive build the initializer vanishes and the preview fails with a cascade of resolution errors.

This removes the `#if DEBUG` gate around the initializer — matching the rest of ScoutUI, where preview fixtures (`.samples`, `.firingSample`, etc.) are deliberately ungated for exactly this reason. This was the only `#if DEBUG` in ScoutUI.

## Verification

`swift build -c release --target ScoutUI` fails before this change (same errors as CI) and passes after it.