### PR TITLE
Wrap call arguments one per line across the library sources

### DIFF
--- a/Sources/Connectors/Demo/DemoActivity.swift
+++ b/Sources/Connectors/Demo/DemoActivity.swift
@@ -31,6 +31,10 @@ struct DemoActivity {
         }
 
         cohorts = RetentionCohort.build(
-            installDays: installDays, sessionDays: sessionDays, in: range, asOf: scenario.clock.now)
+            installDays: installDays,
+            sessionDays: sessionDays,
+            in: range,
+            asOf: scenario.clock.now
+        )
     }
 }

--- a/Sources/Connectors/Demo/DemoDatabase.swift
+++ b/Sources/Connectors/Demo/DemoDatabase.swift
@@ -35,7 +35,11 @@ final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
     }
 
     func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
-        try await read(matching: query, fields: fields, limit: .max)
+        try await read(
+            matching: query,
+            fields: fields,
+            limit: .max
+        )
     }
 
     func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
@@ -44,7 +48,17 @@ final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
         }
         for sort in query.sort.reversed() {
             matches.sort { lhs, rhs in
-                sort.ascending ? before(lhs, rhs, on: sort.field) : before(rhs, lhs, on: sort.field)
+                sort.ascending
+                    ? before(
+                        lhs,
+                        rhs,
+                        on: sort.field
+                    )
+                    : before(
+                        rhs,
+                        lhs,
+                        on: sort.field
+                    )
             }
         }
         return RecordChunk(records: Array(matches.prefix(limit)), cursor: nil)

--- a/Sources/Connectors/Demo/DemoIncidents.swift
+++ b/Sources/Connectors/Demo/DemoIncidents.swift
@@ -64,7 +64,11 @@ struct DemoIncidents {
         ]
 
         let crashProne = Set(
-            stride(from: 0, to: scenario.installs.count, by: 60).map { scenario.installs[$0].id }
+            stride(
+                from: 0,
+                to: scenario.installs.count,
+                by: 60
+            ).map { scenario.installs[$0].id }
         )
 
         for session in scenario.sessions {
@@ -91,7 +95,13 @@ struct DemoIncidents {
 
                 record["app_version"] = session.version.version
                 records.append(record)
-                crashes.append(Point(date: date, version: session.version.version, installID: session.install.id))
+                crashes.append(
+                    Point(
+                        date: date,
+                        version: session.version.version,
+                        installID: session.install.id
+                    )
+                )
             }
 
             if random.double(in: 0...1) < 0.012 {
@@ -116,7 +126,13 @@ struct DemoIncidents {
 
                 record["app_version"] = session.version.version
                 records.append(record)
-                hangs.append(Point(date: date, version: session.version.version, installID: session.install.id))
+                hangs.append(
+                    Point(
+                        date: date,
+                        version: session.version.version,
+                        installID: session.install.id
+                    )
+                )
             }
         }
 

--- a/Sources/Connectors/Demo/DemoMetrics.swift
+++ b/Sources/Connectors/Demo/DemoMetrics.swift
@@ -44,25 +44,51 @@ struct DemoMetrics {
             for name in names {
                 moments(spanDays: 60, perDay: perDay) { date in
                     samples.append(
-                        DemoSample(name: name, category: category, date: date, value: value(&random)))
+                        DemoSample(
+                            name: name,
+                            category: category,
+                            date: date,
+                            value: value(&random)
+                        )
+                    )
                 }
             }
         }
 
-        telemetry(Self.counters, category: Telemetry.Export.counter.rawValue, perDay: 6) {
+        telemetry(
+            Self.counters,
+            category: Telemetry.Export.counter.rawValue,
+            perDay: 6
+        ) {
             .int($0.int(in: 0...40))
         }
-        telemetry(["bytes_downloaded_mb"], category: Telemetry.Export.floatingCounter.rawValue, perDay: 6) {
+        telemetry(
+            ["bytes_downloaded_mb"],
+            category: Telemetry.Export.floatingCounter.rawValue,
+            perDay: 6
+        ) {
             .double($0.double(in: 0...12))
         }
-        telemetry(["memory_usage_mb", "active_connections"], category: Telemetry.Export.meter.rawValue, perDay: 6) {
+        telemetry(
+            ["memory_usage_mb", "active_connections"],
+            category: Telemetry.Export.meter.rawValue,
+            perDay: 6
+        ) {
             .double($0.double(in: 120...480))
         }
-        telemetry(Self.recorders, category: Telemetry.Export.recorder.rawValue, perDay: 6) {
+        telemetry(
+            Self.recorders,
+            category: Telemetry.Export.recorder.rawValue,
+            perDay: 6
+        ) {
             .int($0.int(in: 200...9000))
         }
         // Timers are stored in seconds and rendered as durations, so sub-second values read naturally.
-        telemetry(Self.timers, category: Telemetry.Export.timer.rawValue, perDay: 6) {
+        telemetry(
+            Self.timers,
+            category: Telemetry.Export.timer.rawValue,
+            perDay: 6
+        ) {
             .double($0.double(in: 0.02...1.4))
         }
 
@@ -70,34 +96,61 @@ struct DemoMetrics {
             for day in stride(from: 40, through: 0, by: -20) {
                 samples.append(
                     DemoSample(
-                        name: name, category: ResetMarker.category, date: clock.momentDaysAgo(day),
-                        value: .int(random.int(in: 1...3))))
+                        name: name,
+                        category: ResetMarker.category,
+                        date: clock.momentDaysAgo(day),
+                        value: .int(random.int(in: 1...3))
+                    )
+                )
             }
         }
 
         for endpoint in Self.endpoints {
             samples += Self.histogram(
-                name: endpoint, categories: LatencyBuckets.categories, center: 0.45, scale: 180,
-                clock: clock, random: &random)
-            samples += Self.statuses(endpoint: endpoint, clock: clock, random: &random)
+                name: endpoint,
+                categories: LatencyBuckets.categories,
+                center: 0.45,
+                scale: 180,
+                clock: clock,
+                random: &random
+            )
+            samples += Self.statuses(
+                endpoint: endpoint,
+                clock: clock,
+                random: &random
+            )
         }
 
         for name in Self.timers {
             samples += Self.histogram(
-                name: name, categories: LatencyBuckets.categories, center: 0.4, scale: 140,
-                clock: clock, random: &random)
+                name: name,
+                categories: LatencyBuckets.categories,
+                center: 0.4,
+                scale: 140,
+                clock: clock,
+                random: &random
+            )
         }
         for name in Self.recorders {
             samples += Self.histogram(
-                name: name, categories: RecorderBuckets.categories, center: 0.55, scale: 140,
-                clock: clock, random: &random)
+                name: name,
+                categories: RecorderBuckets.categories,
+                center: 0.55,
+                scale: 140,
+                clock: clock,
+                random: &random
+            )
         }
 
         self.samples = samples
     }
 
     private static func histogram(
-        name: String, categories: [String], center ratio: Double, scale: Double, clock: DemoClock,
+        name: String,
+        categories: [String],
+        center ratio: Double,
+        scale: Double,
+        clock: DemoClock,
         random: inout DemoRandom
     ) -> [DemoSample] {
         var samples: [DemoSample] = []
@@ -109,8 +162,12 @@ struct DemoMetrics {
             for day in stride(from: 56, through: 0, by: -7) {
                 samples.append(
                     DemoSample(
-                        name: name, category: category, date: clock.momentDaysAgo(day),
-                        value: .int(Int((weight * scale).rounded()) + random.int(in: 0...4))))
+                        name: name,
+                        category: category,
+                        date: clock.momentDaysAgo(day),
+                        value: .int(Int((weight * scale).rounded()) + random.int(in: 0...4))
+                    )
+                )
             }
         }
         return samples
@@ -125,8 +182,12 @@ struct DemoMetrics {
             for day in stride(from: 56, through: 0, by: -7) {
                 samples.append(
                     DemoSample(
-                        name: endpoint, category: category, date: clock.momentDaysAgo(day),
-                        value: .int(Int((weight * 600).rounded()) + random.int(in: 0...2))))
+                        name: endpoint,
+                        category: category,
+                        date: clock.momentDaysAgo(day),
+                        value: .int(Int((weight * 600).rounded()) + random.int(in: 0...2))
+                    )
+                )
             }
         }
         return samples

--- a/Sources/Connectors/Demo/DemoReleases.swift
+++ b/Sources/Connectors/Demo/DemoReleases.swift
@@ -15,16 +15,32 @@ struct DemoReleases {
         var samples: [DemoSample] = []
 
         samples += scenario.sessions.map {
-            DemoSample(name: SessionEntry.recordType, version: $0.version.version, date: $0.start)
+            DemoSample(
+                name: SessionEntry.recordType,
+                version: $0.version.version,
+                date: $0.start
+            )
         }
         samples += incidents.crashes.map {
-            DemoSample(name: CrashEntry.recordType, version: $0.version, date: $0.date)
+            DemoSample(
+                name: CrashEntry.recordType,
+                version: $0.version,
+                date: $0.date
+            )
         }
         samples += incidents.hangs.map {
-            DemoSample(name: HangEntry.recordType, version: $0.version, date: $0.date)
+            DemoSample(
+                name: HangEntry.recordType,
+                version: $0.version,
+                date: $0.date
+            )
         }
         samples += scenario.adoption.map {
-            DemoSample(name: VersionEntry.recordType, version: $0.version, date: $0.date)
+            DemoSample(
+                name: VersionEntry.recordType,
+                version: $0.version,
+                date: $0.date
+            )
         }
         samples += DemoReleases.crashedInstalls(incidents.crashes)
 
@@ -37,7 +53,11 @@ struct DemoReleases {
             guard seen.insert("\(crash.installID)-\(crash.version)").inserted else {
                 return nil
             }
-            return DemoSample(name: MarkerEntry.crashName, version: crash.version, date: crash.date)
+            return DemoSample(
+                name: MarkerEntry.crashName,
+                version: crash.version,
+                date: crash.date
+            )
         }
     }
 }

--- a/Sources/Connectors/Demo/DemoSample.swift
+++ b/Sources/Connectors/Demo/DemoSample.swift
@@ -27,7 +27,11 @@ struct DemoSample {
 extension [DemoSample] {
     func series(matching query: SeriesQuery) -> [MetricSeries] {
         let groups = Dictionary(grouping: filter { $0.matches(query) }) {
-            SeriesKey(name: $0.name, category: $0.category, version: query.byVersion ? $0.version : nil)
+            SeriesKey(
+                name: $0.name,
+                category: $0.category,
+                version: query.byVersion ? $0.version : nil
+            )
         }
 
         return groups.compactMap { key, samples in
@@ -35,7 +39,12 @@ extension [DemoSample] {
             guard points.count > 0 else {
                 return nil
             }
-            return MetricSeries(name: key.name, category: key.category, version: key.version, points: points)
+            return MetricSeries(
+                name: key.name,
+                category: key.category,
+                version: key.version,
+                points: points
+            )
         }
     }
 

--- a/Sources/Connectors/Demo/DemoScenario.swift
+++ b/Sources/Connectors/Demo/DemoScenario.swift
@@ -68,9 +68,21 @@ struct DemoScenario {
         var random = DemoRandom(seed: 0x5C0_17_DE_A11)
 
         let versions = [
-            AppVersion(version: "2.1.0", build: "210", releasedDaysAgo: 64),
-            AppVersion(version: "2.2.0", build: "220", releasedDaysAgo: 35),
-            AppVersion(version: "2.3.0", build: "230", releasedDaysAgo: 12),
+            AppVersion(
+                version: "2.1.0",
+                build: "210",
+                releasedDaysAgo: 64
+            ),
+            AppVersion(
+                version: "2.2.0",
+                build: "220",
+                releasedDaysAgo: 35
+            ),
+            AppVersion(
+                version: "2.3.0",
+                build: "230",
+                releasedDaysAgo: 12
+            ),
         ]
         self.versions = versions
 
@@ -101,7 +113,11 @@ struct DemoScenario {
 
             let install = InstallInfo(
                 id: random.uuid(),
-                device: DeviceInfo(id: random.uuid(), model: model.0, os: model.1),
+                device: DeviceInfo(
+                    id: random.uuid(),
+                    model: model.0,
+                    os: model.1
+                ),
                 date: clock.momentDaysAgo(installDaysAgo),
                 version: activeVersion(daysAgo: installDaysAgo),
                 locale: locales[index % locales.count],

--- a/Sources/Connectors/Hosted/HTTPDatabase.swift
+++ b/Sources/Connectors/Hosted/HTTPDatabase.swift
@@ -26,9 +26,19 @@ extension HTTPDatabase {
     func ping() async throws {
         let query = RecordQuery(
             recordType: Event.self,
-            filters: [RecordQuery.Filter(field: "name", op: .equals, value: .string(""))]
+            filters: [
+                RecordQuery.Filter(
+                    field: "name",
+                    op: .equals,
+                    value: .string("")
+                )
+            ]
         )
-        _ = try await read(matching: query, fields: nil, limit: 1)
+        _ = try await read(
+            matching: query,
+            fields: nil,
+            limit: 1
+        )
     }
 }
 

--- a/Sources/Connectors/Hosted/HTTPRecordCoding.swift
+++ b/Sources/Connectors/Hosted/HTTPRecordCoding.swift
@@ -22,6 +22,10 @@ extension HTTPRecord {
     }
 
     func toRecord() -> Record {
-        Record(recordType: recordType, recordID: recordID, fields: fields)
+        Record(
+            recordType: recordType,
+            recordID: recordID,
+            fields: fields
+        )
     }
 }

--- a/Sources/Connectors/Hosted/HostedReader.swift
+++ b/Sources/Connectors/Hosted/HostedReader.swift
@@ -10,7 +10,11 @@ import Scout
 
 extension HTTPDatabase: DatabaseReader {
     func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
-        try await read(matching: query, fields: fields, limit: defaultRecordPageSize)
+        try await read(
+            matching: query,
+            fields: fields,
+            limit: defaultRecordPageSize
+        )
     }
 
     func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
@@ -18,7 +22,11 @@ extension HTTPDatabase: DatabaseReader {
     }
 
     private func run(query: HTTPQuery) async throws -> RecordChunk {
-        let response = try await send(query, to: "api/v1/records/query", into: HTTPQueryResponse.self)
+        let response = try await send(
+            query,
+            to: "api/v1/records/query",
+            into: HTTPQueryResponse.self
+        )
         return RecordChunk(
             records: response.records.map { $0.toRecord() },
             cursor: response.cursor.map { token in
@@ -33,7 +41,11 @@ extension HTTPDatabase: DatabaseReader {
 
     func lookup(recordName: String, fields: [String]?) async throws -> Record {
         let endpoint = recordEndpoint(recordName: recordName, fields: fields)
-        return try await get(from: endpoint, reason: "Malformed record URL", as: HTTPRecord.self).toRecord()
+        return try await get(
+            from: endpoint,
+            reason: "Malformed record URL",
+            as: HTTPRecord.self
+        ).toRecord()
     }
 
     private func get<T: Decodable>(from endpoint: URL?, reason: String, as type: T.Type) async throws -> T {
@@ -56,8 +68,12 @@ extension HTTPDatabase: DatabaseReader {
     }
 
     func series(matching query: SeriesQuery) async throws -> [MetricSeries] {
-        try await get(from: seriesEndpoint(for: query), reason: "Malformed metrics URL", as: MetricSeriesResponse.self)
-            .series
+        try await get(
+            from: seriesEndpoint(for: query),
+            reason: "Malformed metrics URL",
+            as: MetricSeriesResponse.self
+        )
+        .series
     }
 
     func seriesEndpoint(for query: SeriesQuery) -> URL? {
@@ -102,7 +118,11 @@ extension HTTPDatabase: DatabaseReader {
         let from = range.lowerBound.millisecondsSince1970
         let to = range.upperBound.millisecondsSince1970
         let endpoint = URL(string: "api/v1/metrics/active-users?from=\(from)&to=\(to)", relativeTo: url)
-        return try await get(from: endpoint, reason: "Malformed metrics URL", as: ActivityResponse.self).series
+        return try await get(
+            from: endpoint,
+            reason: "Malformed metrics URL",
+            as: ActivityResponse.self
+        ).series
     }
 
     private struct ActivityResponse: Decodable {
@@ -113,9 +133,17 @@ extension HTTPDatabase: DatabaseReader {
         let from = range.lowerBound.millisecondsSince1970
         let to = range.upperBound.millisecondsSince1970
         let endpoint = URL(string: "api/v1/metrics/retention?from=\(from)&to=\(to)", relativeTo: url)
-        let response = try await get(from: endpoint, reason: "Malformed metrics URL", as: RetentionResponse.self)
+        let response = try await get(
+            from: endpoint,
+            reason: "Malformed metrics URL",
+            as: RetentionResponse.self
+        )
         return response.cohorts.map {
-            RetentionCohort(date: $0.date, size: $0.size, retained: $0.retained)
+            RetentionCohort(
+                date: $0.date,
+                size: $0.size,
+                retained: $0.retained
+            )
         }
     }
 

--- a/Sources/Connectors/Hosted/HostedWriter.swift
+++ b/Sources/Connectors/Hosted/HostedWriter.swift
@@ -16,7 +16,11 @@ extension HTTPDatabase: DatabaseWriter {
     func write(records: [Record]) async throws {
         for chunk in records.chunked(into: Self.maxBatchSize) {
             let request = HTTPWriteRequest(records: chunk.map(HTTPRecord.init))
-            try await send(request, to: "api/v1/records", into: HTTPWriteAck.self)
+            try await send(
+                request,
+                to: "api/v1/records",
+                into: HTTPWriteAck.self
+            )
         }
     }
 

--- a/Sources/Connectors/Native/EntityCatalog.swift
+++ b/Sources/Connectors/Native/EntityCatalog.swift
@@ -125,7 +125,13 @@ enum EntityCatalog {
             ("param_count", .int),
             ("date", .timestamp),
         ],
-        views: [AggregateView(name: eventCountView, groupBy: "name", bucket: .hour)]
+        views: [
+            AggregateView(
+                name: eventCountView,
+                groupBy: "name",
+                bucket: .hour
+            )
+        ]
     )
 
     private static let session = definition(
@@ -218,7 +224,14 @@ enum EntityCatalog {
                     ("value", valueType),
                     ("date", .timestamp),
                 ],
-                views: [AggregateView(name: metricSeriesView, groupBy: metricSeriesKey, bucket: .hour, sum: "value")]
+                views: [
+                    AggregateView(
+                        name: metricSeriesView,
+                        groupBy: metricSeriesKey,
+                        bucket: .hour,
+                        sum: "value"
+                    )
+                ]
             ),
             derive: seriesKey
         )
@@ -227,14 +240,21 @@ enum EntityCatalog {
     private typealias Spec = (String, FieldType)
 
     private static func definition(
-        entity: String, fields: [Spec], trailing: [Spec] = [], envelopeDate: String = "date",
+        entity: String,
+        fields: [Spec],
+        trailing: [Spec] = [],
+        envelopeDate: String = "date",
         views: [AggregateView]? = nil
     )
         -> EntityDefinition
     {
         EntityDefinition(
-            entity: entity, version: 1, fields: slotted(fields + metadata + trailing), envelopeDate: envelopeDate,
-            views: views)
+            entity: entity,
+            version: 1,
+            fields: slotted(fields + metadata + trailing),
+            envelopeDate: envelopeDate,
+            views: views
+        )
     }
 
     private static let metadata: [Spec] = [
@@ -255,7 +275,17 @@ enum EntityCatalog {
             let index = next[pool, default: 0]
             next[pool] = index + 1
             return FieldDefinition(
-                name: name, type: type, storage: .slot(pool, String(format: "%@_%02d", pool.rawValue, index)))
+                name: name,
+                type: type,
+                storage: .slot(
+                    pool,
+                    String(
+                        format: "%@_%02d",
+                        pool.rawValue,
+                        index
+                    )
+                )
+            )
         }
     }
 

--- a/Sources/Connectors/Native/NativeDatabase.swift
+++ b/Sources/Connectors/Native/NativeDatabase.swift
@@ -23,7 +23,11 @@ struct NativeDatabase: Sendable {
 extension NativeDatabase: DatabaseWriter {
     func write(record: Record) async throws {
         await registration.value
-        try await store.write(Self.values(for: record), entity: record.recordType, uuid: record.recordID)
+        try await store.write(
+            Self.values(for: record),
+            entity: record.recordType,
+            uuid: record.recordID
+        )
     }
 
     func write(records: [Record]) async throws {
@@ -74,19 +78,35 @@ extension NativeDatabase: DatabaseReader {
     // re-queries the store for the following bounded slice instead of retaining
     // the whole pre-fetched tail in memory.
     private func page(
-        entity: String, filters: [EntityStore.Filter], field: String, ascending: Bool, limit: Int,
+        entity: String,
+        filters: [EntityStore.Filter],
+        field: String,
+        ascending: Bool,
+        limit: Int,
         after cursor: FieldCursor?
     ) async throws
         -> RecordChunk
     {
         let page = try await store.read(
-            entity: entity, filters: filters, orderedBy: field, descending: !ascending, limit: limit, after: cursor)
+            entity: entity,
+            filters: filters,
+            orderedBy: field,
+            descending: !ascending,
+            limit: limit,
+            after: cursor
+        )
         return RecordChunk(
             records: page.records.map(Record.init(entityRecord:)),
             cursor: page.cursor.map { next in
                 RecordCursor { _ in
                     try await self.page(
-                        entity: entity, filters: filters, field: field, ascending: ascending, limit: limit, after: next)
+                        entity: entity,
+                        filters: filters,
+                        field: field,
+                        ascending: ascending,
+                        limit: limit,
+                        after: next
+                    )
                 }
             }
         )
@@ -120,23 +140,44 @@ extension NativeDatabase {
         // back the days written before markers existed. The union dedupes, so
         // dropping the session leg once every client ships markers is safe.
         let window = lookback..<range.upperBound
-        async let markers = visits(entity: VisitEntry.recordType, dateField: "date", in: window)
-        async let sessions = visits(entity: SessionEntry.recordType, dateField: "start_date", in: window)
+        async let markers = visits(
+            entity: VisitEntry.recordType,
+            dateField: "date",
+            in: window
+        )
+        async let sessions = visits(
+            entity: SessionEntry.recordType,
+            dateField: "start_date",
+            in: window
+        )
 
         return ActivityPoint.points(visits: try await markers + sessions, in: range)
     }
 
     private func visits(entity: String, dateField: String, in window: Range<Date>) async throws -> [ActivityVisit] {
-        try await datedIDs(entity: entity, dateField: dateField, idField: "device_id", in: window)
-            .map { ActivityVisit(date: $0.date, user: $0.id) }
+        try await datedIDs(
+            entity: entity,
+            dateField: dateField,
+            idField: "device_id",
+            in: window
+        )
+        .map { ActivityVisit(date: $0.date, user: $0.id) }
     }
 }
 
 extension NativeDatabase {
     static func dateFilters(_ field: String, in range: Range<Date>) -> [EntityStore.Filter] {
         [
-            EntityStore.Filter(field: field, op: .greaterThanOrEquals, value: .date(range.lowerBound)),
-            EntityStore.Filter(field: field, op: .lessThan, value: .date(range.upperBound)),
+            EntityStore.Filter(
+                field: field,
+                op: .greaterThanOrEquals,
+                value: .date(range.lowerBound)
+            ),
+            EntityStore.Filter(
+                field: field,
+                op: .lessThan,
+                value: .date(range.upperBound)
+            ),
         ]
     }
 
@@ -144,7 +185,10 @@ extension NativeDatabase {
         -> [(date: Date, id: String)]
     {
         let records = try await store.read(
-            entity: entity, filters: Self.dateFilters(dateField, in: range), fields: [dateField, idField])
+            entity: entity,
+            filters: Self.dateFilters(dateField, in: range),
+            fields: [dateField, idField]
+        )
 
         return records.compactMap { record -> (date: Date, id: String)? in
             guard case .date(let date)? = record.values[dateField] else { return nil }
@@ -159,9 +203,17 @@ extension NativeDatabase {
         await registration.value
 
         async let installs = datedIDs(
-            entity: InstallEntry.recordType, dateField: "date", idField: "install_id", in: range)
+            entity: InstallEntry.recordType,
+            dateField: "date",
+            idField: "install_id",
+            in: range
+        )
         async let sessions = datedIDs(
-            entity: SessionEntry.recordType, dateField: "start_date", idField: "install_id", in: range)
+            entity: SessionEntry.recordType,
+            dateField: "start_date",
+            idField: "install_id",
+            in: range
+        )
 
         var installDays: [String: Date] = [:]
         for install in try await installs {
@@ -173,6 +225,11 @@ extension NativeDatabase {
             sessionDays[session.id, default: []].insert(session.date.startOfDay)
         }
 
-        return RetentionCohort.build(installDays: installDays, sessionDays: sessionDays, in: range, asOf: Date())
+        return RetentionCohort.build(
+            installDays: installDays,
+            sessionDays: sessionDays,
+            in: range,
+            asOf: Date()
+        )
     }
 }

--- a/Sources/Connectors/Native/NativeSeries.swift
+++ b/Sources/Connectors/Native/NativeSeries.swift
@@ -24,7 +24,11 @@ struct NativeSeries {
             try await collectInt(into: &intTotals, store: store)
         }
         if query.values != .int && collectsDoubleMetrics {
-            try await collectMetrics(entity: DoubleMetricsEntry.recordType, into: &doubleTotals, store: store)
+            try await collectMetrics(
+                entity: DoubleMetricsEntry.recordType,
+                into: &doubleTotals,
+                store: store
+            )
         }
 
         var series: [MetricSeries] = []
@@ -61,11 +65,22 @@ struct NativeSeries {
         -> [MetricSeries]
     {
         let filters = [
-            EntityStore.Filter(field: "date", op: .greaterThanOrEquals, value: .date(from)),
-            EntityStore.Filter(field: "date", op: .lessThan, value: .date(query.range.upperBound)),
+            EntityStore.Filter(
+                field: "date",
+                op: .greaterThanOrEquals,
+                value: .date(from)
+            ),
+            EntityStore.Filter(
+                field: "date",
+                op: .lessThan,
+                value: .date(query.range.upperBound)
+            ),
         ]
         let records = try await store.read(
-            entity: entity, filters: filters, fields: ["date", "value", "name", "category"])
+            entity: entity,
+            filters: filters,
+            fields: ["date", "value", "name", "category"]
+        )
 
         var latest: [GroupKey: [Date: (date: Date, sample: Double)]] = [:]
         for record in records {
@@ -83,7 +98,11 @@ struct NativeSeries {
             default: continue
             }
 
-            let key = GroupKey(name: name, category: category.flatMap { $0.isEmpty ? nil : $0 }, version: nil)
+            let key = GroupKey(
+                name: name,
+                category: category.flatMap { $0.isEmpty ? nil : $0 },
+                version: nil
+            )
             let bucket = bucketStart(of: date)
             if let existing = latest[key]?[bucket], existing.date >= date { continue }
             latest[key, default: [:]][bucket] = (date, sample)
@@ -94,7 +113,12 @@ struct NativeSeries {
                 buckets
                 .sorted { $0.key < $1.key }
                 .map { MetricSeriesPoint(date: $0.key.millisecondsSince1970, value: value($0.value.sample)) }
-            return MetricSeries(name: key.name, category: key.category, version: key.version, points: points)
+            return MetricSeries(
+                name: key.name,
+                category: key.category,
+                version: key.version,
+                points: points
+            )
         }
     }
 
@@ -122,13 +146,25 @@ struct NativeSeries {
     private func collectInt(into totals: inout [GroupKey: [Date: Double]], store: EntityStore) async throws {
         switch query.source {
         case .event:
-            try await collectEvents(name: query.name, into: &totals, store: store)
+            try await collectEvents(
+                name: query.name,
+                into: &totals,
+                store: store
+            )
         case .lifecycle:
             if let source = query.name.flatMap(Self.lifecycle(named:)) {
-                try await collectCounts(of: source, into: &totals, store: store)
+                try await collectCounts(
+                    of: source,
+                    into: &totals,
+                    store: store
+                )
             }
         case .metric:
-            try await collectMetrics(entity: IntMetricsEntry.recordType, into: &totals, store: store)
+            try await collectMetrics(
+                entity: IntMetricsEntry.recordType,
+                into: &totals,
+                store: store
+            )
         case nil:
             try await collectGuessed(into: &totals, store: store)
         }
@@ -137,19 +173,51 @@ struct NativeSeries {
     private func collectGuessed(into totals: inout [GroupKey: [Date: Double]], store: EntityStore) async throws {
         switch (query.name, query.category) {
         case (nil, nil):
-            try await collectEvents(name: nil, into: &totals, store: store)
-            try await collectCounts(of: .crashes, into: &totals, store: store)
-            try await collectCounts(of: .hangs, into: &totals, store: store)
-            try await collectMetrics(entity: IntMetricsEntry.recordType, into: &totals, store: store)
+            try await collectEvents(
+                name: nil,
+                into: &totals,
+                store: store
+            )
+            try await collectCounts(
+                of: .crashes,
+                into: &totals,
+                store: store
+            )
+            try await collectCounts(
+                of: .hangs,
+                into: &totals,
+                store: store
+            )
+            try await collectMetrics(
+                entity: IntMetricsEntry.recordType,
+                into: &totals,
+                store: store
+            )
         case (let name?, nil):
             if let source = Self.lifecycle(named: name) {
-                try await collectCounts(of: source, into: &totals, store: store)
+                try await collectCounts(
+                    of: source,
+                    into: &totals,
+                    store: store
+                )
             } else {
-                try await collectEvents(name: name, into: &totals, store: store)
-                try await collectMetrics(entity: IntMetricsEntry.recordType, into: &totals, store: store)
+                try await collectEvents(
+                    name: name,
+                    into: &totals,
+                    store: store
+                )
+                try await collectMetrics(
+                    entity: IntMetricsEntry.recordType,
+                    into: &totals,
+                    store: store
+                )
             }
         default:
-            try await collectMetrics(entity: IntMetricsEntry.recordType, into: &totals, store: store)
+            try await collectMetrics(
+                entity: IntMetricsEntry.recordType,
+                into: &totals,
+                store: store
+            )
         }
     }
 
@@ -168,10 +236,21 @@ struct NativeSeries {
         async throws
     {
         let points = try await store.series(
-            entity: EventEntry.recordType, view: EntityCatalog.eventCountView, from: from, to: query.range.upperBound)
+            entity: EventEntry.recordType,
+            view: EntityCatalog.eventCountView,
+            from: from,
+            to: query.range.upperBound
+        )
 
         for point in points where point.date >= from && (name == nil || point.group == name) {
-            add(Double(point.count), name: point.group, category: nil, version: nil, date: point.date, to: &totals)
+            add(
+                Double(point.count),
+                name: point.group,
+                category: nil,
+                version: nil,
+                date: point.date,
+                to: &totals
+            )
         }
     }
 
@@ -179,7 +258,11 @@ struct NativeSeries {
         async throws
     {
         let points = try await store.series(
-            entity: entity, view: EntityCatalog.metricSeriesView, from: from, to: query.range.upperBound)
+            entity: entity,
+            view: EntityCatalog.metricSeriesView,
+            from: from,
+            to: query.range.upperBound
+        )
 
         for point in points where point.date >= from {
             guard let (category, metric) = EntityCatalog.decodeSeriesKey(point.group) else { continue }
@@ -205,19 +288,38 @@ struct NativeSeries {
     private func collectCounts(of source: Source, into totals: inout [GroupKey: [Date: Double]], store: EntityStore)
         async throws
     {
-        let (entity, dateField, name) = Self.layout(of: source)
+        let (
+            entity,
+            dateField,
+            name
+        ) = Self.layout(of: source)
         let filters = [
-            EntityStore.Filter(field: dateField, op: .greaterThanOrEquals, value: .date(from)),
-            EntityStore.Filter(field: dateField, op: .lessThan, value: .date(query.range.upperBound)),
+            EntityStore.Filter(
+                field: dateField,
+                op: .greaterThanOrEquals,
+                value: .date(from)
+            ),
+            EntityStore.Filter(
+                field: dateField,
+                op: .lessThan,
+                value: .date(query.range.upperBound)
+            ),
         ]
 
         let records = try await store.read(
-            entity: entity, filters: filters, fields: [dateField, "app_version", "install_id"])
+            entity: entity,
+            filters: filters,
+            fields: [dateField, "app_version", "install_id"]
+        )
         var visits = records.compactMap { record -> (date: Date, version: String?, install: String?)? in
             guard case .date(let date)? = record.values[dateField] else { return nil }
             let version: String? = record["app_version"]
             let install: String? = record["install_id"]
-            return (date, version, install)
+            return (
+                date,
+                version,
+                install
+            )
         }
 
         if source == .firstCrashes {
@@ -258,10 +360,18 @@ struct NativeSeries {
     }
 
     private func add(
-        _ value: Double, name: String, category: String?, version: String?, date: Date,
+        _ value: Double,
+        name: String,
+        category: String?,
+        version: String?,
+        date: Date,
         to totals: inout [GroupKey: [Date: Double]]
     ) {
-        let key = GroupKey(name: name, category: category, version: version)
+        let key = GroupKey(
+            name: name,
+            category: category,
+            version: version
+        )
         totals[key, default: [:]][bucketStart(of: date), default: 0] += value
     }
 
@@ -271,7 +381,12 @@ struct NativeSeries {
             .filter { $0.value != 0 }
             .sorted { $0.key < $1.key }
             .map { MetricSeriesPoint(date: $0.key.millisecondsSince1970, value: value($0.value)) }
-        return MetricSeries(name: key.name, category: key.category, version: key.version, points: points)
+        return MetricSeries(
+            name: key.name,
+            category: key.category,
+            version: key.version,
+            points: points
+        )
     }
 
     private struct GroupKey: Hashable {

--- a/Sources/Connectors/Native/NativeValues.swift
+++ b/Sources/Connectors/Native/NativeValues.swift
@@ -65,7 +65,11 @@ extension Record {
 
 extension RecordQuery.Filter {
     var storeFilter: EntityStore.Filter {
-        EntityStore.Filter(field: field, op: storeMatch, value: value.storeValue)
+        EntityStore.Filter(
+            field: field,
+            op: storeMatch,
+            value: value.storeValue
+        )
     }
 
     private var storeMatch: EntityStore.Match {

--- a/Sources/LookupIndex/CachedDatabase.swift
+++ b/Sources/LookupIndex/CachedDatabase.swift
@@ -23,7 +23,11 @@ struct CachedDatabase: Database {
     }
 
     func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
-        try await base.read(matching: query, fields: fields, limit: limit)
+        try await base.read(
+            matching: query,
+            fields: fields,
+            limit: limit
+        )
     }
 
     func lookup(recordName: String, fields: [String]?) async throws -> Record {
@@ -55,7 +59,11 @@ struct CachedDatabase: Database {
         }
 
         let fingerprint = CachedMetricSeries.fingerprint(scope: scope, query: query)
-        var cachedUpper = await cachedUpper(for: fingerprint, in: query.range, frozenUpper: frozenUpper)
+        var cachedUpper = await cachedUpper(
+            for: fingerprint,
+            in: query.range,
+            frozenUpper: frozenUpper
+        )
 
         var cached: [Record] = []
         if cachedUpper > query.range.lowerBound {
@@ -74,7 +82,11 @@ struct CachedDatabase: Database {
 
             if cachedUpper < frozenUpper {
                 let records = CachedMetricSeries.records(from: fetched)
-                await cache.store(records, for: fingerprint, covering: cachedUpper..<frozenUpper)
+                await cache.store(
+                    records,
+                    for: fingerprint,
+                    covering: cachedUpper..<frozenUpper
+                )
             }
         }
         return CachedMetricSeries.series(cached: cached, fetched: fetched)
@@ -113,7 +125,11 @@ enum DatabaseCacheRegistry {
 
     static func database(for backend: Backend) -> any Database {
         guard let cache = sharedCache() else { return backend.database }
-        return CachedDatabase(base: backend.database, scope: backend.id, cache: cache)
+        return CachedDatabase(
+            base: backend.database,
+            scope: backend.id,
+            cache: cache
+        )
     }
 
     private static func sharedCache() -> (any RecordCaching)? {

--- a/Sources/LookupIndex/CachedMetricSeries.swift
+++ b/Sources/LookupIndex/CachedMetricSeries.swift
@@ -49,7 +49,11 @@ enum CachedMetricSeries {
                 if case .string(let category)? = record.fields["category"] { category } else { nil }
             let version: String? =
                 if case .string(let version)? = record.fields["app_version"] { version } else { nil }
-            let key = SeriesKey(name: name, category: category, version: version)
+            let key = SeriesKey(
+                name: name,
+                category: category,
+                version: version
+            )
             groups.append(MetricSeriesPoint(date: date.millisecondsSince1970, value: value), to: key)
         }
 

--- a/Sources/LookupIndex/CachedRecordPayload.swift
+++ b/Sources/LookupIndex/CachedRecordPayload.swift
@@ -22,6 +22,11 @@ struct CachedRecordPayload: Codable {
     }
 
     var record: Record {
-        Record(recordType: recordType, recordID: recordID, fields: fields, metadata: metadata)
+        Record(
+            recordType: recordType,
+            recordID: recordID,
+            fields: fields,
+            metadata: metadata
+        )
     }
 }

--- a/Sources/LookupIndex/RecordCache.swift
+++ b/Sources/LookupIndex/RecordCache.swift
@@ -49,7 +49,13 @@ actor RecordCache<Row: CacheRow> {
             guard case .date(let date)? = record.fields["date"] else { return }
             guard range.contains(date) else { continue }
             guard let payload = try? encoder.encode(CachedRecordPayload(record: record)) else { return }
-            entries.append(Row(fingerprint: fingerprint, date: date, payload: payload))
+            entries.append(
+                Row(
+                    fingerprint: fingerprint,
+                    date: date,
+                    payload: payload
+                )
+            )
         }
 
         if let span = span(for: fingerprint), span.lowerDate <= range.lowerBound, range.lowerBound <= span.upperDate {
@@ -58,7 +64,12 @@ actor RecordCache<Row: CacheRow> {
         } else {
             deleteAll(for: fingerprint)
             modelContext.insert(
-                CachedSpan(fingerprint: fingerprint, lowerDate: range.lowerBound, upperDate: range.upperBound))
+                CachedSpan(
+                    fingerprint: fingerprint,
+                    lowerDate: range.lowerBound,
+                    upperDate: range.upperBound
+                )
+            )
         }
 
         for entry in entries {
@@ -79,7 +90,13 @@ actor RecordCache<Row: CacheRow> {
         guard let payload = try? JSONEncoder().encode(CachedRecordPayload(record: record)) else { return }
         let predicate = #Predicate<Row> { $0.fingerprint == fingerprint }
         try? modelContext.delete(model: Row.self, where: predicate)
-        modelContext.insert(Row(fingerprint: fingerprint, date: .distantPast, payload: payload))
+        modelContext.insert(
+            Row(
+                fingerprint: fingerprint,
+                date: .distantPast,
+                payload: payload
+            )
+        )
         try? modelContext.save()
     }
 

--- a/Sources/LookupIndex/RecordCacheStore.swift
+++ b/Sources/LookupIndex/RecordCacheStore.swift
@@ -76,13 +76,25 @@ enum RecordCacheStore {
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let url = directory.appending(path: "RecordCache.store")
         if #available(iOS 18, macOS 15, *) {
-            return cache(IndexedCachedRecord.self, at: url, defaults: .standard)
+            return cache(
+                IndexedCachedRecord.self,
+                at: url,
+                defaults: .standard
+            )
         }
-        return cache(CachedRecord.self, at: url, defaults: .standard)
+        return cache(
+            CachedRecord.self,
+            at: url,
+            defaults: .standard
+        )
     }
 
     static func cache<Row: CacheRow>(_ row: Row.Type, at url: URL, defaults: UserDefaults) -> RecordCache<Row>? {
-        container(for: row, at: url, defaults: defaults).map { RecordCache<Row>(modelContainer: $0) }
+        container(
+            for: row,
+            at: url,
+            defaults: defaults
+        ).map { RecordCache<Row>(modelContainer: $0) }
     }
 
     // The cache is disposable: any schema mismatch destroys the store instead of migrating.

--- a/Sources/Scout/Activity/MarkerEntry.Trigger.swift
+++ b/Sources/Scout/Activity/MarkerEntry.Trigger.swift
@@ -12,9 +12,17 @@ extension MarkerEntry {
         let installID: UUID
 
         func execute(in context: NSManagedObjectContext) throws {
-            let install = try context.existing(InstallEntry.self, key: "installID", id: installID)
+            let install = try context.existing(
+                InstallEntry.self,
+                key: "installID",
+                id: installID
+            )
             try MarkerEntry.mark(
-                name: MarkerEntry.installName, install: install, appVersion: Bundle.main.marketingVersion, in: context)
+                name: MarkerEntry.installName,
+                install: install,
+                appVersion: Bundle.main.marketingVersion,
+                in: context
+            )
 
             if context.hasChanges {
                 try context.save()

--- a/Sources/Scout/Activity/RetentionCohort+Build.swift
+++ b/Sources/Scout/Activity/RetentionCohort+Build.swift
@@ -27,7 +27,10 @@ extension RetentionCohort {
     /// - Returns: one cohort per install week in `range`, sorted by week ascending.
     ///
     package static func build(
-        installDays: [String: Date], sessionDays: [String: Set<Date>], in range: Range<Date>, asOf: Date
+        installDays: [String: Date],
+        sessionDays: [String: Set<Date>],
+        in range: Range<Date>,
+        asOf: Date
     )
         -> [RetentionCohort]
     {
@@ -43,7 +46,11 @@ extension RetentionCohort {
 
             let active = sessionDays[install] ?? []
             for (index, offset) in dayOffsets.enumerated() {
-                let target = calendar.date(byAdding: .day, value: offset, to: installDay)!
+                let target = calendar.date(
+                    byAdding: .day,
+                    value: offset,
+                    to: installDay
+                )!
                 if active.contains(target) {
                     counts[week, default: [:]][index, default: 0] += 1
                 }
@@ -54,7 +61,11 @@ extension RetentionCohort {
             let cohortCounts = counts[week] ?? [:]
 
             let retained = dayOffsets.enumerated().map { index, offset -> Int? in
-                let matured = calendar.date(byAdding: .day, value: 7 + offset, to: week)!
+                let matured = calendar.date(
+                    byAdding: .day,
+                    value: 7 + offset,
+                    to: week
+                )!
                 guard matured < asOf else {
                     return nil
                 }

--- a/Sources/Scout/Activity/VisitEntry.Trigger.swift
+++ b/Sources/Scout/Activity/VisitEntry.Trigger.swift
@@ -23,7 +23,11 @@ extension VisitEntry {
             let visit = context.insert(VisitEntry.self)
             visit.visitID = UUID()
             visit.date = date
-            visit.launch = try context.existing(LaunchEntry.self, key: "launchID", id: launchID)
+            visit.launch = try context.existing(
+                LaunchEntry.self,
+                key: "launchID",
+                id: launchID
+            )
             try context.save()
         }
     }

--- a/Sources/Scout/Database/Access/Range+Predicate.swift
+++ b/Sources/Scout/Database/Access/Range+Predicate.swift
@@ -10,8 +10,16 @@ import Foundation
 extension Range<Date> {
     package var dateFilters: [RecordQuery.Filter] {
         [
-            RecordQuery.Filter(field: "date", op: .greaterThanOrEquals, value: .date(lowerBound)),
-            RecordQuery.Filter(field: "date", op: .lessThan, value: .date(upperBound)),
+            RecordQuery.Filter(
+                field: "date",
+                op: .greaterThanOrEquals,
+                value: .date(lowerBound)
+            ),
+            RecordQuery.Filter(
+                field: "date",
+                op: .lessThan,
+                value: .date(upperBound)
+            ),
         ]
     }
 }

--- a/Sources/Scout/Database/Record/RecordValue.swift
+++ b/Sources/Scout/Database/Record/RecordValue.swift
@@ -38,7 +38,8 @@ extension RecordValue: Codable {
             self = .strings(value)
         } else {
             throw DecodingError.dataCorrupted(
-                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown field value type"))
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown field value type")
+            )
         }
     }
 

--- a/Sources/Scout/Diagnostics/Crash/Crash.swift
+++ b/Sources/Scout/Diagnostics/Crash/Crash.swift
@@ -20,8 +20,16 @@ package struct Crash {
     package let sessionID: UUID?
 
     package init(
-        name: String, fingerprint: String, reason: String?, stackTrace: [String], date: Date?, id: String,
-        deviceID: UUID?, installID: UUID?, launchID: UUID?, sessionID: UUID?
+        name: String,
+        fingerprint: String,
+        reason: String?,
+        stackTrace: [String],
+        date: Date?,
+        id: String,
+        deviceID: UUID?,
+        installID: UUID?,
+        launchID: UUID?,
+        sessionID: UUID?
     ) {
         self.name = name
         self.fingerprint = fingerprint
@@ -74,7 +82,12 @@ extension Crash: RecordDecodable {
             stackTrace = []
         }
         fingerprint =
-            record["fingerprint"] ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value
+            record["fingerprint"]
+            ?? CrashFingerprint(
+                name: name,
+                reason: reason,
+                stackTrace: stackTrace
+            ).value
     }
 }
 

--- a/Sources/Scout/Diagnostics/Crash/CrashArchive.swift
+++ b/Sources/Scout/Diagnostics/Crash/CrashArchive.swift
@@ -13,7 +13,11 @@ struct CrashArchive {
     private let archive: IncidentArchive<CrashInfo>
 
     init(directory: URL) {
-        archive = IncidentArchive(directory: directory, pathExtension: "crash", persist: logCrash)
+        archive = IncidentArchive(
+            directory: directory,
+            pathExtension: "crash",
+            persist: logCrash
+        )
     }
 
     static let system = CrashArchive(

--- a/Sources/Scout/Diagnostics/Crash/CrashFingerprint.swift
+++ b/Sources/Scout/Diagnostics/Crash/CrashFingerprint.swift
@@ -14,7 +14,11 @@ package struct CrashFingerprint {
     package let value: String
 
     package init(name: String, reason: String?, stackTrace: [String]) {
-        let signature = Self.signature(name: name, reason: reason, stackTrace: stackTrace)
+        let signature = Self.signature(
+            name: name,
+            reason: reason,
+            stackTrace: stackTrace
+        )
         value = SHA256.hash(data: Data(signature.utf8)).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/Scout/Diagnostics/Hang/Hang.swift
+++ b/Sources/Scout/Diagnostics/Hang/Hang.swift
@@ -21,8 +21,17 @@ package struct Hang {
     package let sessionID: UUID?
 
     package init(
-        name: String, fingerprint: String, reason: String?, stackTrace: [String], duration: TimeInterval, date: Date?,
-        id: String, deviceID: UUID?, installID: UUID?, launchID: UUID?, sessionID: UUID?
+        name: String,
+        fingerprint: String,
+        reason: String?,
+        stackTrace: [String],
+        duration: TimeInterval,
+        date: Date?,
+        id: String,
+        deviceID: UUID?,
+        installID: UUID?,
+        launchID: UUID?,
+        sessionID: UUID?
     ) {
         self.name = name
         self.fingerprint = fingerprint
@@ -78,7 +87,12 @@ extension Hang: RecordDecodable {
         }
         // Stored fingerprints from older builds hashed the reason, which embeds
         // the per-occurrence duration — recompute so legacy records group too.
-        fingerprint = CrashFingerprint(name: name, reason: nil, stackTrace: stackTrace).value
+        fingerprint =
+            CrashFingerprint(
+                name: name,
+                reason: nil,
+                stackTrace: stackTrace
+            ).value
     }
 }
 

--- a/Sources/Scout/Diagnostics/Hang/HangArchive.swift
+++ b/Sources/Scout/Diagnostics/Hang/HangArchive.swift
@@ -13,7 +13,11 @@ struct HangArchive {
     private let archive: IncidentArchive<HangInfo>
 
     init(directory: URL) {
-        archive = IncidentArchive(directory: directory, pathExtension: "hang", persist: logHang)
+        archive = IncidentArchive(
+            directory: directory,
+            pathExtension: "hang",
+            persist: logHang
+        )
     }
 
     static let system = HangArchive(

--- a/Sources/Scout/Diagnostics/Hang/MainThreadBacktrace.swift
+++ b/Sources/Scout/Diagnostics/Hang/MainThreadBacktrace.swift
@@ -121,7 +121,12 @@ enum MainThreadBacktrace {
 
         let result = withUnsafeMutablePointer(to: &state) { pointer in
             pointer.withMemoryRebound(to: natural_t.self, capacity: Int(count)) { rebound in
-                thread_get_state(thread, thread_state_flavor_t(ARM_THREAD_STATE64), rebound, &count)
+                thread_get_state(
+                    thread,
+                    thread_state_flavor_t(ARM_THREAD_STATE64),
+                    rebound,
+                    &count
+                )
             }
         }
 
@@ -135,7 +140,12 @@ enum MainThreadBacktrace {
 
         let result = withUnsafeMutablePointer(to: &state) { pointer in
             pointer.withMemoryRebound(to: natural_t.self, capacity: Int(count)) { rebound in
-                thread_get_state(thread, thread_state_flavor_t(x86_THREAD_STATE64), rebound, &count)
+                thread_get_state(
+                    thread,
+                    thread_state_flavor_t(x86_THREAD_STATE64),
+                    rebound,
+                    &count
+                )
             }
         }
 

--- a/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
+++ b/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
@@ -10,7 +10,13 @@ import CoreData
 struct IncidentArchive<Payload: Codable & Sendable> {
     let directory: URL
     let pathExtension: String
-    let persist: @Sendable (Payload, UUID, UUID, NSManagedObjectContext) throws -> Void
+    let persist:
+        @Sendable (
+            Payload,
+            UUID,
+            UUID,
+            NSManagedObjectContext
+        ) throws -> Void
 
     func write(_ payload: Payload) {
         let encoder = JSONEncoder()
@@ -47,7 +53,12 @@ struct IncidentArchive<Payload: Codable & Sendable> {
             do {
                 let id = UUID(uuidString: file.deletingPathExtension().lastPathComponent) ?? UUID()
                 try await persistentContainer.performBackgroundTask { context in
-                    try persist(payload, id, deviceID, context)
+                    try persist(
+                        payload,
+                        id,
+                        deviceID,
+                        context
+                    )
                 }
                 try FileManager.default.removeItem(at: file)
             } catch {

--- a/Sources/Scout/Diagnostics/Incident/IncidentEntry.swift
+++ b/Sources/Scout/Diagnostics/Incident/IncidentEntry.swift
@@ -22,7 +22,12 @@ extension HasSession where Self: IncidentEntry {
 
         record["name"] = name
         record["fingerprint"] =
-            fingerprint ?? CrashFingerprint(name: name ?? "", reason: reason, stackTrace: decodedStackTrace).value
+            fingerprint
+            ?? CrashFingerprint(
+                name: name ?? "",
+                reason: reason,
+                stackTrace: decodedStackTrace
+            ).value
         record["reason"] = reason
         record["stack_trace"] = stackTrace
         record["date"] = date

--- a/Sources/Scout/Diagnostics/Incident/LogIncident.swift
+++ b/Sources/Scout/Diagnostics/Incident/LogIncident.swift
@@ -21,7 +21,11 @@ protocol IncidentInfo {
 
 extension CrashInfo: IncidentInfo {
     var fingerprint: String {
-        CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value
+        CrashFingerprint(
+            name: name,
+            reason: reason,
+            stackTrace: stackTrace
+        ).value
     }
 }
 
@@ -29,19 +33,33 @@ extension HangInfo: IncidentInfo {
     // A hang's reason embeds the per-occurrence duration, which would make
     // every fingerprint unique — identity comes from the name and stack alone.
     var fingerprint: String {
-        CrashFingerprint(name: name, reason: nil, stackTrace: stackTrace).value
+        CrashFingerprint(
+            name: name,
+            reason: nil,
+            stackTrace: stackTrace
+        ).value
     }
 }
 
 func logIncident<Entry: IncidentEntry, Info: IncidentInfo>(
-    _ info: Info, id: UUID, deviceID: UUID, entityName: String, idKey: String, markerName: String,
-    context: NSManagedObjectContext, configure: (Entry, SessionEntry) -> Void
+    _ info: Info,
+    id: UUID,
+    deviceID: UUID,
+    entityName: String,
+    idKey: String,
+    markerName: String,
+    context: NSManagedObjectContext,
+    configure: (Entry, SessionEntry) -> Void
 ) throws {
     // The id doubles as the archive file's UUID, so a flush interrupted
     // between the save and the file removal doesn't insert a duplicate
     // on the next launch.
     let request = NSFetchRequest<Entry>(entityName: entityName)
-    request.predicate = NSPredicate(format: "%K == %@", idKey, id as CVarArg)
+    request.predicate = NSPredicate(
+        format: "%K == %@",
+        idKey,
+        id as CVarArg
+    )
     request.fetchLimit = 1
     guard try context.count(for: request) == 0 else { return }
 

--- a/Sources/Scout/Diagnostics/Log/Event.swift
+++ b/Sources/Scout/Diagnostics/Log/Event.swift
@@ -19,8 +19,15 @@ package struct Event: Identifiable {
     package let deviceID: UUID?
 
     package init(
-        name: String, level: EventLevel?, date: Date?, paramCount: Int?, uuid: UUID?, id: String, installID: UUID?,
-        sessionID: UUID?, deviceID: UUID?
+        name: String,
+        level: EventLevel?,
+        date: Date?,
+        paramCount: Int?,
+        uuid: UUID?,
+        id: String,
+        installID: UUID?,
+        sessionID: UUID?,
+        deviceID: UUID?
     ) {
         self.name = name
         self.level = level

--- a/Sources/Scout/Diagnostics/Log/Log.swift
+++ b/Sources/Scout/Diagnostics/Log/Log.swift
@@ -13,7 +13,11 @@ func log(_ event: LogEvent, date: Date, sessionID: UUID, context: NSManagedObjec
 
     object.eventID = UUID()
     object.date = date
-    object.session = try context.existing(SessionEntry.self, key: "sessionID", id: sessionID)
+    object.session = try context.existing(
+        SessionEntry.self,
+        key: "sessionID",
+        id: sessionID
+    )
     object.level = event.level.rawValue
     object.name = event.message.description
 

--- a/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
+++ b/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
@@ -27,7 +27,12 @@ struct ScoutLogHandler: LogHandler {
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
-                    try Scout.log(event, date: Date(), sessionID: sessionID, context: context)
+                    try Scout.log(
+                        event,
+                        date: Date(),
+                        sessionID: sessionID,
+                        context: context
+                    )
                 }
                 try await self.sync()
             } catch {

--- a/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
+++ b/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
@@ -9,7 +9,10 @@ import Foundation
 
 extension DatabaseReader {
     package func metricSeries<T: MetricScalar>(
-        _ valueType: T.Type, category: String, reduce: SeriesQuery.Reduce = .sum, in range: Range<Date>
+        _ valueType: T.Type,
+        category: String,
+        reduce: SeriesQuery.Reduce = .sum,
+        in range: Range<Date>
     ) async throws -> [MetricSeries] {
         try await series(
             matching: SeriesQuery(
@@ -23,12 +26,18 @@ extension DatabaseReader {
     }
 
     package func metricSeries<T: MetricScalar>(
-        _ valueType: T.Type, categories: [String], in range: Range<Date>
+        _ valueType: T.Type,
+        categories: [String],
+        in range: Range<Date>
     ) async throws -> [MetricSeries] {
         try await withThrowingTaskGroup(of: [MetricSeries].self) { group in
             for category in categories {
                 group.addTask {
-                    try await self.metricSeries(T.self, category: category, in: range)
+                    try await self.metricSeries(
+                        T.self,
+                        category: category,
+                        in: range
+                    )
                 }
             }
             var series: [MetricSeries] = []
@@ -67,8 +76,14 @@ package struct SeriesQuery: Sendable {
     package var range: Range<Date>
 
     package init(
-        name: String? = nil, category: String? = nil, values: Values? = nil, bucket: Bucket = .day,
-        byVersion: Bool = false, source: Source? = nil, reduce: Reduce = .sum, range: Range<Date>
+        name: String? = nil,
+        category: String? = nil,
+        values: Values? = nil,
+        bucket: Bucket = .day,
+        byVersion: Bool = false,
+        source: Source? = nil,
+        reduce: Reduce = .sum,
+        range: Range<Date>
     ) {
         self.name = name
         self.category = category

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryFactory.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryFactory.swift
@@ -13,24 +13,48 @@ struct TelemetryFactory: MetricsFactory {
     let session: Protected<UUID>
 
     func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
-        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        TelemetryHandler(
+            label: label,
+            dimensions: dimensions,
+            sync: sync,
+            session: session
+        )
     }
 
     func makeFloatingPointCounter(label: String, dimensions: [(String, String)]) -> FloatingPointCounterHandler {
-        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        TelemetryHandler(
+            label: label,
+            dimensions: dimensions,
+            sync: sync,
+            session: session
+        )
     }
 
     func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
-        GaugeHandler(label: label, sync: sync, session: session)
+        GaugeHandler(
+            label: label,
+            sync: sync,
+            session: session
+        )
     }
 
     func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
         guard aggregate else { return GaugeHandler(label: label, sync: sync, session: session) }
-        return TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        return TelemetryHandler(
+            label: label,
+            dimensions: dimensions,
+            sync: sync,
+            session: session
+        )
     }
 
     func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
-        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        TelemetryHandler(
+            label: label,
+            dimensions: dimensions,
+            sync: sync,
+            session: session
+        )
     }
 
     func destroyCounter(_ handler: CounterHandler) {}

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -17,7 +17,14 @@ extension TelemetryPersisting {
         let label = self.label
         let sessionID = session.current
         persistMetrics { context in
-            try saveMetrics(label, date: Date(), category: category, value: value, sessionID: sessionID, context)
+            try saveMetrics(
+                label,
+                date: Date(),
+                category: category,
+                value: value,
+                sessionID: sessionID,
+                context
+            )
         }
     }
 
@@ -27,11 +34,21 @@ extension TelemetryPersisting {
         persistMetrics { context in
             let date = Date()
             try saveMetrics(
-                label, date: date, category: Telemetry.Export.timer.rawValue, value: seconds, sessionID: sessionID,
-                context)
+                label,
+                date: date,
+                category: Telemetry.Export.timer.rawValue,
+                value: seconds,
+                sessionID: sessionID,
+                context
+            )
             try saveMetrics(
-                label, date: date, category: LatencyBuckets.category(for: seconds), value: 1, sessionID: sessionID,
-                context)
+                label,
+                date: date,
+                category: LatencyBuckets.category(for: seconds),
+                value: 1,
+                sessionID: sessionID,
+                context
+            )
         }
     }
 
@@ -45,11 +62,21 @@ extension TelemetryPersisting {
         persistMetrics { context in
             let date = Date()
             try saveMetrics(
-                label, date: date, category: Telemetry.Export.recorder.rawValue, value: value, sessionID: sessionID,
-                context)
+                label,
+                date: date,
+                category: Telemetry.Export.recorder.rawValue,
+                value: value,
+                sessionID: sessionID,
+                context
+            )
             try saveMetrics(
-                label, date: date, category: RecorderBuckets.category(for: value), value: 1, sessionID: sessionID,
-                context)
+                label,
+                date: date,
+                category: RecorderBuckets.category(for: value),
+                value: 1,
+                sessionID: sessionID,
+                context
+            )
         }
     }
 
@@ -69,7 +96,12 @@ extension TelemetryPersisting {
 }
 
 func saveMetrics<T: MetricScalar>(
-    _ name: String, date: Date, category: String, value: T, sessionID: UUID, _ context: NSManagedObjectContext
+    _ name: String,
+    date: Date,
+    category: String,
+    value: T,
+    sessionID: UUID,
+    _ context: NSManagedObjectContext
 ) throws {
     let metrics = context.insert(T.Object.self)
 
@@ -77,7 +109,11 @@ func saveMetrics<T: MetricScalar>(
     metrics.telemetry = category
     metrics.date = date
     metrics.name = name
-    metrics.session = try context.existing(SessionEntry.self, key: "sessionID", id: sessionID)
+    metrics.session = try context.existing(
+        SessionEntry.self,
+        key: "sessionID",
+        id: sessionID
+    )
 
     try context.save()
 }

--- a/Sources/Scout/Identity/ActionTable.swift
+++ b/Sources/Scout/Identity/ActionTable.swift
@@ -18,7 +18,11 @@ struct ActionTable {
 
     func startListening(completion: @escaping Action) {
         for (name, action) in actions {
-            NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil) { _ in
+            NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: nil
+            ) { _ in
                 Task {
                     await run(action)
                     await run(completion)

--- a/Sources/Scout/Lifecycle/Base/CurrentHub.swift
+++ b/Sources/Scout/Lifecycle/Base/CurrentHub.swift
@@ -10,7 +10,11 @@ import CoreData
 extension NSManagedObjectContext {
     func existing<T: NSManagedObject>(_ type: T.Type, key: String, id: UUID) throws -> T? {
         let request = NSFetchRequest<T>(entityName: String(describing: type))
-        request.predicate = NSPredicate(format: "%K == %@", key, id as CVarArg)
+        request.predicate = NSPredicate(
+            format: "%K == %@",
+            key,
+            id as CVarArg
+        )
         request.sortDescriptors = [NSSortDescriptor(key: DateEntry.datePrimitiveKey, ascending: false)]
         request.fetchLimit = 1
         return try fetch(request).first
@@ -19,21 +23,37 @@ extension NSManagedObjectContext {
     func linkedSession(deviceID: UUID, installID: UUID, launchID: UUID, sessionID: UUID, date: Date) throws
         -> SessionEntry
     {
-        let device = try fetchOrCreate(DeviceEntry.self, key: "deviceID", id: deviceID) {
+        let device = try fetchOrCreate(
+            DeviceEntry.self,
+            key: "deviceID",
+            id: deviceID
+        ) {
             $0.deviceID = deviceID
             $0.date = date
         }
-        let install = try fetchOrCreate(InstallEntry.self, key: "installID", id: installID) {
+        let install = try fetchOrCreate(
+            InstallEntry.self,
+            key: "installID",
+            id: installID
+        ) {
             $0.installID = installID
             $0.date = date
             $0.device = device
         }
-        let launch = try fetchOrCreate(LaunchEntry.self, key: "launchID", id: launchID) {
+        let launch = try fetchOrCreate(
+            LaunchEntry.self,
+            key: "launchID",
+            id: launchID
+        ) {
             $0.launchID = launchID
             $0.date = date
             $0.install = install
         }
-        return try fetchOrCreate(SessionEntry.self, key: "sessionID", id: sessionID) {
+        return try fetchOrCreate(
+            SessionEntry.self,
+            key: "sessionID",
+            id: sessionID
+        ) {
             $0.sessionID = sessionID
             $0.date = date
             $0.launch = launch

--- a/Sources/Scout/Lifecycle/Install/InstallEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Install/InstallEntry.Trigger.swift
@@ -24,7 +24,11 @@ extension InstallEntry {
             let install = context.insert(InstallEntry.self)
             install.installID = installID
             install.date = Date()
-            install.device = try context.existing(DeviceEntry.self, key: "deviceID", id: deviceID)
+            install.device = try context.existing(
+                DeviceEntry.self,
+                key: "deviceID",
+                id: deviceID
+            )
             try context.save()
         }
     }

--- a/Sources/Scout/Lifecycle/Launch/LaunchEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Launch/LaunchEntry.Trigger.swift
@@ -16,7 +16,11 @@ extension LaunchEntry {
             let launch = context.insert(LaunchEntry.self)
             launch.launchID = launchID
             launch.date = Date()
-            launch.install = try context.existing(InstallEntry.self, key: "installID", id: installID)
+            launch.install = try context.existing(
+                InstallEntry.self,
+                key: "installID",
+                id: installID
+            )
             try context.save()
         }
     }

--- a/Sources/Scout/Lifecycle/Session/SessionEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.Trigger.swift
@@ -20,7 +20,11 @@ extension SessionEntry {
             let object = context.insert(SessionEntry.self)
             object.sessionID = sessionID
             object.date = Date()
-            object.launch = try context.existing(LaunchEntry.self, key: "launchID", id: launchID)
+            object.launch = try context.existing(
+                LaunchEntry.self,
+                key: "launchID",
+                id: launchID
+            )
             object.appVersion = bundle.marketingVersion
             object.buildNumber = bundle.buildNumber
             object.osVersion = SystemInfo.osVersion

--- a/Sources/Scout/Lifecycle/Version/VersionEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Version/VersionEntry.Trigger.swift
@@ -31,7 +31,11 @@ extension VersionEntry {
             version.date = Date()
             version.appVersion = appVersion
             version.buildNumber = buildNumber
-            version.launch = try context.existing(LaunchEntry.self, key: "launchID", id: launchID)
+            version.launch = try context.existing(
+                LaunchEntry.self,
+                key: "launchID",
+                id: launchID
+            )
             try context.save()
         }
     }

--- a/Sources/Scout/Setup/Setup.swift
+++ b/Sources/Scout/Setup/Setup.swift
@@ -55,7 +55,11 @@ public func setup(backends: [Backend]) async throws {
     identity.table.startListening(completion: sync)
 
     LoggingSystem.bootstrap {
-        ScoutLogHandler(sync: sync, session: session, label: $0)
+        ScoutLogHandler(
+            sync: sync,
+            session: session,
+            label: $0
+        )
     }
     MetricsSystem.bootstrap(
         TelemetryFactory(sync: sync, session: session)

--- a/Sources/Scout/Utilities/Array+Chunked.swift
+++ b/Sources/Scout/Utilities/Array+Chunked.swift
@@ -9,7 +9,11 @@ import Foundation
 
 extension Array {
     package func chunked(into size: Int) -> [[Element]] {
-        stride(from: 0, to: count, by: size).map {
+        stride(
+            from: 0,
+            to: count,
+            by: size
+        ).map {
             Array(self[$0..<Swift.min($0 + size, count)])
         }
     }

--- a/Sources/Scout/Utilities/Date/Date+Add.swift
+++ b/Sources/Scout/Utilities/Date/Date+Add.swift
@@ -9,22 +9,42 @@ import Foundation
 
 extension Date {
     package func adding(_ component: Calendar.Component, value: Int = 1) -> Date {
-        Calendar.utc.date(byAdding: component, value: value, to: self)!
+        Calendar.utc.date(
+            byAdding: component,
+            value: value,
+            to: self
+        )!
     }
 
     package func addingDay(_ value: Int = 1) -> Date {
-        Calendar.utc.date(byAdding: .day, value: value, to: self)!
+        Calendar.utc.date(
+            byAdding: .day,
+            value: value,
+            to: self
+        )!
     }
 
     package func addingWeek(_ value: Int = 1) -> Date {
-        Calendar.utc.date(byAdding: .weekOfYear, value: value, to: self)!
+        Calendar.utc.date(
+            byAdding: .weekOfYear,
+            value: value,
+            to: self
+        )!
     }
 
     package func addingMonth(_ value: Int = 1) -> Date {
-        Calendar.utc.date(byAdding: .month, value: value, to: self)!
+        Calendar.utc.date(
+            byAdding: .month,
+            value: value,
+            to: self
+        )!
     }
 
     package func addingYear(_ value: Int = 1) -> Date {
-        Calendar.utc.date(byAdding: .year, value: value, to: self)!
+        Calendar.utc.date(
+            byAdding: .year,
+            value: value,
+            to: self
+        )!
     }
 }

--- a/Sources/Scout/Utilities/Dispatcher/Dispatcher.swift
+++ b/Sources/Scout/Utilities/Dispatcher/Dispatcher.swift
@@ -25,7 +25,9 @@ extension Dispatcher {
             try await perform { @MainActor in
                 let work = Task(operation: work)
                 let task = UIApplication.shared.beginBackgroundTask(
-                    withName: "scout.sync", expirationHandler: work.cancel)
+                    withName: "scout.sync",
+                    expirationHandler: work.cancel
+                )
 
                 defer { UIApplication.shared.endBackgroundTask(task) }
 

--- a/Sources/ScoutUI/Analytics/Event/Analytics/EventFilter.swift
+++ b/Sources/ScoutUI/Analytics/Event/Analytics/EventFilter.swift
@@ -10,7 +10,13 @@ import SwiftUI
 
 extension View {
     func eventFilter(_ filter: Binding<EventQuery>, provider: EventProvider, search: EventProvider) -> some View {
-        modifier(EventFilter(filter: filter, provider: provider, search: search))
+        modifier(
+            EventFilter(
+                filter: filter,
+                provider: provider,
+                search: search
+            )
+        )
     }
 }
 

--- a/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
@@ -88,10 +88,18 @@ extension EventView {
 
     let param = ParamProvider(.success(params.sorted()), recordID: event.id)
 
-    let stat = StatProvider(.success(.samples), eventName: event.name, periods: Period.allCases)
+    let stat = StatProvider(
+        .success(.samples),
+        eventName: event.name,
+        periods: Period.allCases
+    )
 
     return NavigationStack {
-        EventView(event: event, param: param, stat: stat)
+        EventView(
+            event: event,
+            param: param,
+            stat: stat
+        )
     }
     .environmentObject(Tint())
 }

--- a/Sources/ScoutUI/Analytics/Event/Detail/StatRow.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/StatRow.swift
@@ -30,7 +30,13 @@ struct StatRow<Destination: View>: View {
             Spacer()
 
             RowSummary(
-                series: points.map { MiniChartSeries(points: $0, range: period.initialRange, aggregation: .total) },
+                series: points.map {
+                    MiniChartSeries(
+                        points: $0,
+                        range: period.initialRange,
+                        aggregation: .total
+                    )
+                },
                 count: points?.bucket(on: period).total,
                 color: color
             )

--- a/Sources/ScoutUI/Analytics/Event/Provider/EventQuery.swift
+++ b/Sources/ScoutUI/Analytics/Event/Provider/EventQuery.swift
@@ -29,19 +29,49 @@ struct EventQuery: Hashable {
         var filters: [RecordQuery.Filter] = []
 
         if levels != EventQuery.allLevels {
-            filters.append(RecordQuery.Filter(field: "level", op: .in, value: .strings(levels.map(\.rawValue))))
+            filters.append(
+                RecordQuery.Filter(
+                    field: "level",
+                    op: .in,
+                    value: .strings(levels.map(\.rawValue))
+                )
+            )
         }
         if !text.isEmpty {
-            filters.append(RecordQuery.Filter(field: "name", op: .beginsWith, value: .string(text)))
+            filters.append(
+                RecordQuery.Filter(
+                    field: "name",
+                    op: .beginsWith,
+                    value: .string(text)
+                )
+            )
         }
         if !name.isEmpty {
-            filters.append(RecordQuery.Filter(field: "name", op: .equals, value: .string(name)))
+            filters.append(
+                RecordQuery.Filter(
+                    field: "name",
+                    op: .equals,
+                    value: .string(name)
+                )
+            )
         }
         if let sessionID {
-            filters.append(RecordQuery.Filter(field: "session_id", op: .equals, value: .string(sessionID.uuidString)))
+            filters.append(
+                RecordQuery.Filter(
+                    field: "session_id",
+                    op: .equals,
+                    value: .string(sessionID.uuidString)
+                )
+            )
         }
         if let deviceID {
-            filters.append(RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString)))
+            filters.append(
+                RecordQuery.Filter(
+                    field: "device_id",
+                    op: .equals,
+                    value: .string(deviceID.uuidString)
+                )
+            )
         }
         if let dates {
             filters.append(contentsOf: dates.dateFilters)

--- a/Sources/ScoutUI/Analytics/Retention/RetentionCohort+Fixture.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionCohort+Fixture.swift
@@ -29,7 +29,11 @@ extension RetentionCohort: Fixture {
                 return day == 0 ? 1 : min(target * quality, 0.95)
             }
 
-            return RetentionCohort(id: start, size: size, retention: retention)
+            return RetentionCohort(
+                id: start,
+                size: size,
+                retention: retention
+            )
         }
     }
 }

--- a/Sources/ScoutUI/Analytics/Retention/RetentionCohort.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionCohort.swift
@@ -48,8 +48,11 @@ extension RetentionCohort {
             let rates = cohorts.compactMap { $0.retention[index] }
             guard rates.count > 0 else { return nil }
             return DayStat(
-                day: day, average: rates.reduce(0, +) / Double(rates.count), low: rates.min() ?? 0,
-                high: rates.max() ?? 0)
+                day: day,
+                average: rates.reduce(0, +) / Double(rates.count),
+                low: rates.min() ?? 0,
+                high: rates.max() ?? 0
+            )
         }
     }
 }

--- a/Sources/ScoutUI/Analytics/Retention/RetentionCohortDetailView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionCohortDetailView.swift
@@ -60,7 +60,8 @@ struct RetentionCohortDetailView: View {
                         AxisGridLine()
                         if let rate = value.as(Double.self) {
                             AxisValueLabel(
-                                rate.formatted(.retentionRate))
+                                rate.formatted(.retentionRate)
+                            )
                         }
                     }
                 }
@@ -93,8 +94,16 @@ struct RetentionCohortDetailView: View {
 
     private var legend: some View {
         HStack(spacing: 16) {
-            RetentionLegendItem(color: .green, dashed: false, title: "This cohort")
-            RetentionLegendItem(color: Color(.systemGray4), dashed: true, title: "Average")
+            RetentionLegendItem(
+                color: .green,
+                dashed: false,
+                title: "This cohort"
+            )
+            RetentionLegendItem(
+                color: Color(.systemGray4),
+                dashed: true,
+                title: "Average"
+            )
         }
     }
 

--- a/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionHeroChartView.swift
@@ -71,7 +71,8 @@ private struct RetentionHeroChart: View {
                         AxisGridLine()
                         if let rate = value.as(Double.self) {
                             AxisValueLabel(
-                                rate.formatted(.retentionRate))
+                                rate.formatted(.retentionRate)
+                            )
                         }
                     }
                 }

--- a/Sources/ScoutUI/Analytics/Retention/RetentionSegmentDetailView.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionSegmentDetailView.swift
@@ -65,7 +65,8 @@ struct RetentionSegmentDetailView: View {
                         AxisGridLine()
                         if let rate = value.as(Double.self) {
                             AxisValueLabel(
-                                rate.formatted(.retentionRate))
+                                rate.formatted(.retentionRate)
+                            )
                         }
                     }
                 }
@@ -80,8 +81,16 @@ struct RetentionSegmentDetailView: View {
             Header(title: "Stability")
 
             HStack(spacing: 24) {
-                stabilityStat(title: "Crashes", value: segment.crashRate, color: .red)
-                stabilityStat(title: "Hangs", value: segment.hangRate, color: .orange)
+                stabilityStat(
+                    title: "Crashes",
+                    value: segment.crashRate,
+                    color: .red
+                )
+                stabilityStat(
+                    title: "Hangs",
+                    value: segment.hangRate,
+                    color: .orange
+                )
             }
 
             if crashMultiplier > 1.2 {
@@ -99,8 +108,16 @@ struct RetentionSegmentDetailView: View {
 
     private var legend: some View {
         HStack(spacing: 16) {
-            RetentionLegendItem(color: .orange, dashed: false, title: segment.name)
-            RetentionLegendItem(color: Color(.systemGray4), dashed: true, title: "Cohort")
+            RetentionLegendItem(
+                color: .orange,
+                dashed: false,
+                title: segment.name
+            )
+            RetentionLegendItem(
+                color: Color(.systemGray4),
+                dashed: true,
+                title: "Cohort"
+            )
         }
     }
 

--- a/Sources/ScoutUI/Analytics/Session/SessionHeader.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionHeader.swift
@@ -15,19 +15,41 @@ struct SessionHeader: View {
         VStack(alignment: .leading, spacing: 12) {
             FlowLayout(spacing: 6) {
                 if let model = info.model.map(DeviceModel.init) {
-                    InfoChip(systemImage: model.symbol, text: model.name, color: .blue)
+                    InfoChip(
+                        systemImage: model.symbol,
+                        text: model.name,
+                        color: .blue
+                    )
                 }
                 if let osVersion = info.osVersion {
-                    InfoChip(systemImage: "gearshape", text: osVersion, color: .indigo)
+                    InfoChip(
+                        systemImage: "gearshape",
+                        text: osVersion,
+                        color: .indigo
+                    )
                 }
                 if let locale = info.locale {
-                    InfoChip(systemImage: "globe", text: locale, color: .teal, monospaced: true)
+                    InfoChip(
+                        systemImage: "globe",
+                        text: locale,
+                        color: .teal,
+                        monospaced: true
+                    )
                 }
                 if let channel = info.channel {
-                    InfoChip(systemImage: info.channelIcon, text: channel, color: info.channelColor)
+                    InfoChip(
+                        systemImage: info.channelIcon,
+                        text: channel,
+                        color: info.channelColor
+                    )
                 }
                 if let version = info.version {
-                    InfoChip(systemImage: "tag", text: version, color: .green, monospaced: true)
+                    InfoChip(
+                        systemImage: "tag",
+                        text: version,
+                        color: .green,
+                        monospaced: true
+                    )
                 }
             }
 

--- a/Sources/ScoutUI/Delivery/Devices/Model/DeviceSummary.swift
+++ b/Sources/ScoutUI/Delivery/Devices/Model/DeviceSummary.swift
@@ -30,7 +30,8 @@ extension DeviceSummary {
         let sessionsByDevice = Dictionary(grouping: sessions.compactMap(SessionFields.init), by: \.deviceID)
         let crashCounts = Dictionary(
             crashes.compactMap { (record: Record) -> String? in record["device_id"] }.map { ($0, 1) },
-            uniquingKeysWith: +)
+            uniquingKeysWith: +
+        )
         let models: [String: String] = devices.reduce(into: [:]) { models, device in
             if let deviceID: String = device["device_id"], let model: String = device["model"] {
                 models[deviceID] = model
@@ -71,31 +72,76 @@ extension DeviceSummary {
 extension DeviceSummary: Fixture {
     static let samples: [DeviceSummary] = [
         DeviceSummary(
-            id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -15 * 60),
-            sessions: 812, crashes: 3),
+            id: UUID(),
+            model: "iPhone15,3",
+            osVersion: "iOS 17.4",
+            lastSeen: Date(timeIntervalSinceNow: -15 * 60),
+            sessions: 812,
+            crashes: 3
+        ),
         DeviceSummary(
-            id: UUID(), model: "iPhone15,3", osVersion: "iOS 17.3", lastSeen: Date(timeIntervalSinceNow: -3 * 3600),
-            sessions: 540, crashes: 0),
+            id: UUID(),
+            model: "iPhone15,3",
+            osVersion: "iOS 17.3",
+            lastSeen: Date(timeIntervalSinceNow: -3 * 3600),
+            sessions: 540,
+            crashes: 0
+        ),
         DeviceSummary(
-            id: UUID(), model: "iPhone14,2", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -6 * 3600),
-            sessions: 391, crashes: 1),
+            id: UUID(),
+            model: "iPhone14,2",
+            osVersion: "iOS 17.4",
+            lastSeen: Date(timeIntervalSinceNow: -6 * 3600),
+            sessions: 391,
+            crashes: 1
+        ),
         DeviceSummary(
-            id: UUID(), model: "iPhone14,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -2 * 86400),
-            sessions: 205, crashes: 0),
+            id: UUID(),
+            model: "iPhone14,2",
+            osVersion: "iOS 16.7",
+            lastSeen: Date(timeIntervalSinceNow: -2 * 86400),
+            sessions: 205,
+            crashes: 0
+        ),
         DeviceSummary(
-            id: UUID(), model: "iPhone13,2", osVersion: "iOS 17.3", lastSeen: Date(timeIntervalSinceNow: -1 * 86400),
-            sessions: 178, crashes: 2),
+            id: UUID(),
+            model: "iPhone13,2",
+            osVersion: "iOS 17.3",
+            lastSeen: Date(timeIntervalSinceNow: -1 * 86400),
+            sessions: 178,
+            crashes: 2
+        ),
         DeviceSummary(
-            id: UUID(), model: "iPhone13,2", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -9 * 86400),
-            sessions: 96, crashes: 0),
+            id: UUID(),
+            model: "iPhone13,2",
+            osVersion: "iOS 16.7",
+            lastSeen: Date(timeIntervalSinceNow: -9 * 86400),
+            sessions: 96,
+            crashes: 0
+        ),
         DeviceSummary(
-            id: UUID(), model: "iPad13,1", osVersion: "iOS 17.4", lastSeen: Date(timeIntervalSinceNow: -4 * 3600),
-            sessions: 143, crashes: 0),
+            id: UUID(),
+            model: "iPad13,1",
+            osVersion: "iOS 17.4",
+            lastSeen: Date(timeIntervalSinceNow: -4 * 3600),
+            sessions: 143,
+            crashes: 0
+        ),
         DeviceSummary(
-            id: UUID(), model: "iPad14,1", osVersion: "iOS 17.2", lastSeen: Date(timeIntervalSinceNow: -12 * 86400),
-            sessions: 64, crashes: 1),
+            id: UUID(),
+            model: "iPad14,1",
+            osVersion: "iOS 17.2",
+            lastSeen: Date(timeIntervalSinceNow: -12 * 86400),
+            sessions: 64,
+            crashes: 1
+        ),
         DeviceSummary(
-            id: UUID(), model: "iPhone12,1", osVersion: "iOS 16.7", lastSeen: Date(timeIntervalSinceNow: -30 * 86400),
-            sessions: 22, crashes: 0),
+            id: UUID(),
+            model: "iPhone12,1",
+            osVersion: "iOS 16.7",
+            lastSeen: Date(timeIntervalSinceNow: -30 * 86400),
+            sessions: 22,
+            crashes: 0
+        ),
     ]
 }

--- a/Sources/ScoutUI/Delivery/Devices/Model/DevicesReport.swift
+++ b/Sources/ScoutUI/Delivery/Devices/Model/DevicesReport.swift
@@ -20,7 +20,11 @@ struct DevicesReport {
 
 extension DevicesReport {
     init(devices: [Record], sessions: [Record], crashes: [Record]) {
-        summaries = DeviceSummary.summaries(devices: devices, sessions: sessions, crashes: crashes)
+        summaries = DeviceSummary.summaries(
+            devices: devices,
+            sessions: sessions,
+            crashes: crashes
+        )
         visits = sessions.compactMap { record in
             guard let deviceID: String = record["device_id"], let date: Date = record["start_date"] else {
                 return nil

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
@@ -21,16 +21,36 @@ struct DeviceDetailView: View {
     var body: some View {
         InsetList {
             FlowLayout(spacing: 6) {
-                InfoChip(systemImage: device.symbol, text: device.modelName, color: .blue)
-                InfoChip(systemImage: "gearshape", text: device.osVersion, color: .indigo)
-                InfoChip(systemImage: "clock", text: "seen \(device.lastSeen.relativeString)", color: .teal)
+                InfoChip(
+                    systemImage: device.symbol,
+                    text: device.modelName,
+                    color: .blue
+                )
+                InfoChip(
+                    systemImage: "gearshape",
+                    text: device.osVersion,
+                    color: .indigo
+                )
+                InfoChip(
+                    systemImage: "clock",
+                    text: "seen \(device.lastSeen.relativeString)",
+                    color: .teal
+                )
             }
             .listRowSeparator(.hidden)
             .padding(.vertical)
 
             HStack(spacing: 28) {
-                Readout(title: "Sessions", value: device.sessions.plain, color: .primary)
-                Readout(title: "Crashes", value: device.crashes.plain, color: device.crashes > 0 ? .red : .primary)
+                Readout(
+                    title: "Sessions",
+                    value: device.sessions.plain,
+                    color: .primary
+                )
+                Readout(
+                    title: "Crashes",
+                    value: device.crashes.plain,
+                    color: device.crashes > 0 ? .red : .primary
+                )
                 Spacer()
             }
 

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceIncidentsProvider.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceIncidentsProvider.swift
@@ -29,7 +29,13 @@ final class DeviceIncidentsProvider: ObservableObject, Provider {
     private func query(for recordType: any RecordDecodable.Type) -> RecordQuery {
         RecordQuery(
             recordType: recordType,
-            filters: [RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))],
+            filters: [
+                RecordQuery.Filter(
+                    field: "device_id",
+                    op: .equals,
+                    value: .string(deviceID.uuidString)
+                )
+            ],
             sort: [RecordQuery.Sort(field: "date", ascending: false)]
         )
     }

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesProvider.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesProvider.swift
@@ -32,6 +32,10 @@ final class DevicesProvider: ObservableObject, Provider {
             fields: ["device_id"]
         )
 
-        return try await DevicesReport(devices: devices, sessions: sessions, crashes: crashes)
+        return try await DevicesReport(
+            devices: devices,
+            sessions: sessions,
+            crashes: crashes
+        )
     }
 }

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesView.swift
@@ -37,9 +37,21 @@ struct DevicesView: View {
 
         return InsetList {
             HStack(spacing: 28) {
-                Readout(title: "Devices", value: devices.count.plain, color: .primary)
-                Readout(title: "Active 7d", value: activeCount.plain, color: .blue)
-                Readout(title: "With Crashes", value: crashingCount.plain, color: crashingCount > 0 ? .red : .primary)
+                Readout(
+                    title: "Devices",
+                    value: devices.count.plain,
+                    color: .primary
+                )
+                Readout(
+                    title: "Active 7d",
+                    value: activeCount.plain,
+                    color: .blue
+                )
+                Readout(
+                    title: "With Crashes",
+                    value: crashingCount.plain,
+                    color: crashingCount > 0 ? .red : .primary
+                )
                 Spacer()
             }
 

--- a/Sources/ScoutUI/Delivery/Releases/View/DailyCount.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/DailyCount.swift
@@ -15,7 +15,10 @@ struct DailyCount: Equatable {
 
 extension DailyCount {
     static func series(
-        from records: [some Incident], days: Int = 14, calendar: Calendar = .current, endingOn today: Date = Date()
+        from records: [some Incident],
+        days: Int = 14,
+        calendar: Calendar = .current,
+        endingOn today: Date = Date()
     ) -> [DailyCount] {
         let start = calendar.startOfDay(for: today)
 
@@ -26,7 +29,12 @@ extension DailyCount {
         }
 
         return (0..<days).reversed().map { offset in
-            let day = calendar.date(byAdding: .day, value: -offset, to: start) ?? start
+            let day =
+                calendar.date(
+                    byAdding: .day,
+                    value: -offset,
+                    to: start
+                ) ?? start
             return DailyCount(date: day, count: counts[day] ?? 0)
         }
     }

--- a/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthProvider.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/ReleaseHealthProvider.swift
@@ -36,6 +36,12 @@ final class ReleaseHealthProvider: ObservableObject, Provider {
     }
 
     private func query(name: String, in range: Range<Date>) -> SeriesQuery {
-        SeriesQuery(name: name, bucket: .day, byVersion: true, source: .lifecycle, range: range)
+        SeriesQuery(
+            name: name,
+            bucket: .day,
+            byVersion: true,
+            source: .lifecycle,
+            range: range
+        )
     }
 }

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -18,7 +18,8 @@ struct VersionDetailView: View {
     @State private var showAllHangs = false
 
     init(
-        release: ReleaseHealth, crashes: VersionIncidentProvider<Crash>? = nil,
+        release: ReleaseHealth,
+        crashes: VersionIncidentProvider<Crash>? = nil,
         hangs: VersionIncidentProvider<Hang>? = nil
     ) {
         self.release = release
@@ -47,13 +48,21 @@ struct VersionDetailView: View {
             .padding(.bottom, 4)
             .listRowSeparator(.hidden, edges: .top)
 
-            IncidentTrendSection(title: "Crashes", records: crashRecords, color: .red) {
+            IncidentTrendSection(
+                title: "Crashes",
+                records: crashRecords,
+                color: .red
+            ) {
                 if crashRecords.count > 0 {
                     AllButton { showAllCrashes = true }
                 }
             }
 
-            IncidentTrendSection(title: "Hangs", records: hangRecords, color: .orange) {
+            IncidentTrendSection(
+                title: "Hangs",
+                records: hangRecords,
+                color: .orange
+            ) {
                 if hangRecords.count > 0 {
                     AllButton { showAllHangs = true }
                 }

--- a/Sources/ScoutUI/Home/Connection/Connection.swift
+++ b/Sources/ScoutUI/Home/Connection/Connection.swift
@@ -24,7 +24,12 @@ extension Connection {
     }
 
     func refreshingStatus() async -> Connection {
-        Connection(id: id, name: name, status: await probe(), probe: probe)
+        Connection(
+            id: id,
+            name: name,
+            status: await probe(),
+            probe: probe
+        )
     }
 }
 
@@ -49,9 +54,24 @@ extension [Connection] {
 extension Connection: Fixture {
     static var samples: [Connection] {
         [
-            Connection(id: "https://api.scout.app", name: "Production", status: .reachable, probe: { .reachable }),
-            Connection(id: "https://staging.scout.app", name: "Staging", status: .unknown, probe: { .unknown }),
-            Connection(id: "http://localhost:8080", name: "Local", status: .unreachable, probe: { .unreachable }),
+            Connection(
+                id: "https://api.scout.app",
+                name: "Production",
+                status: .reachable,
+                probe: { .reachable }
+            ),
+            Connection(
+                id: "https://staging.scout.app",
+                name: "Staging",
+                status: .unknown,
+                probe: { .unknown }
+            ),
+            Connection(
+                id: "http://localhost:8080",
+                name: "Local",
+                status: .unreachable,
+                probe: { .unreachable }
+            ),
         ]
     }
 }

--- a/Sources/ScoutUI/Home/Connection/ConnectionRow.swift
+++ b/Sources/ScoutUI/Home/Connection/ConnectionRow.swift
@@ -49,8 +49,18 @@ struct ConnectionRow: View {
 
 #Preview {
     VStack(spacing: 0) {
-        ConnectionRow(connection: [Connection].samples[0], isActive: true, showsSeparator: true, action: {})
-        ConnectionRow(connection: [Connection].samples[1], isActive: false, showsSeparator: false, action: {})
+        ConnectionRow(
+            connection: [Connection].samples[0],
+            isActive: true,
+            showsSeparator: true,
+            action: {}
+        )
+        ConnectionRow(
+            connection: [Connection].samples[1],
+            isActive: false,
+            showsSeparator: false,
+            action: {}
+        )
     }
     .frame(minWidth: 240)
 }

--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -66,7 +66,11 @@ struct HomeList: View {
             case .sessions:
                 statView
             case .log:
-                LogView(period: period, log: logs, devices: devices)
+                LogView(
+                    period: period,
+                    log: logs,
+                    devices: devices
+                )
             case .releaseHealth:
                 ReleaseHealthView(provider: releases)
             case .alerts:
@@ -80,9 +84,13 @@ struct HomeList: View {
     }
 
     private var statView: some View {
-        StatView(showList: false, extent: ChartExtent(period: period), stat: sessions)
-            .environment(\.chartColor, .purple)
-            .navigationTitle(en: "Sessions")
+        StatView(
+            showList: false,
+            extent: ChartExtent(period: period),
+            stat: sessions
+        )
+        .environment(\.chartColor, .purple)
+        .navigationTitle(en: "Sessions")
     }
 }
 

--- a/Sources/ScoutUI/Home/Search/Detail/EndpointSearchDetail.swift
+++ b/Sources/ScoutUI/Home/Search/Detail/EndpointSearchDetail.swift
@@ -18,7 +18,11 @@ struct EndpointSearchDetail: View {
             let range = Period.today.initialRange
 
             if let endpoint = report.endpoints(in: range).first(where: { $0.name == name }) {
-                NetworkEndpointDetailView(endpoint: endpoint, report: report, range: range)
+                NetworkEndpointDetailView(
+                    endpoint: endpoint,
+                    report: report,
+                    range: range
+                )
             } else {
                 Placeholder(
                     text: "No requests",

--- a/Sources/ScoutUI/Home/Search/Detail/MetricSearchDetail.swift
+++ b/Sources/ScoutUI/Home/Search/Detail/MetricSearchDetail.swift
@@ -15,11 +15,23 @@ struct MetricSearchDetail: View {
     var body: some View {
         switch telemetry {
         case .floatingCounter, .recorder, .meter:
-            MetricSearchContent(name: name, telemetry: telemetry, formatter: \Double.decimal)
+            MetricSearchContent(
+                name: name,
+                telemetry: telemetry,
+                formatter: \Double.decimal
+            )
         case .timer:
-            MetricSearchContent(name: name, telemetry: telemetry, formatter: \TimeInterval.duration)
+            MetricSearchContent(
+                name: name,
+                telemetry: telemetry,
+                formatter: \TimeInterval.duration
+            )
         default:
-            MetricSearchContent(name: name, telemetry: telemetry, formatter: \Int.plain)
+            MetricSearchContent(
+                name: name,
+                telemetry: telemetry,
+                formatter: \Int.plain
+            )
         }
     }
 }
@@ -45,7 +57,11 @@ private struct MetricSearchContent<T: ChartNumeric>: View {
             if let group = groups.named(name) {
                 switch telemetry {
                 case .timer:
-                    MetricsView(group: group, formatter: formatter, period: .today) { extent in
+                    MetricsView(
+                        group: group,
+                        formatter: formatter,
+                        period: .today
+                    ) { extent in
                         MetricDistributionSection<LatencyHistogram>(
                             name: group.name,
                             categories: LatencyBuckets.categories,
@@ -54,7 +70,11 @@ private struct MetricSearchContent<T: ChartNumeric>: View {
                         )
                     }
                 case .recorder:
-                    MetricsView(group: group, formatter: formatter, period: .today) { extent in
+                    MetricsView(
+                        group: group,
+                        formatter: formatter,
+                        period: .today
+                    ) { extent in
                         MetricDistributionSection<RecorderHistogram>(
                             name: group.name,
                             categories: RecorderBuckets.categories,
@@ -64,7 +84,11 @@ private struct MetricSearchContent<T: ChartNumeric>: View {
                     }
                 default:
                     MetricsView(
-                        group: group, formatter: formatter, period: .today, tracksResets: telemetry.hasResets)
+                        group: group,
+                        formatter: formatter,
+                        period: .today,
+                        tracksResets: telemetry.hasResets
+                    )
                 }
             } else {
                 Placeholder(

--- a/Sources/ScoutUI/Home/Search/Index/GlobalSearchIndex.swift
+++ b/Sources/ScoutUI/Home/Search/Index/GlobalSearchIndex.swift
@@ -16,8 +16,11 @@ struct GlobalSearchIndex {
     let hangs: [IncidentGroup<Hang>]
 
     init?(
-        series: [MetricSeries]?, devices: [DeviceSummary]?, releases: [ReleaseHealth]?,
-        crashes: [IncidentGroup<Crash>]?, hangs: [IncidentGroup<Hang>]?
+        series: [MetricSeries]?,
+        devices: [DeviceSummary]?,
+        releases: [ReleaseHealth]?,
+        crashes: [IncidentGroup<Crash>]?,
+        hangs: [IncidentGroup<Hang>]?
     ) {
         guard let series, let devices, let releases, let crashes, let hangs else {
             return nil

--- a/Sources/ScoutUI/Home/Search/Results/GlobalSearchList.swift
+++ b/Sources/ScoutUI/Home/Search/Results/GlobalSearchList.swift
@@ -35,10 +35,26 @@ struct GlobalSearchList: View {
 #Preview {
     let index = GlobalSearchIndex(
         series: [
-            MetricSeries(name: "session_start", category: nil, points: []),
-            MetricSeries(name: "session_end", category: nil, points: []),
-            MetricSeries(name: "session_duration", category: Telemetry.Export.timer.rawValue, points: []),
-            MetricSeries(name: "GET /v1/sessions", category: StatusBuckets.categories[0], points: []),
+            MetricSeries(
+                name: "session_start",
+                category: nil,
+                points: []
+            ),
+            MetricSeries(
+                name: "session_end",
+                category: nil,
+                points: []
+            ),
+            MetricSeries(
+                name: "session_duration",
+                category: Telemetry.Export.timer.rawValue,
+                points: []
+            ),
+            MetricSeries(
+                name: "GET /v1/sessions",
+                category: StatusBuckets.categories[0],
+                points: []
+            ),
         ],
         devices: .samples,
         releases: .samples,

--- a/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
+++ b/Sources/ScoutUI/Home/Section/Log/HomeLogProvider.swift
@@ -47,7 +47,11 @@ final class HomeLogProvider: ObservableObject, Provider {
             report = nil
             return
         }
-        report = LogReport(series: series, visits: visits, period: period)
+        report = LogReport(
+            series: series,
+            visits: visits,
+            period: period
+        )
     }
 
     func fetch(in database: DatabaseReader) async throws -> Output {

--- a/Sources/ScoutUI/Home/Section/Log/LogReport.swift
+++ b/Sources/ScoutUI/Home/Section/Log/LogReport.swift
@@ -12,7 +12,11 @@ struct LogReport {
     private let trends: [LogCategory: Trend]
 
     init(series: [MetricSeries], visits: [DeviceVisit], period: Period) {
-        trends = Self.trends(series: series, visits: visits, period: period)
+        trends = Self.trends(
+            series: series,
+            visits: visits,
+            period: period
+        )
     }
 
     func trend(for category: LogCategory) -> Trend {
@@ -42,7 +46,9 @@ struct LogReport {
 
         return [
             .events: Trend(
-                points: span.points { $0 != CrashEntry.recordType && $0 != HangEntry.recordType }, period: period),
+                points: span.points { $0 != CrashEntry.recordType && $0 != HangEntry.recordType },
+                period: period
+            ),
             .crashes: Trend(points: span.points { $0 == CrashEntry.recordType }, period: period),
             .hangs: Trend(points: span.points { $0 == HangEntry.recordType }, period: period),
             .network: Trend(points: span.points(inCategories: Set(StatusBuckets.categories)), period: period),

--- a/Sources/ScoutUI/Home/Section/Log/LogView.swift
+++ b/Sources/ScoutUI/Home/Section/Log/LogView.swift
@@ -24,7 +24,11 @@ struct LogView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
-                SegmentStrip(selection: $period, distribution: .justified, title: \.shortTitle)
+                SegmentStrip(
+                    selection: $period,
+                    distribution: .justified,
+                    title: \.shortTitle
+                )
 
                 LazyVGrid(columns: columns, spacing: 36) {
                     ForEach(LogCategory.allCases) { category in

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionRow.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionRow.swift
@@ -14,10 +14,14 @@ struct HomeRetentionRow: View {
 
     var body: some View {
         Button(action: action) {
-            Sparkline(series: series, color: .green, gridlinesAtPoints: true)
-                .frame(height: 68)
-                .padding(.horizontal, 16)
-                .padding(.bottom, 12)
+            Sparkline(
+                series: series,
+                color: .green,
+                gridlinesAtPoints: true
+            )
+            .frame(height: 68)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
         }
         .buttonStyle(.plain)
         .listRowSeparator(.hidden)

--- a/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
@@ -52,7 +52,11 @@ final class BackendHealthProvider: ObservableObject {
         let start = clock.now
         let status = await probe()
         let elapsed = start.duration(to: clock.now)
-        return ProbeResult(id: id, status: status, latency: status == .reachable ? elapsed.milliseconds : nil)
+        return ProbeResult(
+            id: id,
+            status: status,
+            latency: status == .reachable ? elapsed.milliseconds : nil
+        )
     }
 
     private func apply(_ result: ProbeResult) {

--- a/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
+++ b/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
@@ -31,7 +31,11 @@ struct SettingsOverviewView: View {
                 Row {
                     BackendRow(backend: backend, isActive: backend.id == activeID)
                 } destination: {
-                    BackendDetailView(provider: provider, id: backend.id, activeID: $activeID)
+                    BackendDetailView(
+                        provider: provider,
+                        id: backend.id,
+                        activeID: $activeID
+                    )
                 }
             }
 

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
@@ -11,7 +11,8 @@
 
     protocol AlertTaskScheduler: Sendable {
         func register(
-            forTaskWithIdentifier identifier: String, using queue: DispatchQueue?,
+            forTaskWithIdentifier identifier: String,
+            using queue: DispatchQueue?,
             launchHandler: @escaping @Sendable (BGTask) -> Void
         ) -> Bool
         func submit(_ taskRequest: BGTaskRequest) throws
@@ -32,7 +33,8 @@
         private let refresh: @Sendable () async -> Void
 
         init(
-            scheduler: AlertTaskScheduler = BGTaskScheduler.shared, interval: TimeInterval = 1800,
+            scheduler: AlertTaskScheduler = BGTaskScheduler.shared,
+            interval: TimeInterval = 1800,
             refresh: @escaping @Sendable () async -> Void
         ) {
             self.scheduler = scheduler

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertBacktest.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertBacktest.swift
@@ -26,7 +26,12 @@ struct AlertBacktest: Equatable {
                 baseline: Array(values[(end - window * 2)..<(end - window)]).median ?? 0,
                 recent: Array(values[(end - window)..<end])
             )
-            let outcome = evaluator.evaluate(rule, reading: reading, state: state, now: Date(timeIntervalSince1970: 0))
+            let outcome = evaluator.evaluate(
+                rule,
+                reading: reading,
+                state: state,
+                now: Date(timeIntervalSince1970: 0)
+            )
 
             state = outcome.state
 

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
@@ -35,7 +35,11 @@ final class AlertEngine {
                 state: registry.state(for: rule),
                 now: now
             )
-            return AlertStatus(rule: rule, outcome: outcome, reading: reading)
+            return AlertStatus(
+                rule: rule,
+                outcome: outcome,
+                reading: reading
+            )
         }
     }
 

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertDraft.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertDraft.swift
@@ -95,7 +95,12 @@ extension AlertDraft {
     }
 
     var rule: AlertRule {
-        AlertRule(metric: metric, condition: condition, holdBuckets: hold.buckets, notifies: notifies)
+        AlertRule(
+            metric: metric,
+            condition: condition,
+            holdBuckets: hold.buckets,
+            notifies: notifies
+        )
     }
 
     var isValid: Bool {

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertMetric.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertMetric.swift
@@ -22,7 +22,11 @@ extension AlertMetric {
             return MetricReading(points: try await eventPoints(in: database, range: range), period: period)
         case .crashFreeSessions:
             let (sessions, crashes) = try await lifecyclePoints(in: database, range: range)
-            return MetricReading(sessions: sessions, crashes: crashes, period: period)
+            return MetricReading(
+                sessions: sessions,
+                crashes: crashes,
+                period: period
+            )
         }
     }
 
@@ -36,7 +40,12 @@ extension AlertMetric {
 
         case .crashFreeSessions:
             let (sessions, crashes) = try await lifecyclePoints(in: database, range: range)
-            return MetricReading.stabilities(sessions: sessions, crashes: crashes, in: range, component: .hour)
+            return MetricReading.stabilities(
+                sessions: sessions,
+                crashes: crashes,
+                in: range,
+                component: .hour
+            )
         }
     }
 
@@ -44,7 +53,11 @@ extension AlertMetric {
         guard case .eventCount(let name) = self else { return [] }
 
         let series = try await database.series(
-            matching: SeriesQuery(name: name, bucket: .hour, range: range)
+            matching: SeriesQuery(
+                name: name,
+                bucket: .hour,
+                range: range
+            )
         )
         return series.flatMap { $0.chartPoints() }
     }
@@ -53,10 +66,20 @@ extension AlertMetric {
         sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>]
     ) {
         async let sessions = database.series(
-            matching: SeriesQuery(name: SessionEntry.recordType, bucket: .hour, source: .lifecycle, range: range)
+            matching: SeriesQuery(
+                name: SessionEntry.recordType,
+                bucket: .hour,
+                source: .lifecycle,
+                range: range
+            )
         )
         async let crashes = database.series(
-            matching: SeriesQuery(name: CrashEntry.recordType, bucket: .hour, source: .lifecycle, range: range)
+            matching: SeriesQuery(
+                name: CrashEntry.recordType,
+                bucket: .hour,
+                source: .lifecycle,
+                range: range
+            )
         )
 
         return (

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading+ChartPoints.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading+ChartPoints.swift
@@ -21,15 +21,26 @@ extension MetricReading {
 
     init(sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], period: some ChartTimeScale) {
         let previous = Self.stabilities(
-            sessions: sessions, crashes: crashes, in: period.previousRange, component: period.pointComponent)
+            sessions: sessions,
+            crashes: crashes,
+            in: period.previousRange,
+            component: period.pointComponent
+        )
         let current = Self.stabilities(
-            sessions: sessions, crashes: crashes, in: period.initialRange, component: period.pointComponent)
+            sessions: sessions,
+            crashes: crashes,
+            in: period.initialRange,
+            component: period.pointComponent
+        )
 
         self.init(baseline: previous.median ?? 0, recent: current)
     }
 
     static func stabilities(
-        sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], in range: Range<Date>, component: Calendar.Component
+        sessions: [ChartPoint<Int>],
+        crashes: [ChartPoint<Int>],
+        in range: Range<Date>,
+        component: Calendar.Component
     ) -> [Double] {
         zip(
             sessions.bucket(in: range, component: component).reversed(),

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
@@ -16,7 +16,9 @@ struct IncidentBreakdown: Equatable {
     let versionsBySession: [UUID: String]
 
     init(
-        devices: [Segment], osVersions: [Segment], modelsByDevice: [UUID: String] = [:],
+        devices: [Segment],
+        osVersions: [Segment],
+        modelsByDevice: [UUID: String] = [:],
         versionsBySession: [UUID: String] = [:]
     ) {
         self.devices = devices
@@ -32,12 +34,22 @@ extension IncidentBreakdown {
         let ranked = counts.sorted { $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key }
 
         var segments = zip(ranked.prefix(top), colors).map { pair, color in
-            Segment(label: pair.key, count: pair.value, color: color)
+            Segment(
+                label: pair.key,
+                count: pair.value,
+                color: color
+            )
         }
 
         let other = ranked.count > top ? ranked[top...].reduce(0) { $0 + $1.value } : 0
         if other > 0 {
-            segments.append(Segment(count: other, color: .gray, kind: .other))
+            segments.append(
+                Segment(
+                    count: other,
+                    color: .gray,
+                    kind: .other
+                )
+            )
         }
 
         return segments
@@ -92,10 +104,12 @@ extension IncidentBreakdown {
                 from: Array(repeating: "iPhone15,3", count: 5) + Array(repeating: "iPhone14,2", count: 3)
                     + Array(repeating: "iPhone13,2", count: 2) + [
                         "iPad13,1"
-                    ]),
+                    ]
+            ),
             osVersions: segments(
                 from: Array(repeating: "iOS 17.4", count: 6) + Array(repeating: "iOS 17.3", count: 3)
-                    + Array(repeating: "iOS 16.7", count: 2))
+                    + Array(repeating: "iOS 16.7", count: 2)
+            )
         )
     }
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownProvider.swift
@@ -50,7 +50,11 @@ final class IncidentBreakdownProvider: ObservableObject, Provider {
             ]
         )
         let records: [Record] = try await database.readAll(matching: query, fields: ["device_id", "model"])
-        return dictionary(from: records, key: "device_id", value: "model")
+        return dictionary(
+            from: records,
+            key: "device_id",
+            value: "model"
+        )
     }
 
     private func osVersions(in database: DatabaseReader) async throws -> [UUID: String] {
@@ -74,7 +78,11 @@ final class IncidentBreakdownProvider: ObservableObject, Provider {
             fields: ["session_id", "os_version"]
         )
 
-        return dictionary(from: records, key: "session_id", value: "os_version")
+        return dictionary(
+            from: records,
+            key: "session_id",
+            value: "os_version"
+        )
     }
 
     private func dictionary(from records: [Record], key: String, value: String) -> [UUID: String] {

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownSection.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdownSection.swift
@@ -59,7 +59,11 @@ struct IncidentBreakdownSection<Element: Incident, RowContent: View>: View {
     }
 
     private func matches(in dimension: IncidentBreakdown.Dimension, segment: Segment) -> [Element] {
-        breakdown.records(from: records, in: dimension, matching: segment)
+        breakdown.records(
+            from: records,
+            in: dimension,
+            matching: segment
+        )
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/Crash+Fixture.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/Crash+Fixture.swift
@@ -21,7 +21,11 @@ extension Crash: Fixture {
 
         return Crash(
             name: name,
-            fingerprint: CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value,
+            fingerprint: CrashFingerprint(
+                name: name,
+                reason: reason,
+                stackTrace: stackTrace
+            ).value,
             reason: reason,
             stackTrace: stackTrace,
             date: Date(),
@@ -36,7 +40,11 @@ extension Crash: Fixture {
     static func sample(_ name: String, at date: Date, sessionID: UUID? = nil) -> Crash {
         Crash(
             name: name,
-            fingerprint: CrashFingerprint(name: name, reason: nil, stackTrace: []).value,
+            fingerprint: CrashFingerprint(
+                name: name,
+                reason: nil,
+                stackTrace: []
+            ).value,
             reason: nil,
             stackTrace: [],
             date: date,

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashExport.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashExport.swift
@@ -12,7 +12,11 @@ struct CrashExport {
     let crash: Crash
 
     var text: String {
-        IncidentExport(incident: crash, kind: "Crash", detail: []).text
+        IncidentExport(
+            incident: crash,
+            kind: "Crash",
+            detail: []
+        ).text
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/Hang+Fixture.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/Hang+Fixture.swift
@@ -21,7 +21,11 @@ extension Hang: Fixture {
 
         return Hang(
             name: name,
-            fingerprint: CrashFingerprint(name: name, reason: nil, stackTrace: stackTrace).value,
+            fingerprint: CrashFingerprint(
+                name: name,
+                reason: nil,
+                stackTrace: stackTrace
+            ).value,
             reason: reason,
             stackTrace: stackTrace,
             duration: 6.4,
@@ -37,7 +41,11 @@ extension Hang: Fixture {
     static func sample(_ name: String, duration: TimeInterval, at date: Date, sessionID: UUID? = nil) -> Hang {
         Hang(
             name: name,
-            fingerprint: CrashFingerprint(name: name, reason: nil, stackTrace: []).value,
+            fingerprint: CrashFingerprint(
+                name: name,
+                reason: nil,
+                stackTrace: []
+            ).value,
             reason: nil,
             stackTrace: [],
             duration: duration,

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangGroupDetailView.swift
@@ -18,14 +18,19 @@ struct HangGroupDetailView: View {
         self.group = group
         self._breakdown = StateObject(
             wrappedValue: breakdown
-                ?? IncidentBreakdownProvider(deviceIDs: group.deviceIDs, sessionIDs: group.sessionIDs))
+                ?? IncidentBreakdownProvider(deviceIDs: group.deviceIDs, sessionIDs: group.sessionIDs)
+        )
     }
 
     var body: some View {
         InsetList {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 16) {
-                    Readout(title: "Duration", value: group.durationText, color: group.severity.color)
+                    Readout(
+                        title: "Duration",
+                        value: group.durationText,
+                        color: group.severity.color
+                    )
                     Readout(title: "Occurrences", value: "\(group.count)")
                     Readout(title: "Devices", value: "\(group.affectedDevices)")
                     Readout(title: "Sessions", value: "\(group.affectedSessions)")
@@ -40,7 +45,11 @@ struct HangGroupDetailView: View {
             .padding(.bottom)
 
             if let value = try? breakdown.result?.get() {
-                IncidentBreakdownSection(breakdown: value, records: group.records, row: occurrenceRow)
+                IncidentBreakdownSection(
+                    breakdown: value,
+                    records: group.records,
+                    row: occurrenceRow
+                )
             }
 
             Header(title: "Occurrences")

--- a/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentRow.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentRow.swift
@@ -28,7 +28,11 @@ struct IncidentRow<Element: Incident, Destination: View>: View {
 
             if group.count > 1 {
                 if let accent {
-                    CountBadge(count: group.count, prefix: "×", color: accent.color)
+                    CountBadge(
+                        count: group.count,
+                        prefix: "×",
+                        color: accent.color
+                    )
                 } else {
                     CountBadge(count: group.count, prefix: "×")
                 }

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistribution.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistribution.swift
@@ -48,7 +48,11 @@ struct MetricDistribution<H: QuantileHistogram>: Equatable {
             return nil
         }
 
-        return Percentiles(p50: p50, p90: p90, p99: p99)
+        return Percentiles(
+            p50: p50,
+            p90: p90,
+            p99: p99
+        )
     }
 
     func trend(in range: Range<Date>, component: Calendar.Component) -> [PercentileTrendPoint] {

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
@@ -16,13 +16,17 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
     @StateObject var provider: MetricDistributionProvider<H>
 
     init(
-        name: String, categories: [String], extent: ChartExtent<Period>, formatter: KeyPath<Double, String>,
+        name: String,
+        categories: [String],
+        extent: ChartExtent<Period>,
+        formatter: KeyPath<Double, String>,
         provider: MetricDistributionProvider<H>? = nil
     ) {
         self.extent = extent
         self.formatter = formatter
         self._provider = StateObject(
-            wrappedValue: provider ?? MetricDistributionProvider(name: name, categories: categories))
+            wrappedValue: provider ?? MetricDistributionProvider(name: name, categories: categories)
+        )
     }
 
     var body: some View {

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionView.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionView.swift
@@ -31,22 +31,35 @@ struct MetricDistributionView: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(Color.gray)
 
-            PercentileTrendChart(trend: trend, unit: unit, formatter: formatter)
+            PercentileTrendChart(
+                trend: trend,
+                unit: unit,
+                formatter: formatter
+            )
         }
     }
 }
 
 extension Percentiles {
     static var sample: Percentiles {
-        Percentiles(p50: 0.081, p90: 0.42, p99: 3.8)
+        Percentiles(
+            p50: 0.081,
+            p90: 0.42,
+            p99: 3.8
+        )
     }
 }
 
 #Preview("MetricDistributionView") {
     NavigationStack {
         ScrollView {
-            MetricDistributionView(percentiles: .sample, trend: .sample, unit: .hour, formatter: \TimeInterval.duration)
-                .padding(.horizontal)
+            MetricDistributionView(
+                percentiles: .sample,
+                trend: .sample,
+                unit: .hour,
+                formatter: \TimeInterval.duration
+            )
+            .padding(.horizontal)
         }
         .monospacedNavigationTitle(en: "http_request")
     }

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/PercentileRow.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/PercentileRow.swift
@@ -15,9 +15,21 @@ struct PercentileRow: View {
 
     var body: some View {
         HStack(spacing: 34) {
-            Readout(title: "P50", value: percentiles.p50[keyPath: formatter], color: .blue)
-            Readout(title: "P90", value: percentiles.p90[keyPath: formatter], color: .teal)
-            Readout(title: "P99", value: percentiles.p99[keyPath: formatter], color: .orange)
+            Readout(
+                title: "P50",
+                value: percentiles.p50[keyPath: formatter],
+                color: .blue
+            )
+            Readout(
+                title: "P90",
+                value: percentiles.p90[keyPath: formatter],
+                color: .teal
+            )
+            Readout(
+                title: "P99",
+                value: percentiles.p99[keyPath: formatter],
+                color: .orange
+            )
             Spacer()
         }
     }

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/PercentileTrendChart.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/PercentileTrendChart.swift
@@ -73,6 +73,10 @@ extension [PercentileTrendPoint] {
 }
 
 #Preview("PercentileTrendChart") {
-    PercentileTrendChart(trend: .sample, unit: .hour, formatter: \TimeInterval.duration)
-        .padding(.horizontal)
+    PercentileTrendChart(
+        trend: .sample,
+        unit: .hour,
+        formatter: \TimeInterval.duration
+    )
+    .padding(.horizontal)
 }

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsContent.swift
@@ -54,7 +54,11 @@ struct MetricsContent<T: ChartNumeric>: View {
     private func destination(group: PointGroup<T>) -> some View {
         switch telemetry {
         case .timer:
-            MetricsView(group: group, formatter: formatter, period: period) { extent in
+            MetricsView(
+                group: group,
+                formatter: formatter,
+                period: period
+            ) { extent in
                 MetricDistributionSection<LatencyHistogram>(
                     name: group.name,
                     categories: LatencyBuckets.categories,
@@ -63,7 +67,11 @@ struct MetricsContent<T: ChartNumeric>: View {
                 )
             }
         case .recorder:
-            MetricsView(group: group, formatter: formatter, period: period) { extent in
+            MetricsView(
+                group: group,
+                formatter: formatter,
+                period: period
+            ) { extent in
                 MetricDistributionSection<RecorderHistogram>(
                     name: group.name,
                     categories: RecorderBuckets.categories,
@@ -72,7 +80,12 @@ struct MetricsContent<T: ChartNumeric>: View {
                 )
             }
         default:
-            MetricsView(group: group, formatter: formatter, period: period, tracksResets: telemetry.hasResets)
+            MetricsView(
+                group: group,
+                formatter: formatter,
+                period: period,
+                tracksResets: telemetry.hasResets
+            )
         }
     }
 

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsList.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsList.swift
@@ -38,11 +38,19 @@ struct MetricsList: View {
     @State private var scope: Scope = .int
 
     var body: some View {
-        SegmentStrip(selection: $period, distribution: .justified, title: \.shortTitle)
-            .padding()
+        SegmentStrip(
+            selection: $period,
+            distribution: .justified,
+            title: \.shortTitle
+        )
+        .padding()
 
-        SegmentStrip(selection: $scope, distribution: .justified, title: \.rawValue)
-            .padding(.horizontal)
+        SegmentStrip(
+            selection: $scope,
+            distribution: .justified,
+            title: \.rawValue
+        )
+        .padding(.horizontal)
 
         switch scope {
         case .int:

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
@@ -21,7 +21,10 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
     @StateObject private var resets: ResetMarkerProvider
 
     init(
-        group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period, tracksResets: Bool = false,
+        group: PointGroup<T>,
+        formatter: KeyPath<T, String>,
+        period: Period,
+        tracksResets: Bool = false,
         @ViewBuilder extra: @escaping (ChartExtent<Period>) -> Extra
     ) {
         self.group = group
@@ -29,7 +32,8 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
         self.extra = extra
         self._extent = State(wrappedValue: ChartExtent(period: period))
         self._resets = StateObject(
-            wrappedValue: ResetMarkerProvider(name: group.name, isEnabled: tracksResets))
+            wrappedValue: ResetMarkerProvider(name: group.name, isEnabled: tracksResets)
+        )
     }
 
     var body: some View {

--- a/Sources/ScoutUI/Monitoring/Metrics/Series/MetricsFormatters.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Series/MetricsFormatters.swift
@@ -88,7 +88,11 @@ extension TimeInterval {
         if self < .hour {
             let seconds = Int(rounded())
             if seconds < Int(.hour) {
-                return String(format: "%d min %d s", seconds / Int(.minute), seconds % Int(.minute))
+                return String(
+                    format: "%d min %d s",
+                    seconds / Int(.minute),
+                    seconds % Int(.minute)
+                )
             }
         }
         if self < .day {

--- a/Sources/ScoutUI/Monitoring/Network/Model/NetworkEndpoint.swift
+++ b/Sources/ScoutUI/Monitoring/Network/Model/NetworkEndpoint.swift
@@ -50,10 +50,35 @@ struct NetworkEndpoint: Identifiable {
 
 extension NetworkEndpoint: Fixture {
     static let samples = [
-        NetworkEndpoint(name: "GET /v1/events", requests: 8_420, successRate: 0.998, p99: 0.21),
-        NetworkEndpoint(name: "POST /v1/metrics", requests: 5_210, successRate: 0.991, p99: 0.62),
-        NetworkEndpoint(name: "GET /v1/releases", requests: 3_140, successRate: 0.972, p99: 1.9),
-        NetworkEndpoint(name: "POST /v1/crash", requests: 1_180, successRate: 0.883, p99: 4.4),
-        NetworkEndpoint(name: "GET /health", requests: 640, successRate: 1.0, p99: 0.04),
+        NetworkEndpoint(
+            name: "GET /v1/events",
+            requests: 8_420,
+            successRate: 0.998,
+            p99: 0.21
+        ),
+        NetworkEndpoint(
+            name: "POST /v1/metrics",
+            requests: 5_210,
+            successRate: 0.991,
+            p99: 0.62
+        ),
+        NetworkEndpoint(
+            name: "GET /v1/releases",
+            requests: 3_140,
+            successRate: 0.972,
+            p99: 1.9
+        ),
+        NetworkEndpoint(
+            name: "POST /v1/crash",
+            requests: 1_180,
+            successRate: 0.883,
+            p99: 4.4
+        ),
+        NetworkEndpoint(
+            name: "GET /health",
+            requests: 640,
+            successRate: 1.0,
+            p99: 0.04
+        ),
     ]
 }

--- a/Sources/ScoutUI/Monitoring/Network/Model/NetworkReport.swift
+++ b/Sources/ScoutUI/Monitoring/Network/Model/NetworkReport.swift
@@ -89,7 +89,11 @@ struct NetworkReport {
     }
 
     func requestsPerMinute(in range: Range<Date>, until now: Date = .now) -> Int {
-        requestsPerMinute(endpoints(in: range), in: range, until: now)
+        requestsPerMinute(
+            endpoints(in: range),
+            in: range,
+            until: now
+        )
     }
 
     func requestsPerMinute(_ endpoints: [NetworkEndpoint], in range: Range<Date>, until now: Date = .now) -> Int {

--- a/Sources/ScoutUI/Monitoring/Network/Model/StatusBreakdown.swift
+++ b/Sources/ScoutUI/Monitoring/Network/Model/StatusBreakdown.swift
@@ -30,7 +30,11 @@ struct StatusBreakdown: Equatable {
 
     var segments: [Segment] {
         zip(StatusBuckets.classes, zip(counts, Self.colors)).map { label, pair in
-            Segment(label: label, count: pair.0, color: pair.1)
+            Segment(
+                label: label,
+                count: pair.0,
+                color: pair.1
+            )
         }
     }
 }

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointDetailView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointDetailView.swift
@@ -47,8 +47,12 @@ struct NetworkEndpointDetailView: View {
 
             if let trend = distribution?.trend(in: range, component: unit), trend.count > 0 {
                 Header(title: "P99 trend")
-                PercentileTrendChart(trend: trend, unit: unit, formatter: \TimeInterval.duration)
-                    .listRowSeparator(.hidden)
+                PercentileTrendChart(
+                    trend: trend,
+                    unit: unit,
+                    formatter: \TimeInterval.duration
+                )
+                .listRowSeparator(.hidden)
             }
 
             if let breakdown = statuses?.summary(in: range), breakdown.total > 0 {
@@ -67,6 +71,10 @@ struct NetworkEndpointDetailView: View {
     let endpoint = report.endpoints(in: range)[2]
 
     NavigationStack {
-        NetworkEndpointDetailView(endpoint: endpoint, report: report, range: range)
+        NetworkEndpointDetailView(
+            endpoint: endpoint,
+            report: report,
+            range: range
+        )
     }
 }

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointRow.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkEndpointRow.swift
@@ -42,7 +42,11 @@ struct NetworkEndpointRow: View {
             }
             .frame(height: 70)
         } destination: {
-            NetworkEndpointDetailView(endpoint: endpoint, report: report, range: range)
+            NetworkEndpointDetailView(
+                endpoint: endpoint,
+                report: report,
+                range: range
+            )
         }
     }
 }
@@ -54,7 +58,11 @@ struct NetworkEndpointRow: View {
     NavigationStack {
         InsetList {
             ForEach(report.endpoints(in: range)) { endpoint in
-                NetworkEndpointRow(endpoint: endpoint, report: report, range: range)
+                NetworkEndpointRow(
+                    endpoint: endpoint,
+                    report: report,
+                    range: range
+                )
             }
         }
     }

--- a/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
+++ b/Sources/ScoutUI/Monitoring/Network/View/NetworkView.swift
@@ -37,16 +37,32 @@ struct NetworkView: View {
 
         return InsetList {
             HStack(spacing: 28) {
-                Readout(title: "P99", value: report.percentiles(in: range)?.p99.duration ?? "—", color: .orange)
-                Readout(title: "Success", value: successRate?.formatted ?? "—", color: successRate?.color ?? .primary)
-                Readout(title: "Req/min", value: report.requestsPerMinute(endpoints, in: range).plain, color: .primary)
+                Readout(
+                    title: "P99",
+                    value: report.percentiles(in: range)?.p99.duration ?? "—",
+                    color: .orange
+                )
+                Readout(
+                    title: "Success",
+                    value: successRate?.formatted ?? "—",
+                    color: successRate?.color ?? .primary
+                )
+                Readout(
+                    title: "Req/min",
+                    value: report.requestsPerMinute(endpoints, in: range).plain,
+                    color: .primary
+                )
                 Spacer()
             }
 
             if trend.count > 0 {
                 Header(title: "Latency P99")
-                PercentileTrendChart(trend: trend, unit: .hour, formatter: \TimeInterval.duration)
-                    .listRowSeparator(.hidden)
+                PercentileTrendChart(
+                    trend: trend,
+                    unit: .hour,
+                    formatter: \TimeInterval.duration
+                )
+                .listRowSeparator(.hidden)
             }
 
             Header(title: "Status codes")

--- a/Sources/ScoutUI/Primitives/Calendar/CalendarMonth.swift
+++ b/Sources/ScoutUI/Primitives/Calendar/CalendarMonth.swift
@@ -55,10 +55,18 @@ struct CalendarMonth {
             return Day(
                 date: date,
                 number: calendar.component(.day, from: date),
-                isCurrentMonth: calendar.isDate(date, equalTo: month, toGranularity: .month)
+                isCurrentMonth: calendar.isDate(
+                    date,
+                    equalTo: month,
+                    toGranularity: .month
+                )
             )
         }
-        return stride(from: 0, to: days.count, by: 7).map { Array(days[$0..<$0 + 7]) }
+        return stride(
+            from: 0,
+            to: days.count,
+            by: 7
+        ).map { Array(days[$0..<$0 + 7]) }
     }
 
     func isToday(_ day: Day) -> Bool { day.date == Date().startOfDay }

--- a/Sources/ScoutUI/Primitives/Calendar/ConnectedMonthGrid.swift
+++ b/Sources/ScoutUI/Primitives/Calendar/ConnectedMonthGrid.swift
@@ -27,7 +27,11 @@ struct ConnectedMonthGrid: View {
                 ForEach(Array(month.weeks.enumerated()), id: \.offset) { _, week in
                     HStack(spacing: 0) {
                         ForEach(Array(week.enumerated()), id: \.element.id) { index, day in
-                            cell(day, isFirstColumn: index == 0, isLastColumn: index == week.count - 1)
+                            cell(
+                                day,
+                                isFirstColumn: index == 0,
+                                isLastColumn: index == week.count - 1
+                            )
                         }
                     }
                 }
@@ -42,7 +46,13 @@ struct ConnectedMonthGrid: View {
             .foregroundStyle(textStyle(day, isEndpoint: isEndpoint))
             .frame(height: 40)
             .frame(maxWidth: .infinity)
-            .background { rangeBackground(day, isFirstColumn: isFirstColumn, isLastColumn: isLastColumn) }
+            .background {
+                rangeBackground(
+                    day,
+                    isFirstColumn: isFirstColumn,
+                    isLastColumn: isLastColumn
+                )
+            }
             .background {
                 if isEndpoint {
                     Circle().fill(.tint).frame(width: 40, height: 40)

--- a/Sources/ScoutUI/Primitives/Indicators/InfoChip.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/InfoChip.swift
@@ -34,11 +34,33 @@ struct InfoChip: View {
 
 #Preview {
     FlowLayout(spacing: 6) {
-        InfoChip(systemImage: "iphone", text: "iPhone16,1", color: .blue)
-        InfoChip(systemImage: "gearshape", text: "iOS 17.4", color: .indigo)
-        InfoChip(systemImage: "globe", text: "en-US", color: .teal, monospaced: true)
-        InfoChip(systemImage: "airplane", text: "TestFlight", color: .orange)
-        InfoChip(systemImage: "tag", text: "v2.3.1 (412)", color: .green, monospaced: true)
+        InfoChip(
+            systemImage: "iphone",
+            text: "iPhone16,1",
+            color: .blue
+        )
+        InfoChip(
+            systemImage: "gearshape",
+            text: "iOS 17.4",
+            color: .indigo
+        )
+        InfoChip(
+            systemImage: "globe",
+            text: "en-US",
+            color: .teal,
+            monospaced: true
+        )
+        InfoChip(
+            systemImage: "airplane",
+            text: "TestFlight",
+            color: .orange
+        )
+        InfoChip(
+            systemImage: "tag",
+            text: "v2.3.1 (412)",
+            color: .green,
+            monospaced: true
+        )
     }
     .padding()
 }

--- a/Sources/ScoutUI/Primitives/Indicators/Readout.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/Readout.swift
@@ -29,6 +29,10 @@ struct Readout: View {
 
 extension Readout {
     init(title: String, stability: Stability) {
-        self.init(title: title, value: stability.formatted, color: stability.color)
+        self.init(
+            title: title,
+            value: stability.formatted,
+            color: stability.color
+        )
     }
 }

--- a/Sources/ScoutUI/Primitives/Indicators/StatProvider.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatProvider.swift
@@ -23,7 +23,11 @@ final class StatProvider: ObservableObject, Provider {
 
     func fetch(in database: DatabaseReader) async throws -> [ChartPoint<Int>] {
         let series = try await database.series(
-            matching: SeriesQuery(name: eventName, bucket: .hour, range: Calendar.utc.defaultRange)
+            matching: SeriesQuery(
+                name: eventName,
+                bucket: .hour,
+                range: Calendar.utc.defaultRange
+            )
         )
         return series.flatMap { $0.chartPoints() }
     }

--- a/Sources/ScoutUI/Primitives/Indicators/TrendCard.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/TrendCard.swift
@@ -65,17 +65,29 @@ struct TrendCard: View {
         TrendCard(
             title: "Sessions",
             color: .purple,
-            trend: Trend(count: 8420, previous: 7500, values: [3, 5, 4, 7, 6, 9, 12])
+            trend: Trend(
+                count: 8420,
+                previous: 7500,
+                values: [3, 5, 4, 7, 6, 9, 12]
+            )
         )
         TrendCard(
             title: "Crashes",
             color: .red,
-            trend: Trend(count: 87, previous: 101, values: [9, 7, 8, 6, 7, 5, 4])
+            trend: Trend(
+                count: 87,
+                previous: 101,
+                values: [9, 7, 8, 6, 7, 5, 4]
+            )
         )
         TrendCard(
             title: "Empty",
             color: .red,
-            trend: Trend(count: 0, previous: 0, values: [0, 0, 0, 0, 0, 0, 0])
+            trend: Trend(
+                count: 0,
+                previous: 0,
+                values: [0, 0, 0, 0, 0, 0, 0]
+            )
         )
         TrendCard(
             title: "Loading",

--- a/Sources/ScoutUI/Primitives/Pickers/SegmentStrip.swift
+++ b/Sources/ScoutUI/Primitives/Pickers/SegmentStrip.swift
@@ -83,8 +83,16 @@ struct SegmentStrip<Value: Hashable & CaseIterable>: View {
     @Previewable @State var selection = Period.today
 
     VStack(spacing: 24) {
-        SegmentStrip(selection: $selection, distribution: .justified, title: \.shortTitle)
-        SegmentStrip(selection: $selection, distribution: .compact(spacing: 12), title: \.shortTitle)
+        SegmentStrip(
+            selection: $selection,
+            distribution: .justified,
+            title: \.shortTitle
+        )
+        SegmentStrip(
+            selection: $selection,
+            distribution: .compact(spacing: 12),
+            title: \.shortTitle
+        )
     }
     .padding()
 }

--- a/Sources/ScoutUI/Primitives/Platform/NSColor+macOS.swift
+++ b/Sources/ScoutUI/Primitives/Platform/NSColor+macOS.swift
@@ -13,32 +13,72 @@
         static var systemGray3: NSColor {
             NSColor(name: nil) { appearance in
                 appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                    ? NSColor(red: 72 / 255, green: 72 / 255, blue: 74 / 255, alpha: 1)
-                    : NSColor(red: 199 / 255, green: 199 / 255, blue: 204 / 255, alpha: 1)
+                    ? NSColor(
+                        red: 72 / 255,
+                        green: 72 / 255,
+                        blue: 74 / 255,
+                        alpha: 1
+                    )
+                    : NSColor(
+                        red: 199 / 255,
+                        green: 199 / 255,
+                        blue: 204 / 255,
+                        alpha: 1
+                    )
             }
         }
 
         static var systemGray4: NSColor {
             NSColor(name: nil) { appearance in
                 appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                    ? NSColor(red: 58 / 255, green: 58 / 255, blue: 60 / 255, alpha: 1)
-                    : NSColor(red: 209 / 255, green: 209 / 255, blue: 214 / 255, alpha: 1)
+                    ? NSColor(
+                        red: 58 / 255,
+                        green: 58 / 255,
+                        blue: 60 / 255,
+                        alpha: 1
+                    )
+                    : NSColor(
+                        red: 209 / 255,
+                        green: 209 / 255,
+                        blue: 214 / 255,
+                        alpha: 1
+                    )
             }
         }
 
         static var systemGray5: NSColor {
             NSColor(name: nil) { appearance in
                 appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                    ? NSColor(red: 44 / 255, green: 44 / 255, blue: 46 / 255, alpha: 1)
-                    : NSColor(red: 229 / 255, green: 229 / 255, blue: 234 / 255, alpha: 1)
+                    ? NSColor(
+                        red: 44 / 255,
+                        green: 44 / 255,
+                        blue: 46 / 255,
+                        alpha: 1
+                    )
+                    : NSColor(
+                        red: 229 / 255,
+                        green: 229 / 255,
+                        blue: 234 / 255,
+                        alpha: 1
+                    )
             }
         }
 
         static var systemGray6: NSColor {
             NSColor(name: nil) { appearance in
                 appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                    ? NSColor(red: 28 / 255, green: 28 / 255, blue: 30 / 255, alpha: 1)
-                    : NSColor(red: 242 / 255, green: 242 / 255, blue: 247 / 255, alpha: 1)
+                    ? NSColor(
+                        red: 28 / 255,
+                        green: 28 / 255,
+                        blue: 30 / 255,
+                        alpha: 1
+                    )
+                    : NSColor(
+                        red: 242 / 255,
+                        green: 242 / 255,
+                        blue: 247 / 255,
+                        alpha: 1
+                    )
             }
         }
     }

--- a/Sources/ScoutUI/Primitives/Refresh/ForegroundTask.swift
+++ b/Sources/ScoutUI/Primitives/Refresh/ForegroundTask.swift
@@ -33,7 +33,13 @@ private struct ForegroundTaskModifier: ViewModifier {
         .onDisappear {
             isVisible = false
         }
-        .task(id: Trigger(phase: scenePhase, isVisible: isVisible, token: token)) {
+        .task(
+            id: Trigger(
+                phase: scenePhase,
+                isVisible: isVisible,
+                token: token
+            )
+        ) {
             if isVisible, scenePhase == .active {
                 await action()
             }

--- a/Sources/ScoutUI/Primitives/Rows/InsetList.swift
+++ b/Sources/ScoutUI/Primitives/Rows/InsetList.swift
@@ -9,7 +9,12 @@ import Scout
 import SwiftUI
 
 extension EdgeInsets {
-    static let sideInsets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+    static let sideInsets = EdgeInsets(
+        top: 0,
+        leading: 16,
+        bottom: 0,
+        trailing: 16
+    )
 }
 
 struct InsetList<Content: View>: View {

--- a/Sources/ScoutUI/Primitives/Rows/RowSummary.swift
+++ b/Sources/ScoutUI/Primitives/Rows/RowSummary.swift
@@ -32,24 +32,38 @@ struct RowSummary: View {
             HStack {
                 Text(verbatim: "Loaded")
                 Spacer()
-                RowSummary(series: MiniChartSeries(values: [2, 4, 3, 7, 6, 11, 16]), count: 49, color: .red)
+                RowSummary(
+                    series: MiniChartSeries(values: [2, 4, 3, 7, 6, 11, 16]),
+                    count: 49,
+                    color: .red
+                )
             }
             HStack {
                 Text(verbatim: "Wide count")
                 Spacer()
-                RowSummary(series: MiniChartSeries(values: [3, 1, 4, 1, 5, 9, 2]), count: 19_989, color: .green)
+                RowSummary(
+                    series: MiniChartSeries(values: [3, 1, 4, 1, 5, 9, 2]),
+                    count: 19_989,
+                    color: .green
+                )
             }
             HStack {
                 Text(verbatim: "Loading")
                 Spacer()
-                RowSummary(series: nil, count: nil, color: .purple)
+                RowSummary(
+                    series: nil,
+                    count: nil,
+                    color: .purple
+                )
             }
             HStack {
                 Text(verbatim: "Empty")
                 Spacer()
                 RowSummary(
-                    series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)), count: 0,
-                    color: .blue)
+                    series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)),
+                    count: 0,
+                    color: .blue
+                )
             }
         }
     }

--- a/Sources/ScoutUI/Primitives/States/ErrorView.swift
+++ b/Sources/ScoutUI/Primitives/States/ErrorView.swift
@@ -71,7 +71,11 @@ struct ErrorView: View {
 
 extension ErrorView {
     init(description: String, retry: (() async -> Void)?, isRetrying: Bool = false) {
-        self.init(description: Text(verbatim: description), retry: retry, isRetrying: isRetrying)
+        self.init(
+            description: Text(verbatim: description),
+            retry: retry,
+            isRetrying: isRetrying
+        )
     }
 }
 

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparableChart.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparableChart.swift
@@ -25,8 +25,12 @@ struct ComparableChart<T: ChartNumeric, S: ChartTimeScale>: View {
                 color: color
             )
         } else {
-            ChartView(segment: segment, timing: extent, markers: markers)
-                .foregroundStyle(color)
+            ChartView(
+                segment: segment,
+                timing: extent,
+                markers: markers
+            )
+            .foregroundStyle(color)
         }
     }
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonChartView.swift
@@ -88,7 +88,12 @@ struct ComparisonChartView<T: ChartNumeric>: View {
         )
 
         Text(verbatim: "Empty State").font(.headline)
-        ComparisonChartView(segment: .empty, reference: .empty, timing: extent, color: .blue)
+        ComparisonChartView(
+            segment: .empty,
+            reference: .empty,
+            timing: extent,
+            color: .blue
+        )
     }
     .padding()
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ReferenceOverlay.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ReferenceOverlay.swift
@@ -21,7 +21,13 @@ struct ReferenceOverlay<T: ChartNumeric>: View {
     let color: Color
 
     var body: some View {
-        let levels = pairs.compactMap { ReferenceLevel(pair: $0, proxy: proxy, plotFrame: plotFrame) }
+        let levels = pairs.compactMap {
+            ReferenceLevel(
+                pair: $0,
+                proxy: proxy,
+                plotFrame: plotFrame
+            )
+        }
         let gains = levels.gains
         let drops = levels.drops
 

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportButton.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportButton.swift
@@ -25,7 +25,11 @@ struct ChartExportButton<ChartContent: View>: View {
         }
         .sheet(isPresented: $isExporting) {
             NavigationStack {
-                ChartExportSheet(title: title, rangeLabel: rangeLabel, chart: chart)
+                ChartExportSheet(
+                    title: title,
+                    rangeLabel: rangeLabel,
+                    chart: chart
+                )
             }
         }
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportRenderer.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportRenderer.swift
@@ -47,7 +47,11 @@ enum ChartExportRenderer {
             var box = CGRect(origin: .zero, size: size)
 
             guard let consumer = CGDataConsumer(data: pdf as CFMutableData),
-                let context = CGContext(consumer: consumer, mediaBox: &box, nil)
+                let context = CGContext(
+                    consumer: consumer,
+                    mediaBox: &box,
+                    nil
+                )
             else {
                 return
             }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportSheet.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Export/ChartExportSheet.swift
@@ -140,7 +140,11 @@ struct ChartExportSheet<ChartContent: View>: View {
         guard let data = ChartExportRenderer.data(for: exportView, format: options.format, scale: displayScale) else {
             return nil
         }
-        let file = ChartExportFile(data: data, name: title, format: options.format)
+        let file = ChartExportFile(
+            data: data,
+            name: title,
+            format: options.format
+        )
         return try? file.write()
     }
 

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Model/ChartPoint.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Model/ChartPoint.swift
@@ -50,7 +50,11 @@ extension [ChartPoint<Int>] {
     static var sample: Self {
         let end = Date()
         return (0..<168).compactMap { i in
-            Calendar.utc.date(byAdding: .hour, value: -i, to: end).map {
+            Calendar.utc.date(
+                byAdding: .hour,
+                value: -i,
+                to: end
+            ).map {
                 ChartPoint(date: $0, count: .random(in: 0...20))
             }
         }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Model/Range+Slices.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Model/Range+Slices.swift
@@ -18,7 +18,8 @@ extension Range where Bound == Date {
 
         return (0..<count).map { index in
             lowerBound.addingTimeInterval(
-                step * Double(index))..<lowerBound.addingTimeInterval(step * Double(index + 1))
+                step * Double(index)
+            )..<lowerBound.addingTimeInterval(step * Double(index + 1))
         }
     }
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Model/Trend.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Model/Trend.swift
@@ -15,7 +15,11 @@ struct Trend {
 }
 
 extension Trend {
-    static let loading = Trend(count: nil, delta: nil, series: nil)
+    static let loading = Trend(
+        count: nil,
+        delta: nil,
+        series: nil
+    )
 
     init(points: [ChartPoint<Int>], period: some ChartTimeScale) {
         let current = points.bucket(on: period).total
@@ -23,7 +27,11 @@ extension Trend {
 
         count = current
         delta = Delta(current: current, previous: previous)
-        series = MiniChartSeries(points: points, range: period.initialRange, aggregation: .total)
+        series = MiniChartSeries(
+            points: points,
+            range: period.initialRange,
+            aggregation: .total
+        )
     }
 
     init(levels: [ChartPoint<Int>], period: some ChartTimeScale) {
@@ -32,7 +40,11 @@ extension Trend {
 
         count = current
         delta = Delta(current: current, previous: previous)
-        series = MiniChartSeries(points: levels, range: period.initialRange, aggregation: .latest)
+        series = MiniChartSeries(
+            points: levels,
+            range: period.initialRange,
+            aggregation: .latest
+        )
     }
 
     init(count: Int, previous: Int, values: [Int]) {

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Scale/ChartTiming.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Scale/ChartTiming.swift
@@ -37,7 +37,11 @@ extension ChartTiming {
         }
         let starts = segment.map { binRange(of: $0.date, unit: unit).lowerBound }.sorted()
         let step = max(1, (starts.count + 3) / 4)
-        return stride(from: 0, to: starts.count, by: step).map { starts[$0] }
+        return stride(
+            from: 0,
+            to: starts.count,
+            by: step
+        ).map { starts[$0] }
     }
 }
 

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/View/MiniChart.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/View/MiniChart.swift
@@ -25,10 +25,20 @@ struct MiniChart: View {
     var body: some View {
         Group {
             if let series {
-                Sparkline(series: series, color: color, lineWidth: 1.5, showsGridlines: false)
+                Sparkline(
+                    series: series,
+                    color: color,
+                    lineWidth: 1.5,
+                    showsGridlines: false
+                )
             } else {
-                Sparkline(series: .placeholder, color: Color(.systemGray3), lineWidth: 1.5, showsGridlines: false)
-                    .redacted(reason: .placeholder)
+                Sparkline(
+                    series: .placeholder,
+                    color: Color(.systemGray3),
+                    lineWidth: 1.5,
+                    showsGridlines: false
+                )
+                .redacted(reason: .placeholder)
             }
         }
         .frame(width: Self.size.width, height: Self.size.height)
@@ -52,7 +62,8 @@ struct MiniChart: View {
                 Text(verbatim: "Empty")
                 Spacer()
                 MiniChart(
-                    series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)), color: .red
+                    series: MiniChartSeries(values: Array(repeating: 0, count: MiniChartSeries.sliceCount)),
+                    color: .red
                 )
             }
         }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/View/SegmentBar.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/View/SegmentBar.swift
@@ -21,7 +21,11 @@ struct Segment: Identifiable, Equatable {
     let kind: Kind
 
     init(label: String, count: Int, color: Color) {
-        self.init(count: count, color: color, kind: .value(label))
+        self.init(
+            count: count,
+            color: color,
+            kind: .value(label)
+        )
     }
 
     init(count: Int, color: Color, kind: Kind) {
@@ -69,7 +73,14 @@ extension [Segment] {
         var otherCount = first { $0.kind == .other }?.count ?? 0
 
         func candidate() -> [Segment] {
-            otherCount > 0 ? named + [Segment(count: otherCount, color: .gray, kind: .other)] : named
+            otherCount > 0
+                ? named + [
+                    Segment(
+                        count: otherCount,
+                        color: .gray,
+                        kind: .other
+                    )
+                ] : named
         }
 
         while named.count > 1 {

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/View/Sparkline.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/View/Sparkline.swift
@@ -22,7 +22,13 @@ struct Sparkline: View {
         let last = Double(max(values.count - 1, 1))
         let xGridlines =
             gridlinesAtPoints
-            ? Array(stride(from: 0, through: last, by: 1))
+            ? Array(
+                stride(
+                    from: 0,
+                    through: last,
+                    by: 1
+                )
+            )
             : (0...3).map { last * Double($0) / 3 }
 
         Chart(Array(values.enumerated()), id: \.offset) { index, value in

--- a/Sources/ScoutUI/Primitives/Visualization/Heatmap/HeatmapGrid.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Heatmap/HeatmapGrid.swift
@@ -34,7 +34,13 @@ struct HeatmapGrid {
 
     func maxBlockCount(hours: Int) -> Int {
         (0..<7).flatMap { day in
-            (0..<24 / hours).map { blockCount(day: day, block: $0, hours: hours) }
+            (0..<24 / hours).map {
+                blockCount(
+                    day: day,
+                    block: $0,
+                    hours: hours
+                )
+            }
         }
         .max() ?? 0
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Heatmap/HeatmapView.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Heatmap/HeatmapView.swift
@@ -35,7 +35,11 @@ struct HeatmapView: View {
                         .foregroundStyle(.secondary)
                         .frame(width: 30, alignment: .leading)
                     ForEach(0..<24 / hours, id: \.self) { block in
-                        cell(day: day, block: block, maxBlock: maxBlock)
+                        cell(
+                            day: day,
+                            block: block,
+                            maxBlock: maxBlock
+                        )
                     }
                 }
             }
@@ -44,7 +48,11 @@ struct HeatmapView: View {
     }
 
     private func cell(day: Int, block: Int, maxBlock: Int) -> some View {
-        let count = grid.blockCount(day: day, block: block, hours: hours)
+        let count = grid.blockCount(
+            day: day,
+            block: block,
+            hours: hours
+        )
         let intensity = maxBlock > 0 ? Double(count) / Double(maxBlock) : 0
         return RoundedRectangle(cornerRadius: 6)
             .fill(count > 0 ? color.opacity(0.12 + 0.88 * intensity) : Color(.systemGray5))

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Export/ExportFormat.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Export/ExportFormat.swift
@@ -76,9 +76,14 @@ extension ExportFormat {
     private static let iso8601 = Date.ISO8601FormatStyle()
     private static let dayStyle = utcStyle("\(year: .padded(4))-\(month: .twoDigits)-\(day: .twoDigits)")
     private static let timeStyle = utcStyle(
-        "\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits)")
+        "\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits)"
+    )
 
     private static func utcStyle(_ format: Date.FormatString) -> Date.VerbatimFormatStyle {
-        Date.VerbatimFormatStyle(format: format, timeZone: .gmt, calendar: Calendar(identifier: .gregorian))
+        Date.VerbatimFormatStyle(
+            format: format,
+            timeZone: .gmt,
+            calendar: Calendar(identifier: .gregorian)
+        )
     }
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Export/TimelineExport.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Export/TimelineExport.swift
@@ -85,11 +85,21 @@ extension TimelineExport {
     }
 
     private func header(for install: Install) -> ExportLine {
-        header(level: 2, word: "Install", date: install.date.map(ExportFormat.day), id: install.installID)
+        header(
+            level: 2,
+            word: "Install",
+            date: install.date.map(ExportFormat.day),
+            id: install.installID
+        )
     }
 
     private func header(for launch: Launch) -> ExportLine {
-        header(level: 3, word: "Launch", date: launch.startDate.map(ExportFormat.minute), id: launch.launchID)
+        header(
+            level: 3,
+            word: "Launch",
+            date: launch.startDate.map(ExportFormat.minute),
+            id: launch.launchID
+        )
     }
 
     private func header(for session: Session) -> ExportLine {

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Event+Fetch.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Event+Fetch.swift
@@ -21,9 +21,21 @@ extension Event {
     }
 
     private static func filters(ids: [String], name: String?) -> [RecordQuery.Filter] {
-        var filters = [RecordQuery.Filter(field: "session_id", op: .in, value: .strings(ids))]
+        var filters = [
+            RecordQuery.Filter(
+                field: "session_id",
+                op: .in,
+                value: .strings(ids)
+            )
+        ]
         if let name {
-            filters.append(RecordQuery.Filter(field: "name", op: .equals, value: .string(name)))
+            filters.append(
+                RecordQuery.Filter(
+                    field: "name",
+                    op: .equals,
+                    value: .string(name)
+                )
+            )
         }
         return filters
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Rail+Merged.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Rail+Merged.swift
@@ -36,6 +36,12 @@ extension Rail {
         let sessions = self.installs.flatMap { $0.launches.flatMap { $0.sessions.map(\.session) } }
         let events = self.installs.flatMap { $0.launches.flatMap { $0.sessions.flatMap(\.events) } }
         let crashes = self.installs.flatMap { $0.launches.flatMap { $0.sessions.flatMap(\.crashes) } }
-        return (installs, launches, sessions, events, crashes)
+        return (
+            installs,
+            launches,
+            sessions,
+            events,
+            crashes
+        )
     }
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/RailLane.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/RailLane.swift
@@ -115,7 +115,12 @@ final class RailLane: ObservableObject {
     private func chunk(in database: DatabaseReader) async throws -> RecordChunk {
         guard let cursor else {
             return try await Session.fetchChunk(
-                installIDs: pendingInstalls, anchor: anchorDate, ascending: ascending, limit: chunkLimit, in: database)
+                installIDs: pendingInstalls,
+                anchor: anchorDate,
+                ascending: ascending,
+                limit: chunkLimit,
+                in: database
+            )
         }
         return try await database.readMore(from: cursor, fields: Session.desiredKeys)
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Session+FetchChunk.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Session+FetchChunk.swift
@@ -13,13 +13,20 @@ extension Session {
         async throws -> RecordChunk
     {
         var filters = [
-            RecordQuery.Filter(field: "install_id", op: .in, value: .strings(installIDs.map(\.uuidString)))
+            RecordQuery.Filter(
+                field: "install_id",
+                op: .in,
+                value: .strings(installIDs.map(\.uuidString))
+            )
         ]
 
         if let anchor {
             filters.append(
                 RecordQuery.Filter(
-                    field: "start_date", op: ascending ? .greaterThan : .lessThanOrEquals, value: .date(anchor))
+                    field: "start_date",
+                    op: ascending ? .greaterThan : .lessThanOrEquals,
+                    value: .date(anchor)
+                )
             )
         }
 
@@ -29,6 +36,10 @@ extension Session {
             sort: [RecordQuery.Sort(field: "start_date", ascending: ascending)]
         )
 
-        return try await database.read(matching: query, fields: Session.desiredKeys, limit: limit)
+        return try await database.read(
+            matching: query,
+            fields: Session.desiredKeys,
+            limit: limit
+        )
     }
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Provider/Rail+Init.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Provider/Rail+Init.swift
@@ -10,7 +10,11 @@ import Scout
 
 extension Rail {
     init(
-        device: Device, installs: [Install], launches: [Launch], sessions: [Session] = [], events: [Event] = [],
+        device: Device,
+        installs: [Install],
+        launches: [Launch],
+        sessions: [Session] = [],
+        events: [Event] = [],
         crashes: [Crash] = []
     ) {
         let installs = Dictionary(grouping: installs, by: \.deviceID)

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Provider/TimelineFeed.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Provider/TimelineFeed.swift
@@ -15,7 +15,13 @@ struct TimelineFeed {
     func device() async throws -> Device {
         let query = RecordQuery(
             recordType: Device.self,
-            filters: [RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))]
+            filters: [
+                RecordQuery.Filter(
+                    field: "device_id",
+                    op: .equals,
+                    value: .string(deviceID.uuidString)
+                )
+            ]
         )
         if let record = try await database.read(matching: query, fields: Device.desiredKeys, limit: 1).records.first {
             return try Device(record: record)
@@ -30,7 +36,13 @@ struct TimelineFeed {
     func installs() async throws -> [Install] {
         let query = RecordQuery(
             recordType: Install.self,
-            filters: [RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))]
+            filters: [
+                RecordQuery.Filter(
+                    field: "device_id",
+                    op: .equals,
+                    value: .string(deviceID.uuidString)
+                )
+            ]
         )
         return try await database.readAll(matching: query, fields: Install.desiredKeys)
     }
@@ -38,7 +50,13 @@ struct TimelineFeed {
     func launches() async throws -> [Launch] {
         let query = RecordQuery(
             recordType: Launch.self,
-            filters: [RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))]
+            filters: [
+                RecordQuery.Filter(
+                    field: "device_id",
+                    op: .equals,
+                    value: .string(deviceID.uuidString)
+                )
+            ]
         )
         return try await database.readAll(matching: query, fields: Launch.desiredKeys)
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Session+Fixture.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Session+Fixture.swift
@@ -10,7 +10,10 @@ import Scout
 
 extension Session: Fixture {
     static func sample(
-        minutesAgo: Double = 0, sessionID: UUID = UUID(), launchID: UUID = UUID(), installID: UUID = UUID(),
+        minutesAgo: Double = 0,
+        sessionID: UUID = UUID(),
+        launchID: UUID = UUID(),
+        installID: UUID = UUID(),
         ongoing: Bool = false
     ) -> Session {
         let startDate = Date(timeIntervalSinceNow: -minutesAgo * 60)

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Version+Fixture.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Version+Fixture.swift
@@ -10,7 +10,10 @@ import Scout
 
 extension Version: Fixture {
     static func sample(
-        appVersion: String = "2.4.1", buildNumber: String = "214", minutesAgo: Double = 0, launchID: UUID = UUID()
+        appVersion: String = "2.4.1",
+        buildNumber: String = "214",
+        minutesAgo: Double = 0,
+        launchID: UUID = UUID()
     ) -> Version {
         Version(
             appVersion: appVersion,

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/View/TimelineRow.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/View/TimelineRow.swift
@@ -21,7 +21,12 @@ struct TimelineRow: View {
         VStack(spacing: 0) {
             HStack(spacing: 4) {
                 ForEach(LegendKind.allCases, id: \.self) { kind in
-                    TimelineSegment(kind: kind, row: row, prev: prev, next: next)
+                    TimelineSegment(
+                        kind: kind,
+                        row: row,
+                        prev: prev,
+                        next: next
+                    )
                 }
 
                 Text(row.name)

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/View/TimelineSegment.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/View/TimelineSegment.swift
@@ -35,7 +35,19 @@ extension TimelineSegment {
 
         self.color = kind.color
         self.isActive = active
-        self.topRadius = (active && !connected(prev, row, on: kind)) ? 4 : 0
-        self.bottomRadius = (active && !connected(next, row, on: kind)) ? 4 : 0
+        self.topRadius =
+            (active
+                && !connected(
+                    prev,
+                    row,
+                    on: kind
+                )) ? 4 : 0
+        self.bottomRadius =
+            (active
+                && !connected(
+                    next,
+                    row,
+                    on: kind
+                )) ? 4 : 0
     }
 }


### PR DESCRIPTION
This applies the call-site wrapping rule documented in #1123 to everything under Sources: a call with three or more arguments, or one that would exceed the 120-character limit, now puts every argument on its own line with the closing parenthesis on a line of its own. It landed in two passes, first expanding calls that sat entirely on one line, then re-breaking calls that were already wrapped but packed several arguments per line, and swift-format was run afterwards so the result is stable under the repository configuration with no formatter flag changes.

Tests are deliberately untouched, matching how #1123 scopes the three-argument threshold to the library sources. Expanding the several hundred compact fixture calls there would have cost readability rather than buying it.

Two categories are worth a look during review, since the rule reaches them by its own terms and the result is more verbose than what it replaced: calls sitting in a ternary branch, and calls that carry a trailing closure, where the arguments now expand above the closure brace. Say the word and I will exempt either category.

The change is formatting only, verified with build-for-testing and the full test bundle on the simulator, all suites passing.