### PR TITLE
Ungate the section debug initializers so release builds compile

### DIFF
--- a/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
+++ b/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
@@ -75,16 +75,14 @@ struct HomeAlertSection: View {
     }
 }
 
-#if DEBUG
-    extension HomeAlertSection {
-        init(statuses: [AlertStatus]) {
-            let alerts = AlertProvider()
-            alerts.result = .success(statuses)
+extension HomeAlertSection {
+    init(statuses: [AlertStatus]) {
+        let alerts = AlertProvider()
+        alerts.result = .success(statuses)
 
-            self.init(alerts: alerts, path: .constant([]))
-        }
+        self.init(alerts: alerts, path: .constant([]))
     }
-#endif
+}
 
 #Preview {
     NavigationStack {

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
@@ -51,23 +51,21 @@ struct HomeLogSection: View {
     }
 }
 
-#if DEBUG
-    extension HomeLogSection {
-        init(period: Period) {
-            let log = HomeLogProvider()
-            for value in Period.allCases {
-                log.period = value
-                log.result = .success(HomeLogProvider.sample(for: value))
-            }
-            log.period = period
-
-            let devices = DevicesProvider()
-            devices.result = .success(.sample)
-
-            self.init(period: period, log: log, devices: devices, path: .constant([]))
+extension HomeLogSection {
+    init(period: Period) {
+        let log = HomeLogProvider()
+        for value in Period.allCases {
+            log.period = value
+            log.result = .success(HomeLogProvider.sample(for: value))
         }
+        log.period = period
+
+        let devices = DevicesProvider()
+        devices.result = .success(.sample)
+
+        self.init(period: period, log: log, devices: devices, path: .constant([]))
     }
-#endif
+}
 
 #Preview {
     NavigationStack {


### PR DESCRIPTION
## Summary

Follow-up to #1080: #1078 introduced the same release-build breakage in two more files. `HomeAlertSection(statuses:)` and `HomeLogSection(period:)` are wrapped in `#if DEBUG`, but the `#Preview` blocks that call them compile in release configurations too, so an archive build of ScoutUI fails the same way the scout-ip TestFlight run did.

This removes both gates, matching the rest of ScoutUI where preview fixtures and debug initializers are ungated. No `#if DEBUG` remains in ScoutUI.

## Verification

`swift build -c release --target ScoutUI` fails on main and passes with this change.