### PR TITLE
Compare only public API in the api-breakage check

### DIFF
--- a/.github/scripts/dump-api-set.sh
+++ b/.github/scripts/dump-api-set.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Dump the package's public + package API as a module-agnostic set, one
+# Dump the package's public API as a module-agnostic set, one
 # "<declKind> <qualified printed name>" per line.
 #
 # Most declarations live in `Scout` (the package's base module) and the
@@ -53,9 +53,15 @@ xcrun swift-api-digester -dump-sdk "${module_flags[@]}" -o "$dump" \
 # Qualify each declaration with its ancestor names so members don't collide
 # across types, and drop the module identity so a cross-module move is not a
 # change. Imports and synthesized accessors are noise.
+#
+# The dump also carries `package` declarations, which the digester marks
+# `isInternal`. They are unreachable outside this package, so removing one
+# cannot break an integration — skip those subtrees and compare public API
+# only.
 jq -r '
   def emit($prefix):
-    if (.declKind != null and .declKind != "Import" and .declKind != "Accessor")
+    if .isInternal == true then empty
+    elif (.declKind != null and .declKind != "Import" and .declKind != "Accessor")
     then ($prefix + (if $prefix == "" then "" else "." end) + .printedName) as $qualified
          | "\(.declKind) \($qualified)", (.children[]? | emit($qualified))
     else (.children[]? | emit($prefix)) end;

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -85,13 +85,15 @@ jobs:
 
       # The baseline dump depends only on the base commit, which changes far
       # less often than the PR head: on a cache hit the whole baseline build
-      # is skipped.
+      # is skipped. The dump script is part of the key as well — both sides
+      # are dumped by the PR's copy of it, so a baseline cached by an older
+      # copy would be compared against a differently-shaped current set.
       - name: Cache baseline API set
         id: baseline-cache
         uses: actions/cache@v6
         with:
           path: /tmp/baseline.set
-          key: api-baseline-set-${{ github.event.pull_request.base.sha }}
+          key: api-baseline-set-${{ github.event.pull_request.base.sha }}-${{ hashFiles('.github/scripts/dump-api-set.sh') }}
 
       - name: Dump baseline API
         if: steps.baseline-cache.outputs.cache-hit != 'true'
@@ -146,7 +148,7 @@ jobs:
           # sets (the sets are module-agnostic), so the split does not flag.
           removed="$(comm -23 /tmp/baseline.set /tmp/current.set || true)"
           if [ -z "$removed" ]; then
-            echo "No public or package API was removed against the base branch." >> "$GITHUB_STEP_SUMMARY"
+            echo "No public API was removed against the base branch." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           {


### PR DESCRIPTION
The api-breakage check diffs the symbol set the package vends against the base branch, but swift-api-digester emits `package` declarations alongside the public ones, and here they are the overwhelming majority — of the 751 declarations the Scout module contributes, 723 are `package`. Nothing outside the package can reference them, so deleting one can never break a host app, yet the check failed on exactly that and asked for the `api-breaking` label, which is meant to acknowledge a real major-release break.

The digester marks those declarations `isInternal`, so the dump script now skips them along with their subtrees. What remains is the surface a host app links against: `setup(backends:)`, the `Backend` factories, `scoutHome(isPresented:backends:)` and `ScoutAlerts` — verified locally by running the script over a full simulator build.

One thing worth attention in review: the baseline set is cached per base commit but is produced by the PR's copy of the dump script, so a baseline cached before this change would be diffed against a differently-shaped current set and report the entire package layer as removed. The script hash joins the cache key so both sides always come from the same script.

Follow-up spotted while here and left out on purpose: the module list in the dump script still covers only `Scout*`, `NativeConnector`, `HostedConnector` and `Cache`, so `DemoConnector` and `LookupIndex` are built by the workflow but never dumped — `Backend.demo()` and `LookupIndex.enable()` sit outside the check today.
