### PR TITLE
Skip macro validation in the CodeQL build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,7 @@ jobs:
             xcodebuild \
               -scheme "$scheme" \
               -destination 'generic/platform=iOS Simulator' \
+              -skipMacroValidation \
               ARCHS=arm64 \
               build
           done


### PR DESCRIPTION
Since #1111 the CodeQL build loops over every library product, which includes NativeConnector and with it scout-db's ScoutDBMacros compiler plugin. Unlike every other xcodebuild invocation in the workflows, the CodeQL one does not pass -skipMacroValidation, so the next scheduled run would fail on the macro-approval prompt that CI cannot answer. This adds the flag, matching swift.yml, api.yml, and server.yml.