### PR TITLE
Poll the gate less often and survive a rate-limited lookup

### DIFF
--- a/.github/scripts/wait-for-checks.sh
+++ b/.github/scripts/wait-for-checks.sh
@@ -16,21 +16,31 @@ set -euo pipefail
 : "${SHAS:?SHAS is required}"
 : "${CHECKS:?CHECKS is required}"
 timeout="${TIMEOUT:-10800}"
-interval="${INTERVAL:-15}"
+interval="${INTERVAL:-60}"
 
 read -ra shas <<< "$SHAS"
 read -ra names <<< "$CHECKS"
 
 deadline=$(( SECONDS + timeout ))
 while :; do
-  runs="$(
+  # A shared installation token means the API can rate-limit a long wait. A lookup that fails
+  # says nothing about the checks themselves, so treat it as one more round of waiting.
+  if ! runs="$(
     for sha in "${shas[@]}"; do
       [ -n "$sha" ] || continue
       gh api --paginate \
         "repos/$GITHUB_REPOSITORY/commits/$sha/check-runs" \
         --jq '.check_runs[] | {name, status, conclusion, started_at}'
     done | jq -s '.'
-  )"
+  )"; then
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "::error::Timed out after ${timeout}s; the last check-run lookup failed."
+      exit 1
+    fi
+    echo "Check-run lookup failed; retrying in ${interval}s"
+    sleep "$interval"
+    continue
+  fi
 
   pending=()
   for name in "${names[@]}"; do


### PR DESCRIPTION
Raising the gate's wait to three hours in #1098 turned it into a heavy API client. Three gate jobs per pull request, each polling the check-runs endpoint every 15 seconds for up to three hours, exhausted the shared installation's rate limit — and since the script runs under `set -e`, the first 403 killed the job outright. The gate then reported a failure for a pull request whose checks were all green, which is exactly the false red the longer wait was meant to remove.

This polls once a minute rather than four times a minute, cutting the request volume by four, and treats a failed lookup as one more round of waiting instead of a verdict: a lookup that does not answer says nothing about the checks themselves. The deadline still governs, so a permanently broken lookup times out with a message naming the cause rather than spinning forever, and a check that genuinely concludes in failure still fails the gate immediately.

Verified against a stubbed `gh`: a rate-limited lookup retries and then times out, an all-green set passes, and a failed check still fails fast.