### PR TITLE
Tighten spacing in Home sections

### DIFF
--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -28,7 +28,6 @@ struct HomeList: View {
                 distribution: .justified,
                 title: \.shortTitle
             )
-            .padding(.top, 8)
             .listRowSeparator(.hidden)
 
             HomeAlertSection(

--- a/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
+++ b/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
@@ -32,6 +32,7 @@ struct HomeAlertSection: View {
                 }
             }
         }
+        .padding(.top, -16)
         .sheet(isPresented: $isEditorPresented) {
             Task { await alerts.fetchAgain(in: database) }
         } content: {
@@ -69,7 +70,7 @@ struct HomeAlertSection: View {
             .font(.body)
             .fontWeight(.medium)
             .foregroundStyle(color.opacity(0.7))
-            .frame(height: 68)
+            .frame(height: 44)
             .frame(maxWidth: .infinity)
             .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
     }

--- a/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
+++ b/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
@@ -40,7 +40,8 @@ struct HomeMetricSection: View {
             }
             .buttonStyle(.plain)
         }
-        .listRowSeparator(.hidden)
+        .padding(.top, 24)
+        .listRowSeparator(.hidden, edges: .bottom)
     }
 
     private var activityTrend: Trend? {

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -52,8 +52,8 @@ struct HomeRetentionSection: View {
 
         case .success:
             Text(verbatim: "No results")
-                .font(.placeholderTitle)
-                .foregroundStyle(.gray.opacity(0.7))
+                .font(.body)
+                .foregroundStyle(.gray)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 20)
                 .listRowSeparator(.hidden, edges: .bottom)


### PR DESCRIPTION
## Summary

- Drop the segment strip's top padding above the Home list.
- Alert section: pull section content up 16pt and shrink the empty/loading row placeholder height from 68 to 44 to match the tighter layout.
- Metric section: replace the bottom row separator with top padding for consistent spacing.
- Retention section: match the "No results" placeholder's font/color to the alert section's placeholder text style.

## Test plan

- [x] `xcodebuild build -scheme ScoutUI -destination 'generic/platform=iOS Simulator'` succeeds
- [x] Rendered HomeList's `#Preview` and confirmed the tighter spacing looks correct