### PR TITLE
Fail the contract ran-something guard when the count is unreadable

### DIFF
--- a/.github/scripts/verify-contract-ran.sh
+++ b/.github/scripts/verify-contract-ran.sh
@@ -6,9 +6,9 @@ summary="$(xcrun xcresulttool get test-results summary \
 passed="$(echo "$summary" | jq '.passedTests // empty' || true)"
 case "$passed" in
   '' | *[!0-9]*)
-    echo "::warning::Could not read a passedTests count from the result bundle; skipping the ran-something check."
+    echo "::error::Could not read a passedTests count from the result bundle, so there is no proof the contract suite ran anything."
     printf '%s\n' "$summary" | head -c 2000 || true
-    exit 0
+    exit 1
     ;;
 esac
 echo "Contract tests passed: $passed"


### PR DESCRIPTION
verify-contract-ran.sh exists to catch the vacuous -only-testing pass where the contract suite runs zero tests yet the job goes green. When xcresulttool or jq output changed shape it printed a warning and exited 0, silently disabling itself in exactly the scenario it guards against — an Xcode bump altering the summary JSON. An unreadable passedTests count is now an error: with no proof the suite ran, the step fails instead of waving the run through.