### PR TITLE
Trigger the contract check on changes to the scripts it runs

### DIFF
--- a/.github/scripts/detect-wire-changes.sh
+++ b/.github/scripts/detect-wire-changes.sh
@@ -25,7 +25,7 @@ fi
 
 : "${BASE_SHA:?BASE_SHA is required on a pull_request}"
 changed="$(git diff --name-only "$BASE_SHA"...HEAD)"
-if grep -qE '^(Sources/Connectors/Hosted/|Sources/Scout/Database/|Tests/Connectors/Hosted/|\.github/workflows/server\.yml$)' <<<"$changed"; then
+if grep -qE '^(Sources/Connectors/Hosted/|Sources/Scout/Database/|Tests/Connectors/Hosted/|\.github/workflows/server\.yml$|\.github/scripts/)' <<<"$changed"; then
   echo "backend=true" >> "$GITHUB_OUTPUT"
 else
   echo "backend=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -10,8 +10,8 @@ name: Server
 # HTTPQueryCoding/HTTPRecordCoding wire coders, and the HostedRecord readers and
 # writers), the Core/Database record model and the RecordReader/RecordChunk/
 # RecordCursor pagination and cursor semantics they ride on, the contract tests,
-# or this workflow — or when scout-server pushes to main (repository_dispatch
-# from its Notify workflow).
+# or this workflow and the scripts it runs — or when scout-server pushes to main
+# (repository_dispatch from its Notify workflow).
 #
 # A weekly schedule runs the contract unconditionally as a safety net: the path
 # filter duplicates the knowledge of where the wire code lives, so if it ever
@@ -32,6 +32,7 @@ on:
       - "Sources/Scout/Database/**"
       - "Tests/Connectors/Hosted/**"
       - ".github/workflows/server.yml"
+      - ".github/scripts/**"
   pull_request:
   repository_dispatch:
     types: [scout-server-updated]


### PR DESCRIPTION
The Server workflow claims in its header that the contract runs when the
workflow itself changes, but #963 moved that workflow's inline logic into
.github/scripts and neither the push path filter nor the pull-request probe
was widened to follow. A PR that changes the health-check port in
start-scout-server.sh, or the probe regex in detect-wire-changes.sh,
touches no watched path today: backend comes out false, contract skips, and
contract-gate reports green. The break would sit unnoticed until an
unrelated wire change or the Monday safety-net run.

Both filters now watch .github/scripts as well.
