### PR TITLE
Page demo reads and order records like a backend

### DIFF
--- a/Sources/Connectors/Demo/DemoBackend.swift
+++ b/Sources/Connectors/Demo/DemoBackend.swift
@@ -27,6 +27,7 @@ extension Backend {
             database: DemoDatabase(corpus: now.map(DemoCorpus.make(now:)) ?? DemoCorpus.shared),
             checkAvailability: { true },
             displayName: "Demo",
+            engine: .local,
             probeStatus: { .reachable }
         )
     }

--- a/Sources/Connectors/Demo/DemoDatabase.swift
+++ b/Sources/Connectors/Demo/DemoDatabase.swift
@@ -21,8 +21,6 @@ final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
         self.retentionCohorts = corpus.retention
     }
 
-    // The corpus is a fixed exhibit: host telemetry is accepted and dropped rather than mixed into the
-    // lists, which would leave real records showing up next to aggregates that never move.
     func write(record: Record) async throws {}
 
     func write(records: [Record]) async throws {}
@@ -39,19 +37,20 @@ final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
     }
 
     func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
-        var matches = records.filter {
-            query.matches($0)
-        }
-        for sort in query.sort.reversed() {
-            matches.sort { lhs, rhs in
-                sort.ascending ? before(lhs, rhs, on: sort.field) : before(rhs, lhs, on: sort.field)
-            }
-        }
-        return RecordChunk(records: Array(matches.prefix(limit)), cursor: nil)
+        page(matching: query, limit: limit, after: 0)
     }
 
-    func readMore(from cursor: RecordCursor, fields: [String]?) async throws -> RecordChunk {
-        RecordChunk(records: [], cursor: nil)
+    private func page(matching query: RecordQuery, limit: Int, after offset: Int) -> RecordChunk {
+        let matches = records.filter { query.matches($0) }.sorted(by: query.ordering)
+        let page = matches.dropFirst(offset).prefix(limit)
+        let next = offset + page.count
+
+        return RecordChunk(
+            records: Array(page),
+            cursor: next < matches.count
+                ? RecordCursor { _ in self.page(matching: query, limit: limit, after: next) }
+                : nil
+        )
     }
 
     func series(matching query: SeriesQuery) async throws -> [MetricSeries] {
@@ -65,9 +64,37 @@ final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
     func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
         retentionCohorts.filter { range.contains($0.id) }
     }
+}
 
-    private func before(_ lhs: Record, _ rhs: Record, on field: String) -> Bool {
-        (lhs.fields[field]?.value ?? -.greatestFiniteMagnitude)
-            < (rhs.fields[field]?.value ?? -.greatestFiniteMagnitude)
+extension RecordQuery {
+    fileprivate var ordering: (Record, Record) -> Bool {
+        { lhs, rhs in
+            for key in sort {
+                let order = RecordValue.compare(lhs.fields[key.field], rhs.fields[key.field])
+                guard order != .orderedSame else { continue }
+                return key.ascending ? order == .orderedAscending : order == .orderedDescending
+            }
+            return false
+        }
+    }
+}
+
+extension RecordValue {
+    fileprivate static func compare(_ lhs: RecordValue?, _ rhs: RecordValue?) -> ComparisonResult {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return .orderedSame
+        case (nil, _):
+            return .orderedAscending
+        case (_, nil):
+            return .orderedDescending
+        case (.string(let lhs), .string(let rhs)):
+            return lhs < rhs ? .orderedAscending : lhs == rhs ? .orderedSame : .orderedDescending
+        case (let lhs?, let rhs?):
+            guard let lhs = lhs.value, let rhs = rhs.value else {
+                return .orderedSame
+            }
+            return lhs < rhs ? .orderedAscending : lhs == rhs ? .orderedSame : .orderedDescending
+        }
     }
 }

--- a/Sources/Connectors/Demo/DemoMetrics.swift
+++ b/Sources/Connectors/Demo/DemoMetrics.swift
@@ -61,7 +61,6 @@ struct DemoMetrics {
         telemetry(Self.recorders, category: Telemetry.Export.recorder.rawValue, perDay: 6) {
             .int($0.int(in: 200...9000))
         }
-        // Timers are stored in seconds and rendered as durations, so sub-second values read naturally.
         telemetry(Self.timers, category: Telemetry.Export.timer.rawValue, perDay: 6) {
             .double($0.double(in: 0.02...1.4))
         }

--- a/Sources/Connectors/Demo/DemoSample.swift
+++ b/Sources/Connectors/Demo/DemoSample.swift
@@ -66,13 +66,7 @@ private struct SeriesKey: Hashable {
 
 extension DemoSample {
     fileprivate func matches(_ query: SeriesQuery) -> Bool {
-        guard query.name == nil || name == query.name else {
-            return false
-        }
-        guard query.category == nil || category == query.category else {
-            return false
-        }
-        guard !query.byVersion || version != nil else {
+        guard query.matches(name: name, category: category, version: version) else {
             return false
         }
         guard query.values == nil || query.values == (value.isInt ? .int : .double) else {

--- a/Tests/Connectors/Demo/DemoDatabaseTests.swift
+++ b/Tests/Connectors/Demo/DemoDatabaseTests.swift
@@ -77,7 +77,6 @@ import Testing
         #expect(try await database.metricSeries(Int.self, categories: RecorderBuckets.categories, in: range).count > 0)
     }
 
-    // Timers are seconds, so a plausible request duration has to stay far below a minute.
     @Test func timerSeriesAreRecordedInSeconds() async throws {
         let series = try await database.metricSeries(
             Double.self, category: Telemetry.Export.timer.rawValue, in: range)
@@ -96,6 +95,34 @@ import Testing
 
         #expect(series.count == 1)
         #expect(try #require(series.first).points.count > 1)
+    }
+
+    @Test func pagedReadsContinueThroughTheCursor() async throws {
+        let query = RecordQuery(
+            recordType: Session.self, sort: [.init(field: "start_date", ascending: false)])
+
+        var chunk = try await database.read(matching: query, fields: nil, limit: 25)
+        var pages = 1
+        var total = chunk.records.count
+
+        while let cursor = chunk.cursor {
+            chunk = try await database.readMore(from: cursor, fields: nil)
+            total += chunk.records.count
+            pages += 1
+        }
+
+        #expect(pages > 1)
+        #expect(try await total == records(Session.self).count)
+    }
+
+    @Test func stringFieldsSortLexicographically() async throws {
+        let query = RecordQuery(recordType: Session.self, sort: [.init(field: "app_version", ascending: true)])
+        let versions = try await database.read(matching: query, fields: nil).records.compactMap { record -> String? in
+            record["app_version"]
+        }
+
+        #expect(versions.count > 0)
+        #expect(versions == versions.sorted())
     }
 
     @Test func lookupResolvesSeededRecords() async throws {


### PR DESCRIPTION
The demo database handed every read back as a single chunk with no continuation. A lane that pages — the device timeline — reads a nil cursor as "lane exhausted", so it stopped after the first 25 sessions and never showed the rest, along with their events. Reads now return a cursor that resumes at the next offset.

Sorting had two problems. It projected each value onto a scalar that is meaningless for strings, so any sort on a string field such as `app_version` collapsed into corpus insertion order while a real backend sorts lexically; and it applied each sort key as its own full pass, which is only correct if the sort is stable, something the standard library does not promise. A single lexicographic comparator over the sort keys handles both.

Also switches the demo onto the shared series-query matcher and the new local engine from the base PR, so the settings screen stops describing it as CloudKit. Stacked on #1094 for those two, and retargets to main once it merges.