### PR TITLE
Include query.reduce in the series cache fingerprint

### DIFF
--- a/Sources/LookupIndex/CachedMetricSeries.swift
+++ b/Sources/LookupIndex/CachedMetricSeries.swift
@@ -18,6 +18,7 @@ enum CachedMetricSeries {
             query.bucket.rawValue,
             query.byVersion ? "version" : "*",
             query.source?.rawValue ?? "*",
+            query.reduce.rawValue,
         ]
         .joined(separator: "|")
     }


### PR DESCRIPTION
The series cache fingerprint hashed every query dimension except `reduce`, so a `.sum` and a `.last` aggregation of the same metric mapped to the same frozen-week cache entry and could read back each other's points. It is not reachable today only because the sole `.last` caller (meter) also carries a distinct `category`, but the key must still capture `reduce` like every other dimension. Fixed by appending `query.reduce.rawValue` to the fingerprint.

Note: adding `reduce` changes the fingerprint strings, so pre-existing cache rows under the old keys become orphaned. The cache is disposable and self-healing (it re-fetches on a miss), so no schema-version bump is needed.

Verified with the `LookupIndexTests` suite on the iOS 26 simulator.
