### PR TITLE
Remove the remaining comments from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,6 @@ updates:
     schedule:
       interval: monthly
 
-  # This one has never opened a pull request, and that is expected rather than
-  # broken. Every Swift dependency is declared with an open-ended requirement
-  # (`from:`, or a range for swift-metrics) and no Package.resolved is committed,
-  # so resolution already lands on the newest allowed version on every build and
-  # there is no pin for Dependabot to bump. It only has something to say when a
-  # dependency ships a new major outside the declared range — which is precisely
-  # the case worth being told about, so the entry stays.
   - package-ecosystem: swift
     directory: /
     schedule:


### PR DESCRIPTION
Finishes the comment removal that #1100 started. That PR covered the workflows and the scripts under .github/scripts but left dependabot.yml untouched, so seven comment lines above the swift ecosystem entry survived. This removes them, leaving no comment lines anywhere under .github apart from the scripts' shebangs.

Deletions only — seven lines, no other edit — and the file still parses as YAML with both ecosystem entries intact.