### PR TITLE
Fail contract-gate when the fast-check gate did not pass

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -163,9 +163,14 @@ jobs:
   # The required status check. Always runs so it reports on every PR; passes
   # when `contract` succeeded or was not applicable (skipped on PRs that leave
   # the wire surface untouched), fails when `contract` failed or `changes` broke.
+  #
+  # `gate` is in `needs` because a failed gate skips `contract` too, and a skip
+  # is indistinguishable here from "the wire surface was untouched" — without
+  # this the gate timing out would report green on a PR that rewrote the wire
+  # format and never ran the suite.
   contract-gate:
     name: contract-gate
-    needs: [changes, contract]
+    needs: [changes, gate, contract]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -176,6 +181,14 @@ jobs:
             echo "::error::The changes job did not succeed (${{ needs.changes.result }})."
             exit 1
           fi
+          # `gate` is PR-only, so a skip is expected on push/schedule/dispatch.
+          case "${{ needs.gate.result }}" in
+            success | skipped) ;;
+            *)
+              echo "::error::The fast-check gate did not pass (${{ needs.gate.result }})."
+              exit 1
+              ;;
+          esac
           result="${{ needs.contract.result }}"
           echo "contract job result: $result"
           case "$result" in


### PR DESCRIPTION
contract-gate is the required check for the wire contract and treats a
skipped contract job as "not applicable", which is right when the PR left
the wire surface untouched. But contract is also skipped when the gate it
depends on fails, and the gate fails on a 40-minute wait timeout or a
single transient gh api error as readily as on a genuinely red fast check.
A PR that rewrote HTTPQueryCoding could therefore report green with the
suite never having run.

The gate result now feeds contract-gate, which distinguishes the expected
skip on push, schedule and dispatch events from a gate that actually
failed.
