### PR TITLE
Document the wrapping rule for function and initializer calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,31 @@
 
 - Function/method **signatures** (declarations) should be written on a single line, even with many parameters or default values — do not wrap parameters onto separate lines.
 - Exception: when a single-line signature would exceed the 120-character `lineLength` limit in `.swift-format` (a CI lint gate, so the limit wins), let `swift-format` wrap it; don't fight the formatter.
-- This applies to declarations only, not to call sites: a function or initializer **call** with several arguments wraps each argument onto its own line.
+- This applies to declarations only, not to call sites — see below.
+
+## Function and initializer calls
+
+- Once a **call** is written across multiple lines, every argument gets its own line, with the closing `)` on its own line:
+
+```swift
+cohorts = RetentionCohort.build(
+    installDays: installDays,
+    sessionDays: sessionDays,
+    in: range,
+    asOf: scenario.clock.now
+)
+```
+
+- Never pack several arguments onto one wrapped line, even when they fit within the 120-character limit:
+
+```swift
+cohorts = RetentionCohort.build(
+    installDays: installDays, sessionDays: sessionDays,
+    in: range, asOf: scenario.clock.now
+)
+```
+
+- Signatures are the exception: a declaration too long for one line is wrapped by `swift-format` as it sees fit, packed lines included.
 
 ## Array extensions
 


### PR DESCRIPTION
The call-site style was buried as a sub-bullet under the signature rules and only said that a call with several arguments wraps each argument onto its own line, which left the threshold open to interpretation. It now has its own section stating the single condition that matters: a call stays on one line while it fits within the 120-character limit, and wraps each argument with the closing parenthesis on its own line once it doesn't — regardless of how many arguments it takes.

Deliberately no argument-count threshold here. Tying the wrap to the line limit alone keeps calls in Sources and Tests under one rule, leaves compact fixture calls untouched, and matches what swift-format actually does, so the convention needs no separate enforcement carve-out.

The signature rule is unchanged and now cross-references the new section, so it stays clear that declarations remain single-line no matter how many parameters they take.