### PR TITLE
Fail the wire-filter guard when a pattern matches nothing

### DIFF
--- a/.github/scripts/guard-filter-covers-wire.sh
+++ b/.github/scripts/guard-filter-covers-wire.sh
@@ -8,13 +8,49 @@
 # mention pins them down; the Record pagination types are shared infra used all
 # over the app, so only their definition sites matter (their use sites
 # legitimately live outside the watched roots).
+#
+# Every pattern is asserted to match something, one at a time. Checking them as
+# a group hides rot behind whichever pattern still resolves, and because the
+# guard keys on symbol names, a rename that empties one pattern retires that
+# part of the tripwire without anyone noticing — the failure it exists to catch.
+set -euo pipefail
 
-escaped="$(
-  {
-    grep -rlE 'HTTPDatabase|HTTPQueryCoding|HTTPRecordCoding' Sources
-    grep -rlE '(struct|enum|final class|class) +(RecordReader|RecordChunk|RecordCursor)\b' Sources
-  } | sort -u | grep -vE '^Sources/(Connectors/Hosted/|Scout/Database/)' || true
-)"
+matched=""
+missing=""
+
+# Args: <label> <extended regex>
+check() {
+  local label="$1" pattern="$2" hits status
+  set +e
+  hits="$(grep -rlE "$pattern" Sources)"
+  status=$?
+  set -e
+  # grep exits 1 for "no match" and 2 or more for a real error; only the former
+  # means the symbol is gone, so anything else has to stop the job outright.
+  if [ "$status" -gt 1 ]; then
+    echo "::error::grep exited $status while searching for $label."
+    exit 1
+  fi
+  if [ -z "$hits" ]; then
+    missing="$missing $label"
+    return
+  fi
+  matched="$matched$hits"$'\n'
+}
+
+check HTTPDatabase 'HTTPDatabase'
+check HTTPQuery 'HTTPQuery'
+check HTTPRecord 'HTTPRecord'
+check RecordChunk '(struct|enum|final class|class) +RecordChunk\b'
+check RecordCursor '(struct|enum|final class|class) +RecordCursor\b'
+
+if [ -n "$missing" ]; then
+  echo "::error::These guard patterns match nothing under Sources, so the guard can no longer tell whether the wire code moved:$missing"
+  echo "Rename them here to the current symbol names, and check the Server workflow's paths still cover where those symbols now live."
+  exit 1
+fi
+
+escaped="$(printf '%s' "$matched" | sort -u | grep -vE '^Sources/(Connectors/Hosted/|Scout/Database/)' || true)"
 if [ -n "$escaped" ]; then
   echo "::error::Wire-contract code lives outside the Server filter's watched paths; update the paths in this workflow to cover:"
   echo "$escaped"


### PR DESCRIPTION
The guard reports files that sit outside the Server workflow's watched
paths, but never checked that its searches found anything. Renaming a
symbol it keys on empties that search, empties the escape list with it, and
leaves the script exiting zero forever after — reporting health while
guarding nothing, which is exactly the drift it was written to catch.

Three of its six patterns had already rotted this way. HTTPQueryCoding and
HTTPRecordCoding survive only as file names — the types inside are
HTTPQuery and HTTPRecord — and RecordReader does not appear under Sources at
all. Grouping the patterns hid it: HTTPDatabase and RecordChunk still
matched, so the group was non-empty and the guard stayed green over three
dead patterns.

Each pattern is now asserted on its own and named in the error when it goes
empty, the three dead ones are corrected, and a grep that fails outright
(exit 2 or above) is separated from a grep that merely found nothing rather
than being reported as a rename.
