### PR TITLE
Remove comments from the CI/CD workflows and scripts

### DIFF
--- a/.github/scripts/detect-wire-changes.sh
+++ b/.github/scripts/detect-wire-changes.sh
@@ -1,19 +1,4 @@
 #!/usr/bin/env bash
-# Decide whether the wire surface changed and write the `backend` output.
-# Non-PR events always exercise the contract; PRs diff against the base SHA.
-# EVENT_NAME and BASE_SHA are supplied by the workflow from the GitHub context.
-#
-# The diff is captured into a variable before it is matched so that a git
-# failure aborts the job. Piping git straight into grep hides it: a diff that
-# cannot be computed prints nothing, grep reads that as "no wire files touched",
-# the contract job skips, and contract-gate reports green on a PR nothing
-# checked.
-#
-# The match then reads that variable through a here-string rather than a pipe.
-# `grep -q` exits at the first match, so with pipefail on, a writer feeding it
-# more than a pipe buffer's worth of paths dies of SIGPIPE and the pipeline
-# reports 141 even though grep matched — inverting the result into the same
-# silent backend=false this file exists to avoid.
 set -euo pipefail
 
 : "${EVENT_NAME:?EVENT_NAME is required}"

--- a/.github/scripts/dump-api-set.sh
+++ b/.github/scripts/dump-api-set.sh
@@ -1,16 +1,4 @@
 #!/usr/bin/env bash
-# Dump the package's public API as a module-agnostic set, one
-# "<declKind> <qualified printed name>" per line.
-#
-# Most declarations live in `Scout` (the package's base module) and the
-# adapter modules (`NativeConnector`, `HostedConnector`, `ScoutUI`, `Cache`).
-# swift-api-digester keys every symbol by its defining module, so moving a
-# symbol between these modules reports as a removal even though downstream
-# consumers still compile. Flattening every package module into one
-# module-agnostic set makes a move a no-op (the symbol still exists somewhere)
-# while a genuine deletion still drops out of the set.
-#
-# Args: <derived-data-path> <output-set-file>
 set -euo pipefail
 
 dd="$1"
@@ -20,33 +8,19 @@ sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
 manifest="$(swift package dump-package)"
 ios="$(echo "$manifest" | jq -r '.platforms[] | select(.platformName == "ios") | .version')"
 
-# swift-api-digester loads modules through the Clang importer, which doesn't
-# discover a Swift package's C-target module maps on its own — point it at the
-# ones xcodebuild already generated for this build.
 cc_flags=()
 for modulemap in "$dd"/Build/Intermediates.noindex/GeneratedModuleMaps-iphonesimulator/*.modulemap; do
   [ -f "$modulemap" ] && cc_flags+=(-Xcc -fmodule-map-file="$modulemap")
 done
 
-# The modules to dump are the targets the package vends as library products,
-# read from the manifest rather than spelled out here: a hardcoded list turns
-# vacuous the moment a target is renamed, which is how the module formerly
-# called Cache silently dropped out of the comparison. CScoutHang is a C target
-# with no .swiftmodule and vends no library product, and the external scout-db
-# products are not in this manifest's products at all.
 module_flags=()
 found=0
 while IFS= read -r name; do
-  # A .swiftmodule can be either a file or a multi-arch directory, so test for
-  # either kind of entry; a product whose scheme the workflow did not build has
-  # none at all.
   [ -e "$products/$name.swiftmodule" ] || continue
   module_flags+=(-module "$name")
   found=$((found + 1))
 done < <(echo "$manifest" | jq -r '.products[] | select(.type.library) | .targets[]' | sort -u)
 
-# An empty dump would compare as "every symbol removed" on the current side and
-# as "nothing to compare" on the baseline side, so stop instead of guessing.
 if [ "$found" -eq 0 ]; then
   echo "No library product modules were built into $products" >&2
   exit 1
@@ -59,14 +33,6 @@ xcrun swift-api-digester -dump-sdk "${module_flags[@]}" -o "$dump" \
   -I "$products" \
   "${cc_flags[@]}"
 
-# Qualify each declaration with its ancestor names so members don't collide
-# across types, and drop the module identity so a cross-module move is not a
-# change. Imports and synthesized accessors are noise.
-#
-# The dump also carries `package` declarations, which the digester marks
-# `isInternal`. They are unreachable outside this package, so removing one
-# cannot break an integration — skip those subtrees and compare public API
-# only.
 jq -r '
   def emit($prefix):
     if .isInternal == true then empty

--- a/.github/scripts/guard-filter-covers-wire.sh
+++ b/.github/scripts/guard-filter-covers-wire.sh
@@ -1,32 +1,15 @@
 #!/usr/bin/env bash
-# Tripwire against filter drift. The Server workflow's path filter duplicates
-# the knowledge of where the wire code lives, so a future move out of the
-# watched directories would silently stop triggering `contract` while the gate
-# stays green. Symbol names outlive folder layout, so assert the wire code still
-# sits under a watched root and fail loudly (red PR) when it escapes — that is
-# the signal to widen the filter. The HTTP* coders are wire-specific, so any
-# mention pins them down; the Record pagination types are shared infra used all
-# over the app, so only their definition sites matter (their use sites
-# legitimately live outside the watched roots).
-#
-# Every pattern is asserted to match something, one at a time. Checking them as
-# a group hides rot behind whichever pattern still resolves, and because the
-# guard keys on symbol names, a rename that empties one pattern retires that
-# part of the tripwire without anyone noticing — the failure it exists to catch.
 set -euo pipefail
 
 matched=""
 missing=""
 
-# Args: <label> <extended regex>
 check() {
   local label="$1" pattern="$2" hits status
   set +e
   hits="$(grep -rlE "$pattern" Sources)"
   status=$?
   set -e
-  # grep exits 1 for "no match" and 2 or more for a real error; only the former
-  # means the symbol is gone, so anything else has to stop the job outright.
   if [ "$status" -gt 1 ]; then
     echo "::error::grep exited $status while searching for $label."
     exit 1

--- a/.github/scripts/start-postgres.sh
+++ b/.github/scripts/start-postgres.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Bring up the server's default Fluent config: user scout, password scout,
-# database scout on localhost:5432.
 set -euo pipefail
 
 brew install postgresql@17

--- a/.github/scripts/start-scout-server.sh
+++ b/.github/scripts/start-scout-server.sh
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
-# Build and launch scout-server (checked out under ./scout-server), then wait
-# for its health endpoint. Strict mode matters most for `swift build`: an
-# unchecked compile failure used to fall through to a 60-second health poll and
-# report "did not come up on port 8080" instead of the build error.
 set -euo pipefail
 
 cd scout-server
-# Created before the build so the workflow's failure() log dump always has a
-# file to read, even when the build is what failed.
 : > server.log
 swift build
 nohup swift run --skip-build > server.log 2>&1 &

--- a/.github/scripts/verify-contract-ran.sh
+++ b/.github/scripts/verify-contract-ran.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
-# The suite is skipped unless SCOUT_SERVER_URL reaches the test process, so a
-# broken env hand-off (or an -only-testing identifier that matches nothing)
-# would skip every test while xcodebuild still exits 0. Fail loudly when nothing
-# actually ran rather than report a green that tested nothing.
 set -euo pipefail
 
 summary="$(xcrun xcresulttool get test-results summary \
   --path TestResults.xcresult --compact || true)"
-# `0 passed` is a real count (jq's // keeps it); only a missing field
-# yields empty, in which case the schema changed — warn, don't block. Anything
-# non-numeric takes the same path, since it would otherwise make the comparison
-# below error out and the script fall through as if it had passed.
 passed="$(echo "$summary" | jq '.passedTests // empty' || true)"
 case "$passed" in
   '' | *[!0-9]*)

--- a/.github/scripts/wait-for-checks.sh
+++ b/.github/scripts/wait-for-checks.sh
@@ -1,28 +1,4 @@
 #!/usr/bin/env bash
-# Hold an expensive job until the cheap PR checks it should never outrun have
-# finished. A failing fast check — lint, the Core Data model-version rules, the
-# wire-change probe — already red-flags the PR, so there is no point spending
-# 20–30 minutes of macOS runner time on the long job behind it. This gate fails
-# the instant any awaited check concludes in failure (which skips the dependent
-# long job) and passes once they are all green (which lets it proceed).
-#
-# CHECKS holds check-run names, i.e. bare job names — "lint", "model-versions",
-# "changes" — not the "Workflow / job" label the UI shows. A pull_request run
-# attaches its check-runs to the head commit, but the merge commit is queried
-# too so the lookup is robust to either association. SHAS and CHECKS are
-# supplied by the workflow; TIMEOUT/INTERVAL fall back to sensible defaults.
-#
-# The lookup itself is best-effort on purpose. This gate exists to save runner
-# minutes, not to decide whether a PR is correct, so failing to read the API
-# must never be what turns a PR red. GITHUB_TOKEN is rate limited per repository
-# per hour and every gate job on every open PR draws on that one budget, so a
-# batch of PRs exhausts it and each poll comes back 403. A failed lookup
-# therefore backs off and retries, and a sustained run of them gives up waiting
-# and lets the expensive job start.
-#
-# The interval grows toward MAX_INTERVAL for the same reason: a long wait is the
-# congested case, which is exactly where polling hardest costs the most and buys
-# the least.
 set -euo pipefail
 
 : "${SHAS:?SHAS is required}"
@@ -43,9 +19,6 @@ back_off() {
 deadline=$(( SECONDS + timeout ))
 failures=0
 while :; do
-  # `|| exit 1` inside the loop makes one failed SHA fail the whole pipeline;
-  # without it only the last SHA's status counts and a partial answer would be
-  # read as though the missing checks simply did not exist yet.
   if ! runs="$(
     for sha in "${shas[@]}"; do
       [ -n "$sha" ] || continue
@@ -67,7 +40,6 @@ while :; do
 
   pending=()
   for name in "${names[@]}"; do
-    # Reruns leave older entries behind, so pick the most recently started run.
     run="$(echo "$runs" | jq -c --arg n "$name" \
       '[.[] | select(.name == $n)] | sort_by(.started_at) | last')"
     if [ -z "$run" ] || [ "$run" = "null" ]; then

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,11 +1,5 @@
 name: API
 
-# No paths filter: this is a required status check, and a required check that
-# never runs blocks the merge. The labeled/unlabeled triggers let the
-# api-breaking label re-evaluate an intentional break without a new push.
-# Make `API / api-gate` the required check, not `API / api-breakage`: the diff
-# job is skipped rather than failed when the gate does not succeed, and branch
-# protection accepts a skipped check.
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -18,10 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # The fast PR checks (lint, the Core Data model rules, the wire-change probe)
-  # live in sibling workflows, out of `needs` reach. This cheap ubuntu job waits
-  # for their check-runs and fails if any fails, so the 30-minute macOS diff
-  # below never starts behind an already-red fast check.
   gate:
     name: gate
     runs-on: ubuntu-latest
@@ -49,9 +39,6 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      # blob:none avoids downloading every historical blob (snapshot PNGs
-      # included): only HEAD is materialized at checkout, and `git worktree add`
-      # below batch-fetches just the baseline commit's blobs on demand.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -64,22 +51,6 @@ jobs:
           key: spm-${{ hashFiles('Package.swift') }}
           restore-keys: spm-
 
-      # The package does not build with plain SwiftPM (Scout.xcdatamodeld is
-      # only processed by the Xcode build system), so instead of
-      # `swift package diagnose-api-breaking-changes` we build both versions
-      # with xcodebuild and compare swift-api-digester dumps. Building each
-      # library product's own scheme (not the *-Package scheme) covers every
-      # library module the package vends without also building the test
-      # targets — Scout no longer re-exports the adapters transitively now
-      # that the umbrella target is gone, so each one needs its own build.
-      #
-      # The list is read from the manifest's library products, the same source
-      # dump-api-set.sh derives its module list from, so the two cannot drift
-      # apart and a newly vended library is covered without editing this file.
-      # SwiftPM names a scheme after the product, so this reads product names
-      # while the script reads the targets behind them. An empty list means the
-      # manifest could not be read; building nothing would compare an empty
-      # current set against the baseline and report every symbol as removed.
       - name: Dump current API
         run: |
           set -eo pipefail
@@ -100,11 +71,6 @@ jobs:
           done
           .github/scripts/dump-api-set.sh /tmp/dd-current /tmp/current.set
 
-      # The set is whatever swift-api-digester emits, so the toolchain that ran
-      # it belongs in the cache key alongside the script. Read from xcodebuild
-      # rather than the runner's ImageVersion variable, which the `env` context
-      # does not carry — it would expand to nothing and drop out of the key
-      # unnoticed.
       - name: Identify the toolchain
         id: toolchain
         run: |
@@ -117,11 +83,6 @@ jobs:
           echo "Toolchain: $id"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
-      # The baseline dump depends only on the base commit, which changes far
-      # less often than the PR head: on a cache hit the whole baseline build
-      # is skipped. The dump script is part of the key as well — both sides
-      # are dumped by the PR's copy of it, so a baseline cached by an older
-      # copy would be compared against a differently-shaped current set.
       - name: Cache baseline API set
         id: baseline-cache
         uses: actions/cache@v6
@@ -132,8 +93,6 @@ jobs:
       - name: Dump baseline API
         if: steps.baseline-cache.outputs.cache-hit != 'true'
         run: |
-          # Compare against the PR's base (main), so the check flags only the
-          # API changes this PR introduces — not cumulative drift since release.
           baseline="${{ github.event.pull_request.base.sha }}"
           if [ -z "$baseline" ]; then
             echo "No base revision to compare against."
@@ -142,16 +101,6 @@ jobs:
           echo "Comparing against base $baseline"
           git worktree add /tmp/baseline "$baseline"
           cd /tmp/baseline
-          # The baseline resolves dependencies fresh (Package.resolved is not
-          # committed), so a dependency release that breaks the old code makes
-          # the baseline unbuildable. Nothing to compare against then — skip.
-          #
-          # The scheme list comes from the baseline's own manifest, so every
-          # scheme in it exists at that commit however far back it is, and a
-          # build that fails is a real failure rather than a product that did
-          # not exist yet. Swallowing it would drop that module from the
-          # baseline set and quietly stop reporting removals from it — and the
-          # truncated set would then be cached against this base SHA.
           schemes="$(swift package dump-package | jq -r '.products[] | select(.type.library) | .name')"
           if [ -z "$schemes" ]; then
             echo "The baseline manifest vends no library products; nothing to compare against."
@@ -177,9 +126,6 @@ jobs:
           if [ ! -f /tmp/baseline.set ]; then
             exit 0
           fi
-          # A symbol in the baseline set but not the current set is gone from
-          # every module — a real removal. Moves between modules stay in both
-          # sets (the sets are module-agnostic), so the split does not flag.
           removed="$(comm -23 /tmp/baseline.set /tmp/current.set || true)"
           if [ -z "$removed" ]; then
             echo "No public API was removed against the base branch." >> "$GITHUB_STEP_SUMMARY"
@@ -203,10 +149,6 @@ jobs:
           echo "api-breaking label to this PR to acknowledge it."
           exit 1
 
-  # The required status check. `api-breakage` carries a bare `needs: gate`, so a
-  # gate that fails skips it rather than failing it, and branch protection reads
-  # a skipped check as satisfied. This job always runs and passes only when the
-  # diff actually succeeded.
   api-gate:
     name: api-gate
     needs: [gate, api-breakage]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,5 @@
 name: CodeQL
 
-# GitHub's CodeQL static analysis for Swift, uploading results to the
-# security-events dashboard. Analysis needs a full manual build, so this runs
-# nightly on a schedule (and on demand) rather than per-PR: tracing slows
-# compilation down severalfold, so it builds a single architecture.
 on:
   schedule:
     - cron: "33 2 * * *"
@@ -29,18 +25,6 @@ jobs:
           languages: swift
           build-mode: manual
 
-      # CodeQL analyses only what the traced build compiles, and Scout stopped
-      # covering the rest of the package when the split removed the umbrella
-      # target — building that scheme alone left the connectors, ScoutUI and
-      # LookupIndex unanalysed while the dashboard read as clean. The scheme list
-      # comes from the manifest's library products — SwiftPM names a scheme after
-      # the product — so a newly vended one is picked up without editing this
-      # file. An empty list is an error: a scan that compiles nothing analyses
-      # nothing and still reports clean, which is the failure being fixed here.
-      #
-      # Tracing slows compilation down severalfold, so build a single
-      # architecture: the generic simulator destination would otherwise build
-      # both arm64 and x86_64, doubling the traced work for no analysis gain.
       - name: Build
         run: |
           set -eo pipefail

--- a/.github/workflows/coredata.yml
+++ b/.github/workflows/coredata.yml
@@ -1,8 +1,5 @@
 name: Core Data
 
-# No paths filter: this is a required status check, and a required check that
-# never runs blocks the merge. With no model changes the diff is empty and the
-# job passes in seconds.
 on:
   pull_request:
 
@@ -15,9 +12,6 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      # blob:none keeps the full-history fetch below from downloading every
-      # historical blob (snapshot PNGs included): the name-status diff only
-      # walks commit trees, so content is never needed.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,5 @@
 name: Docs
 
-# Builds the DocC documentation and publishes it to GitHub Pages. Runs on every
-# push to main (and on demand) so the hosted docs track the shipped API; the two
-# jobs split generation (macOS, needs the Swift toolchain) from deployment
-# (ubuntu, just uploads the artifact to Pages).
 on:
   push:
     branches: [ "main" ]
@@ -26,14 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Every library product the package vends, not just Scout: the connectors
-      # and ScoutUI carry the setup and transport API integrators actually
-      # adopt, and documenting Scout alone left all of it unpublished. Combined
-      # documentation is what lets several targets share one archive.
-      #
-      # The targets behind those products are read from the manifest rather than
-      # listed here, so a newly vended library cannot end up built by CI and
-      # shipped to integrators while silently missing from the published docs.
       - name: Generate documentation
         run: |
           set -eo pipefail

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,38 +1,21 @@
 name: Notify
 
-# Fans a green main out to the downstream scout-ip repository. When the Swift
-# workflow completes successfully on main, this fires a repository_dispatch so
-# scout-ip can pick up the new Scout revision. It keys off workflow_run (not
-# push) so the notification only goes out once CI has actually passed.
 on:
   workflow_run:
     workflows: [Swift]
     types: [completed]
     branches: [main]
 
-# The dispatch authenticates with GH_PAT, so the workflow token itself needs
-# nothing beyond the default read scope — without this block it would inherit
-# whatever the repository default is, up to and including write.
 permissions:
   contents: read
 
 jobs:
   notify:
-    # Only upstream: a fork has no GH_PAT, so the dispatch would send a bare
-    # bearer token, take the 401 below and turn the fork's main red on every
-    # green build.
     if: github.repository == 'kasianov-mikhail/scout' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      # --fail-with-body turns an HTTP error into a non-zero exit while still
-      # printing GitHub's error body — without it an expired or rotated GH_PAT
-      # (401) or a renamed repository (404) left the step green and scout-ip
-      # quietly stopped receiving revisions, and with a plain --fail the log
-      # would show a bare status code instead of which of the two it was. The
-      # retries cover a transient 5xx from api.github.com, which should not
-      # redden main.
       - name: Trigger scout-ip
         run: |
           curl --fail-with-body -sS \

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,29 +1,5 @@
 name: Server
 
-# Contract tests against a live scout-server. The HTTP wire format
-# (HTTPQueryCoding/HTTPRecordCoding) is shared with that repository, and unit
-# tests can only verify Scout's side of it, so this workflow boots the server
-# on top of PostgreSQL and runs ServerContractTests through HTTPDatabase.
-#
-# The expensive `contract` job runs only when the wire surface changes — the
-# Hosted transport/access code that travels over it (HTTPDatabase, the
-# HTTPQueryCoding/HTTPRecordCoding wire coders, and the HostedRecord readers and
-# writers), the Core/Database record model and the RecordReader/RecordChunk/
-# RecordCursor pagination and cursor semantics they ride on, the contract tests,
-# or this workflow and the scripts it runs — or when scout-server pushes to main
-# (repository_dispatch from its Notify workflow).
-#
-# A weekly schedule runs the contract unconditionally as a safety net: the path
-# filter duplicates the knowledge of where the wire code lives, so if it ever
-# drifts and a wire change slips through with `contract` skipped, the next
-# scheduled run surfaces the break instead of letting it sit green indefinitely.
-#
-# A required status check must report on every PR, but a path-filtered job never
-# reports on PRs outside its paths, which would wedge them forever. So the PR
-# trigger is unfiltered, a lightweight `changes` job decides whether `contract`
-# runs, and an always-running `contract-gate` reports the result on every PR
-# (passing when `contract` succeeded or was not applicable). Make
-# `Server / contract-gate` the required check, not `Server / contract`.
 on:
   push:
     branches: [main]
@@ -37,7 +13,6 @@ on:
   repository_dispatch:
     types: [scout-server-updated]
   schedule:
-    # Monday 06:00 UTC — unconditional safety-net run (see header).
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
@@ -49,25 +24,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Decide whether the wire surface changed. Required checks must report on
-  # every PR (see header), so this runs unconditionally and `contract` keys off
-  # its output; non-PR events always exercise the contract.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
-      # blob:none keeps the full-history fetch below from downloading every
-      # historical blob (snapshot PNGs included): this job only greps the
-      # working tree and diffs file names, so historical content is never
-      # needed.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: blob:none
 
-      # Tripwire against filter drift — see the script header for the rationale.
       - name: Guard the filter covers the wire code
         run: .github/scripts/guard-filter-covers-wire.sh
 
@@ -78,12 +45,6 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: .github/scripts/detect-wire-changes.sh
 
-  # This workflow's own fast check is `changes` (gated below via `needs`); the
-  # other fast checks (lint, the Core Data model rules) live in sibling
-  # workflows out of `needs` reach. This cheap ubuntu job waits for their
-  # check-runs and fails if either fails, so the 30-minute contract run never
-  # starts behind an already-red fast check. It runs only on PRs — on
-  # push/schedule/dispatch those sibling checks do not run.
   gate:
     name: gate
     if: github.event_name == 'pull_request'
@@ -108,10 +69,6 @@ jobs:
 
   contract:
     needs: [changes, gate]
-    # Run when the wire surface changed and the fast checks passed. On a PR that
-    # leaves the wire surface untouched, backend is 'false' and this skips; on
-    # push/schedule/dispatch `gate` is skipped (PR-only) and backend is 'true',
-    # so a skipped gate is allowed through while a failed one blocks.
     if: >-
       ${{ always()
       && needs.changes.result == 'success'
@@ -134,13 +91,6 @@ jobs:
       - name: Start scout-server
         run: .github/scripts/start-scout-server.sh
 
-      # The contract is platform-independent, so the tests run on the macOS
-      # destination — no simulator needed. xcodebuild forwards only variables
-      # with the TEST_RUNNER_ prefix into the test process (which reads them
-      # without it), so an API key would have to be set as
-      # TEST_RUNNER_SCOUT_SERVER_API_KEY — a bare SCOUT_SERVER_API_KEY never
-      # arrives. The default server accepts unauthenticated requests, so none
-      # is set today.
       - name: Run contract tests
         env:
           TEST_RUNNER_SCOUT_SERVER_URL: http://127.0.0.1:8080
@@ -153,7 +103,6 @@ jobs:
             -resultBundlePath TestResults.xcresult \
             test
 
-      # Fail loudly when the suite skipped everything — see the script header.
       - name: Verify the contract suite ran
         run: .github/scripts/verify-contract-ran.sh
 
@@ -161,14 +110,6 @@ jobs:
         if: failure()
         run: cat scout-server/server.log
 
-  # The required status check. Always runs so it reports on every PR; passes
-  # when `contract` succeeded or was not applicable (skipped on PRs that leave
-  # the wire surface untouched), fails when `contract` failed or `changes` broke.
-  #
-  # `gate` is in `needs` because a failed gate skips `contract` too, and a skip
-  # is indistinguishable here from "the wire surface was untouched" — without
-  # this the gate timing out would report green on a PR that rewrote the wire
-  # format and never ran the suite.
   contract-gate:
     name: contract-gate
     needs: [changes, gate, contract]
@@ -182,7 +123,6 @@ jobs:
             echo "::error::The changes job did not succeed (${{ needs.changes.result }})."
             exit 1
           fi
-          # `gate` is PR-only, so a skip is expected on push/schedule/dispatch.
           case "${{ needs.gate.result }}" in
             success | skipped) ;;
             *)

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,5 @@
 name: Stale
 
-# Housekeeping for inactive issues and pull requests. Runs daily on a schedule
-# (and on demand): anything untouched for 60 days is marked stale, then closed
-# 14 days later unless activity resumes. Items labelled pinned or security are
-# exempt.
 on:
   schedule:
     - cron: "17 3 * * *"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,19 +1,5 @@
 name: Swift
 
-# The primary CI: lints with swift-format, then builds and tests the package
-# across a matrix of iOS versions. The matrix spans the package's minimum
-# deployment target (iOS 16) up to the latest public-preview toolchain
-# (xcode-27), so both old-SDK breakage and new-SDK regressions surface here.
-# Coverage is collected on the iOS 26 leg only — the reports differ between legs
-# by fractions of a percent, and that leg is the one where the snapshot suites
-# run. `tests-gate` is the required check on main rather than the individual
-# legs: a leg that is skipped instead of run reports a conclusion branch
-# protection accepts, so only an always-running summary job can hold the line.
-#
-# `pull_request` carries no base-branch filter on purpose. A PR stacked on
-# another PR's branch would otherwise skip this workflow entirely, and the gate
-# jobs in the sibling workflows — which wait for this workflow's `lint`
-# check-run — would hang until their timeout and fail the PR.
 on:
   push:
     branches: [ "main" ]
@@ -50,12 +36,6 @@ jobs:
             exit 1
           fi
 
-  # `needs: lint` gates the matrix on this workflow's own fast check; the other
-  # fast checks (Core Data model rules, the wire-change probe) live in sibling
-  # workflows where `needs` cannot reach them. This cheap ubuntu job waits for
-  # their check-runs on the PR and fails if either fails, so the expensive macOS
-  # matrix below never starts behind an already-red fast check. It runs only on
-  # PRs — on a push to main those sibling checks do not run.
   gate:
     name: gate
     if: github.event_name == 'pull_request'
@@ -81,8 +61,6 @@ jobs:
   tests:
     name: test-ios-${{ matrix.ios }}
     needs: [lint, gate]
-    # On a push to main `gate` is skipped (it is PR-only); require lint and let
-    # a skipped gate through, but block on a gate that actually failed.
     if: ${{ always() && needs.lint.result == 'success' && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -91,26 +69,9 @@ jobs:
       contents: read
 
     strategy:
-      # Each leg reports on its own. Cancelling the siblings on the first
-      # failure saved runner minutes but let the least stable leg — the
-      # arm64-only xcode-27 public-preview image — cancel the stable iOS 18 and
-      # iOS 26 legs that `tests-gate` reports on, turning one flake into a red
-      # PR and a full 20-minute re-run of the whole matrix.
       fail-fast: false
       matrix:
-        # Coverage is collected on one leg only: the reports differ between
-        # legs by fractions of a percent, and instrumentation and the xccov
-        # report cost minutes on every run. The report goes to the step
-        # summary; nothing is uploaded anywhere. The iOS 26 leg carries it
-        # because the snapshot suites only execute there.
         include:
-          # iOS 16 and 17 are not built-in runtimes on the macos-15 image, and a
-          # bare -downloadPlatform iOS only fetches the newest runtime. Pin an
-          # exact version so the download step pulls each older runtime
-          # explicitly. iOS 16 is the package's minimum deployment target.
-          # LookupIndexTests links SwiftData (iOS 17+), so its bundle can't load
-          # on iOS 16; skip it there. The rest of the suites carry no SwiftData
-          # and run, exercising the package's minimum deployment target.
           - os: macos-15
             device: iPhone 14
             ios: 16
@@ -130,10 +91,6 @@ jobs:
             device: iPhone 17
             ios: 26
             coverage: true
-          # Public-preview image, labelled by Xcode major version rather than
-          # the OS and arm64-only. It runs alongside the stable legs and feeds
-          # `tests-gate` like the rest, so its failures block merges. Snapshot
-          # baselines are iOS 26 only, so those suites skip on this leg.
           - os: xcode-27
             device: iPhone 17
             ios: 27
@@ -142,10 +99,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # A name-only destination resolves to the newest runtime on the image,
-      # so the iOS 18 leg was silently running its tests on an iOS 26
-      # simulator. Resolve a device on the matrix major version explicitly and
-      # address it by UDID.
       - name: Prepare simulator
         id: sim
         run: |
@@ -172,10 +125,6 @@ jobs:
           fi
           echo "udid=$udid" >> "$GITHUB_OUTPUT"
 
-      # Package.resolved is not committed, so the key falls back to the
-      # manifest: any Package.swift change starts a fresh cache, and
-      # restore-keys reuse the previous checkouts for the git fetches that
-      # resolution still performs.
       - name: Cache Swift package checkouts
         uses: actions/cache@v6
         with:
@@ -193,11 +142,6 @@ jobs:
             -skipMacroValidation \
             build-for-testing
 
-      # test-without-building still loads the package graph, so it needs the
-      # same checkout directory the build used: pointed anywhere else it
-      # re-clones every dependency into the default DerivedData location, and
-      # with no committed Package.resolved and scout-db tracked by branch it can
-      # resolve a different revision than the one just built against.
       - name: Test
         run: |
           xcodebuild \
@@ -221,13 +165,6 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The required status check for the matrix. `tests` is skipped rather than
-  # failed whenever `lint` or `gate` does not succeed, and branch protection
-  # counts a skipped required check as satisfied — so a gate that times out on
-  # a backed-up runner queue, or trips over a transient `gh api` error, would
-  # otherwise let a PR merge with the matrix never having run. This job always
-  # runs and passes only when the legs actually succeeded. Make
-  # `Swift / tests-gate` the required check, not the individual legs.
   tests-gate:
     name: tests-gate
     needs: [lint, gate, tests]
@@ -242,7 +179,6 @@ jobs:
             echo "::error::Lint did not succeed (${{ needs.lint.result }})."
             exit 1
           fi
-          # `gate` is PR-only, so a skip is expected on a push to main.
           case "${{ needs.gate.result }}" in
             success | skipped) ;;
             *)


### PR DESCRIPTION
Strips every comment from the eight workflow files and the seven scripts
under .github/scripts, leaving only the shebang lines. Deletions only — 347
lines — with no edit to any step, script, or expression, and all files still
parse: bash -n on the scripts, a YAML load on the workflows, shebangs and
executable bits unchanged.

Rebuilt on top of the CI review batch (#1101-#1115), which is why the count
grew from the 219 lines this branch removed when it was first written: those
PRs documented the invariants they introduced, and those notes go too.

Worth repeating from the original description, because the batch added more
of exactly this kind: most of these comments explained the why behind
non-obvious CI choices — why the gate fails open on a rate-limited lookup
rather than reddening the PR, why the wire probe reads its diff through a
here-string instead of a pipe, why tests-gate and api-gate exist rather than
requiring the jobs they front, why the API and Core Data workflows carry no
paths filter. That rationale now lives only in the commit messages.