### PR TITLE
Add a DemoConnector backed by a seeded offline database

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,10 @@ let package = Package(
             name: "LookupIndex",
             targets: ["LookupIndex"]
         ),
+        .library(
+            name: "DemoConnector",
+            targets: ["DemoConnector"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
@@ -79,6 +83,13 @@ let package = Package(
             dependencies: [
                 "Scout"
             ]
+        ),
+        .target(
+            name: "DemoConnector",
+            dependencies: [
+                "Scout"
+            ],
+            path: "Sources/Connectors/Demo"
         ),
         .target(
             name: "Support",
@@ -136,6 +147,16 @@ let package = Package(
                 "Support",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ]
+        ),
+        .testTarget(
+            name: "DemoConnectorTests",
+            dependencies: [
+                "DemoConnector",
+                "ScoutUI",
+                "Scout",
+                "Support",
+            ],
+            path: "Tests/Connectors/Demo"
         ),
     ]
 )

--- a/Sources/Connectors/Demo/DemoActivity.swift
+++ b/Sources/Connectors/Demo/DemoActivity.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct DemoActivity {
+    let points: [ActivityPoint]
+    let cohorts: [RetentionCohort]
+
+    init(scenario: DemoScenario) {
+        let range = scenario.clock.foldRange
+
+        let visits = scenario.sessions.map {
+            ActivityVisit(date: $0.start, user: $0.device.id.uuidString)
+        }
+        points = ActivityPoint.points(visits: visits, in: range)
+
+        var installDays: [String: Date] = [:]
+        for install in scenario.installs where range.contains(install.date) {
+            installDays[install.id.uuidString] = install.date
+        }
+
+        var sessionDays: [String: Set<Date>] = [:]
+        for session in scenario.sessions {
+            sessionDays[session.install.id.uuidString, default: []].insert(session.start.startOfDay)
+        }
+
+        cohorts = RetentionCohort.build(
+            installDays: installDays, sessionDays: sessionDays, in: range, asOf: scenario.clock.now)
+    }
+}

--- a/Sources/Connectors/Demo/DemoBackend.swift
+++ b/Sources/Connectors/Demo/DemoBackend.swift
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+extension Backend {
+    /// A self-contained demo backend backed by a local, offline database that is
+    /// preloaded with fabricated data covering every dashboard screen.
+    ///
+    /// Nothing here touches the network or iCloud: the returned backend reports
+    /// itself reachable and answers every query from an in-memory corpus, so it
+    /// can drive `scoutHome(isPresented:backends:)` for previews, screenshots,
+    /// and App Store demos.
+    ///
+    /// - Parameter now: The reference moment to generate the corpus relative to. Passing `nil` reuses the
+    ///   shared corpus built for the current date, so repeated calls don't rebuild it.
+    /// - Returns: A `Backend` whose database is a seeded ``DemoDatabase``.
+    ///
+    public static func demo(now: Date? = nil) -> Backend {
+        Backend(
+            id: "scout.demo",
+            database: DemoDatabase(corpus: now.map(DemoCorpus.make(now:)) ?? DemoCorpus.shared),
+            checkAvailability: { true },
+            displayName: "Demo",
+            probeStatus: { .reachable }
+        )
+    }
+}

--- a/Sources/Connectors/Demo/DemoClock.swift
+++ b/Sources/Connectors/Demo/DemoClock.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct DemoClock {
+    let now: Date
+
+    var today: Date {
+        now.startOfDay
+    }
+
+    func daysAgo(_ days: Int) -> Date {
+        today.addingTimeInterval(-TimeInterval(days) * .day)
+    }
+
+    var foldRange: Range<Date> {
+        today.addingYear(-1).addingWeek(-1)..<today.addingDay()
+    }
+
+    func middayDaysAgo(_ days: Int) -> Date {
+        daysAgo(days).addingTimeInterval(12 * 3600)
+    }
+
+    func momentDaysAgo(_ days: Int) -> Date {
+        min(middayDaysAgo(days), now.addingTimeInterval(-60))
+    }
+
+    func moment(daysAgo: Int, spread: TimeInterval, after earliest: Date) -> Date {
+        let ceiling = now.addingTimeInterval(-1)
+        let floor = min(earliest.addingTimeInterval(30), ceiling)
+        return min(max(middayDaysAgo(daysAgo).addingTimeInterval(spread), floor), ceiling)
+    }
+
+    func minutesAgo(_ minutes: Int) -> Date {
+        now.addingTimeInterval(-TimeInterval(minutes) * 60)
+    }
+}

--- a/Sources/Connectors/Demo/DemoCorpus.swift
+++ b/Sources/Connectors/Demo/DemoCorpus.swift
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+enum DemoCorpus {
+    static let shared = make()
+
+    struct Corpus {
+        var records: [Record]
+        var samples: [DemoSample]
+        var activity: [ActivityPoint]
+        var retention: [RetentionCohort]
+    }
+
+    static func make(now: Date = Date()) -> Corpus {
+        let clock = DemoClock(now: now)
+        let scenario = DemoScenario(clock: clock)
+        let incidents = DemoIncidents(scenario: scenario)
+        let events = DemoEvents(scenario: scenario)
+        let releases = DemoReleases(scenario: scenario, incidents: incidents)
+        let metrics = DemoMetrics(clock: clock)
+        let activity = DemoActivity(scenario: scenario)
+
+        return Corpus(
+            records: scenario.records + incidents.records + events.records,
+            samples: releases.samples + events.samples + metrics.samples,
+            activity: activity.points,
+            retention: activity.cohorts
+        )
+    }
+}

--- a/Sources/Connectors/Demo/DemoDatabase.swift
+++ b/Sources/Connectors/Demo/DemoDatabase.swift
@@ -1,0 +1,73 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
+    private let records: [Record]
+    private let samples: [DemoSample]
+    private let activityPoints: [ActivityPoint]
+    private let retentionCohorts: [RetentionCohort]
+
+    init(corpus: DemoCorpus.Corpus) {
+        self.records = corpus.records
+        self.samples = corpus.samples
+        self.activityPoints = corpus.activity
+        self.retentionCohorts = corpus.retention
+    }
+
+    // The corpus is a fixed exhibit: host telemetry is accepted and dropped rather than mixed into the
+    // lists, which would leave real records showing up next to aggregates that never move.
+    func write(record: Record) async throws {}
+
+    func write(records: [Record]) async throws {}
+
+    func lookup(recordName: String, fields: [String]?) async throws -> Record {
+        guard let record = records.first(where: { $0.recordID == recordName }) else {
+            throw RecordNotFoundError()
+        }
+        return record
+    }
+
+    func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
+        try await read(matching: query, fields: fields, limit: .max)
+    }
+
+    func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
+        var matches = records.filter {
+            query.matches($0)
+        }
+        for sort in query.sort.reversed() {
+            matches.sort { lhs, rhs in
+                sort.ascending ? before(lhs, rhs, on: sort.field) : before(rhs, lhs, on: sort.field)
+            }
+        }
+        return RecordChunk(records: Array(matches.prefix(limit)), cursor: nil)
+    }
+
+    func readMore(from cursor: RecordCursor, fields: [String]?) async throws -> RecordChunk {
+        RecordChunk(records: [], cursor: nil)
+    }
+
+    func series(matching query: SeriesQuery) async throws -> [MetricSeries] {
+        samples.series(matching: query)
+    }
+
+    func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
+        activityPoints.filter { range.contains(Date(millisecondsSince1970: $0.date)) }
+    }
+
+    func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
+        retentionCohorts.filter { range.contains($0.id) }
+    }
+
+    private func before(_ lhs: Record, _ rhs: Record, on field: String) -> Bool {
+        (lhs.fields[field]?.value ?? -.greatestFiniteMagnitude)
+            < (rhs.fields[field]?.value ?? -.greatestFiniteMagnitude)
+    }
+}

--- a/Sources/Connectors/Demo/DemoEvents.swift
+++ b/Sources/Connectors/Demo/DemoEvents.swift
@@ -1,0 +1,82 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct DemoEvents {
+    static let names = [
+        "Search_Performed",
+        "Item_Viewed",
+        "Purchase_Completed",
+        "Onboarding_Finished",
+        "Share_Tapped",
+        "Settings_Opened",
+        "Notification_Received",
+        "Sync_Failed",
+    ]
+
+    let records: [Record]
+    let samples: [DemoSample]
+
+    init(scenario: DemoScenario) {
+        var random = DemoRandom(seed: 0xE_1E_17_5)
+        var records: [Record] = []
+        var samples: [DemoSample] = []
+
+        let encoder = JSONEncoder()
+
+        let paramPools: [String: [String: [String]]] = [
+            "Search_Performed": ["query": ["coffee", "sneakers", "flights"], "result_count": ["0", "8", "23"]],
+            "Item_Viewed": ["item_id": ["SKU-1042", "SKU-2231"], "category": ["shoes", "audio", "home"]],
+            "Purchase_Completed": ["amount": ["4.99", "19.99", "49.00"], "currency": ["USD", "EUR", "GBP"]],
+            "Onboarding_Finished": ["steps": ["3", "4"], "skipped": ["true", "false"]],
+            "Share_Tapped": ["destination": ["messages", "mail", "twitter"]],
+            "Settings_Opened": ["section": ["privacy", "notifications", "account"]],
+            "Notification_Received": ["kind": ["promo", "reminder", "digest"]],
+            "Sync_Failed": ["reason": ["timeout", "offline", "server_error"], "attempt": ["1", "2", "3"]],
+        ]
+
+        let levels: [EventLevel] = [.info, .info, .info, .notice, .warning, .error]
+
+        for (index, session) in scenario.sessions.enumerated() {
+            let span = max(1, session.end.timeIntervalSince(session.start))
+
+            for _ in 0..<random.int(in: 0...2) {
+                let name = DemoEvents.names[random.int(in: 0...DemoEvents.names.count - 1)]
+                let date = session.start.addingTimeInterval(random.double(in: 0...span))
+                let level = name == "Sync_Failed" ? EventLevel.error : levels[index % levels.count]
+
+                var params: [String: String] = [:]
+                for (key, options) in paramPools[name] ?? [:] {
+                    params[key] = options[random.int(in: 0...options.count - 1)]
+                }
+
+                let id = random.uuid()
+                var record = Event(
+                    name: name,
+                    level: level,
+                    date: date,
+                    paramCount: params.count,
+                    uuid: id,
+                    id: id.uuidString,
+                    installID: session.install.id,
+                    sessionID: session.id,
+                    deviceID: session.device.id
+                )
+                .record
+
+                record["params"] = try? encoder.encode(params)
+                records.append(record)
+                samples.append(DemoSample(name: name, date: date))
+            }
+        }
+
+        self.records = records
+        self.samples = samples
+    }
+}

--- a/Sources/Connectors/Demo/DemoIncidents.swift
+++ b/Sources/Connectors/Demo/DemoIncidents.swift
@@ -1,0 +1,127 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct DemoIncidents {
+    struct Point {
+        let date: Date
+        let version: String
+        let installID: UUID
+    }
+
+    let records: [Record]
+    let crashes: [Point]
+    let hangs: [Point]
+
+    init(scenario: DemoScenario) {
+        var random = DemoRandom(seed: 0xDEAD_FA11)
+        var records: [Record] = []
+        var crashes: [Point] = []
+        var hangs: [Point] = []
+
+        let crashSignatures: [(name: String, reason: String, frames: [String])] = [
+            (
+                "EXC_BAD_ACCESS", "Attempted to dereference a nil value",
+                ["FeedViewController.reload()", "DataSource.item(at:)", "Array.subscript.getter"]
+            ),
+            (
+                "NSInvalidArgumentException", "-[__NSCFString objectForKey:]: unrecognized selector",
+                ["ProfileStore.decode()", "JSONDecoder.decode(_:from:)", "objc_exception_throw"]
+            ),
+            (
+                "SIGABRT", "Fatal error: Index out of range",
+                ["Paginator.page(_:)", "Array.subscript.getter", "CheckoutView.body.getter"]
+            ),
+            (
+                "EXC_BREAKPOINT", "Swift runtime failure: force unwrap of nil",
+                ["PaymentCoordinator.confirm()", "Optional.unsafelyUnwrapped", "Wallet.charge(_:)"]
+            ),
+        ]
+
+        let hangSignatures: [(name: String, reason: String, frames: [String])] = [
+            (
+                "Main thread blocked", "Synchronous network request on the main queue",
+                ["SyncManager.flush()", "URLSession.dataTask(with:)", "RunLoop.run()"]
+            ),
+            (
+                "Main thread blocked", "Heavy image decode during scroll",
+                ["ImageCache.decode(_:)", "UIImage.init(data:)", "CATransaction.commit()"]
+            ),
+            (
+                "Main thread blocked", "Large Core Data fetch on the main context",
+                ["Library.reload()", "NSManagedObjectContext.fetch(_:)", "sqlite3_step"]
+            ),
+            (
+                "Main thread blocked", "JSON parse of a large payload",
+                ["Importer.run()", "JSONSerialization.jsonObject(with:)", "memmove"]
+            ),
+        ]
+
+        let crashProne = Set(
+            stride(from: 0, to: scenario.installs.count, by: 60).map { scenario.installs[$0].id }
+        )
+
+        for session in scenario.sessions {
+            let span = max(1, session.end.timeIntervalSince(session.start))
+
+            if crashProne.contains(session.install.id), random.double(in: 0...1) < 0.4 {
+                let signature = crashSignatures[random.int(in: 0...crashSignatures.count - 1)]
+                let date = session.start.addingTimeInterval(random.double(in: 0...span))
+                let id = random.uuid()
+
+                var record = Crash(
+                    name: signature.name,
+                    fingerprint: "crash-\(signature.name)",
+                    reason: signature.reason,
+                    stackTrace: signature.frames,
+                    date: date,
+                    id: id.uuidString,
+                    deviceID: session.device.id,
+                    installID: session.install.id,
+                    launchID: session.launchID,
+                    sessionID: session.id
+                )
+                .record
+
+                record["app_version"] = session.version.version
+                records.append(record)
+                crashes.append(Point(date: date, version: session.version.version, installID: session.install.id))
+            }
+
+            if random.double(in: 0...1) < 0.012 {
+                let signature = hangSignatures[random.int(in: 0...hangSignatures.count - 1)]
+                let date = session.start.addingTimeInterval(random.double(in: 0...span))
+                let id = random.uuid()
+
+                var record = Hang(
+                    name: signature.name,
+                    fingerprint: "hang-\(signature.reason)",
+                    reason: signature.reason,
+                    stackTrace: signature.frames,
+                    duration: random.double(in: 0.3...6),
+                    date: date,
+                    id: id.uuidString,
+                    deviceID: session.device.id,
+                    installID: session.install.id,
+                    launchID: session.launchID,
+                    sessionID: session.id
+                )
+                .record
+
+                record["app_version"] = session.version.version
+                records.append(record)
+                hangs.append(Point(date: date, version: session.version.version, installID: session.install.id))
+            }
+        }
+
+        self.records = records
+        self.crashes = crashes
+        self.hangs = hangs
+    }
+}

--- a/Sources/Connectors/Demo/DemoMetrics.swift
+++ b/Sources/Connectors/Demo/DemoMetrics.swift
@@ -1,0 +1,134 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct DemoMetrics {
+    static let endpoints = [
+        "GET /v1/sessions",
+        "POST /v1/events",
+        "GET /v1/releases",
+        "POST /v1/metrics/records",
+        "GET /v1/metrics/series",
+    ]
+
+    static let timers = ["api_response_time", "frame_render_time"]
+    static let recorders = ["payload_size_bytes", "row_count"]
+    static let counters = ["api_requests", "cache_hits", "login_attempts"]
+
+    let samples: [DemoSample]
+
+    init(clock: DemoClock) {
+        var random = DemoRandom(seed: 0x0FF1_CE_5EED)
+        var samples: [DemoSample] = []
+
+        func moments(spanDays: Int, perDay: Int, _ body: (Date) -> Void) {
+            for day in stride(from: spanDays, through: 0, by: -1) {
+                for slot in 0..<perDay {
+                    let offset = TimeInterval(slot) * (24 * 3600 / TimeInterval(perDay))
+                    let date = min(
+                        clock.daysAgo(day).addingTimeInterval(offset + random.double(in: 0...3600)),
+                        clock.now.addingTimeInterval(-60)
+                    )
+                    body(date)
+                }
+            }
+        }
+
+        func telemetry(_ names: [String], category: String, perDay: Int, _ value: (inout DemoRandom) -> MetricValue) {
+            for name in names {
+                moments(spanDays: 60, perDay: perDay) { date in
+                    samples.append(
+                        DemoSample(name: name, category: category, date: date, value: value(&random)))
+                }
+            }
+        }
+
+        telemetry(Self.counters, category: Telemetry.Export.counter.rawValue, perDay: 6) {
+            .int($0.int(in: 0...40))
+        }
+        telemetry(["bytes_downloaded_mb"], category: Telemetry.Export.floatingCounter.rawValue, perDay: 6) {
+            .double($0.double(in: 0...12))
+        }
+        telemetry(["memory_usage_mb", "active_connections"], category: Telemetry.Export.meter.rawValue, perDay: 6) {
+            .double($0.double(in: 120...480))
+        }
+        telemetry(Self.recorders, category: Telemetry.Export.recorder.rawValue, perDay: 6) {
+            .int($0.int(in: 200...9000))
+        }
+        // Timers are stored in seconds and rendered as durations, so sub-second values read naturally.
+        telemetry(Self.timers, category: Telemetry.Export.timer.rawValue, perDay: 6) {
+            .double($0.double(in: 0.02...1.4))
+        }
+
+        for name in Self.counters + ["bytes_downloaded_mb"] {
+            for day in stride(from: 40, through: 0, by: -20) {
+                samples.append(
+                    DemoSample(
+                        name: name, category: ResetMarker.category, date: clock.momentDaysAgo(day),
+                        value: .int(random.int(in: 1...3))))
+            }
+        }
+
+        for endpoint in Self.endpoints {
+            samples += Self.histogram(
+                name: endpoint, categories: LatencyBuckets.categories, center: 0.45, scale: 180,
+                clock: clock, random: &random)
+            samples += Self.statuses(endpoint: endpoint, clock: clock, random: &random)
+        }
+
+        for name in Self.timers {
+            samples += Self.histogram(
+                name: name, categories: LatencyBuckets.categories, center: 0.4, scale: 140,
+                clock: clock, random: &random)
+        }
+        for name in Self.recorders {
+            samples += Self.histogram(
+                name: name, categories: RecorderBuckets.categories, center: 0.55, scale: 140,
+                clock: clock, random: &random)
+        }
+
+        self.samples = samples
+    }
+
+    private static func histogram(
+        name: String, categories: [String], center ratio: Double, scale: Double, clock: DemoClock,
+        random: inout DemoRandom
+    ) -> [DemoSample] {
+        var samples: [DemoSample] = []
+        let center = Double(categories.count) * ratio
+
+        for (index, category) in categories.enumerated() {
+            let weight = exp(-pow(Double(index) - center, 2) / 14)
+
+            for day in stride(from: 56, through: 0, by: -7) {
+                samples.append(
+                    DemoSample(
+                        name: name, category: category, date: clock.momentDaysAgo(day),
+                        value: .int(Int((weight * scale).rounded()) + random.int(in: 0...4))))
+            }
+        }
+        return samples
+    }
+
+    private static func statuses(endpoint: String, clock: DemoClock, random: inout DemoRandom) -> [DemoSample] {
+        var samples: [DemoSample] = []
+
+        for (index, category) in StatusBuckets.categories.enumerated() {
+            let weight = [0.94, 0.03, 0.025, 0.005][min(index, 3)]
+
+            for day in stride(from: 56, through: 0, by: -7) {
+                samples.append(
+                    DemoSample(
+                        name: endpoint, category: category, date: clock.momentDaysAgo(day),
+                        value: .int(Int((weight * 600).rounded()) + random.int(in: 0...2))))
+            }
+        }
+        return samples
+    }
+}

--- a/Sources/Connectors/Demo/DemoRandom.swift
+++ b/Sources/Connectors/Demo/DemoRandom.swift
@@ -1,0 +1,52 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct DemoRandom: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    mutating func int(in range: ClosedRange<Int>) -> Int {
+        Int.random(in: range, using: &self)
+    }
+
+    mutating func double(in range: ClosedRange<Double>) -> Double {
+        Double.random(in: range, using: &self)
+    }
+
+    mutating func uuid() -> UUID {
+        let high = next()
+        let low = next()
+        var bytes: [UInt8] = []
+
+        withUnsafeBytes(of: high) {
+            bytes.append(contentsOf: $0)
+        }
+        withUnsafeBytes(of: low) {
+            bytes.append(contentsOf: $0)
+        }
+
+        return UUID(
+            uuid: (
+                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+                bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+            )
+        )
+    }
+}

--- a/Sources/Connectors/Demo/DemoReleases.swift
+++ b/Sources/Connectors/Demo/DemoReleases.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct DemoReleases {
+    let samples: [DemoSample]
+
+    init(scenario: DemoScenario, incidents: DemoIncidents) {
+        var samples: [DemoSample] = []
+
+        samples += scenario.sessions.map {
+            DemoSample(name: SessionEntry.recordType, version: $0.version.version, date: $0.start)
+        }
+        samples += incidents.crashes.map {
+            DemoSample(name: CrashEntry.recordType, version: $0.version, date: $0.date)
+        }
+        samples += incidents.hangs.map {
+            DemoSample(name: HangEntry.recordType, version: $0.version, date: $0.date)
+        }
+        samples += scenario.adoption.map {
+            DemoSample(name: VersionEntry.recordType, version: $0.version, date: $0.date)
+        }
+        samples += DemoReleases.crashedInstalls(incidents.crashes)
+
+        self.samples = samples
+    }
+
+    private static func crashedInstalls(_ crashes: [DemoIncidents.Point]) -> [DemoSample] {
+        var seen: Set<String> = []
+        return crashes.compactMap { crash in
+            guard seen.insert("\(crash.installID)-\(crash.version)").inserted else {
+                return nil
+            }
+            return DemoSample(name: MarkerEntry.crashName, version: crash.version, date: crash.date)
+        }
+    }
+}

--- a/Sources/Connectors/Demo/DemoSample.swift
+++ b/Sources/Connectors/Demo/DemoSample.swift
@@ -1,0 +1,109 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct DemoSample {
+    let name: String
+    let category: String?
+    let version: String?
+    let date: Date
+    let value: MetricValue
+
+    init(name: String, category: String? = nil, version: String? = nil, date: Date, value: MetricValue = .int(1)) {
+        self.name = name
+        self.category = category
+        self.version = version
+        self.date = date
+        self.value = value
+    }
+}
+
+extension [DemoSample] {
+    func series(matching query: SeriesQuery) -> [MetricSeries] {
+        let groups = Dictionary(grouping: filter { $0.matches(query) }) {
+            SeriesKey(name: $0.name, category: $0.category, version: query.byVersion ? $0.version : nil)
+        }
+
+        return groups.compactMap { key, samples in
+            let points = samples.points(bucket: query.bucket, reduce: query.reduce)
+            guard points.count > 0 else {
+                return nil
+            }
+            return MetricSeries(name: key.name, category: key.category, version: key.version, points: points)
+        }
+    }
+
+    private func points(bucket: SeriesQuery.Bucket, reduce: SeriesQuery.Reduce) -> [MetricSeriesPoint] {
+        Dictionary(grouping: self) { $0.date.start(of: bucket) }
+            .sorted { $0.key < $1.key }
+            .map { date, samples in
+                MetricSeriesPoint(date: date.millisecondsSince1970, value: samples.reduced(reduce))
+            }
+    }
+
+    private func reduced(_ rule: SeriesQuery.Reduce) -> MetricValue {
+        switch rule {
+        case .last:
+            return self.max { $0.date < $1.date }?.value ?? .int(0)
+        case .sum:
+            let total = self.reduce(0.0) { $0 + $1.value.scalar }
+            return allSatisfy(\.value.isInt) ? .int(Int(total)) : .double(total)
+        }
+    }
+}
+
+private struct SeriesKey: Hashable {
+    let name: String
+    let category: String?
+    let version: String?
+}
+
+extension DemoSample {
+    fileprivate func matches(_ query: SeriesQuery) -> Bool {
+        guard query.name == nil || name == query.name else {
+            return false
+        }
+        guard query.category == nil || category == query.category else {
+            return false
+        }
+        guard !query.byVersion || version != nil else {
+            return false
+        }
+        guard query.values == nil || query.values == (value.isInt ? .int : .double) else {
+            return false
+        }
+        return query.range.contains(date)
+    }
+}
+
+extension MetricValue {
+    fileprivate var isInt: Bool {
+        if case .int = self { true } else { false }
+    }
+
+    fileprivate var scalar: Double {
+        switch self {
+        case .int(let value): Double(value)
+        case .double(let value): value
+        }
+    }
+}
+
+extension Date {
+    fileprivate func start(of bucket: SeriesQuery.Bucket) -> Date {
+        switch bucket {
+        case .hour:
+            Date(timeIntervalSince1970: (timeIntervalSince1970 / 3600).rounded(.down) * 3600)
+        case .day:
+            startOfDay
+        case .week:
+            startOfWeek
+        }
+    }
+}

--- a/Sources/Connectors/Demo/DemoScenario.swift
+++ b/Sources/Connectors/Demo/DemoScenario.swift
@@ -1,0 +1,218 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct DemoScenario {
+    struct AppVersion {
+        let version: String
+        let build: String
+        let releasedDaysAgo: Int
+    }
+
+    struct DeviceInfo {
+        let id: UUID
+        let model: String
+        let os: String
+    }
+
+    struct InstallInfo {
+        let id: UUID
+        let device: DeviceInfo
+        let date: Date
+        let version: AppVersion
+        let locale: String
+        let channel: String
+    }
+
+    struct SessionInfo {
+        let id: UUID
+        let install: InstallInfo
+        let launchID: UUID
+        let start: Date
+        let end: Date
+        let version: AppVersion
+
+        var device: DeviceInfo { install.device }
+    }
+
+    static let installCount = 300
+    static let spanDays = 120
+
+    let clock: DemoClock
+    let versions: [AppVersion]
+    let installs: [InstallInfo]
+    let sessions: [SessionInfo]
+
+    var devices: [DeviceInfo] {
+        installs.map(\.device)
+    }
+
+    var adoption: [(version: String, date: Date)] {
+        var seen: Set<String> = []
+        return sessions.compactMap { session in
+            guard seen.insert("\(session.install.id)-\(session.version.version)").inserted else {
+                return nil
+            }
+            return (session.version.version, session.start)
+        }
+    }
+
+    init(clock: DemoClock) {
+        self.clock = clock
+        var random = DemoRandom(seed: 0x5C0_17_DE_A11)
+
+        let versions = [
+            AppVersion(version: "2.1.0", build: "210", releasedDaysAgo: 64),
+            AppVersion(version: "2.2.0", build: "220", releasedDaysAgo: 35),
+            AppVersion(version: "2.3.0", build: "230", releasedDaysAgo: 12),
+        ]
+        self.versions = versions
+
+        let models = [
+            ("iPhone 15 Pro", "17.5.1"),
+            ("iPhone 14", "17.4.1"),
+            ("iPhone SE (3rd generation)", "16.7.8"),
+            ("iPad Pro 11-inch", "17.5"),
+            ("iPhone 13 mini", "17.3.1"),
+            ("iPhone 15", "18.0"),
+            ("iPad Air", "17.4"),
+            ("iPhone 12", "16.6.1"),
+        ]
+        let locales = ["en_US", "en_GB", "de_DE", "fr_FR", "ja_JP", "es_ES"]
+        let channels = ["AppStore", "AppStore", "AppStore", "TestFlight"]
+
+        func activeVersion(daysAgo: Int) -> AppVersion {
+            versions.filter { $0.releasedDaysAgo >= daysAgo }
+                .min { $0.releasedDaysAgo < $1.releasedDaysAgo } ?? versions[0]
+        }
+
+        var installs: [InstallInfo] = []
+        var sessions: [SessionInfo] = []
+
+        for index in 0..<Self.installCount {
+            let installDaysAgo = index * Self.spanDays / Self.installCount
+            let model = models[index % models.count]
+
+            let install = InstallInfo(
+                id: random.uuid(),
+                device: DeviceInfo(id: random.uuid(), model: model.0, os: model.1),
+                date: clock.momentDaysAgo(installDaysAgo),
+                version: activeVersion(daysAgo: installDaysAgo),
+                locale: locales[index % locales.count],
+                channel: channels[index % channels.count]
+            )
+            installs.append(install)
+
+            var activeDays = [0]
+            for (milestone, offset) in [1, 3, 7, 14, 30].enumerated() where installDaysAgo - offset >= 0 {
+                let keepChance = 0.82 - Double(milestone) * 0.14
+
+                if random.double(in: 0...1) < keepChance {
+                    activeDays.append(offset)
+                }
+            }
+
+            for offset in activeDays {
+                let sessionDaysAgo = installDaysAgo - offset
+
+                for _ in 0..<random.int(in: 1...3) {
+                    let start = clock.moment(
+                        daysAgo: sessionDaysAgo,
+                        spread: random.double(in: -5 * 3600...5 * 3600),
+                        after: install.date
+                    )
+                    let end = min(
+                        start.addingTimeInterval(random.double(in: 45...2100)),
+                        clock.now.addingTimeInterval(-1)
+                    )
+
+                    sessions.append(
+                        SessionInfo(
+                            id: random.uuid(),
+                            install: install,
+                            launchID: random.uuid(),
+                            start: start,
+                            end: end,
+                            version: activeVersion(daysAgo: sessionDaysAgo)
+                        )
+                    )
+                }
+            }
+        }
+
+        self.installs = installs
+        self.sessions = sessions
+    }
+
+    var records: [Record] {
+        deviceRecords + installRecords + launchRecords + sessionRecords
+    }
+
+    private var deviceRecords: [Record] {
+        installs.map { install in
+            var record = Device(
+                date: install.date,
+                id: install.device.id.uuidString,
+                deviceID: install.device.id
+            )
+            .record
+            record["model"] = install.device.model
+            return record
+        }
+    }
+
+    private var installRecords: [Record] {
+        installs.map { install in
+            Install(
+                date: install.date,
+                id: install.id.uuidString,
+                installID: install.id,
+                deviceID: install.device.id
+            )
+            .record
+        }
+    }
+
+    private var launchRecords: [Record] {
+        sessions.map { session in
+            var record = Launch(
+                startDate: session.start,
+                endDate: session.end,
+                id: session.launchID.uuidString,
+                launchID: session.launchID,
+                installID: session.install.id
+            )
+            .record
+            record["device_id"] = session.device.id.uuidString
+            return record
+        }
+    }
+
+    private var sessionRecords: [Record] {
+        sessions.map { session in
+            var record = Session(
+                startDate: session.start,
+                endDate: session.end,
+                id: session.id.uuidString,
+                sessionID: session.id,
+                launchID: session.launchID,
+                installID: session.install.id
+            )
+            .record
+
+            record["device_id"] = session.device.id.uuidString
+            record["os_version"] = session.device.os
+            record["app_version"] = session.version.version
+            record["build_number"] = session.version.build
+            record["locale"] = session.install.locale
+            record["channel"] = session.install.channel
+            return record
+        }
+    }
+}

--- a/Tests/Connectors/Demo/DemoDatabaseTests.swift
+++ b/Tests/Connectors/Demo/DemoDatabaseTests.swift
@@ -1,0 +1,166 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import DemoConnector
+@testable import Scout
+@testable import ScoutUI
+
+@Suite struct DemoDatabaseTests {
+    static let corpus = DemoCorpus.shared
+
+    let database = DemoDatabase(corpus: DemoDatabaseTests.corpus)
+    let range = Calendar.utc.defaultRange
+
+    private func records(_ type: any RecordDecodable.Type) async throws -> [Record] {
+        try await database.read(matching: RecordQuery(recordType: type), fields: nil).records
+    }
+
+    @Test func rawRecordsPresentForEveryListType() async throws {
+        #expect(try await records(Device.self).count > 0)
+        #expect(try await records(Install.self).count > 0)
+        #expect(try await records(Launch.self).count > 0)
+        #expect(try await records(Session.self).count > 0)
+        #expect(try await records(Crash.self).count > 0)
+        #expect(try await records(Hang.self).count > 0)
+        #expect(try await records(Event.self).count > 0)
+    }
+
+    @Test func lifecycleSeriesPopulateWithAndWithoutVersions() async throws {
+        for name in [SessionEntry.recordType, CrashEntry.recordType, HangEntry.recordType] {
+            let byVersion = try await database.series(
+                matching: SeriesQuery(name: name, bucket: .day, byVersion: true, source: .lifecycle, range: range))
+            #expect(byVersion.count > 0, "expected by-version \(name) series")
+            #expect(byVersion.allSatisfy { $0.version != nil })
+
+            let aggregate = try await database.series(matching: SeriesQuery(name: name, range: range))
+            #expect(aggregate.count == 1, "expected one aggregate \(name) series")
+            #expect(aggregate.allSatisfy { $0.version == nil })
+        }
+    }
+
+    @Test func aggregateSeriesEqualsSumOfVersions() async throws {
+        let byVersion = try await database.series(
+            matching: SeriesQuery(name: SessionEntry.recordType, byVersion: true, range: range))
+        let aggregate = try await database.series(matching: SeriesQuery(name: SessionEntry.recordType, range: range))
+
+        #expect(byVersion.total == aggregate.total)
+        #expect(try await aggregate.total == records(Session.self).count)
+    }
+
+    @Test func eventSeriesTotalsMatchEventRecords() async throws {
+        for name in DemoEvents.names {
+            let series = try await database.series(matching: SeriesQuery(name: name, range: range))
+            let stored = try await database.read(
+                matching: RecordQuery(
+                    recordType: Event.self,
+                    filters: [.init(field: "name", op: .equals, value: .string(name))]),
+                fields: nil
+            ).records.count
+
+            #expect(series.total == stored, "\(name): series \(series.total) != \(stored) records")
+        }
+    }
+
+    @Test func telemetryAndNetworkSeriesPopulate() async throws {
+        #expect(try await database.metricSeries(Int.self, category: "counter", in: range).count > 0)
+        #expect(
+            try await database.metricSeries(
+                Int.self, categories: LatencyBuckets.categories + StatusBuckets.categories, in: range
+            ).count > 0)
+        #expect(try await database.metricSeries(Int.self, categories: RecorderBuckets.categories, in: range).count > 0)
+    }
+
+    // Timers are seconds, so a plausible request duration has to stay far below a minute.
+    @Test func timerSeriesAreRecordedInSeconds() async throws {
+        let series = try await database.metricSeries(
+            Double.self, category: Telemetry.Export.timer.rawValue, in: range)
+
+        #expect(series.count > 0)
+        let values = series.flatMap(\.points).map(\.value.scalar)
+        #expect(values.allSatisfy { $0 > 0 && $0 < 10 }, "timer values out of range: \(values.max() ?? 0)")
+    }
+
+    @Test func hourlyBucketsResolveWithinToday() async throws {
+        let today = Date().startOfDay..<Date().startOfDay.addingDay()
+        let series = try await database.series(
+            matching: SeriesQuery(
+                name: DemoMetrics.counters[0], category: Telemetry.Export.counter.rawValue, bucket: .hour,
+                range: today))
+
+        #expect(series.count == 1)
+        #expect(try #require(series.first).points.count > 1)
+    }
+
+    @Test func lookupResolvesSeededRecords() async throws {
+        let session = try await records(Session.self).first
+        let record = try await database.lookup(recordName: try #require(session).recordID, fields: nil)
+        #expect(record.fields["app_version"] != nil)
+    }
+
+    @Test func activityAndRetentionAggregate() async throws {
+        #expect(try await database.activity(in: range).count > 0)
+        #expect(try await database.retention(in: range).count > 0)
+    }
+
+    @Test func activityCountsDistinctDevices() async throws {
+        let points = try await database.activity(in: range)
+
+        #expect(points.map(\.mau).max() ?? 0 > 50)
+        #expect(points.map(\.dau).max() ?? 0 > 5)
+    }
+
+    @Test func retentionMaturityFollowsCorpusNow() async throws {
+        let pinned = DemoDatabase(corpus: DemoCorpus.make(now: Date().addingTimeInterval(-200 * 86400)))
+        let cohorts = try await pinned.retention(in: range)
+
+        #expect(cohorts.count > 0)
+        #expect(cohorts.contains { $0.retention.contains { $0 == nil } })
+    }
+
+    @Test func sessionsNeverStartBeforeTheirInstall() async throws {
+        var installDates: [String: Date] = [:]
+        for record in try await records(Install.self) {
+            installDates[record["install_id"] ?? ""] = record["date"]
+        }
+
+        let early = try await records(Session.self).filter { record in
+            guard let installID: String = record["install_id"], let start: Date = record["start_date"],
+                let installed = installDates[installID]
+            else {
+                return false
+            }
+            return start < installed
+        }
+
+        #expect(early.count == 0, "\(early.count) sessions start before their install")
+    }
+
+    @Test func hostWritesDoNotLeakIntoTheExhibit() async throws {
+        let before = try await records(Event.self).count
+        try await database.write(record: Record(recordType: EventEntry.recordType, recordID: UUID().uuidString))
+
+        #expect(try await records(Event.self).count == before)
+    }
+}
+
+extension [MetricSeries] {
+    fileprivate var total: Int {
+        flatMap(\.points).reduce(0) { $0 + Int($1.value.scalar) }
+    }
+}
+
+extension MetricValue {
+    fileprivate var scalar: Double {
+        switch self {
+        case .int(let value): Double(value)
+        case .double(let value): value
+        }
+    }
+}

--- a/Tests/Connectors/Demo/DemoScreensTests.swift
+++ b/Tests/Connectors/Demo/DemoScreensTests.swift
@@ -1,0 +1,91 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import DemoConnector
+@testable import Scout
+@testable import ScoutUI
+
+@MainActor
+@Suite struct DemoScreensTests {
+    let database = DemoDatabase(corpus: DemoDatabaseTests.corpus)
+
+    @Test func releaseHealthLightsUp() async throws {
+        let health = try await ReleaseHealthProvider().fetch(in: database)
+        #expect(health.count > 0)
+    }
+
+    @Test func releaseHealthReadsHealthy() async throws {
+        let health = try await ReleaseHealthProvider().fetch(in: database)
+
+        for release in health {
+            #expect(release.freeSessions.value >= 0.99, "\(release.id) crash-free sessions reads as a disaster")
+            #expect(release.freeUsers?.value ?? 1 >= 0.98, "\(release.id) crash-free users reads red")
+            #expect(release.sessions > 0)
+        }
+    }
+
+    @Test func devicesLightUp() async throws {
+        let report = try await DevicesProvider().fetch(in: database)
+        #expect(report.summaries.count > 0)
+    }
+
+    @Test func networkLightsUp() async throws {
+        let report = try await NetworkProvider().fetch(in: database)
+        #expect(!report.isEmpty)
+    }
+
+    @Test func timerDistributionLightsUp() async throws {
+        let distribution = try await MetricDistributionProvider<LatencyHistogram>(
+            name: DemoMetrics.timers[0], categories: LatencyBuckets.categories
+        ).fetch(in: database)
+        #expect(!distribution.isEmpty)
+    }
+
+    @Test func activityLightsUp() async throws {
+        let points = try await ActivityProvider().fetch(in: database)
+        #expect(points.count > 0)
+    }
+
+    @Test func retentionLightsUp() async throws {
+        let cohorts = try await RetentionProvider().fetch(in: database)
+        #expect(cohorts.count > 0)
+    }
+
+    @Test func homeSessionStatLightsUp() async throws {
+        let points = try await StatProvider(eventName: SessionEntry.recordType, periods: [.year]).fetch(in: database)
+        #expect(points.count > 0)
+    }
+
+    @Test func eventStatLightsUp() async throws {
+        let points = try await StatProvider(eventName: "Search_Performed", periods: [.year]).fetch(in: database)
+        #expect(points.count > 0)
+    }
+
+    @Test func homeLogLightsUp() async throws {
+        let series = try await HomeLogProvider().fetch(in: database)
+        #expect(series.count > 0)
+    }
+
+    @Test func deviceTimelineLightsUp() async throws {
+        let records = try await database.read(
+            matching: RecordQuery(recordType: Device.self), fields: nil, limit: 1
+        ).records
+        let stored: String? = records.first?["device_id"]
+        let deviceID = try #require(stored.flatMap(UUID.init))
+
+        let provider = TimelineProvider()
+        await provider.start(
+            feed: TimelineFeed(deviceID: deviceID, database: database), anchorEvent: nil, eventName: nil)
+
+        let rail = try #require(try provider.result?.get())
+        #expect(rail.installs.count > 0)
+        #expect(provider.items.count > 0, "device timeline renders no rows")
+    }
+}


### PR DESCRIPTION
Adds a third connector alongside Native and Hosted that serves a fabricated corpus entirely from memory, so the dashboard can be driven without iCloud, a server, or any network access — the groundwork for an App Store demo app. `Backend.demo()` returns a `DemoDatabase` built from one coherent, fixed-seed scenario, so the lists and the charts are folded from the same data instead of being authored separately.

Following the hosted client rather than the native one, the reader stays thin: it filters records, folds raw samples into series honoring the bucket and reduce a query asks for, and serves activity and retention that were pre-computed at build time. Writes are accepted and dropped, so host telemetry never mixes into the exhibit.

The generated data is meant to read as a real app rather than as filler: one device per install, timers in seconds, and crashes clustered on a few unlucky installs, which lands crash-free sessions at 99.25–99.75% and crash-free users at 98.5–98.9% instead of painting every release red. The corpus is 7022 records and 9825 samples, built once in roughly 80ms and shared across calls. The 24 tests cover both that every screen's provider lights up — including the device timeline and the Home log — and the invariants behind those numbers.