### PR TITLE
Let the gate wait three hours for the fast checks

### DIFF
--- a/.github/scripts/wait-for-checks.sh
+++ b/.github/scripts/wait-for-checks.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 : "${SHAS:?SHAS is required}"
 : "${CHECKS:?CHECKS is required}"
-timeout="${TIMEOUT:-2400}"
+timeout="${TIMEOUT:-10800}"
 interval="${INTERVAL:-15}"
 
 read -ra shas <<< "$SHAS"

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -22,7 +22,7 @@ jobs:
   gate:
     name: gate
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 190
 
     permissions:
       contents: read

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -87,7 +87,7 @@ jobs:
     name: gate
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 190
 
     permissions:
       contents: read

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -58,7 +58,7 @@ jobs:
     name: gate
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 190
 
     permissions:
       contents: read


### PR DESCRIPTION
The gate job holds an expensive macOS job until the cheap checks it should never outrun — lint, the Core Data model-version rules, the wire-change probe — have concluded, and it gave up after 40 minutes. Lint runs on macOS, so when those runners are saturated it can sit queued well past that, and the gate then fails a PR that has nothing wrong with it. That just happened on #1094: the log ends with `Timed out after 2400s still waiting on: lint(queued)` while every check that did run was green.

This raises the wait to three hours and lifts the three gate jobs' ceilings to 190 minutes to match, so a runner backlog delays a run instead of failing it. The gate still fails the instant an awaited check actually concludes in failure, so nothing waits on a known-red PR — waiting on a queue is now distinguished from waiting on a failure. The wait costs an idle ubuntu runner, which is far cheaper than a spurious red on a required check.