### PR TITLE
Document the wrapping rule for function and initializer calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ cohorts = RetentionCohort.build(
 
 - Calls with one or two arguments that fit within the limit stay on a single line.
 - This is the opposite of the signature rule above: declarations stay single-line no matter how many parameters they take, and only calls expand.
+- The three-argument threshold applies to `Sources`. Under `Tests`, calls stay compact on one line until they exceed the limit — expanding every `make…`/fixture call there costs readability instead of buying it.
 
 ## Array extensions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,23 @@
 
 - Function/method **signatures** (declarations) should be written on a single line, even with many parameters or default values — do not wrap parameters onto separate lines.
 - Exception: when a single-line signature would exceed the 120-character `lineLength` limit in `.swift-format` (a CI lint gate, so the limit wins), let `swift-format` wrap it; don't fight the formatter.
-- This applies to declarations only, not to call sites: a function or initializer **call** with several arguments wraps each argument onto its own line.
+- This applies to declarations only, not to call sites — see below.
+
+## Function and initializer calls
+
+- A **call** wraps each argument onto its own line, with the closing `)` on its own line, when it has three or more arguments or when it would exceed the 120-character limit on one line:
+
+```swift
+cohorts = RetentionCohort.build(
+    installDays: installDays,
+    sessionDays: sessionDays,
+    in: range,
+    asOf: scenario.clock.now
+)
+```
+
+- Calls with one or two arguments that fit within the limit stay on a single line.
+- This is the opposite of the signature rule above: declarations stay single-line no matter how many parameters they take, and only calls expand.
 
 ## Array extensions
 


### PR DESCRIPTION
The call-site style was buried as a sub-bullet under the signature rules and only said that a call with several arguments wraps each argument onto its own line, which left the threshold open to interpretation. It now has its own section that states the condition explicitly: a call expands when it takes three or more arguments or when it would exceed the 120-character limit, with the closing parenthesis on its own line, while calls of one or two arguments that fit stay inline.

The three-argument threshold is scoped to the library sources. Under Tests it would turn several hundred compact fixture calls into five-line blocks without buying any clarity, so test call sites stay on one line until they exceed the limit, and the section says so.

The signature rule is unchanged and now cross-references the new section, so it stays clear that declarations remain single-line no matter how many parameters they take and that only calls expand. Note that swift-format does not currently enforce the new rule: it preserves the expanded form once written, but will not produce it on its own, so this is a review-time convention for now.