### PR TITLE
Reject model-version rollbacks in the Core Data check

### DIFF
--- a/.github/workflows/coredata.yml
+++ b/.github/workflows/coredata.yml
@@ -43,3 +43,15 @@ jobs:
             echo "Mark the new version as current (Xcode: File Inspector > Model Version > Current)."
             exit 1
           fi
+
+          if [ -n "$current" ]; then
+            name=$(sed -n 's:.*<string>\(.*\.xcdatamodel\)</string>.*:\1:p' \
+              "Sources/Scout/Persistence/ScoutModel.xcdatamodeld/.xccurrentversion")
+            if ! grep -qF "$name/" <<< "$added"; then
+              echo
+              echo ".xccurrentversion now points to \"$name\", which is not a model version added by this change."
+              echo "The current version can only move forward to a newly added version:"
+              echo "a store migrated to a newer model cannot be opened by an older one."
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
The model-version check exempted .xccurrentversion from the immutability gate and only verified that adding a version also updates it, so a PR modifying nothing but .xccurrentversion could point the current model back to an older version and pass — even though a store migrated to the newer model can never be opened again. The check now requires any .xccurrentversion change to point at a version added in the same change, which also catches marking a pre-existing older version as current alongside a legitimate addition.