### PR TITLE
Silence the Swift 6.4 warnings raised by Xcode 27

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,8 @@ let package = Package(
         .target(
             name: "ScoutUI",
             dependencies: [
-                "Scout"
+                "Scout",
+                .product(name: "Logging", package: "swift-log"),
             ]
         ),
         .target(

--- a/Sources/Scout/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Database/Access/RecordSender.swift
@@ -21,7 +21,13 @@ extension RecordSender {
 
 @MainActor
 extension RecordSender {
-    func deliver<T: SyncableEntry & RecordEncodable>(type syncable: T.Type, in context: NSManagedObjectContext)
+    func deliver(type syncable: any (SyncableEntry & RecordEncodable).Type, in context: NSManagedObjectContext)
+        async throws
+    {
+        try await deliver(pending: syncable, in: context)
+    }
+
+    private func deliver<T: SyncableEntry & RecordEncodable>(pending: T.Type, in context: NSManagedObjectContext)
         async throws
     {
         let request = NSFetchRequest<T>(entityName: String(describing: T.self))

--- a/Sources/Scout/Sync/SyncableEntry.swift
+++ b/Sources/Scout/Sync/SyncableEntry.swift
@@ -17,9 +17,6 @@ package class SyncableEntry: DateEntry {
 }
 
 extension SyncableEntry {
-    // The single registry of concrete entry types delivered during a sync;
-    // synchronize() iterates this instead of hardcoding the list at the call
-    // site, so a new syncable type is added in one place.
     static let deliverableTypes: [any (SyncableEntry & RecordEncodable).Type] = [
         EventEntry.self,
         SessionEntry.self,

--- a/Sources/Scout/Sync/Synchronize.swift
+++ b/Sources/Scout/Sync/Synchronize.swift
@@ -17,9 +17,6 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
     try DateEntry.cleanup(backends: backends, in: context)
 
     try await dispatcher.performEnsuringBackground {
-        // Probe every backend at once: awaiting availability in the loop
-        // condition let a slow or timing-out backend stall delivery for all
-        // the others queued behind it.
         let availability = await withTaskGroup(of: (Int, Bool).self) { group in
             for (offset, backend) in backends.enumerated() {
                 group.addTask { (offset, await backend.checkAvailability()) }

--- a/Sources/ScoutUI/Analytics/Event/Analytics/EventFilter.swift
+++ b/Sources/ScoutUI/Analytics/Event/Analytics/EventFilter.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import Scout
 import SwiftUI
 
 extension View {

--- a/Sources/ScoutUI/Analytics/Event/Provider/EventQuery.swift
+++ b/Sources/ScoutUI/Analytics/Event/Provider/EventQuery.swift
@@ -6,6 +6,7 @@
 // https://opensource.org/licenses/MIT.
 
 import Foundation
+import Logging
 import Scout
 
 struct EventQuery: Hashable {

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Scale/ChartExtentSegmentTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Scale/ChartExtentSegmentTests.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import Charts
 import Foundation
 import Testing
 


### PR DESCRIPTION
Building the package with the Xcode 27 beta toolchain surfaces four warnings that the current release toolchain does not emit, so the app shows them without CI ever failing.

The isolated-conformances rules now reject handing an abstract `RecordEncodable` conformance to a main-actor-isolated call from an unrelated context, which is exactly what `synchronize` did: its task group opened the existential entry type in a nonisolated closure and passed it straight into the `@MainActor` `deliver`. `RecordSender` grows a non-generic entry point taking the existential metatype, so `T` is opened once the call is already on the main actor; the generic body is unchanged and now private, and neither the call in `synchronize` nor the one in `DeliverTests` needed touching.

The other three are files using types they never imported themselves — `DatabaseReader` from Scout in `EventFilter`, `Logger.Level` behind `EventLevel` in `EventQuery`, and `Int: Plottable` from Charts in `ChartExtentSegmentTests`. Logging becomes an explicit ScoutUI dependency rather than being picked up transitively. Three comments around the sync path that only restated the code are dropped as well.

Verified with `build-for-testing` on both toolchains — clean under Xcode 27 beta, and the full suite passes on the release one. The one remaining beta warning is an unrelated `init(traitsFrom:)` deprecation in `ViewSnapshot`, left as is.