### PR TITLE
Seed provider state through the initializer instead of holding()

### DIFF
--- a/Sources/ScoutUI/Analytics/Activity/ActivityProvider.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityProvider.swift
@@ -12,6 +12,10 @@ import Scout
 final class ActivityProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[ActivityPoint]>?
 
+    init(_ result: ProviderResult<Output>? = nil) {
+        self.result = result
+    }
+
     func fetch(in database: DatabaseReader) async throws -> [ActivityPoint] {
         try await database.activity(in: Calendar.utc.defaultRange)
     }

--- a/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
@@ -76,7 +76,7 @@ struct ActivityView: View {
 #Preview("ActivityView") {
     NavigationStack {
         ActivityView(
-            activity: .init().holding([]),
+            activity: .init(.success([])),
             period: .daily
         )
     }

--- a/Sources/ScoutUI/Analytics/Event/Analytics/AnalyticsView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Analytics/AnalyticsView.swift
@@ -29,7 +29,7 @@ struct AnalyticsView: View {
 
 #Preview {
     NavigationStack {
-        AnalyticsView(provider: .init().holding(.samples))
+        AnalyticsView(provider: .init(.samples))
             .environmentObject(Tint())
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
@@ -86,9 +86,9 @@ extension EventView {
         deviceID: UUID()
     )
 
-    let param = ParamProvider(recordID: event.id).holding(params.sorted())
+    let param = ParamProvider(.success(params.sorted()), recordID: event.id)
 
-    let stat = StatProvider(eventName: event.name, periods: Period.allCases).holding(.samples)
+    let stat = StatProvider(.success(.samples), eventName: event.name, periods: Period.allCases)
 
     return NavigationStack {
         EventView(event: event, param: param, stat: stat)

--- a/Sources/ScoutUI/Analytics/Event/List/EventList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventList.swift
@@ -76,6 +76,6 @@ extension EventList where Header == EmptyView {
 
 #Preview("Empty State") {
     NavigationStack {
-        EventList(provider: .init().holding([]))
+        EventList(provider: .init([]))
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
@@ -35,7 +35,7 @@ struct EventStatList: View {
         EventStatList(
             eventName: "Event",
             range: Period.week.initialRange,
-            provider: .init().holding(.samples)
+            provider: .init(.samples)
         )
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/Param/ParamProvider.swift
+++ b/Sources/ScoutUI/Analytics/Event/Param/ParamProvider.swift
@@ -14,8 +14,9 @@ final class ParamProvider: ObservableObject, Provider {
 
     private let recordID: String
 
-    init(recordID: String) {
+    init(_ result: ProviderResult<Output>? = nil, recordID: String) {
         self.recordID = recordID
+        self.result = result
     }
 
     func fetch(in database: DatabaseReader) async throws -> Output {

--- a/Sources/ScoutUI/Analytics/Event/Provider/EventProvider.swift
+++ b/Sources/ScoutUI/Analytics/Event/Provider/EventProvider.swift
@@ -13,9 +13,9 @@ import SwiftUI
 final class EventProvider: FeedProvider<Event>, Periodic {
     let filter: EventQuery
 
-    init(filter: EventQuery = EventQuery()) {
+    init(_ records: [Event]? = nil, filter: EventQuery = EventQuery()) {
         self.filter = filter
-        super.init()
+        super.init(records)
     }
 
     func fetch(for filter: EventQuery, in database: DatabaseReader) async {

--- a/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
@@ -113,6 +113,6 @@ private struct RetentionHeroChart: View {
 
 #Preview("RetentionHeroChartView") {
     NavigationStack {
-        RetentionHeroChartView(provider: .init().holding(.samples))
+        RetentionHeroChartView(provider: .init(.success(.samples)))
     }
 }

--- a/Sources/ScoutUI/Analytics/Retention/RetentionProvider.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionProvider.swift
@@ -12,6 +12,10 @@ import Scout
 final class RetentionProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[RetentionCohort]>?
 
+    init(_ result: ProviderResult<Output>? = nil) {
+        self.result = result
+    }
+
     func fetch(in database: DatabaseReader) async throws -> [RetentionCohort] {
         try await database.retention(in: Calendar.utc.defaultRange)
     }

--- a/Sources/ScoutUI/Analytics/Session/SessionInfoProvider.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionInfoProvider.swift
@@ -15,9 +15,10 @@ final class SessionInfoProvider: ObservableObject, Provider {
     private let sessionID: UUID
     private let deviceID: UUID?
 
-    init(sessionID: UUID, deviceID: UUID?) {
+    init(_ result: ProviderResult<Output>? = nil, sessionID: UUID, deviceID: UUID?) {
         self.sessionID = sessionID
         self.deviceID = deviceID
+        self.result = result
     }
 
     func fetch(in database: DatabaseReader) async throws -> SessionInfo {

--- a/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
@@ -39,8 +39,8 @@ struct SessionInspector: View {
         SessionInspector(
             sessionID: UUID(),
             deviceID: UUID(),
-            events: .init().holding(.samples),
-            info: .init(sessionID: UUID(), deviceID: UUID()).holding(.sample)
+            events: .init(.samples),
+            info: .init(.success(.sample), sessionID: UUID(), deviceID: UUID())
         )
     }
 }

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
@@ -85,8 +85,10 @@ struct DeviceDetailView: View {
     NavigationStack {
         DeviceDetailView(
             device: DeviceSummary.samples[0],
-            incidents: .init(deviceID: DeviceSummary.samples[0].id)
-                .holding(DeviceIncidents(crashes: Crash.samples, hangs: Hang.samples))
+            incidents: .init(
+                .success(DeviceIncidents(crashes: Crash.samples, hangs: Hang.samples)),
+                deviceID: DeviceSummary.samples[0].id
+            )
         )
     }
 }

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceIncidentsProvider.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceIncidentsProvider.swift
@@ -14,8 +14,9 @@ final class DeviceIncidentsProvider: ObservableObject, Provider {
 
     private let deviceID: UUID
 
-    init(deviceID: UUID) {
+    init(_ result: ProviderResult<Output>? = nil, deviceID: UUID) {
         self.deviceID = deviceID
+        self.result = result
     }
 
     func fetch(in database: DatabaseReader) async throws -> DeviceIncidents {

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesProvider.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesProvider.swift
@@ -12,6 +12,10 @@ import SwiftUI
 final class DevicesProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<DevicesReport>?
 
+    init(_ result: ProviderResult<Output>? = nil) {
+        self.result = result
+    }
+
     func fetch(in database: DatabaseReader) async throws -> DevicesReport {
         async let devices: [Record] = database.readAll(
             matching: RecordQuery(recordType: Device.self),

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
@@ -64,12 +64,12 @@ struct DevicesView: View {
 
 #Preview("Devices") {
     NavigationStack {
-        DevicesView(provider: .init().holding(.sample))
+        DevicesView(provider: .init(.success(.sample)))
     }
 }
 
 #Preview("Devices — Empty") {
     NavigationStack {
-        DevicesView(provider: .init().holding(.empty))
+        DevicesView(provider: .init(.success(.empty)))
     }
 }

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthProvider.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthProvider.swift
@@ -12,8 +12,8 @@ import SwiftUI
 final class ReleaseHealthProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[ReleaseHealth]>?
 
-    init(releases: [ReleaseHealth]? = nil) {
-        self.result = releases.map { .success($0) }
+    init(_ result: ProviderResult<Output>? = nil) {
+        self.result = result
     }
 
     func fetch(in database: DatabaseReader) async throws -> [ReleaseHealth] {

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthView.swift
@@ -33,6 +33,6 @@ struct ReleaseHealthView: View {
 
 #Preview {
     NavigationStack {
-        ReleaseHealthView(provider: .init().holding(.samples))
+        ReleaseHealthView(provider: .init(.success(.samples)))
     }
 }

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -209,8 +209,8 @@ private struct IncidentIssuesSection<Element: Incident, Destination: View>: View
     NavigationStack {
         VersionDetailView(
             release: [ReleaseHealth].samples[0],
-            crashes: .init(version: "3.2.0").holding(.samples),
-            hangs: .init(version: "3.2.0").holding(.samples)
+            crashes: .init(.samples, version: "3.2.0"),
+            hangs: .init(.samples, version: "3.2.0")
         )
     }
     .environmentObject(Tint())
@@ -222,8 +222,8 @@ private struct IncidentIssuesSection<Element: Incident, Destination: View>: View
     return NavigationStack {
         VersionDetailView(
             release: release,
-            crashes: .init(version: release.id, records: []),
-            hangs: .init(version: release.id, records: [])
+            crashes: .init([], version: release.id),
+            hangs: .init([], version: release.id)
         )
     }
     .environmentObject(Tint())

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionIncidentProvider.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionIncidentProvider.swift
@@ -12,10 +12,9 @@ import SwiftUI
 final class VersionIncidentProvider<Element: RecordDecodable & Incident>: FeedProvider<Element>, Periodic {
     let version: String
 
-    init(version: String, records: [Element]? = nil) {
+    init(_ records: [Element]? = nil, version: String) {
         self.version = version
-        super.init()
-        self.records = records
+        super.init(records)
     }
 
     private var query: RecordQuery {

--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -93,10 +93,10 @@ struct HomeList: View {
             activities: .init(),
             retention: .init(),
             sessions: .init(eventName: "Session", periods: Period.summary),
-            releases: .init().holding(.samples),
+            releases: .init(.success(.samples)),
             logs: .init(),
             devices: .init(),
-            alerts: .init().holding([.firingSample, .armedSample])
+            alerts: .init(.success([.firingSample, .armedSample]))
         )
         .navigationTitle(en: "Home")
     }
@@ -107,13 +107,13 @@ struct HomeList: View {
     NavigationStack {
         HomeList(
             path: .constant([]),
-            activities: .init().holding(.samples),
-            retention: .init().holding(.samples),
-            sessions: .init(eventName: "Session", periods: Period.summary).holding(.samples),
-            releases: .init().holding(.samples),
-            logs: .init().holding(acrossAllPeriods: MetricSeries.samples(for: .today)),
-            devices: .init().holding(.sample),
-            alerts: .init().holding([.firingSample, .armedSample])
+            activities: .init(.success(.samples)),
+            retention: .init(.success(.samples)),
+            sessions: .init(.success(.samples), eventName: "Session", periods: Period.summary),
+            releases: .init(.success(.samples)),
+            logs: .init(acrossAllPeriods: MetricSeries.samples(for: .today)),
+            devices: .init(.success(.sample)),
+            alerts: .init(.success([.firingSample, .armedSample]))
         )
         .navigationTitle(en: "Home")
     }
@@ -124,13 +124,13 @@ struct HomeList: View {
     NavigationStack {
         HomeList(
             path: .constant([]),
-            activities: .init().holding([]),
-            retention: .init().holding([]),
-            sessions: .init(eventName: "Session", periods: Period.summary).holding([]),
-            releases: .init().holding([]),
-            logs: .init().holding(acrossAllPeriods: []),
-            devices: .init().holding(.empty),
-            alerts: .init().holding([])
+            activities: .init(.success([])),
+            retention: .init(.success([])),
+            sessions: .init(.success([]), eventName: "Session", periods: Period.summary),
+            releases: .init(.success([])),
+            logs: .init(acrossAllPeriods: []),
+            devices: .init(.success(.empty)),
+            alerts: .init(.success([]))
         )
         .navigationTitle(en: "Home")
     }

--- a/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
+++ b/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
@@ -78,7 +78,7 @@ struct HomeAlertSection: View {
 
 extension HomeAlertSection {
     init(statuses: [AlertStatus]) {
-        self.init(alerts: .init().holding(statuses), path: .constant([]))
+        self.init(alerts: .init(.success(statuses)), path: .constant([]))
     }
 }
 

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
@@ -29,8 +29,12 @@ final class HomeLogProvider: ObservableObject, Provider {
 
     private(set) var report: LogReport?
 
-    init() {
+    init(acrossAllPeriods series: Output? = nil) {
         self.period = UserDefaults.standard.string(forKey: "scout_home_log_period").flatMap(Period.init) ?? .today
+        if let series {
+            results = Dictionary(uniqueKeysWithValues: Period.allCases.map { ($0, .success(series)) })
+            rebuildReport()
+        }
     }
 
     var result: ProviderResult<Output>? {
@@ -69,14 +73,5 @@ extension Period {
         case .week, .month, .year:
             .day
         }
-    }
-}
-
-extension HomeLogProvider {
-    func holding(acrossAllPeriods series: Output?) -> Self {
-        if let series {
-            results = Dictionary(uniqueKeysWithValues: Period.allCases.map { ($0, .success(series)) })
-        }
-        return self
     }
 }

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogSection.swift
@@ -55,8 +55,8 @@ extension HomeLogSection {
     init(period: Period) {
         self.init(
             period: period,
-            log: .init().holding(acrossAllPeriods: MetricSeries.samples(for: period)),
-            devices: .init().holding(.sample),
+            log: .init(acrossAllPeriods: MetricSeries.samples(for: period)),
+            devices: .init(.success(.sample)),
             path: .constant([])
         )
     }

--- a/Sources/ScoutUI/Home/Section/Log/LogView.swift
+++ b/Sources/ScoutUI/Home/Section/Log/LogView.swift
@@ -61,8 +61,8 @@ struct LogView: View {
     NavigationStack {
         LogView(
             period: .week,
-            log: .init().holding(acrossAllPeriods: MetricSeries.samples(for: .week)),
-            devices: .init().holding(.sample)
+            log: .init(acrossAllPeriods: MetricSeries.samples(for: .week)),
+            devices: .init(.success(.sample))
         )
     }
 }

--- a/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
+++ b/Sources/ScoutUI/Home/Section/Metric/HomeMetricSection.swift
@@ -66,8 +66,8 @@ struct HomeMetricSection: View {
     NavigationStack {
         InsetList {
             HomeMetricSection(
-                activities: .init().holding(.samples),
-                sessions: .init(eventName: "Session", periods: Period.summary).holding(.samples),
+                activities: .init(.success(.samples)),
+                sessions: .init(.success(.samples), eventName: "Session", periods: Period.summary),
                 period: .today,
                 path: .constant([])
             )

--- a/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
@@ -46,11 +46,11 @@ struct HomeReleaseSection: View {
     NavigationStack {
         InsetList {
             HomeReleaseSection(
-                releases: .init().holding(.samples),
+                releases: .init(.success(.samples)),
                 path: .constant([])
             )
             HomeReleaseSection(
-                releases: .init(releases: []),
+                releases: .init(.success([])),
                 path: .constant([])
             )
         }

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -85,7 +85,7 @@ struct HomeRetentionSection: View {
     NavigationStack {
         InsetList {
             HomeRetentionSection(
-                retention: .init().holding(.samples),
+                retention: .init(.success(.samples)),
                 path: .constant([])
             )
             HomeRetentionSection(

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -127,13 +127,13 @@ private struct AlertChip: View {
 
 #Preview {
     NavigationStack {
-        AlertListView(provider: .init().holding([.firingSample, .armedSample]))
+        AlertListView(provider: .init(.success([.firingSample, .armedSample])))
     }
 }
 
 #Preview("Empty") {
     NavigationStack {
-        AlertListView(provider: .init().holding([]))
+        AlertListView(provider: .init(.success([])))
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
@@ -16,10 +16,15 @@ final class AlertProvider: ObservableObject, Provider {
     private let notifier: AlertNotifier?
     private let engine: AlertEngine
 
-    init(registry: AlertRegistry = AlertRegistry(), notifier: AlertNotifier? = nil) {
+    init(
+        _ result: ProviderResult<Output>? = nil,
+        registry: AlertRegistry = AlertRegistry(),
+        notifier: AlertNotifier? = nil
+    ) {
         self.registry = registry
         self.notifier = notifier
         self.engine = AlertEngine(registry: registry, notifier: notifier)
+        self.result = result
     }
 
     var rules: [AlertRule] {

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownProvider.swift
@@ -16,9 +16,10 @@ final class IncidentBreakdownProvider: ObservableObject, Provider {
     private let deviceIDs: [UUID]
     private let sessionIDs: [UUID]
 
-    init(deviceIDs: [UUID], sessionIDs: [UUID]) {
+    init(_ result: ProviderResult<Output>? = nil, deviceIDs: [UUID], sessionIDs: [UUID]) {
         self.deviceIDs = deviceIDs
         self.sessionIDs = sessionIDs
+        self.result = result
     }
 
     func fetch(in database: DatabaseReader) async throws -> IncidentBreakdown {

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashGroupDetailView.swift
@@ -95,7 +95,7 @@ struct CrashGroupDetailView: View {
                 .sample("NSRangeException", at: Date()),
                 .sample("NSRangeException", at: Date().addingTimeInterval(-3600)),
             ]),
-            breakdown: .init(deviceIDs: [], sessionIDs: []).holding(.sample)
+            breakdown: .init(.success(.sample), deviceIDs: [], sessionIDs: [])
         )
     }
     .environmentObject(Tint())

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
@@ -51,7 +51,7 @@ struct CrashListView: View {
 
 #Preview {
     NavigationStack {
-        CrashListView(provider: .init().holding(.samples))
+        CrashListView(provider: .init(.samples))
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
@@ -80,7 +80,7 @@ struct HangGroupDetailView: View {
                 .sample("Image Layout Pass", duration: 9.8, at: Date()),
                 .sample("Image Layout Pass", duration: 4.6, at: Date().addingTimeInterval(-3600)),
             ]),
-            breakdown: .init(deviceIDs: [], sessionIDs: []).holding(.sample)
+            breakdown: .init(.success(.sample), deviceIDs: [], sessionIDs: [])
         )
     }
     .environmentObject(Tint())

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
@@ -47,7 +47,7 @@ struct HangListView: View {
 
 #Preview {
     NavigationStack {
-        HangListView(provider: .init().holding(.samples))
+        HangListView(provider: .init(.samples))
     }
     .environmentObject(Tint())
 }

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionProvider.swift
@@ -16,9 +16,10 @@ final class MetricDistributionProvider<H: QuantileHistogram>: ObservableObject, 
     private let name: String
     private let categories: [String]
 
-    init(name: String, categories: [String]) {
+    init(_ result: ProviderResult<Output>? = nil, name: String, categories: [String]) {
         self.name = name
         self.categories = categories
+        self.result = result
     }
 
     func fetch(in database: DatabaseReader) async throws -> MetricDistribution<H> {

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
@@ -48,10 +48,10 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
 
 #Preview("Timer") {
     let provider = MetricDistributionProvider<LatencyHistogram>(
+        .success(.sample),
         name: "http_request",
         categories: []
     )
-    .holding(.sample)
 
     return NavigationStack {
         InsetList {
@@ -69,10 +69,10 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
 
 #Preview("Recorder") {
     let provider = MetricDistributionProvider<RecorderHistogram>(
+        .success(.sample),
         name: "payload_size",
         categories: []
     )
-    .holding(.sample)
 
     return NavigationStack {
         InsetList {

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkProvider.swift
@@ -13,6 +13,10 @@ import Scout
 final class NetworkProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<NetworkReport>?
 
+    init(_ result: ProviderResult<Output>? = nil) {
+        self.result = result
+    }
+
     func fetch(in database: DatabaseReader) async throws -> NetworkReport {
         let categories = LatencyBuckets.categories + StatusBuckets.categories
         let series = try await database.metricSeries(

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
@@ -72,7 +72,7 @@ struct NetworkView: View {
 
 #Preview("NetworkView") {
     NavigationStack {
-        NetworkView(provider: .init().holding(.sample))
+        NetworkView(provider: .init(.success(.sample)))
     }
 }
 

--- a/Sources/ScoutUI/Primitives/Indicators/StatProvider.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatProvider.swift
@@ -15,9 +15,10 @@ final class StatProvider: ObservableObject, Provider {
     let eventName: String
     let periods: [Period]
 
-    init(eventName: String, periods: [Period]) {
+    init(_ result: ProviderResult<Output>? = nil, eventName: String, periods: [Period]) {
         self.eventName = eventName
         self.periods = periods
+        self.result = result
     }
 
     func fetch(in database: DatabaseReader) async throws -> [ChartPoint<Int>] {

--- a/Sources/ScoutUI/Primitives/Indicators/StatView.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatView.swift
@@ -95,7 +95,7 @@ extension EnvironmentValues {
         StatView(
             showList: true,
             extent: ChartExtent(period: .yesterday),
-            stat: .init(eventName: "app_launch", periods: Period.allCases).holding([])
+            stat: .init(.success([]), eventName: "app_launch", periods: Period.allCases)
         )
         .navigationTitle(en: "App Launch")
         .environmentObject(Tint())

--- a/Sources/ScoutUI/Support/Provider/FeedProvider.swift
+++ b/Sources/ScoutUI/Support/Provider/FeedProvider.swift
@@ -15,6 +15,10 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
     @Published var cursor: RecordCursor?
     @Published var message: Message?
 
+    init(_ records: [Element]? = nil) {
+        self.records = records
+    }
+
     @discardableResult
     func fetchLatest(matching query: RecordQuery, in database: DatabaseReader) async -> Bool {
         do {
@@ -75,12 +79,5 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
     func clear() {
         records = nil
         cursor = nil
-    }
-}
-
-extension FeedProvider {
-    func holding(_ records: [Element]?) -> Self {
-        self.records = records
-        return self
     }
 }

--- a/Sources/ScoutUI/Support/Provider/Provider.swift
+++ b/Sources/ScoutUI/Support/Provider/Provider.swift
@@ -65,10 +65,3 @@ extension Provider {
         }
     }
 }
-
-extension Provider {
-    func holding(_ output: Output?) -> Self {
-        result = output.map { .success($0) }
-        return self
-    }
-}


### PR DESCRIPTION
Providers primed their preview and test state through a fluent `holding()` helper that mutated the published property after the object was built. This replaces that pattern entirely: the seed value is now passed through the initializer, so an `@StateObject` is fully primed at construction rather than mutated afterwards.

All three `holding()` variants are gone — the `Provider` extension, the `FeedProvider` extension, and `HomeLogProvider`'s across-all-periods helper. `Provider` conformers now take the seed as an unlabeled first parameter, `init(_ result: ProviderResult<Output>? = nil)`, referencing the associated `Output` type rather than each concrete type. `FeedProvider` and its subclasses take an unlabeled `records` seed the same way, with domain parameters (`filter:`, `version:`) following. `HomeLogProvider` folds its seed into `init(acrossAllPeriods:)` and calls `rebuildReport()` explicitly, since `didSet` does not fire during initialization.

A `Provider`-wide `init` requirement with a default implementation was considered but is not expressible: a protocol-extension initializer cannot assign stored properties on a class without first delegating to a designated init, and the requirement could not be satisfied by the providers that need domain parameters. Each provider therefore keeps its own initializer.

Build-for-testing passes on the iOS simulator.
