### PR TITLE
Keep guards inline only for operator-free conditions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,8 @@
 
 ## `guard` statements
 
-- A `guard` stays fully inline only when its single condition contains no `=` — a shorthand binding (`guard let foo else { return }`) or a plain boolean check (`guard !x else { return }`).
-- Any condition with `=` — an assigning binding (`guard let foo = bar.buz`) or pattern matching (`guard case .x = y`) — expands the `else` block onto multiple lines (`else {` / body / `}`).
+- A `guard` stays fully inline only when its single condition is free of binding and comparison operators — a shorthand binding (`guard let foo else { return }`), a bare or negated boolean (`guard isEnabled else { return }`, `guard !x else { return }`), a boolean call (`guard name.hasPrefix(prefix) else { return nil }`), or an availability check.
+- Any condition built with an operator expands the `else` block onto multiple lines (`else {` / body / `}`): an assigning binding (`guard let foo = bar.buz`), pattern matching (`guard case .x = y`), and comparisons or boolean algebra alike (`guard points.count > 0`, `guard token == startToken`, `guard a || b`).
 - Expand the `else` block onto multiple lines as well when the `guard` has multiple conditions, or when its condition or `else` body is long or complex. Multi-condition guards still keep their conditions on a single line.
 
 ## Function and method signatures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,9 @@
 
 ## `guard` statements
 
-- A short, single-condition `guard` stays fully inline — both simple bindings (`guard let x = y else { return }`, `guard !x else { return }`) and pattern matching (`guard case .x = y else { return nil }`).
-- Expand the `else` block onto multiple lines (`else {` / body / `}`) when the `guard` has multiple conditions, or when its condition or `else` body is long or complex. Multi-condition guards still keep their conditions on a single line.
+- A `guard` stays fully inline only when its single condition contains no `=` — a shorthand binding (`guard let foo else { return }`) or a plain boolean check (`guard !x else { return }`).
+- Any condition with `=` — an assigning binding (`guard let foo = bar.buz`) or pattern matching (`guard case .x = y`) — expands the `else` block onto multiple lines (`else {` / body / `}`).
+- Expand the `else` block onto multiple lines as well when the `guard` has multiple conditions, or when its condition or `else` body is long or complex. Multi-condition guards still keep their conditions on a single line.
 
 ## Function and method signatures
 

--- a/Sources/Connectors/Demo/DemoDatabase.swift
+++ b/Sources/Connectors/Demo/DemoDatabase.swift
@@ -71,7 +71,9 @@ extension RecordQuery {
         { lhs, rhs in
             for key in sort {
                 let order = RecordValue.compare(lhs.fields[key.field], rhs.fields[key.field])
-                guard order != .orderedSame else { continue }
+                guard order != .orderedSame else {
+                    continue
+                }
                 return key.ascending ? order == .orderedAscending : order == .orderedDescending
             }
             return false

--- a/Sources/Connectors/Native/NativeDatabase.swift
+++ b/Sources/Connectors/Native/NativeDatabase.swift
@@ -147,8 +147,12 @@ extension NativeDatabase {
             entity: entity, filters: Self.dateFilters(dateField, in: range), fields: [dateField, idField])
 
         return records.compactMap { record -> (date: Date, id: String)? in
-            guard case .date(let date)? = record.values[dateField] else { return nil }
-            guard case .string(let id)? = record.values[idField] else { return nil }
+            guard case .date(let date)? = record.values[dateField] else {
+                return nil
+            }
+            guard case .string(let id)? = record.values[idField] else {
+                return nil
+            }
             return (date, id)
         }
     }

--- a/Sources/Connectors/Native/NativeSeries.swift
+++ b/Sources/Connectors/Native/NativeSeries.swift
@@ -69,7 +69,9 @@ struct NativeSeries {
 
         var latest: [GroupKey: [Date: (date: Date, sample: Double)]] = [:]
         for record in records {
-            guard case .date(let date)? = record.values["date"] else { continue }
+            guard case .date(let date)? = record.values["date"] else {
+                continue
+            }
             let name: String? = record["name"]
             let category: String? = record["category"]
             guard query.name == nil || name == query.name else { continue }
@@ -182,7 +184,9 @@ struct NativeSeries {
             entity: entity, view: EntityCatalog.metricSeriesView, from: from, to: query.range.upperBound)
 
         for point in points where point.date >= from {
-            guard let (category, metric) = EntityCatalog.decodeSeriesKey(point.group) else { continue }
+            guard let (category, metric) = EntityCatalog.decodeSeriesKey(point.group) else {
+                continue
+            }
 
             guard query.name == nil || metric == query.name else { continue }
             guard query.category == nil || category == query.category else { continue }
@@ -214,7 +218,9 @@ struct NativeSeries {
         let records = try await store.read(
             entity: entity, filters: filters, fields: [dateField, "app_version", "install_id"])
         var visits = records.compactMap { record -> (date: Date, version: String?, install: String?)? in
-            guard case .date(let date)? = record.values[dateField] else { return nil }
+            guard case .date(let date)? = record.values[dateField] else {
+                return nil
+            }
             let version: String? = record["app_version"]
             let install: String? = record["install_id"]
             return (date, version, install)

--- a/Sources/Connectors/Native/NativeSeries.swift
+++ b/Sources/Connectors/Native/NativeSeries.swift
@@ -74,8 +74,12 @@ struct NativeSeries {
             }
             let name: String? = record["name"]
             let category: String? = record["category"]
-            guard query.name == nil || name == query.name else { continue }
-            guard query.category == nil || category == query.category else { continue }
+            guard query.name == nil || name == query.name else {
+                continue
+            }
+            guard query.category == nil || category == query.category else {
+                continue
+            }
             guard let name else { continue }
 
             let sample: Double
@@ -188,8 +192,12 @@ struct NativeSeries {
                 continue
             }
 
-            guard query.name == nil || metric == query.name else { continue }
-            guard query.category == nil || category == query.category else { continue }
+            guard query.name == nil || metric == query.name else {
+                continue
+            }
+            guard query.category == nil || category == query.category else {
+                continue
+            }
 
             add(
                 point.value ?? Double(point.count),

--- a/Sources/LookupIndex/CachedDatabase.swift
+++ b/Sources/LookupIndex/CachedDatabase.swift
@@ -112,7 +112,9 @@ enum DatabaseCacheRegistry {
     private static var state: CacheState = .unresolved
 
     static func database(for backend: Backend) -> any Database {
-        guard let cache = sharedCache() else { return backend.database }
+        guard let cache = sharedCache() else {
+            return backend.database
+        }
         return CachedDatabase(base: backend.database, scope: backend.id, cache: cache)
     }
 

--- a/Sources/LookupIndex/CachedMetricSeries.swift
+++ b/Sources/LookupIndex/CachedMetricSeries.swift
@@ -41,9 +41,15 @@ enum CachedMetricSeries {
         var groups = SeriesGroups()
 
         for record in cached {
-            guard case .date(let date)? = record.fields["date"] else { continue }
-            guard case .string(let name)? = record.fields["name"] else { continue }
-            guard let value = metricValue(record.fields["value"]) else { continue }
+            guard case .date(let date)? = record.fields["date"] else {
+                continue
+            }
+            guard case .string(let name)? = record.fields["name"] else {
+                continue
+            }
+            guard let value = metricValue(record.fields["value"]) else {
+                continue
+            }
 
             let category: String? =
                 if case .string(let category)? = record.fields["category"] { category } else { nil }

--- a/Sources/LookupIndex/RecordCache.swift
+++ b/Sources/LookupIndex/RecordCache.swift
@@ -41,7 +41,9 @@ actor RecordCache<Row: CacheRow> {
 
         let decoder = JSONDecoder()
         let records = entries.compactMap { try? decoder.decode(CachedRecordPayload.self, from: $0.payload).record }
-        guard records.count == entries.count else { return nil }
+        guard records.count == entries.count else {
+            return nil
+        }
         return records
     }
 

--- a/Sources/LookupIndex/RecordCache.swift
+++ b/Sources/LookupIndex/RecordCache.swift
@@ -22,7 +22,9 @@ protocol RecordCaching: Actor {
 @ModelActor
 actor RecordCache<Row: CacheRow> {
     func coveredRange(for fingerprint: String) -> Range<Date>? {
-        guard let span = span(for: fingerprint), span.lowerDate < span.upperDate else { return nil }
+        guard let span = span(for: fingerprint), span.lowerDate < span.upperDate else {
+            return nil
+        }
         return span.lowerDate..<span.upperDate
     }
 
@@ -33,7 +35,9 @@ actor RecordCache<Row: CacheRow> {
             $0.fingerprint == fingerprint && $0.date >= lower && $0.date < upper
         }
         let descriptor = FetchDescriptor(predicate: predicate, sortBy: [SortDescriptor(\Row.date)])
-        guard let entries = try? modelContext.fetch(descriptor) else { return nil }
+        guard let entries = try? modelContext.fetch(descriptor) else {
+            return nil
+        }
 
         let decoder = JSONDecoder()
         let records = entries.compactMap { try? decoder.decode(CachedRecordPayload.self, from: $0.payload).record }
@@ -46,9 +50,13 @@ actor RecordCache<Row: CacheRow> {
         var entries: [Row] = []
 
         for record in records {
-            guard case .date(let date)? = record.fields["date"] else { return }
+            guard case .date(let date)? = record.fields["date"] else {
+                return
+            }
             guard range.contains(date) else { continue }
-            guard let payload = try? encoder.encode(CachedRecordPayload(record: record)) else { return }
+            guard let payload = try? encoder.encode(CachedRecordPayload(record: record)) else {
+                return
+            }
             entries.append(Row(fingerprint: fingerprint, date: date, payload: payload))
         }
 
@@ -71,12 +79,16 @@ actor RecordCache<Row: CacheRow> {
         let predicate = #Predicate<Row> { $0.fingerprint == fingerprint }
         var descriptor = FetchDescriptor(predicate: predicate)
         descriptor.fetchLimit = 1
-        guard let entry = try? modelContext.fetch(descriptor).first else { return nil }
+        guard let entry = try? modelContext.fetch(descriptor).first else {
+            return nil
+        }
         return try? JSONDecoder().decode(CachedRecordPayload.self, from: entry.payload).record
     }
 
     func storeLookup(_ record: Record, for fingerprint: String) {
-        guard let payload = try? JSONEncoder().encode(CachedRecordPayload(record: record)) else { return }
+        guard let payload = try? JSONEncoder().encode(CachedRecordPayload(record: record)) else {
+            return
+        }
         let predicate = #Predicate<Row> { $0.fingerprint == fingerprint }
         try? modelContext.delete(model: Row.self, where: predicate)
         modelContext.insert(Row(fingerprint: fingerprint, date: .distantPast, payload: payload))

--- a/Sources/LookupIndex/RecordCacheStore.swift
+++ b/Sources/LookupIndex/RecordCacheStore.swift
@@ -105,7 +105,9 @@ enum RecordCacheStore {
     // Data abort the process. Destroy anything without a valid SQLite header up front so only an
     // openable (or absent) store ever reaches ModelContainer; a valid store keeps its bytes.
     private static func storeHasSQLiteHeader(at url: URL) -> Bool {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return true }
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            return true
+        }
         defer { try? handle.close() }
         let header = (try? handle.read(upToCount: 16)) ?? Data()
         if header.isEmpty { return true }

--- a/Sources/Scout/Activity/ActivityPoint+Build.swift
+++ b/Sources/Scout/Activity/ActivityPoint+Build.swift
@@ -48,7 +48,9 @@ extension ActivityPoint {
             month.remove(users[day.addingTimeInterval(-30 * .day)])
 
             let mau = month.count
-            guard mau > 0 else { continue }
+            guard mau > 0 else {
+                continue
+            }
 
             let dau = users[day]?.count ?? 0
 

--- a/Sources/Scout/Activity/MarkerEntry.Trigger.swift
+++ b/Sources/Scout/Activity/MarkerEntry.Trigger.swift
@@ -25,7 +25,9 @@ extension MarkerEntry {
     static func mark(name: String, install: InstallEntry?, appVersion: String?, in context: NSManagedObjectContext)
         throws
     {
-        guard let appVersion, let install else { return }
+        guard let appVersion, let install else {
+            return
+        }
 
         let request = NSFetchRequest<MarkerEntry>(entityName: "MarkerEntry")
         request.predicate = NSPredicate(

--- a/Sources/Scout/Activity/RetentionCohort.swift
+++ b/Sources/Scout/Activity/RetentionCohort.swift
@@ -28,7 +28,9 @@ extension RetentionCohort {
             id: Date(millisecondsSince1970: date),
             size: size,
             retention: retained.map { count in
-                guard let count, size > 0 else { return nil }
+                guard let count, size > 0 else {
+                    return nil
+                }
                 return Double(count) / Double(size)
             }
         )

--- a/Sources/Scout/Activity/VisitEntry.Trigger.swift
+++ b/Sources/Scout/Activity/VisitEntry.Trigger.swift
@@ -18,7 +18,9 @@ extension VisitEntry {
             request.predicate = NSPredicate(format: "day == %@", date.startOfDay as NSDate)
             request.fetchLimit = 1
 
-            guard try context.fetch(request).first == nil else { return }
+            guard try context.fetch(request).first == nil else {
+                return
+            }
 
             let visit = context.insert(VisitEntry.self)
             visit.visitID = UUID()

--- a/Sources/Scout/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Database/Access/RecordSender.swift
@@ -48,7 +48,9 @@ extension RecordSender {
             }
         }
 
-        guard objects.count > 0 else { return }
+        guard objects.count > 0 else {
+            return
+        }
 
         do {
             try await database.write(records: objects.map(\.record))

--- a/Sources/Scout/Database/Record/RecordValueConvertible.swift
+++ b/Sources/Scout/Database/Record/RecordValueConvertible.swift
@@ -15,7 +15,9 @@ package protocol RecordValueConvertible {
 
 extension String: RecordValueConvertible {
     package init?(recordValue: RecordValue) {
-        guard case .string(let value) = recordValue else { return nil }
+        guard case .string(let value) = recordValue else {
+            return nil
+        }
         self = value
     }
 
@@ -24,7 +26,9 @@ extension String: RecordValueConvertible {
 
 extension Int: RecordValueConvertible {
     package init?(recordValue: RecordValue) {
-        guard case .int(let value) = recordValue else { return nil }
+        guard case .int(let value) = recordValue else {
+            return nil
+        }
         self = Int(value)
     }
 
@@ -33,7 +37,9 @@ extension Int: RecordValueConvertible {
 
 extension Int64: RecordValueConvertible {
     package init?(recordValue: RecordValue) {
-        guard case .int(let value) = recordValue else { return nil }
+        guard case .int(let value) = recordValue else {
+            return nil
+        }
         self = value
     }
 
@@ -42,7 +48,9 @@ extension Int64: RecordValueConvertible {
 
 extension Double: RecordValueConvertible {
     package init?(recordValue: RecordValue) {
-        guard case .double(let value) = recordValue else { return nil }
+        guard case .double(let value) = recordValue else {
+            return nil
+        }
         self = value
     }
 
@@ -51,7 +59,9 @@ extension Double: RecordValueConvertible {
 
 extension Date: RecordValueConvertible {
     package init?(recordValue: RecordValue) {
-        guard case .date(let value) = recordValue else { return nil }
+        guard case .date(let value) = recordValue else {
+            return nil
+        }
         self = value
     }
 
@@ -60,7 +70,9 @@ extension Date: RecordValueConvertible {
 
 extension Data: RecordValueConvertible {
     package init?(recordValue: RecordValue) {
-        guard case .bytes(let value) = recordValue else { return nil }
+        guard case .bytes(let value) = recordValue else {
+            return nil
+        }
         self = value
     }
 
@@ -69,7 +81,9 @@ extension Data: RecordValueConvertible {
 
 extension Array: RecordValueConvertible where Element == String {
     package init?(recordValue: RecordValue) {
-        guard case .strings(let value) = recordValue else { return nil }
+        guard case .strings(let value) = recordValue else {
+            return nil
+        }
         self = value
     }
 

--- a/Sources/Scout/Diagnostics/Hang/MainThreadBacktrace.swift
+++ b/Sources/Scout/Diagnostics/Hang/MainThreadBacktrace.swift
@@ -30,13 +30,17 @@ enum MainThreadBacktrace {
         // deadlock this thread forever. So resume first, then symbolicate.
         var buffer = [UInt64](repeating: 0, count: maximumFrameCount)
         let count = buffer.withUnsafeMutableBufferPointer { captureAddresses(of: mainThread, into: $0) }
-        guard count > 0 else { return [] }
+        guard count > 0 else {
+            return []
+        }
 
         return buffer.prefix(count).enumerated().map(symbolicate)
     }
 
     private static func captureAddresses(of thread: thread_t, into buffer: UnsafeMutableBufferPointer<UInt64>) -> Int {
-        guard thread_suspend(thread) == KERN_SUCCESS else { return 0 }
+        guard thread_suspend(thread) == KERN_SUCCESS else {
+            return 0
+        }
         defer { thread_resume(thread) }
 
         guard let (pc, initialFP) = registerState(of: thread) else {
@@ -131,7 +135,9 @@ enum MainThreadBacktrace {
             }
         }
 
-        guard result == KERN_SUCCESS else { return nil }
+        guard result == KERN_SUCCESS else {
+            return nil
+        }
         return (scout_arm_thread_state64_pc(state), scout_arm_thread_state64_fp(state))
     }
 #elseif arch(x86_64)
@@ -145,7 +151,9 @@ enum MainThreadBacktrace {
             }
         }
 
-        guard result == KERN_SUCCESS else { return nil }
+        guard result == KERN_SUCCESS else {
+            return nil
+        }
         return (state.__rip, state.__rbp)
     }
 #else

--- a/Sources/Scout/Diagnostics/Hang/MainThreadBacktrace.swift
+++ b/Sources/Scout/Diagnostics/Hang/MainThreadBacktrace.swift
@@ -20,7 +20,9 @@ enum MainThreadBacktrace {
     static let maximumFrameCount = 64
 
     static func capture() -> [String] {
-        guard let mainThread = mainMachThread() else { return [] }
+        guard let mainThread = mainMachThread() else {
+            return []
+        }
 
         // Only raw return addresses are collected while the main thread is
         // suspended — no malloc, no dyld lock. If the thread is suspended
@@ -37,14 +39,18 @@ enum MainThreadBacktrace {
         guard thread_suspend(thread) == KERN_SUCCESS else { return 0 }
         defer { thread_resume(thread) }
 
-        guard let (pc, initialFP) = registerState(of: thread) else { return 0 }
+        guard let (pc, initialFP) = registerState(of: thread) else {
+            return 0
+        }
 
         buffer[0] = pc
         var count = 1
         var fp = initialFP
 
         while count < buffer.count {
-            guard fp != 0, let frame = readFrame(at: fp), frame.returnAddress != 0 else { break }
+            guard fp != 0, let frame = readFrame(at: fp), frame.returnAddress != 0 else {
+                break
+            }
             buffer[count] = frame.returnAddress
             count += 1
             fp = frame.previousFP

--- a/Sources/Scout/Diagnostics/Incident/LogIncident.swift
+++ b/Sources/Scout/Diagnostics/Incident/LogIncident.swift
@@ -43,7 +43,9 @@ func logIncident<Entry: IncidentEntry, Info: IncidentInfo>(
     let request = NSFetchRequest<Entry>(entityName: entityName)
     request.predicate = NSPredicate(format: "%K == %@", idKey, id as CVarArg)
     request.fetchLimit = 1
-    guard try context.count(for: request) == 0 else { return }
+    guard try context.count(for: request) == 0 else {
+        return
+    }
 
     let object = context.insert(Entry.self)
 

--- a/Sources/Scout/Diagnostics/Telemetry/StatusBuckets.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/StatusBuckets.swift
@@ -21,8 +21,12 @@ package enum StatusBuckets {
     }
 
     static func category(in dimensions: [(String, String)]) -> String? {
-        guard let value = dimensions.first(where: { $0.0 == dimension })?.1 else { return nil }
-        guard let code = Int(value) else { return nil }
+        guard let value = dimensions.first(where: { $0.0 == dimension })?.1 else {
+            return nil
+        }
+        guard let code = Int(value) else {
+            return nil
+        }
         return category(for: code)
     }
 

--- a/Sources/Scout/Lifecycle/Base/SystemInfo.swift
+++ b/Sources/Scout/Lifecycle/Base/SystemInfo.swift
@@ -15,7 +15,9 @@ enum SystemInfo {
         var info = utsname()
         uname(&info)
         return Mirror(reflecting: info.machine).children.reduce(into: "") { identifier, element in
-            guard let scalar = element.value as? Int8, scalar != 0 else { return }
+            guard let scalar = element.value as? Int8, scalar != 0 else {
+                return
+            }
             identifier.append(Character(UnicodeScalar(UInt8(scalar))))
         }
     }

--- a/Sources/Scout/Persistence/Registry.swift
+++ b/Sources/Scout/Persistence/Registry.swift
@@ -30,7 +30,9 @@ extension UserDefaults: Registry {
     }
 
     func resolve(_ key: String) -> UUID? {
-        guard let string = string(forKey: key) else { return nil }
+        guard let string = string(forKey: key) else {
+            return nil
+        }
         return UUID(uuidString: string)
     }
 }

--- a/Sources/ScoutUI/Analytics/Event/List/Export/EventListExport.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/Export/EventListExport.swift
@@ -13,7 +13,9 @@ struct EventListExport {
     let events: [Event]
 
     var text: String? {
-        guard events.count > 0 else { return nil }
+        guard events.count > 0 else {
+            return nil
+        }
 
         var lines: [ExportLine] = [.heading(level: 1, title), .text(summary), .blank]
         lines.append(contentsOf: events.map(row))

--- a/Sources/ScoutUI/Analytics/Retention/RetentionCohort+Fixture.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionCohort+Fixture.swift
@@ -25,7 +25,9 @@ extension RetentionCohort: Fixture {
             let size = 620 + (index * 173) % 540
 
             let retention = dayOffsets.map { day -> Double? in
-                guard day <= elapsed, let target = targets[day] else { return nil }
+                guard day <= elapsed, let target = targets[day] else {
+                    return nil
+                }
                 return day == 0 ? 1 : min(target * quality, 0.95)
             }
 

--- a/Sources/ScoutUI/Analytics/Retention/RetentionCohort.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionCohort.swift
@@ -46,7 +46,9 @@ extension RetentionCohort {
     static func stats(for cohorts: [RetentionCohort]) -> [DayStat] {
         dayOffsets.enumerated().compactMap { index, day in
             let rates = cohorts.compactMap { $0.retention[index] }
-            guard rates.count > 0 else { return nil }
+            guard rates.count > 0 else {
+                return nil
+            }
             return DayStat(
                 day: day, average: rates.reduce(0, +) / Double(rates.count), low: rates.min() ?? 0,
                 high: rates.max() ?? 0)

--- a/Sources/ScoutUI/Analytics/Retention/RetentionSegmentDetailView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionSegmentDetailView.swift
@@ -17,7 +17,9 @@ struct RetentionSegmentDetailView: View {
     private var crashMultiplier: Double {
         let others = cohort.segments.filter { $0.name != segment.name }
         let baseline = others.map(\.crashRate).reduce(0, +) / Double(max(others.count, 1))
-        guard baseline > 0 else { return 1 }
+        guard baseline > 0 else {
+            return 1
+        }
         return segment.crashRate / baseline
     }
 

--- a/Sources/ScoutUI/Analytics/Session/SessionInfo.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionInfo.swift
@@ -24,7 +24,9 @@ struct SessionInfo: Equatable {
     }
 
     var duration: String? {
-        guard let startDate, let endDate, endDate >= startDate else { return nil }
+        guard let startDate, let endDate, endDate >= startDate else {
+            return nil
+        }
 
         let seconds = Int(endDate.timeIntervalSince(startDate))
         if seconds < 60 {

--- a/Sources/ScoutUI/Delivery/Devices/Model/DeviceSummary.swift
+++ b/Sources/ScoutUI/Delivery/Devices/Model/DeviceSummary.swift
@@ -38,8 +38,12 @@ extension DeviceSummary {
         }
 
         return sessionsByDevice.compactMap { deviceID, sessions -> DeviceSummary? in
-            guard let uuid = UUID(uuidString: deviceID) else { return nil }
-            guard let latest = sessions.max(by: { $0.startDate < $1.startDate }) else { return nil }
+            guard let uuid = UUID(uuidString: deviceID) else {
+                return nil
+            }
+            guard let latest = sessions.max(by: { $0.startDate < $1.startDate }) else {
+                return nil
+            }
 
             return DeviceSummary(
                 id: uuid,

--- a/Sources/ScoutUI/Delivery/Releases/View/DailyCount.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/DailyCount.swift
@@ -21,7 +21,9 @@ extension DailyCount {
 
         var counts: [Date: Int] = [:]
         for record in records {
-            guard let date = record.date else { continue }
+            guard let date = record.date else {
+                continue
+            }
             counts[calendar.startOfDay(for: date), default: 0] += 1
         }
 

--- a/Sources/ScoutUI/Home/Settings/BackendHealth.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealth.swift
@@ -127,7 +127,9 @@ extension BackendHealth {
     }
 
     var pingSpreadLabel: String? {
-        guard let low = pings.min(), let high = pings.max() else { return nil }
+        guard let low = pings.min(), let high = pings.max() else {
+            return nil
+        }
         let average = pings.reduce(0, +) / pings.count
         return "\(low) / \(average) / \(high) ms"
     }

--- a/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
@@ -37,7 +37,9 @@ final class BackendHealthProvider: ObservableObject {
     }
 
     func refresh(id: String) async {
-        guard let probe = backends.first(where: { $0.id == id })?.probe else { return }
+        guard let probe = backends.first(where: { $0.id == id })?.probe else {
+            return
+        }
         apply(await Self.measure(id: id, probe: probe))
     }
 
@@ -56,7 +58,9 @@ final class BackendHealthProvider: ObservableObject {
     }
 
     private func apply(_ result: ProbeResult) {
-        guard let index = backends.firstIndex(where: { $0.id == result.id }) else { return }
+        guard let index = backends.firstIndex(where: { $0.id == result.id }) else {
+            return
+        }
         backends[index] = backends[index].recording(status: result.status, latency: result.latency, at: Date())
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertMessage.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertMessage.swift
@@ -14,7 +14,9 @@ struct AlertMessage: Equatable {
 
 extension AlertMessage {
     init?(status: AlertStatus) {
-        guard status.outcome.shouldNotify, status.rule.notifies, let detail = status.detail else { return nil }
+        guard status.outcome.shouldNotify, status.rule.notifies, let detail = status.detail else {
+            return nil
+        }
 
         title = status.rule.metric.title
         body = detail

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
@@ -30,7 +30,9 @@ struct AlertNotifier {
 
     func deliver(_ statuses: [AlertStatus]) async {
         for status in statuses {
-            guard let message = AlertMessage(status: status) else { continue }
+            guard let message = AlertMessage(status: status) else {
+                continue
+            }
 
             let content = UNMutableNotificationContent()
             content.title = message.title

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
@@ -48,7 +48,9 @@
         }
 
         private static func refresh(engine: AlertEngine, backends: [Backend]) async {
-            guard let backend = backends.active else { return }
+            guard let backend = backends.active else {
+                return
+            }
             _ = try? await engine.run(in: backend.cachedDatabase)
         }
     }

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
@@ -43,7 +43,9 @@
 
         /// Requests a background refresh, skipped while no alert rules exist.
         public static func scheduleBackgroundRefresh() {
-            guard AlertRegistry().rules.count > 0 else { return }
+            guard AlertRegistry().rules.count > 0 else {
+                return
+            }
             scheduler?.schedule()
         }
 

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertBacktest.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertBacktest.swift
@@ -16,7 +16,9 @@ struct AlertBacktest: Equatable {
         let window = Self.windowBuckets
         let evaluator = AlertEvaluator()
 
-        guard values.count >= window * 2 else { return 0 }
+        guard values.count >= window * 2 else {
+            return 0
+        }
 
         var state = AlertState.armed
         var fires = 0

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertCondition.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertCondition.swift
@@ -27,7 +27,9 @@ extension AlertCondition {
 
 extension AlertCondition {
     func isBreached(by value: Double, in reading: MetricReading) -> Bool {
-        guard let reference = reading.reference(for: reference) else { return false }
+        guard let reference = reading.reference(for: reference) else {
+            return false
+        }
 
         switch comparison {
         case .below:

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertMetric.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertMetric.swift
@@ -41,7 +41,9 @@ extension AlertMetric {
     }
 
     private func eventPoints(in database: DatabaseReader, range: Range<Date>) async throws -> [ChartPoint<Int>] {
-        guard case .eventCount(let name) = self else { return [] }
+        guard case .eventCount(let name) = self else {
+            return []
+        }
 
         let series = try await database.series(
             matching: SeriesQuery(name: name, bucket: .hour, range: range)

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertStatus.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertStatus.swift
@@ -15,7 +15,9 @@ struct AlertStatus: Equatable {
 
 extension AlertStatus {
     var detail: String? {
-        guard let current = reading.recent.last else { return nil }
+        guard let current = reading.recent.last else {
+            return nil
+        }
         return "\(rule.metric.format(current)) — \(rule.condition.summary(format: rule.metric.format))"
     }
 

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading.swift
@@ -27,7 +27,9 @@ extension MetricReading {
 
 extension [Double] {
     var median: Double? {
-        guard count > 0 else { return nil }
+        guard count > 0 else {
+            return nil
+        }
 
         let sorted = sorted()
         let middle = count / 2

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
@@ -65,7 +65,9 @@ struct AlertEditorView: View {
         }
         .task(id: draft.metric) {
             guard draft.isValid else { return }
-            guard (try? await Task.sleep(nanoseconds: 300_000_000)) != nil else { return }
+            guard (try? await Task.sleep(nanoseconds: 300_000_000)) != nil else {
+                return
+            }
 
             backtest.metric = draft.metric
             await backtest.fetchAgain(in: database)

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -120,7 +120,9 @@ private struct AlertChip: View {
     }
 
     private var text: String {
-        guard let current = status.reading.recent.last else { return status.rule.metric.title }
+        guard let current = status.reading.recent.last else {
+            return status.rule.metric.title
+        }
         return "\(status.rule.metric.title) \(status.rule.metric.format(current))"
     }
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
@@ -61,7 +61,9 @@ extension IncidentBreakdown {
 
         let named = Set(segments(in: dimension).compactMap(\.value))
         return records.filter { record in
-            guard let label = label(of: record, in: dimension) else { return false }
+            guard let label = label(of: record, in: dimension) else {
+                return false
+            }
             return !named.contains(label)
         }
     }

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentDonut.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentDonut.swift
@@ -26,7 +26,9 @@ extension [Segment] {
 
     func percent(of segment: Segment) -> String {
         let total = self.total
-        guard total > 0 else { return "0%" }
+        guard total > 0 else {
+            return "0%"
+        }
         return "\(Int((Double(segment.count) / Double(total) * 100).rounded()))%"
     }
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentExport.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentExport.swift
@@ -65,7 +65,9 @@ struct IncidentGroupExport<Element: Incident> {
     }
 
     private func row(for element: Element) -> ExportLine? {
-        guard let date = element.date else { return nil }
+        guard let date = element.date else {
+            return nil
+        }
 
         var ids: [String] = []
         if let deviceID = element.deviceID {

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/QuantileHistogram.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/QuantileHistogram.swift
@@ -14,7 +14,9 @@ protocol QuantileHistogram: MetricHistogram, Equatable {
 
 extension QuantileHistogram {
     func percentile(_ quantile: Double) -> Double? {
-        guard total > 0 else { return nil }
+        guard total > 0 else {
+            return nil
+        }
 
         let target = Double(total) * quantile
         var cumulative = 0

--- a/Sources/ScoutUI/Monitoring/Metrics/ResetMarkerProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/ResetMarkerProvider.swift
@@ -39,7 +39,9 @@ final class ResetMarkerProvider: ObservableObject, Provider {
     }
 
     func dates(in range: Range<Date>) -> [Date] {
-        guard case .success(let dates)? = result else { return [] }
+        guard case .success(let dates)? = result else {
+            return []
+        }
         return dates.filter(range.contains)
     }
 }

--- a/Sources/ScoutUI/Monitoring/Network/Export/NetworkReportExport.swift
+++ b/Sources/ScoutUI/Monitoring/Network/Export/NetworkReportExport.swift
@@ -15,7 +15,9 @@ struct NetworkReportExport {
 
     var text: String? {
         let endpoints = report.endpoints(in: range)
-        guard endpoints.count > 0 else { return nil }
+        guard endpoints.count > 0 else {
+            return nil
+        }
 
         var lines: [ExportLine] = [
             .heading(level: 1, title), .text(summary), .blank, .heading(level: 2, "Status codes"),

--- a/Sources/ScoutUI/Monitoring/Network/Model/NetworkEndpoint.swift
+++ b/Sources/ScoutUI/Monitoring/Network/Model/NetworkEndpoint.swift
@@ -24,7 +24,9 @@ struct NetworkEndpoint: Identifiable {
     }
 
     private static func method(in name: String) -> String? {
-        guard let first = name.split(separator: " ").first.map(String.init) else { return nil }
+        guard let first = name.split(separator: " ").first.map(String.init) else {
+            return nil
+        }
         return methods.contains(first) ? first : nil
     }
 

--- a/Sources/ScoutUI/Monitoring/Network/Model/NetworkReport.swift
+++ b/Sources/ScoutUI/Monitoring/Network/Model/NetworkReport.swift
@@ -33,7 +33,9 @@ struct NetworkReport {
         var status: [String: [MetricSeries]] = [:]
 
         for singleSeries in series {
-            guard let category = singleSeries.category else { continue }
+            guard let category = singleSeries.category else {
+                continue
+            }
 
             if LatencyBuckets.index(of: category) != nil {
                 latency[singleSeries.name, default: []].append(singleSeries)

--- a/Sources/ScoutUI/Primitives/Pickers/JustifiedLayout.swift
+++ b/Sources/ScoutUI/Primitives/Pickers/JustifiedLayout.swift
@@ -16,7 +16,9 @@ struct JustifiedLayout: Layout {
     }
 
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        guard subviews.count > 0 else { return }
+        guard subviews.count > 0 else {
+            return
+        }
 
         let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
         let firstCenter = bounds.minX + (sizes.first?.width ?? 0) / 2

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Provider/TimelineProvider.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Provider/TimelineProvider.swift
@@ -95,7 +95,9 @@ final class TimelineProvider: ObservableObject {
                 }
             }
 
-            guard token == startToken else { return }
+            guard token == startToken else {
+                return
+            }
 
             result = .success(rail.merged(sessions: sessions, events: events))
         } catch is CancellationError {

--- a/Tests/Connectors/Hosted/ServerContractTests.swift
+++ b/Tests/Connectors/Hosted/ServerContractTests.swift
@@ -85,7 +85,9 @@ struct ServerContractTests {
         // Bounded so a server that never stops handing back a cursor fails the
         // assertion below rather than looping until the job's CI timeout.
         for _ in 0..<10 {
-            guard let cursor = chunk.cursor else { break }
+            guard let cursor = chunk.cursor else {
+                break
+            }
             chunk = try await database.readMore(from: cursor, fields: nil)
             indices += paramCounts(in: chunk.records)
         }

--- a/Tests/Connectors/Native/ActivitySeriesTests.swift
+++ b/Tests/Connectors/Native/ActivitySeriesTests.swift
@@ -76,7 +76,9 @@ struct ActivitySeriesTests {
             let dau = users[day]?.count ?? 0
             let wau = distinctUsers(ending: day, days: 7)
             let mau = distinctUsers(ending: day, days: 30)
-            guard mau > 0 else { continue }
+            guard mau > 0 else {
+                continue
+            }
             points.append(ActivityPoint(date: day.millisecondsSince1970, dau: dau, wau: wau, mau: mau))
         }
         return points.sorted { $0.date < $1.date }

--- a/Tests/LookupIndexTests/CachedDatabaseTests.swift
+++ b/Tests/LookupIndexTests/CachedDatabaseTests.swift
@@ -254,7 +254,9 @@ final class SpyDatabase: Database, @unchecked Sendable {
         seriesRanges.append(query.range)
         return series.compactMap { series in
             let points = series.points.filter { query.range.contains(Date(millisecondsSince1970: $0.date)) }
-            guard points.count > 0 else { return nil }
+            guard points.count > 0 else {
+                return nil
+            }
             return MetricSeries(name: series.name, category: series.category, version: series.version, points: points)
         }
     }

--- a/Tests/ScoutTests/Persistence/MigrationTests.swift
+++ b/Tests/ScoutTests/Persistence/MigrationTests.swift
@@ -28,7 +28,9 @@ struct MigrationTests {
 
         for versionURL in versions {
             let old = try #require(NSManagedObjectModel(contentsOf: versionURL))
-            guard old.entityVersionHashesByName != current.entityVersionHashesByName else { continue }
+            guard old.entityVersionHashesByName != current.entityVersionHashesByName else {
+                continue
+            }
 
             let storeURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString)

--- a/Tests/ScoutUITests/Stubs/DatabaseStub.swift
+++ b/Tests/ScoutUITests/Stubs/DatabaseStub.swift
@@ -96,7 +96,9 @@ final class DatabaseStub: DatabaseReader, @unchecked Sendable {
             .filter { query.name == nil || $0.name == query.name }
             .compactMap { series in
                 let points = series.points.filter { query.range.contains(Date(millisecondsSince1970: $0.date)) }
-                guard points.count > 0 else { return nil }
+                guard points.count > 0 else {
+                    return nil
+                }
                 return MetricSeries(
                     name: series.name, category: series.category, version: series.version, points: points)
             }


### PR DESCRIPTION
Tightens the `guard` style rule in CLAUDE.md: a guard stays fully inline only when its single condition is free of binding and comparison operators — a shorthand binding like `guard let foo else { return }`, a bare or negated boolean, a boolean call, or an availability check. Anything built with an operator now takes a multi-line `else` block: assigning bindings (`guard let foo = bar.buz`), `case` patterns, and comparisons or boolean algebra alike (`guard points.count > 0`, `guard token == startToken`, `guard a || b`). The existing reasons to expand — multiple conditions, a long condition or body — still stand.

The rest of the change applies that rule to the code: 82 guards across 51 files in Sources and Tests were expanded. It is formatting only, no logic or signatures changed. `swift-format lint --strict` is clean and `build-for-testing` for Scout-Package on the iOS simulator succeeds.