### PR TITLE
Derive the api-breakage module list from the package manifest

### DIFF
--- a/.github/scripts/dump-api-set.sh
+++ b/.github/scripts/dump-api-set.sh
@@ -17,7 +17,8 @@ dd="$1"
 out="$2"
 products="$dd/Build/Products/Debug-iphonesimulator"
 sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
-ios="$(swift package dump-package | jq -r '.platforms[] | select(.platformName == "ios") | .version')"
+manifest="$(swift package dump-package)"
+ios="$(echo "$manifest" | jq -r '.platforms[] | select(.platformName == "ios") | .version')"
 
 # swift-api-digester loads modules through the Clang importer, which doesn't
 # discover a Swift package's C-target module maps on its own — point it at the
@@ -27,21 +28,29 @@ for modulemap in "$dd"/Build/Intermediates.noindex/GeneratedModuleMaps-iphonesim
   [ -f "$modulemap" ] && cc_flags+=(-Xcc -fmodule-map-file="$modulemap")
 done
 
-# The package's own Swift library modules are the built Scout* modules and the
-# connector modules, minus the external scout-db products; CScoutHang is a C
-# target with no .swiftmodule.
+# The modules to dump are the targets the package vends as library products,
+# read from the manifest rather than spelled out here: a hardcoded list turns
+# vacuous the moment a target is renamed, which is how the module formerly
+# called Cache silently dropped out of the comparison. CScoutHang is a C target
+# with no .swiftmodule and vends no library product, and the external scout-db
+# products are not in this manifest's products at all.
 module_flags=()
-for swiftmodule in "$products"/Scout*.swiftmodule "$products"/NativeConnector.swiftmodule "$products"/HostedConnector.swiftmodule "$products"/Cache.swiftmodule; do
-  # A .swiftmodule can be either a file or a multi-arch directory, and the
-  # explicit non-Scout* globs stay literal when they don't match — so accept
-  # either kind of entry and skip anything that doesn't exist.
-  [ -e "$swiftmodule" ] || continue
-  name="$(basename "$swiftmodule" .swiftmodule)"
-  case "$name" in
-    ScoutDB | ScoutDBTesting) continue ;;
-  esac
+found=0
+while IFS= read -r name; do
+  # A .swiftmodule can be either a file or a multi-arch directory, so test for
+  # either kind of entry; a product whose scheme the workflow did not build has
+  # none at all.
+  [ -e "$products/$name.swiftmodule" ] || continue
   module_flags+=(-module "$name")
-done
+  found=$((found + 1))
+done < <(echo "$manifest" | jq -r '.products[] | select(.type.library) | .targets[]' | sort -u)
+
+# An empty dump would compare as "every symbol removed" on the current side and
+# as "nothing to compare" on the baseline side, so stop instead of guessing.
+if [ "$found" -eq 0 ]; then
+  echo "No library product modules were built into $products" >&2
+  exit 1
+fi
 
 dump="$(mktemp)"
 xcrun swift-api-digester -dump-sdk "${module_flags[@]}" -o "$dump" \

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -69,9 +69,23 @@ jobs:
       # library module the package vends without also building the test
       # targets — Scout no longer re-exports the adapters transitively now
       # that the umbrella target is gone, so each one needs its own build.
+      #
+      # The list is read from the manifest's library products, the same source
+      # dump-api-set.sh derives its module list from, so the two cannot drift
+      # apart and a newly vended library is covered without editing this file.
+      # SwiftPM names a scheme after the product, so this reads product names
+      # while the script reads the targets behind them. An empty list means the
+      # manifest could not be read; building nothing would compare an empty
+      # current set against the baseline and report every symbol as removed.
       - name: Dump current API
         run: |
-          for scheme in Scout NativeConnector HostedConnector ScoutUI LookupIndex DemoConnector; do
+          set -eo pipefail
+          schemes="$(swift package dump-package | jq -r '.products[] | select(.type.library) | .name')"
+          if [ -z "$schemes" ]; then
+            echo "::error::No library products found in the manifest."
+            exit 1
+          fi
+          for scheme in $schemes; do
             xcodebuild \
               -scheme "$scheme" \
               -destination 'generic/platform=iOS Simulator' \
@@ -111,30 +125,30 @@ jobs:
           # The baseline resolves dependencies fresh (Package.resolved is not
           # committed), so a dependency release that breaks the old code makes
           # the baseline unbuildable. Nothing to compare against then — skip.
-          # NativeConnector/HostedConnector/ScoutUI/Cache/DemoConnector may not
-          # exist as their own schemes on an older base (pre-split, or
-          # pre-umbrella-removal where Scout alone covered everything
-          # transitively); build them best-effort.
-          if ! xcodebuild \
-            -scheme Scout \
-            -destination 'generic/platform=iOS Simulator' \
-            -derivedDataPath /tmp/dd-baseline \
-            -clonedSourcePackagesDirPath /tmp/spm \
-            -skipMacroValidation \
-            -quiet \
-            build; then
-            echo "The baseline no longer builds with freshly resolved dependencies; skipping the comparison."
+          #
+          # The scheme list comes from the baseline's own manifest, so every
+          # scheme in it exists at that commit however far back it is, and a
+          # build that fails is a real failure rather than a product that did
+          # not exist yet. Swallowing it would drop that module from the
+          # baseline set and quietly stop reporting removals from it — and the
+          # truncated set would then be cached against this base SHA.
+          schemes="$(swift package dump-package | jq -r '.products[] | select(.type.library) | .name')"
+          if [ -z "$schemes" ]; then
+            echo "The baseline manifest vends no library products; nothing to compare against."
             exit 0
           fi
-          for scheme in NativeConnector HostedConnector ScoutUI LookupIndex DemoConnector; do
-            xcodebuild \
+          for scheme in $schemes; do
+            if ! xcodebuild \
               -scheme "$scheme" \
               -destination 'generic/platform=iOS Simulator' \
               -derivedDataPath /tmp/dd-baseline \
               -clonedSourcePackagesDirPath /tmp/spm \
               -skipMacroValidation \
               -quiet \
-              build || true
+              build; then
+              echo "The baseline no longer builds with freshly resolved dependencies; skipping the comparison."
+              exit 0
+            fi
           done
           "$GITHUB_WORKSPACE/.github/scripts/dump-api-set.sh" /tmp/dd-baseline /tmp/baseline.set
 


### PR DESCRIPTION
The api-breakage check dumps each module's public API and diffs it against
the base branch, but the module list in dump-api-set.sh was spelled out by
hand and had gone stale twice over: it still globbed Cache, renamed to
LookupIndex in #1046, and never matched DemoConnector, whose scheme #1092
added to the workflow. Neither module reached swift-api-digester, so
removing Backend.demo() or any public LookupIndex symbol diffed clean and
the check reported that no API was removed.

Both lists now come from the manifest's library products and cannot drift
apart: the workflow reads product names, which is what SwiftPM names a
scheme after, and the script reads the targets behind them, which is what
the modules are called. An empty list is an error rather than an empty diff.

The baseline loop also stops swallowing build failures with || true. That
was there for products which had no scheme on an older base, but the list
now comes from the baseline's own manifest, so every scheme in it exists at
that commit and a failure can only be a real one — one that would otherwise
drop a module from the baseline set and cache the truncated result against
that base SHA.
