### PR TITLE
Pin the Notify workflow's token scope and job timeout

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -10,10 +10,17 @@ on:
     types: [completed]
     branches: [main]
 
+# The dispatch authenticates with GH_PAT, so the workflow token itself needs
+# nothing beyond the default read scope — without this block it would inherit
+# whatever the repository default is, up to and including write.
+permissions:
+  contents: read
+
 jobs:
   notify:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Trigger scout-ip


### PR DESCRIPTION
Notify was the only one of the eight workflows declaring neither a
permissions block nor timeout-minutes. Its GITHUB_TOKEN therefore inherits
the repository default, which can be read and write, even though the job
never uses it — the repository_dispatch it fires authenticates with GH_PAT.
That hands a write-scoped token to every step for no benefit, and the
missing timeout lets a hung request hold a runner for the six-hour default.

Adds contents: read and a five-minute timeout, matching the sibling
workflows.
