### PR TITLE
Skip the server log dump when the log was never created

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Dump server log
         if: failure()
-        run: cat scout-server/server.log
+        run: test ! -f scout-server/server.log || cat scout-server/server.log
 
   contract-gate:
     name: contract-gate


### PR DESCRIPTION
The Dump server log step fires on any failure in the contract job, but scout-server/server.log only exists once start-scout-server.sh has run. When an earlier step fails — the scout-server checkout or the PostgreSQL bootstrap — the bare cat itself errored with "No such file or directory", adding a second red step that points debugging at the server log instead of the real cause. The dump now no-ops when the file is absent.