### PR TITLE
Run the CI shell scripts under strict mode

### DIFF
--- a/.github/scripts/detect-wire-changes.sh
+++ b/.github/scripts/detect-wire-changes.sh
@@ -2,13 +2,30 @@
 # Decide whether the wire surface changed and write the `backend` output.
 # Non-PR events always exercise the contract; PRs diff against the base SHA.
 # EVENT_NAME and BASE_SHA are supplied by the workflow from the GitHub context.
+#
+# The diff is captured into a variable before it is matched so that a git
+# failure aborts the job. Piping git straight into grep hides it: a diff that
+# cannot be computed prints nothing, grep reads that as "no wire files touched",
+# the contract job skips, and contract-gate reports green on a PR nothing
+# checked.
+#
+# The match then reads that variable through a here-string rather than a pipe.
+# `grep -q` exits at the first match, so with pipefail on, a writer feeding it
+# more than a pipe buffer's worth of paths dies of SIGPIPE and the pipeline
+# reports 141 even though grep matched — inverting the result into the same
+# silent backend=false this file exists to avoid.
+set -euo pipefail
+
+: "${EVENT_NAME:?EVENT_NAME is required}"
 
 if [ "$EVENT_NAME" != "pull_request" ]; then
   echo "backend=true" >> "$GITHUB_OUTPUT"
   exit 0
 fi
-if git diff --name-only "$BASE_SHA"...HEAD \
-  | grep -qE '^(Sources/Connectors/Hosted/|Sources/Scout/Database/|Tests/Connectors/Hosted/|\.github/workflows/server\.yml$)'; then
+
+: "${BASE_SHA:?BASE_SHA is required on a pull_request}"
+changed="$(git diff --name-only "$BASE_SHA"...HEAD)"
+if grep -qE '^(Sources/Connectors/Hosted/|Sources/Scout/Database/|Tests/Connectors/Hosted/|\.github/workflows/server\.yml$)' <<<"$changed"; then
   echo "backend=true" >> "$GITHUB_OUTPUT"
 else
   echo "backend=false" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/start-postgres.sh
+++ b/.github/scripts/start-postgres.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Bring up the server's default Fluent config: user scout, password scout,
 # database scout on localhost:5432.
+set -euo pipefail
 
 brew install postgresql@17
 pgbin="$(brew --prefix postgresql@17)/bin"

--- a/.github/scripts/start-scout-server.sh
+++ b/.github/scripts/start-scout-server.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Build and launch scout-server (checked out under ./scout-server), then wait
-# for its health endpoint.
+# for its health endpoint. Strict mode matters most for `swift build`: an
+# unchecked compile failure used to fall through to a 60-second health poll and
+# report "did not come up on port 8080" instead of the build error.
+set -euo pipefail
 
 cd scout-server
+# Created before the build so the workflow's failure() log dump always has a
+# file to read, even when the build is what failed.
+: > server.log
 swift build
 nohup swift run --skip-build > server.log 2>&1 &
 for _ in $(seq 1 60); do

--- a/.github/scripts/verify-contract-ran.sh
+++ b/.github/scripts/verify-contract-ran.sh
@@ -3,17 +3,22 @@
 # broken env hand-off (or an -only-testing identifier that matches nothing)
 # would skip every test while xcodebuild still exits 0. Fail loudly when nothing
 # actually ran rather than report a green that tested nothing.
+set -euo pipefail
 
 summary="$(xcrun xcresulttool get test-results summary \
-  --path TestResults.xcresult --compact)"
+  --path TestResults.xcresult --compact || true)"
 # `0 passed` is a real count (jq's // keeps it); only a missing field
-# yields empty, in which case the schema changed — warn, don't block.
-passed="$(echo "$summary" | jq '.passedTests // empty')"
-if [ -z "$passed" ]; then
-  echo "::warning::Could not read passedTests from the result bundle; skipping the ran-something check."
-  echo "$summary" | head -c 2000
-  exit 0
-fi
+# yields empty, in which case the schema changed — warn, don't block. Anything
+# non-numeric takes the same path, since it would otherwise make the comparison
+# below error out and the script fall through as if it had passed.
+passed="$(echo "$summary" | jq '.passedTests // empty' || true)"
+case "$passed" in
+  '' | *[!0-9]*)
+    echo "::warning::Could not read a passedTests count from the result bundle; skipping the ran-something check."
+    printf '%s\n' "$summary" | head -c 2000 || true
+    exit 0
+    ;;
+esac
 echo "Contract tests passed: $passed"
 if [ "$passed" -lt 1 ]; then
   echo "::error::No contract tests executed — the suite skipped (SCOUT_SERVER_URL likely never reached the test process) or matched nothing."


### PR DESCRIPTION
Four of the workflow scripts ran without set -euo pipefail, so a failing
command inside them fell through to whatever came next. The consequential
one is detect-wire-changes.sh: git piped straight into grep means a diff
that cannot be computed produces no output, grep reads that as "no wire
files touched", and the contract job skips while contract-gate still
reports green. The diff is now captured first, so git failing aborts the
job, and the required context variables are asserted rather than assumed.

The match reads that variable through a here-string rather than a pipe,
because pipefail and 'grep -q' do not mix: grep exits at the first match, so
on a diff larger than a pipe buffer the writer dies of SIGPIPE and the
pipeline reports 141 despite the match, flipping the result back to the
silent backend=false this change is meant to remove. Reproduced on a 1.7 MB
path list, where the piped form answers false and the here-string true.

start-scout-server.sh gains the most in diagnosability — an unchecked swift
build failure used to be reported 60 seconds later as "did not come up on
port 8080" — and now creates server.log before building so the workflow's
failure() dump still finds a file when the build is what broke.
verify-contract-ran.sh keeps its deliberate warn-don't-block path for a
changed result-bundle schema and routes a non-numeric count there too,
instead of letting the comparison error out and pass by accident.
guard-filter-covers-wire.sh is left for the PR that rewrites it.
