### PR TITLE
Name the backend engine and share the series-query matcher

### DIFF
--- a/Sources/Connectors/Demo/DemoBackend.swift
+++ b/Sources/Connectors/Demo/DemoBackend.swift
@@ -27,6 +27,7 @@ extension Backend {
             database: DemoDatabase(corpus: now.map(DemoCorpus.make(now:)) ?? DemoCorpus.shared),
             checkAvailability: { true },
             displayName: "Demo",
+            engine: .local,
             probeStatus: { .reachable }
         )
     }

--- a/Sources/Connectors/Demo/DemoDatabase.swift
+++ b/Sources/Connectors/Demo/DemoDatabase.swift
@@ -21,8 +21,6 @@ final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
         self.retentionCohorts = corpus.retention
     }
 
-    // The corpus is a fixed exhibit: host telemetry is accepted and dropped rather than mixed into the
-    // lists, which would leave real records showing up next to aggregates that never move.
     func write(record: Record) async throws {}
 
     func write(records: [Record]) async throws {}
@@ -39,19 +37,20 @@ final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
     }
 
     func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
-        var matches = records.filter {
-            query.matches($0)
-        }
-        for sort in query.sort.reversed() {
-            matches.sort { lhs, rhs in
-                sort.ascending ? before(lhs, rhs, on: sort.field) : before(rhs, lhs, on: sort.field)
-            }
-        }
-        return RecordChunk(records: Array(matches.prefix(limit)), cursor: nil)
+        page(matching: query, limit: limit, after: 0)
     }
 
-    func readMore(from cursor: RecordCursor, fields: [String]?) async throws -> RecordChunk {
-        RecordChunk(records: [], cursor: nil)
+    private func page(matching query: RecordQuery, limit: Int, after offset: Int) -> RecordChunk {
+        let matches = records.filter { query.matches($0) }.sorted(by: query.ordering)
+        let page = matches.dropFirst(offset).prefix(limit)
+        let next = offset + page.count
+
+        return RecordChunk(
+            records: Array(page),
+            cursor: next < matches.count
+                ? RecordCursor { _ in self.page(matching: query, limit: limit, after: next) }
+                : nil
+        )
     }
 
     func series(matching query: SeriesQuery) async throws -> [MetricSeries] {
@@ -65,9 +64,37 @@ final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
     func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
         retentionCohorts.filter { range.contains($0.id) }
     }
+}
 
-    private func before(_ lhs: Record, _ rhs: Record, on field: String) -> Bool {
-        (lhs.fields[field]?.value ?? -.greatestFiniteMagnitude)
-            < (rhs.fields[field]?.value ?? -.greatestFiniteMagnitude)
+extension RecordQuery {
+    fileprivate var ordering: (Record, Record) -> Bool {
+        { lhs, rhs in
+            for key in sort {
+                let order = RecordValue.compare(lhs.fields[key.field], rhs.fields[key.field])
+                guard order != .orderedSame else { continue }
+                return key.ascending ? order == .orderedAscending : order == .orderedDescending
+            }
+            return false
+        }
+    }
+}
+
+extension RecordValue {
+    fileprivate static func compare(_ lhs: RecordValue?, _ rhs: RecordValue?) -> ComparisonResult {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return .orderedSame
+        case (nil, _):
+            return .orderedAscending
+        case (_, nil):
+            return .orderedDescending
+        case (.string(let lhs), .string(let rhs)):
+            return lhs < rhs ? .orderedAscending : lhs == rhs ? .orderedSame : .orderedDescending
+        case (let lhs?, let rhs?):
+            guard let lhs = lhs.value, let rhs = rhs.value else {
+                return .orderedSame
+            }
+            return lhs < rhs ? .orderedAscending : lhs == rhs ? .orderedSame : .orderedDescending
+        }
     }
 }

--- a/Sources/Connectors/Demo/DemoMetrics.swift
+++ b/Sources/Connectors/Demo/DemoMetrics.swift
@@ -61,7 +61,6 @@ struct DemoMetrics {
         telemetry(Self.recorders, category: Telemetry.Export.recorder.rawValue, perDay: 6) {
             .int($0.int(in: 200...9000))
         }
-        // Timers are stored in seconds and rendered as durations, so sub-second values read naturally.
         telemetry(Self.timers, category: Telemetry.Export.timer.rawValue, perDay: 6) {
             .double($0.double(in: 0.02...1.4))
         }

--- a/Sources/Connectors/Demo/DemoSample.swift
+++ b/Sources/Connectors/Demo/DemoSample.swift
@@ -66,13 +66,7 @@ private struct SeriesKey: Hashable {
 
 extension DemoSample {
     fileprivate func matches(_ query: SeriesQuery) -> Bool {
-        guard query.name == nil || name == query.name else {
-            return false
-        }
-        guard query.category == nil || category == query.category else {
-            return false
-        }
-        guard !query.byVersion || version != nil else {
+        guard query.matches(name: name, category: category, version: version) else {
             return false
         }
         guard query.values == nil || query.values == (value.isInt ? .int : .double) else {

--- a/Sources/Connectors/Hosted/HostedBackend.swift
+++ b/Sources/Connectors/Hosted/HostedBackend.swift
@@ -15,6 +15,7 @@ extension Backend {
             database: HTTPDatabase(url: url, apiKey: apiKey),
             checkAvailability: { true },
             displayName: url.host ?? url.absoluteString,
+            engine: .server,
             serverInfo: ServerInfo(
                 endpoint: url.hostWithPort ?? url.absoluteString,
                 hasAPIKey: apiKey != nil,

--- a/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
+++ b/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
@@ -81,6 +81,14 @@ package struct SeriesQuery: Sendable {
     }
 }
 
+extension SeriesQuery {
+    package func matches(name: String, category: String?, version: String?) -> Bool {
+        (self.name == nil || self.name == name)
+            && (self.category == nil || self.category == category)
+            && (!byVersion || version != nil)
+    }
+}
+
 package struct MetricSeries: Decodable, Sendable {
     package let name: String
     package let category: String?

--- a/Sources/Scout/Setup/Backend.swift
+++ b/Sources/Scout/Setup/Backend.swift
@@ -15,6 +15,7 @@ public struct Backend: Sendable {
     package let checkAvailability: @Sendable () async -> Bool
     package let displayName: String
 
+    package var engine: Engine = .cloudKit
     package var serverInfo: ServerInfo? = nil
     package var probeStatus: @Sendable () async -> Status = { .unknown }
     package var accountWarning: AccountWarning = { nil }
@@ -25,6 +26,7 @@ public struct Backend: Sendable {
         database: any Database,
         checkAvailability: @escaping @Sendable () async -> Bool,
         displayName: String,
+        engine: Engine = .cloudKit,
         serverInfo: ServerInfo? = nil,
         probeStatus: @escaping @Sendable () async -> Status = { .unknown },
         accountWarning: @escaping AccountWarning = { nil },
@@ -34,10 +36,17 @@ public struct Backend: Sendable {
         self.database = database
         self.checkAvailability = checkAvailability
         self.displayName = displayName
+        self.engine = engine
         self.serverInfo = serverInfo
         self.probeStatus = probeStatus
         self.accountWarning = accountWarning
         self.onSetup = onSetup
+    }
+
+    package enum Engine: Sendable {
+        case cloudKit
+        case server
+        case local
     }
 
     package enum Status: Sendable {

--- a/Sources/ScoutUI/Home/Settings/BackendHealth.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealth.swift
@@ -27,6 +27,7 @@ struct BackendHealth: Identifiable {
     enum Engine {
         case cloudKit
         case server
+        case local
     }
 }
 
@@ -36,7 +37,7 @@ extension BackendHealth {
             id: backend.id,
             name: backend.displayName,
             endpoint: backend.serverInfo?.endpoint ?? backend.id,
-            engine: backend.serverInfo == nil ? .cloudKit : .server,
+            engine: .init(backend.engine),
             hasAPIKey: backend.serverInfo?.hasAPIKey ?? false,
             isSecure: backend.serverInfo?.isSecure ?? true,
             probe: backend.probeStatus
@@ -57,12 +58,25 @@ extension BackendHealth {
 }
 
 extension BackendHealth.Engine {
+    init(_ engine: Backend.Engine) {
+        switch engine {
+        case .cloudKit:
+            self = .cloudKit
+        case .server:
+            self = .server
+        case .local:
+            self = .local
+        }
+    }
+
     var label: String {
         switch self {
         case .cloudKit:
             "CloudKit"
         case .server:
             "Scout Server"
+        case .local:
+            "On Device"
         }
     }
 
@@ -72,6 +86,8 @@ extension BackendHealth.Engine {
             "icloud"
         case .server:
             "server.rack"
+        case .local:
+            "internaldrive"
         }
     }
 }

--- a/Tests/Connectors/Demo/DemoDatabaseTests.swift
+++ b/Tests/Connectors/Demo/DemoDatabaseTests.swift
@@ -77,7 +77,6 @@ import Testing
         #expect(try await database.metricSeries(Int.self, categories: RecorderBuckets.categories, in: range).count > 0)
     }
 
-    // Timers are seconds, so a plausible request duration has to stay far below a minute.
     @Test func timerSeriesAreRecordedInSeconds() async throws {
         let series = try await database.metricSeries(
             Double.self, category: Telemetry.Export.timer.rawValue, in: range)
@@ -101,6 +100,34 @@ import Testing
 
         #expect(series.count == 1)
         #expect(try #require(series.first).points.count > 1)
+    }
+
+    @Test func pagedReadsContinueThroughTheCursor() async throws {
+        let query = RecordQuery(
+            recordType: Session.self, sort: [.init(field: "start_date", ascending: false)])
+
+        var chunk = try await database.read(matching: query, fields: nil, limit: 25)
+        var pages = 1
+        var total = chunk.records.count
+
+        while let cursor = chunk.cursor {
+            chunk = try await database.readMore(from: cursor, fields: nil)
+            total += chunk.records.count
+            pages += 1
+        }
+
+        #expect(pages > 1)
+        #expect(try await total == records(Session.self).count)
+    }
+
+    @Test func stringFieldsSortLexicographically() async throws {
+        let query = RecordQuery(recordType: Session.self, sort: [.init(field: "app_version", ascending: true)])
+        let versions = try await database.read(matching: query, fields: nil).records.compactMap { record -> String? in
+            record["app_version"]
+        }
+
+        #expect(versions.count > 0)
+        #expect(versions == versions.sorted())
     }
 
     @Test func lookupResolvesSeededRecords() async throws {

--- a/Tests/ScoutTests/Activity/ActivityPointTests.swift
+++ b/Tests/ScoutTests/Activity/ActivityPointTests.swift
@@ -6,14 +6,13 @@
 // https://opensource.org/licenses/MIT.
 
 import Foundation
-import Scout
 import Testing
 
-@testable import NativeConnector
+@testable import Scout
 @testable import Support
 
-@Suite("ActivitySeries")
-struct ActivitySeriesTests {
+@Suite("ActivityPoint")
+struct ActivityPointTests {
     @Test("Sliding windows match a brute-force reference over a multi-week dataset")
     func matchesBruteForce() {
         let start = TestDate.reference

--- a/Tests/ScoutUITests/Stubs/DatabaseStub.swift
+++ b/Tests/ScoutUITests/Stubs/DatabaseStub.swift
@@ -93,7 +93,7 @@ final class DatabaseStub: DatabaseReader, @unchecked Sendable {
 
         return
             seriesStorage
-            .filter { query.name == nil || $0.name == query.name }
+            .filter { query.matches(name: $0.name, category: $0.category, version: $0.version) }
             .compactMap { series in
                 let points = series.points.filter { query.range.contains(Date(millisecondsSince1970: $0.date)) }
                 guard points.count > 0 else { return nil }


### PR DESCRIPTION
Backends had no engine of their own, so the settings health screen inferred one from whether `serverInfo` was set and rendered anything without it as CloudKit — which is wrong for any backend that is neither iCloud nor a server. This adds an explicit `Backend.Engine` (`cloudKit`, `server`, `local`), sets it at each factory, and maps the health screen from it, so a local store gets a label and icon of its own instead of borrowing iCloud's.

It also lifts the in-memory series-query predicate into Scout next to the record matcher hoisted earlier, so every in-memory reader shares one implementation. The UI test stub had its own copy that ignored the category and by-version legs, which let a provider bug pass against the stub while failing on a real backend; it now goes through the shared predicate.

Finally, the `ActivityPoint` tests move into the `ScoutTests` tree that mirrors the code they cover, since the fold itself moved into Scout core in #1090 while its tests stayed behind in the connector target.