### PR TITLE
Report a skipped test matrix and API diff as a failure

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -3,6 +3,9 @@ name: API
 # No paths filter: this is a required status check, and a required check that
 # never runs blocks the merge. The labeled/unlabeled triggers let the
 # api-breaking label re-evaluate an intentional break without a new push.
+# Make `API / api-gate` the required check, not `API / api-breakage`: the diff
+# job is skipped rather than failed when the gate does not succeed, and branch
+# protection accepts a skipped check.
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -199,3 +202,27 @@ jobs:
           echo "requires a major release. If the break is intentional, add the"
           echo "api-breaking label to this PR to acknowledge it."
           exit 1
+
+  # The required status check. `api-breakage` carries a bare `needs: gate`, so a
+  # gate that fails skips it rather than failing it, and branch protection reads
+  # a skipped check as satisfied. This job always runs and passes only when the
+  # diff actually succeeded.
+  api-gate:
+    name: api-gate
+    needs: [gate, api-breakage]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Require the API diff to pass
+        run: |
+          if [ "${{ needs.gate.result }}" != "success" ]; then
+            echo "::error::The fast-check gate did not pass (${{ needs.gate.result }})."
+            exit 1
+          fi
+          if [ "${{ needs.api-breakage.result }}" != "success" ]; then
+            echo "::error::The API breakage check did not pass (${{ needs.api-breakage.result }})."
+            exit 1
+          fi
+          echo "Gate passes."

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,7 +6,9 @@ name: Swift
 # (xcode-27), so both old-SDK breakage and new-SDK regressions surface here.
 # Coverage is collected on the iOS 26 leg only — the reports differ between legs
 # by fractions of a percent, and that leg is the one where the snapshot suites
-# run. The stable iOS 18 / iOS 26 legs are the required checks on main.
+# run. `tests-gate` is the required check on main rather than the individual
+# legs: a leg that is skipped instead of run reports a conclusion branch
+# protection accepts, so only an always-running summary job can hold the line.
 #
 # `pull_request` carries no base-branch filter on purpose. A PR stacked on
 # another PR's branch would otherwise skip this workflow entirely, and the gate
@@ -93,8 +95,8 @@ jobs:
       # Each leg reports on its own. Cancelling the siblings on the first
       # failure saved runner minutes but let the least stable leg — the
       # arm64-only xcode-27 public-preview image — cancel the stable iOS 18 and
-      # iOS 26 legs whose checks are required on main, turning one flake into a
-      # red PR and a full 20-minute re-run of the whole matrix.
+      # iOS 26 legs that `tests-gate` reports on, turning one flake into a red
+      # PR and a full 20-minute re-run of the whole matrix.
       fail-fast: false
       matrix:
         # Coverage is collected on one leg only: the reports differ between
@@ -129,9 +131,9 @@ jobs:
             ios: 26
             coverage: true
           # Public-preview image, labelled by Xcode major version rather than
-          # the OS and arm64-only. It runs alongside the stable legs and is a
-          # required check, so its failures block merges. Snapshot baselines are
-          # iOS 26 only, so those suites skip on this leg.
+          # the OS and arm64-only. It runs alongside the stable legs and feeds
+          # `tests-gate` like the rest, so its failures block merges. Snapshot
+          # baselines are iOS 26 only, so those suites skip on this leg.
           - os: xcode-27
             device: iPhone 17
             ios: 27
@@ -218,3 +220,38 @@ jobs:
             xcrun xccov view --report --only-targets TestResults.xcresult
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # The required status check for the matrix. `tests` is skipped rather than
+  # failed whenever `lint` or `gate` does not succeed, and branch protection
+  # counts a skipped required check as satisfied — so a gate that times out on
+  # a backed-up runner queue, or trips over a transient `gh api` error, would
+  # otherwise let a PR merge with the matrix never having run. This job always
+  # runs and passes only when the legs actually succeeded. Make
+  # `Swift / tests-gate` the required check, not the individual legs.
+  tests-gate:
+    name: tests-gate
+    needs: [lint, gate, tests]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Require the matrix to pass
+        run: |
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "::error::Lint did not succeed (${{ needs.lint.result }})."
+            exit 1
+          fi
+          # `gate` is PR-only, so a skip is expected on a push to main.
+          case "${{ needs.gate.result }}" in
+            success | skipped) ;;
+            *)
+              echo "::error::The fast-check gate did not pass (${{ needs.gate.result }})."
+              exit 1
+              ;;
+          esac
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "::error::The iOS test matrix did not succeed (${{ needs.tests.result }})."
+            exit 1
+          fi
+          echo "Gate passes."


### PR DESCRIPTION
Both long jobs hang off a cheap ubuntu gate that waits on the fast checks
in sibling workflows, and when that gate fails they are skipped rather than
failed. Branch protection treats a skipped required check as satisfied, so
a gate that exhausts its 40-minute wait on a backed-up runner queue, or
dies on a single transient gh api error, lets a PR merge with neither the
iOS matrix nor the API diff having run.

Adds always-running tests-gate and api-gate summary jobs that pass only
when the work they front actually succeeded, mirroring contract-gate in the
Server workflow, and rewords the matrix comments that still described the
individual legs as the required checks.

This one needs branch protection changed to take effect: require
Swift / tests-gate and API / api-gate in place of test-ios-16 through
test-ios-27 and API / api-breakage. Because protection is not strict, do
that only once the rest of this batch has merged — flipping it while other
PRs are open leaves them waiting on a context their finished runs cannot
contain, and enforce_admins means it cannot be waved through.
