### PR TITLE
Analyse every library product with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,7 @@ name: CodeQL
 # GitHub's CodeQL static analysis for Swift, uploading results to the
 # security-events dashboard. Analysis needs a full manual build, so this runs
 # nightly on a schedule (and on demand) rather than per-PR: tracing slows
-# compilation down severalfold, so it builds a single architecture of the Scout
-# scheme only.
+# compilation down severalfold, so it builds a single architecture.
 on:
   schedule:
     - cron: "33 2 * * *"
@@ -16,7 +15,7 @@ permissions:
 jobs:
   analyze:
     runs-on: macos-26
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     permissions:
       contents: read
@@ -30,15 +29,32 @@ jobs:
           languages: swift
           build-mode: manual
 
-      # CodeQL tracing slows compilation down severalfold, so build a single
+      # CodeQL analyses only what the traced build compiles, and Scout stopped
+      # covering the rest of the package when the split removed the umbrella
+      # target — building that scheme alone left the connectors, ScoutUI and
+      # LookupIndex unanalysed while the dashboard read as clean. The scheme list
+      # comes from the manifest's library products — SwiftPM names a scheme after
+      # the product — so a newly vended one is picked up without editing this
+      # file. An empty list is an error: a scan that compiles nothing analyses
+      # nothing and still reports clean, which is the failure being fixed here.
+      #
+      # Tracing slows compilation down severalfold, so build a single
       # architecture: the generic simulator destination would otherwise build
       # both arm64 and x86_64, doubling the traced work for no analysis gain.
       - name: Build
         run: |
-          xcodebuild \
-            -scheme Scout \
-            -destination 'generic/platform=iOS Simulator' \
-            ARCHS=arm64 \
-            build
+          set -eo pipefail
+          schemes="$(swift package dump-package | jq -r '.products[] | select(.type.library) | .name')"
+          if [ -z "$schemes" ]; then
+            echo "::error::No library products found in the manifest."
+            exit 1
+          fi
+          for scheme in $schemes; do
+            xcodebuild \
+              -scheme "$scheme" \
+              -destination 'generic/platform=iOS Simulator' \
+              ARCHS=arm64 \
+              build
+          done
 
       - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
CodeQL in manual build mode only sees what the traced build compiles, and
this workflow built the Scout scheme alone. That was enough while Scout
re-exported everything, but the package split and the umbrella removal
ended that — the API workflow spells out the same consequence where it
builds each product separately. The nightly scan has since been reporting
clean over the connectors, ScoutUI, LookupIndex and DemoConnector without
ever having compiled them, including all of the HTTP transport code.

The build loops over the manifest's library products, so a newly vended one
is covered without editing this file, and the job timeout doubles to match
the larger build. The list is resolved into a variable and checked before
the loop: left inline in the for word list, a failing dump-package would
produce an empty list, compile nothing, and let the scan report clean
again — the same silence this change removes.
