### PR TITLE
Point the test step at the cached package checkouts

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -190,12 +190,19 @@ jobs:
             -skipMacroValidation \
             build-for-testing
 
+      # test-without-building still loads the package graph, so it needs the
+      # same checkout directory the build used: pointed anywhere else it
+      # re-clones every dependency into the default DerivedData location, and
+      # with no committed Package.resolved and scout-db tracked by branch it can
+      # resolve a different revision than the one just built against.
       - name: Test
         run: |
           xcodebuild \
             -scheme Scout-Package \
             -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
+            -clonedSourcePackagesDirPath /tmp/spm \
             -enableCodeCoverage ${{ matrix.coverage && 'YES' || 'NO' }} \
+            -skipMacroValidation \
             ${{ matrix.skipTesting && format('-skip-testing:{0}', matrix.skipTesting) || '' }} \
             -parallel-testing-enabled NO \
             -resultBundlePath TestResults.xcresult \


### PR DESCRIPTION
The build step resolves into the cached /tmp/spm checkout directory and
skips macro validation; the test step passed neither. test-without-building
still loads the package graph for the scheme, so on every one of the five
matrix legs it resolved again into the default DerivedData location and
re-cloned swift-log, swift-metrics, scout-db, swift-docc-plugin and
swift-snapshot-testing — precisely the work the cache step above exists to
avoid. With no committed Package.resolved and scout-db tracked by branch,
that second resolution is also free to land on a different revision than
the build used.

Both flags now match the build invocation.
