### PR TITLE
Remove duplicated comment rules from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@
 
 ## Doc comments
 
-- Document only public API: write doc comments (`///`) for `public`/`open` declarations only, and leave `internal`, `private`, and `fileprivate` declarations undocumented (an inline `//` note for genuinely non-obvious logic is still fine).
+- Write doc comments (`///`) for `public`/`open` declarations only; leave `internal`, `private`, and `fileprivate` declarations undocumented.
 - Multi-line doc comments (`///`) must end with a trailing empty `///` line, except when they document a single-line property declaration (a stored `let`/`var` written on one line), where the trailing empty `///` is omitted. Single-line doc comments never need it.
 
 ## `MARK` comments


### PR DESCRIPTION
The `Doc comments` section repeated two things the `Comments` section already states: that doc comments are for public API, and that a rare inline `//` note for non-obvious logic is fine. Dropped both from the `Doc comments` bullet so it only covers what is specific to it — which access levels get `///` — leaving the trailing empty `///` rule untouched.