### PR TITLE
Stop a rate-limited lookup from reddening the gate

### DIFF
--- a/.github/scripts/wait-for-checks.sh
+++ b/.github/scripts/wait-for-checks.sh
@@ -11,26 +11,59 @@
 # attaches its check-runs to the head commit, but the merge commit is queried
 # too so the lookup is robust to either association. SHAS and CHECKS are
 # supplied by the workflow; TIMEOUT/INTERVAL fall back to sensible defaults.
+#
+# The lookup itself is best-effort on purpose. This gate exists to save runner
+# minutes, not to decide whether a PR is correct, so failing to read the API
+# must never be what turns a PR red. GITHUB_TOKEN is rate limited per repository
+# per hour and every gate job on every open PR draws on that one budget, so a
+# batch of PRs exhausts it and each poll comes back 403. A failed lookup
+# therefore backs off and retries, and a sustained run of them gives up waiting
+# and lets the expensive job start.
+#
+# The interval grows toward MAX_INTERVAL for the same reason: a long wait is the
+# congested case, which is exactly where polling hardest costs the most and buys
+# the least.
 set -euo pipefail
 
 : "${SHAS:?SHAS is required}"
 : "${CHECKS:?CHECKS is required}"
 timeout="${TIMEOUT:-10800}"
 interval="${INTERVAL:-15}"
+max_interval="${MAX_INTERVAL:-120}"
+max_failures="${MAX_FAILURES:-10}"
 
 read -ra shas <<< "$SHAS"
 read -ra names <<< "$CHECKS"
 
+back_off() {
+  sleep "$interval"
+  interval=$(( interval * 2 > max_interval ? max_interval : interval * 2 ))
+}
+
 deadline=$(( SECONDS + timeout ))
+failures=0
 while :; do
-  runs="$(
+  # `|| exit 1` inside the loop makes one failed SHA fail the whole pipeline;
+  # without it only the last SHA's status counts and a partial answer would be
+  # read as though the missing checks simply did not exist yet.
+  if ! runs="$(
     for sha in "${shas[@]}"; do
       [ -n "$sha" ] || continue
       gh api --paginate \
         "repos/$GITHUB_REPOSITORY/commits/$sha/check-runs" \
-        --jq '.check_runs[] | {name, status, conclusion, started_at}'
+        --jq '.check_runs[] | {name, status, conclusion, started_at}' || exit 1
     done | jq -s '.'
-  )"
+  )"; then
+    failures=$(( failures + 1 ))
+    if [ "$failures" -ge "$max_failures" ]; then
+      echo "::warning::Could not read check-runs $failures times running (rate limit or API trouble). Starting the job anyway rather than blocking the PR on a lookup this gate only uses to save minutes."
+      exit 0
+    fi
+    echo "Check-run lookup failed ($failures/$max_failures); retrying in ${interval}s."
+    back_off
+    continue
+  fi
+  failures=0
 
   pending=()
   for name in "${names[@]}"; do
@@ -67,5 +100,5 @@ while :; do
   fi
 
   echo "Waiting on: ${pending[*]}"
-  sleep "$interval"
+  back_off
 done


### PR DESCRIPTION
The gate polls the check-runs API to decide whether the fast checks have
finished, and any failure of that call was fatal under strict mode. The call
uses GITHUB_TOKEN, which is rate limited per repository per hour, and every
gate job on every open PR spends from the same budget: three gates per PR,
two SHAs each, a request every 15 seconds. A batch of PRs exhausts the hour
in minutes, every poll comes back 403, and the gates go red — which skips
the long jobs they front, so required checks land as skipped and the PR
reads green having run nothing.

This gate saves runner minutes; it does not decide whether a PR is correct.
So a lookup it cannot complete now backs off and retries, and after a
sustained run of failures it gives up waiting and lets the expensive job
start. A fast check that genuinely concludes in failure still fails the gate
exactly as before — verified against mocked responses covering green, red,
permanent 403, transient 403, and a partial answer where only one of the two
SHAs errors.

The interval also grows to a two-minute cap, because a long wait is the
congested case where frequent polling costs most and buys least: a
forty-minute wait drops from 160 polls to 23.
