### PR TITLE
Record why the Swift Dependabot entry never opens a pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: monthly
 
+  # This one has never opened a pull request, and that is expected rather than
+  # broken. Every Swift dependency is declared with an open-ended requirement
+  # (`from:`, or a range for swift-metrics) and no Package.resolved is committed,
+  # so resolution already lands on the newest allowed version on every build and
+  # there is no pin for Dependabot to bump. It only has something to say when a
+  # dependency ships a new major outside the declared range — which is precisely
+  # the case worth being told about, so the entry stays.
   - package-ecosystem: swift
     directory: /
     schedule:


### PR DESCRIPTION
Dependabot has opened github-actions updates in this repository since it
was configured but never a Swift one, which reads like broken configuration
and invites someone to delete the entry. It is not broken: every Swift
dependency is declared with an open-ended requirement and no Package.resolved
is committed, so each resolution already picks the newest allowed version
and there is no pin left to bump. The entry only has something to report
when a dependency ships a major outside the declared range, which is exactly
the case worth hearing about.

Documents that so the silence is not mistaken for a misconfiguration.
