### PR TITLE
Skip the iOS jobs when only documentation changes

### DIFF
--- a/.github/scripts/detect-code-changes.sh
+++ b/.github/scripts/detect-code-changes.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${EVENT_NAME:?EVENT_NAME is required}"
+
+emit() {
+  echo "code=$1"
+  echo "code=$1" >> "$GITHUB_OUTPUT"
+}
+
+case "$EVENT_NAME" in
+  pull_request)
+    base="${BASE_SHA:?BASE_SHA is required on a pull_request}"
+    ;;
+  push)
+    base="${BEFORE_SHA:-}"
+    ;;
+  *)
+    emit true
+    exit 0
+    ;;
+esac
+
+if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ] \
+  || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+  echo "No usable base revision ($base); treating the change as code."
+  emit true
+  exit 0
+fi
+
+changed="$(git diff --name-only "$base"...HEAD)"
+echo "$changed"
+
+if grep -qE '^(Sources/|Tests/|Package\.swift$|\.swift-format$|\.github/)' <<<"$changed"; then
+  emit true
+else
+  emit false
+fi

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -12,8 +12,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Detect code changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: .github/scripts/detect-code-changes.sh
+
   gate:
     name: gate
+    needs: scope
+    if: needs.scope.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 190
 
@@ -156,7 +178,7 @@ jobs:
 
   api-gate:
     name: api-gate
-    needs: [gate, api-breakage]
+    needs: [scope, gate, api-breakage]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -164,6 +186,14 @@ jobs:
     steps:
       - name: Require the API diff to pass
         run: |
+          if [ "${{ needs.scope.result }}" != "success" ]; then
+            echo "::error::The scope job did not succeed (${{ needs.scope.result }})."
+            exit 1
+          fi
+          if [ "${{ needs.scope.outputs.code }}" != "true" ]; then
+            echo "Nothing outside the docs changed; the public API cannot have moved."
+            exit 0
+          fi
           if [ "${{ needs.gate.result }}" != "success" ]; then
             echo "::error::The fast-check gate did not pass (${{ needs.gate.result }})."
             exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Detect code changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: .github/scripts/detect-code-changes.sh
+
   build:
+    needs: scope
+    if: needs.scope.outputs.code == 'true'
     runs-on: macos-26
     timeout-minutes: 20
 

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   notify:
@@ -16,7 +17,28 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - name: Check the iOS matrix ran
+        id: matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          if ! conclusions="$(gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs" \
+            --jq '.jobs[] | select(.name | startswith("test-ios-")) | .conclusion')"; then
+            echo "::warning::Could not read the Swift run's jobs; notifying anyway."
+            echo "ran=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -qx success <<<"$conclusions"; then
+            echo "ran=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "The iOS matrix did not run for this commit, so scout-ip has nothing new to build."
+            echo "ran=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Trigger scout-ip
+        if: steps.matrix.outputs.ran == 'true'
         run: |
           curl --fail-with-body -sS \
             --retry 3 --retry-all-errors --retry-delay 5 \

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,30 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Detect code changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: .github/scripts/detect-code-changes.sh
+
   lint:
+    needs: scope
+    if: needs.scope.outputs.code == 'true'
     runs-on: macos-26
     timeout-minutes: 5
 
@@ -38,7 +61,8 @@ jobs:
 
   gate:
     name: gate
-    if: github.event_name == 'pull_request'
+    needs: scope
+    if: github.event_name == 'pull_request' && needs.scope.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 190
 
@@ -60,8 +84,12 @@ jobs:
 
   tests:
     name: test-ios-${{ matrix.ios }}
-    needs: [lint, gate]
-    if: ${{ always() && needs.lint.result == 'success' && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
+    needs: [scope, lint, gate]
+    if: >-
+      ${{ always()
+      && needs.scope.outputs.code == 'true'
+      && needs.lint.result == 'success'
+      && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 
@@ -167,7 +195,7 @@ jobs:
 
   tests-gate:
     name: tests-gate
-    needs: [lint, gate, tests]
+    needs: [scope, lint, gate, tests]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -175,6 +203,14 @@ jobs:
     steps:
       - name: Require the matrix to pass
         run: |
+          if [ "${{ needs.scope.result }}" != "success" ]; then
+            echo "::error::The scope job did not succeed (${{ needs.scope.result }})."
+            exit 1
+          fi
+          if [ "${{ needs.scope.outputs.code }}" != "true" ]; then
+            echo "Nothing outside the docs changed; the iOS matrix has nothing to build."
+            exit 0
+          fi
           if [ "${{ needs.lint.result }}" != "success" ]; then
             echo "::error::Lint did not succeed (${{ needs.lint.result }})."
             exit 1


### PR DESCRIPTION
A PR that only touches README.md, CLAUDE.md or docs/ used to run the whole iOS matrix, the api-breakage diff on macOS, the DocC build and a scout-ip dispatch, all for a change that cannot affect any of them. A paths filter on `on:` is not an option here, because lint, tests-gate, contract-gate, model-versions and api-gate are required on main and a workflow that never starts leaves them pending forever.

So each of the affected workflows now opens with a cheap ubuntu `scope` job that runs the new `.github/scripts/detect-code-changes.sh`, following the same shape the Server workflow already uses for its wire filter. The script diffs against the PR base (or the pushed range) and reports whether anything under Sources/, Tests/, Package.swift, .swift-format or .github/ moved; the expensive jobs run only when it did, and the required gates stay in place, verify the scope job itself succeeded, and pass through a documentation-only change. Notify now checks that the Swift run actually executed an iOS leg before dispatching to scout-ip.

The filter is a whitelist of the build inputs, so a new file outside those paths is treated as documentation and skips the checks. Where the base revision cannot be resolved at all — a new branch, a force-push, workflow_dispatch — the script errors on the side of running everything, and Notify dispatches anyway if the jobs API cannot be read.