### PR TITLE
Unify preview provider priming behind a holding() helper

### DIFF
--- a/Sources/ScoutUI/Analytics/Activity/ActivityPoint+Fixture.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityPoint+Fixture.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+extension ActivityPoint: Fixture {
+    static var samples: [ActivityPoint] {
+        let end = Date().startOfDay
+        return (0..<365).map { day in
+            ActivityPoint(
+                date: end.addingDay(-day).millisecondsSince1970,
+                dau: 80 + day % 90 + (day / 7) % 20,
+                wau: 360 + day % 120 + (day / 5) % 80,
+                mau: 950 + day % 240 + (day / 11) % 160
+            )
+        }
+    }
+}

--- a/Sources/ScoutUI/Analytics/Activity/ActivityProvider.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityProvider.swift
@@ -16,17 +16,3 @@ final class ActivityProvider: ObservableObject, Provider {
         try await database.activity(in: Calendar.utc.defaultRange)
     }
 }
-
-extension ActivityPoint: Fixture {
-    static var samples: [ActivityPoint] {
-        let end = Date().startOfDay
-        return (0..<365).map { day in
-            ActivityPoint(
-                date: end.addingDay(-day).millisecondsSince1970,
-                dau: 80 + day % 90 + (day / 7) % 20,
-                wau: 360 + day % 120 + (day / 5) % 80,
-                mau: 950 + day % 240 + (day / 11) % 160
-            )
-        }
-    }
-}

--- a/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
@@ -74,10 +74,10 @@ struct ActivityView: View {
 }
 
 #Preview("ActivityView") {
-    let activity = ActivityProvider()
-    activity.result = .success([])
-
-    return NavigationStack {
-        ActivityView(activity: activity, period: .daily)
+    NavigationStack {
+        ActivityView(
+            activity: ActivityProvider().holding([]),
+            period: .daily
+        )
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/Analytics/AnalyticsView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Analytics/AnalyticsView.swift
@@ -28,11 +28,8 @@ struct AnalyticsView: View {
 }
 
 #Preview {
-    let provider = EventProvider()
-    provider.records = .samples
-
-    return NavigationStack {
-        AnalyticsView(provider: provider)
+    NavigationStack {
+        AnalyticsView(provider: EventProvider().holding(.samples))
             .environmentObject(Tint())
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
@@ -86,11 +86,9 @@ extension EventView {
         deviceID: UUID()
     )
 
-    let param = ParamProvider(recordID: event.id)
-    param.result = .success(params.sorted())
+    let param = ParamProvider(recordID: event.id).holding(params.sorted())
 
-    let stat = StatProvider(eventName: event.name, periods: Period.allCases)
-    stat.result = .success(.samples)
+    let stat = StatProvider(eventName: event.name, periods: Period.allCases).holding(.samples)
 
     return NavigationStack {
         EventView(event: event, param: param, stat: stat)

--- a/Sources/ScoutUI/Analytics/Event/List/EventList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventList.swift
@@ -75,9 +75,7 @@ extension EventList where Header == EmptyView {
 }
 
 #Preview("Empty State") {
-    let provider = EventProvider()
-    provider.records = []
-    return NavigationStack {
-        EventList(provider: provider)
+    NavigationStack {
+        EventList(provider: EventProvider().holding([]))
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
@@ -31,10 +31,11 @@ struct EventStatList: View {
 }
 
 #Preview {
-    let provider = EventProvider()
-    provider.records = .samples
-
-    return NavigationStack {
-        EventStatList(eventName: "Event", range: Period.week.initialRange, provider: provider)
+    NavigationStack {
+        EventStatList(
+            eventName: "Event",
+            range: Period.week.initialRange,
+            provider: EventProvider().holding(.samples)
+        )
     }
 }

--- a/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
@@ -112,10 +112,7 @@ private struct RetentionHeroChart: View {
 }
 
 #Preview("RetentionHeroChartView") {
-    let provider = RetentionProvider()
-    provider.result = .success(.samples)
-
-    return NavigationStack {
-        RetentionHeroChartView(provider: provider)
+    NavigationStack {
+        RetentionHeroChartView(provider: RetentionProvider().holding(.samples))
     }
 }

--- a/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
@@ -35,13 +35,12 @@ struct SessionInspector: View {
 }
 
 #Preview {
-    let events = EventProvider()
-    events.records = .samples
-
-    let info = SessionInfoProvider(sessionID: UUID(), deviceID: UUID())
-    info.result = .success(.sample)
-
-    return NavigationStack {
-        SessionInspector(sessionID: UUID(), deviceID: UUID(), events: events, info: info)
+    NavigationStack {
+        SessionInspector(
+            sessionID: UUID(),
+            deviceID: UUID(),
+            events: EventProvider().holding(.samples),
+            info: SessionInfoProvider(sessionID: UUID(), deviceID: UUID()).holding(.sample)
+        )
     }
 }

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
@@ -82,10 +82,11 @@ struct DeviceDetailView: View {
 }
 
 #Preview {
-    let incidents = DeviceIncidentsProvider(deviceID: DeviceSummary.samples[0].id)
-    incidents.result = .success(DeviceIncidents(crashes: Crash.samples, hangs: Hang.samples))
-
-    return NavigationStack {
-        DeviceDetailView(device: DeviceSummary.samples[0], incidents: incidents)
+    NavigationStack {
+        DeviceDetailView(
+            device: DeviceSummary.samples[0],
+            incidents: DeviceIncidentsProvider(deviceID: DeviceSummary.samples[0].id)
+                .holding(DeviceIncidents(crashes: Crash.samples, hangs: Hang.samples))
+        )
     }
 }

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
@@ -63,19 +63,13 @@ struct DevicesView: View {
 }
 
 #Preview("Devices") {
-    let provider = DevicesProvider()
-    provider.result = .success(.sample)
-
-    return NavigationStack {
-        DevicesView(provider: provider)
+    NavigationStack {
+        DevicesView(provider: DevicesProvider().holding(.sample))
     }
 }
 
 #Preview("Devices — Empty") {
-    let provider = DevicesProvider()
-    provider.result = .success(.empty)
-
-    return NavigationStack {
-        DevicesView(provider: provider)
+    NavigationStack {
+        DevicesView(provider: DevicesProvider().holding(.empty))
     }
 }

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthView.swift
@@ -32,10 +32,7 @@ struct ReleaseHealthView: View {
 }
 
 #Preview {
-    let provider = ReleaseHealthProvider()
-    provider.result = .success(.samples)
-
-    return NavigationStack {
-        ReleaseHealthView(provider: provider)
+    NavigationStack {
+        ReleaseHealthView(provider: ReleaseHealthProvider().holding(.samples))
     }
 }

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -206,17 +206,11 @@ private struct IncidentIssuesSection<Element: Incident, Destination: View>: View
 }
 
 #Preview {
-    let crashes = VersionIncidentProvider<Crash>(version: "3.2.0")
-    crashes.records = .samples
-
-    let hangs = VersionIncidentProvider<Hang>(version: "3.2.0")
-    hangs.records = .samples
-
-    return NavigationStack {
+    NavigationStack {
         VersionDetailView(
             release: [ReleaseHealth].samples[0],
-            crashes: crashes,
-            hangs: hangs
+            crashes: VersionIncidentProvider<Crash>(version: "3.2.0").holding(.samples),
+            hangs: VersionIncidentProvider<Hang>(version: "3.2.0").holding(.samples)
         )
     }
     .environmentObject(Tint())

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionIncidentProvider.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionIncidentProvider.swift
@@ -23,8 +23,8 @@ final class VersionIncidentProvider<Element: RecordDecodable & Incident>: FeedPr
             RecordQuery.Filter(
                 field: "app_version",
                 op: .equals,
-                value:
-                    .string(version))
+                value: .string(version)
+            )
         ])
     }
 

--- a/Sources/ScoutUI/Home/HomeList+Blueprint.swift
+++ b/Sources/ScoutUI/Home/HomeList+Blueprint.swift
@@ -18,42 +18,15 @@ extension HomeList {
         devices: DevicesReport?,
         alerts: [AlertStatus]?
     ) {
-        let activitiesProvider = ActivityProvider()
-        activitiesProvider.result = activities.map { .success($0) }
-
-        let retentionProvider = RetentionProvider()
-        retentionProvider.result = retention.map { .success($0) }
-
-        let sessionsProvider = StatProvider(eventName: "Session", periods: Period.summary)
-        sessionsProvider.result = sessions.map { .success($0) }
-
-        let releasesProvider = ReleaseHealthProvider()
-        releasesProvider.result = releases.map { .success($0) }
-
-        let logsProvider = HomeLogProvider()
-        if let logs {
-            for period in Period.allCases {
-                logsProvider.period = period
-                logsProvider.result = .success(logs)
-            }
-            logsProvider.period = .today
-        }
-
-        let devicesProvider = DevicesProvider()
-        devicesProvider.result = devices.map { .success($0) }
-
-        let alertsProvider = AlertProvider()
-        alertsProvider.result = alerts.map { .success($0) }
-
         self.init(
             path: .constant([]),
-            activities: activitiesProvider,
-            retention: retentionProvider,
-            sessions: sessionsProvider,
-            releases: releasesProvider,
-            logs: logsProvider,
-            devices: devicesProvider,
-            alerts: alertsProvider
+            activities: ActivityProvider().holding(activities),
+            retention: RetentionProvider().holding(retention),
+            sessions: StatProvider(eventName: "Session", periods: Period.summary).holding(sessions),
+            releases: ReleaseHealthProvider().holding(releases),
+            logs: HomeLogProvider().holding(acrossAllPeriods: logs),
+            devices: DevicesProvider().holding(devices),
+            alerts: AlertProvider().holding(alerts)
         )
     }
 }

--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -109,7 +109,7 @@ struct HomeList: View {
             retention: .samples,
             sessions: .samples,
             releases: .samples,
-            logs: HomeLogProvider.sample(for: .today),
+            logs: MetricSeries.samples(for: .today),
             devices: .sample,
             alerts: [.firingSample, .armedSample]
         )

--- a/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
+++ b/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
@@ -78,10 +78,7 @@ struct HomeAlertSection: View {
 
 extension HomeAlertSection {
     init(statuses: [AlertStatus]) {
-        let alerts = AlertProvider()
-        alerts.result = .success(statuses)
-
-        self.init(alerts: alerts, path: .constant([]))
+        self.init(alerts: AlertProvider().holding(statuses), path: .constant([]))
     }
 }
 

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
@@ -23,15 +23,10 @@ final class HomeLogProvider: ObservableObject, Provider {
         didSet { rebuildReport() }
     }
 
-    // Device visits back the "Devices" row of the report; the log section feeds
-    // them in from its sibling DevicesProvider as they arrive.
     @Published var visits: [DeviceVisit] = [] {
         didSet { rebuildReport() }
     }
 
-    // Derived from the current period's series, visits, and period once per
-    // change, so view body re-evaluations (scroll, auto-refresh) read the cached
-    // report instead of rebuilding it and its per-category passes every render.
     private(set) var report: LogReport?
 
     init() {
@@ -58,8 +53,6 @@ final class HomeLogProvider: ObservableObject, Provider {
             matching: SeriesQuery(bucket: period.logBucket, range: window)
         )
 
-        // The fetch was started under `period`; if the user switched meanwhile, dropping the
-        // completion keeps its wrong-bucket series out of the newly selected period's slot.
         guard period == self.period else {
             throw CancellationError()
         }
@@ -80,42 +73,10 @@ extension Period {
 }
 
 extension HomeLogProvider {
-    static func sample(for period: Period) -> Output {
-        let date = period.initialRange.lowerBound
-
-        func point(hour: Int, value: MetricValue) -> MetricSeriesPoint {
-            MetricSeriesPoint(
-                date: date.addingTimeInterval(TimeInterval(hour) * .hour).millisecondsSince1970,
-                value: value
-            )
+    func holding(acrossAllPeriods series: Output?) -> Self {
+        if let series {
+            results = Dictionary(uniqueKeysWithValues: Period.allCases.map { ($0, .success(series)) })
         }
-
-        return [
-            MetricSeries(
-                name: EventEntry.recordType,
-                category: nil,
-                points: [point(hour: 0, value: .int(48))]
-            ),
-            MetricSeries(
-                name: CrashEntry.recordType,
-                category: nil,
-                points: [point(hour: 1, value: .int(3))]
-            ),
-            MetricSeries(
-                name: HangEntry.recordType,
-                category: nil,
-                points: [point(hour: 4, value: .int(6))]
-            ),
-            MetricSeries(
-                name: "api_calls",
-                category: Telemetry.Export.counter.rawValue,
-                points: [point(hour: 2, value: .int(140))]
-            ),
-            MetricSeries(
-                name: "cache_hit_rate",
-                category: Telemetry.Export.floatingCounter.rawValue,
-                points: [point(hour: 3, value: .double(91.5))]
-            ),
-        ]
+        return self
     }
 }

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
@@ -53,17 +53,12 @@ struct HomeLogSection: View {
 
 extension HomeLogSection {
     init(period: Period) {
-        let log = HomeLogProvider()
-        for value in Period.allCases {
-            log.period = value
-            log.result = .success(HomeLogProvider.sample(for: value))
-        }
-        log.period = period
-
-        let devices = DevicesProvider()
-        devices.result = .success(.sample)
-
-        self.init(period: period, log: log, devices: devices, path: .constant([]))
+        self.init(
+            period: period,
+            log: HomeLogProvider().holding(acrossAllPeriods: MetricSeries.samples(for: period)),
+            devices: DevicesProvider().holding(.sample),
+            path: .constant([])
+        )
     }
 }
 

--- a/Sources/ScoutUI/Home/Section/Log/LogView.swift
+++ b/Sources/ScoutUI/Home/Section/Log/LogView.swift
@@ -58,14 +58,11 @@ struct LogView: View {
 }
 
 #Preview {
-    let log = HomeLogProvider()
-    log.period = .week
-    log.result = .success(HomeLogProvider.sample(for: .week))
-
-    let devices = DevicesProvider()
-    devices.result = .success(.sample)
-
-    return NavigationStack {
-        LogView(period: .week, log: log, devices: devices)
+    NavigationStack {
+        LogView(
+            period: .week,
+            log: HomeLogProvider().holding(acrossAllPeriods: MetricSeries.samples(for: .week)),
+            devices: DevicesProvider().holding(.sample)
+        )
     }
 }

--- a/Sources/ScoutUI/Home/Section/Log/MetricSeries+Sample.swift
+++ b/Sources/ScoutUI/Home/Section/Log/MetricSeries+Sample.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+extension MetricSeries {
+    static func samples(for period: Period) -> [MetricSeries] {
+        let date = period.initialRange.lowerBound
+
+        func point(hour: Int, value: MetricValue) -> MetricSeriesPoint {
+            MetricSeriesPoint(
+                date: date.addingTimeInterval(TimeInterval(hour) * .hour).millisecondsSince1970,
+                value: value
+            )
+        }
+
+        return [
+            MetricSeries(
+                name: EventEntry.recordType,
+                category: nil,
+                points: [point(hour: 0, value: .int(48))]
+            ),
+            MetricSeries(
+                name: CrashEntry.recordType,
+                category: nil,
+                points: [point(hour: 1, value: .int(3))]
+            ),
+            MetricSeries(
+                name: HangEntry.recordType,
+                category: nil,
+                points: [point(hour: 4, value: .int(6))]
+            ),
+            MetricSeries(
+                name: "api_calls",
+                category: Telemetry.Export.counter.rawValue,
+                points: [point(hour: 2, value: .int(140))]
+            ),
+            MetricSeries(
+                name: "cache_hit_rate",
+                category: Telemetry.Export.floatingCounter.rawValue,
+                points: [point(hour: 3, value: .double(91.5))]
+            ),
+        ]
+    }
+}

--- a/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
+++ b/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
@@ -63,17 +63,11 @@ struct HomeMetricSection: View {
 }
 
 #Preview {
-    let activities = ActivityProvider()
-    activities.result = .success(.samples)
-
-    let sessions = StatProvider(eventName: "Session", periods: Period.summary)
-    sessions.result = .success(.samples)
-
-    return NavigationStack {
+    NavigationStack {
         InsetList {
             HomeMetricSection(
-                activities: activities,
-                sessions: sessions,
+                activities: ActivityProvider().holding(.samples),
+                sessions: StatProvider(eventName: "Session", periods: Period.summary).holding(.samples),
                 period: .today,
                 path: .constant([])
             )

--- a/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
@@ -43,15 +43,16 @@ struct HomeReleaseSection: View {
 }
 
 #Preview {
-    let releases = ReleaseHealthProvider()
-    releases.result = .success(.samples)
-
-    let empty = ReleaseHealthProvider(releases: [])
-
-    return NavigationStack {
+    NavigationStack {
         InsetList {
-            HomeReleaseSection(releases: releases, path: .constant([]))
-            HomeReleaseSection(releases: empty, path: .constant([]))
+            HomeReleaseSection(
+                releases: ReleaseHealthProvider().holding(.samples),
+                path: .constant([])
+            )
+            HomeReleaseSection(
+                releases: ReleaseHealthProvider(releases: []),
+                path: .constant([])
+            )
         }
     }
 }

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -82,13 +82,16 @@ struct HomeRetentionSection: View {
 }
 
 #Preview {
-    let retention = RetentionProvider()
-    retention.result = .success(.samples)
-
-    return NavigationStack {
+    NavigationStack {
         InsetList {
-            HomeRetentionSection(retention: retention, path: .constant([]))
-            HomeRetentionSection(retention: RetentionProvider(), path: .constant([]))
+            HomeRetentionSection(
+                retention: RetentionProvider().holding(.samples),
+                path: .constant([])
+            )
+            HomeRetentionSection(
+                retention: RetentionProvider(),
+                path: .constant([])
+            )
         }
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -126,20 +126,14 @@ private struct AlertChip: View {
 }
 
 #Preview {
-    let provider = AlertProvider()
-    provider.result = .success([.firingSample, .armedSample])
-
-    return NavigationStack {
-        AlertListView(provider: provider)
+    NavigationStack {
+        AlertListView(provider: AlertProvider().holding([.firingSample, .armedSample]))
     }
 }
 
 #Preview("Empty") {
-    let provider = AlertProvider()
-    provider.result = .success([])
-
-    return NavigationStack {
-        AlertListView(provider: provider)
+    NavigationStack {
+        AlertListView(provider: AlertProvider().holding([]))
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
@@ -89,16 +89,13 @@ struct CrashGroupDetailView: View {
 }
 
 #Preview {
-    let breakdown = IncidentBreakdownProvider(deviceIDs: [], sessionIDs: [])
-    breakdown.result = .success(.sample)
-
-    return NavigationStack {
+    NavigationStack {
         CrashGroupDetailView(
             group: IncidentGroup(records: [
                 .sample("NSRangeException", at: Date()),
                 .sample("NSRangeException", at: Date().addingTimeInterval(-3600)),
             ]),
-            breakdown: breakdown
+            breakdown: IncidentBreakdownProvider(deviceIDs: [], sessionIDs: []).holding(.sample)
         )
     }
     .environmentObject(Tint())

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
@@ -50,11 +50,8 @@ struct CrashListView: View {
 }
 
 #Preview {
-    let provider = IncidentProvider<Crash>()
-    provider.records = .samples
-
-    return NavigationStack {
-        CrashListView(provider: provider)
+    NavigationStack {
+        CrashListView(provider: IncidentProvider<Crash>().holding(.samples))
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
@@ -74,16 +74,13 @@ struct HangGroupDetailView: View {
 }
 
 #Preview {
-    let breakdown = IncidentBreakdownProvider(deviceIDs: [], sessionIDs: [])
-    breakdown.result = .success(.sample)
-
-    return NavigationStack {
+    NavigationStack {
         HangGroupDetailView(
             group: IncidentGroup(records: [
                 .sample("Image Layout Pass", duration: 9.8, at: Date()),
                 .sample("Image Layout Pass", duration: 4.6, at: Date().addingTimeInterval(-3600)),
             ]),
-            breakdown: breakdown
+            breakdown: IncidentBreakdownProvider(deviceIDs: [], sessionIDs: []).holding(.sample)
         )
     }
     .environmentObject(Tint())

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
@@ -46,11 +46,8 @@ struct HangListView: View {
 }
 
 #Preview {
-    let provider = IncidentProvider<Hang>()
-    provider.records = [Hang].samples
-
-    return NavigationStack {
-        HangListView(provider: provider)
+    NavigationStack {
+        HangListView(provider: IncidentProvider<Hang>().holding(.samples))
     }
     .environmentObject(Tint())
 }

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
@@ -47,8 +47,11 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
 }
 
 #Preview("Timer") {
-    let provider = MetricDistributionProvider<LatencyHistogram>(name: "http_request", categories: [])
-    provider.result = .success(.sample)
+    let provider = MetricDistributionProvider<LatencyHistogram>(
+        name: "http_request",
+        categories: []
+    )
+    .holding(.sample)
 
     return NavigationStack {
         InsetList {
@@ -65,8 +68,11 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
 }
 
 #Preview("Recorder") {
-    let provider = MetricDistributionProvider<RecorderHistogram>(name: "payload_size", categories: [])
-    provider.result = .success(.sample)
+    let provider = MetricDistributionProvider<RecorderHistogram>(
+        name: "payload_size",
+        categories: []
+    )
+    .holding(.sample)
 
     return NavigationStack {
         InsetList {

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
@@ -71,11 +71,8 @@ struct NetworkView: View {
 }
 
 #Preview("NetworkView") {
-    let provider = NetworkProvider()
-    provider.result = .success(.sample)
-
-    return NavigationStack {
-        NetworkView(provider: provider)
+    NavigationStack {
+        NetworkView(provider: NetworkProvider().holding(.sample))
     }
 }
 

--- a/Sources/ScoutUI/Primitives/Indicators/StatView.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatView.swift
@@ -91,14 +91,11 @@ extension EnvironmentValues {
 }
 
 #Preview("StatView") {
-    let stat = StatProvider(eventName: "app_launch", periods: Period.allCases)
-    stat.result = .success([])
-
-    return NavigationStack {
+    NavigationStack {
         StatView(
             showList: true,
             extent: ChartExtent(period: .yesterday),
-            stat: stat
+            stat: StatProvider(eventName: "app_launch", periods: Period.allCases).holding([])
         )
         .navigationTitle(en: "App Launch")
         .environmentObject(Tint())

--- a/Sources/ScoutUI/Support/Provider/FeedProvider.swift
+++ b/Sources/ScoutUI/Support/Provider/FeedProvider.swift
@@ -77,3 +77,10 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
         cursor = nil
     }
 }
+
+extension FeedProvider {
+    func holding(_ records: [Element]?) -> Self {
+        self.records = records
+        return self
+    }
+}

--- a/Sources/ScoutUI/Support/Provider/Provider.swift
+++ b/Sources/ScoutUI/Support/Provider/Provider.swift
@@ -65,3 +65,10 @@ extension Provider {
         }
     }
 }
+
+extension Provider {
+    func holding(_ output: Output?) -> Self {
+        result = output.map { .success($0) }
+        return self
+    }
+}


### PR DESCRIPTION
Previews and blueprint initializers used to construct a provider into a local and then mutate its `result`/`records` before passing it in. This introduces a `holding(_:)` helper on both the Provider and FeedProvider families so a provider is primed with sample data in one chained call, and inlines the resulting single-use locals into their view constructors. HomeLogProvider keeps a distinct `holding(acrossAllPeriods:)` because its result is period-keyed and previews want every period populated; the explicit argument label keeps it from silently shadowing the protocol `holding(_:)`.

It also moves the two fixtures that were hosted on providers onto their models, matching the rest of the sample layer: `ActivityPoint.samples` gets its own `+Fixture` file and `HomeLogProvider.sample(for:)` becomes `MetricSeries.samples(for:)`. The only non-preview production change is a cosmetic reformat of a VersionIncidentProvider filter. Purely a preview/fixture-layer refactor with no behavior change to the app; verified with an app build and swift-format lint.