### PR TITLE
Anchor the wire guard's HTTP patterns to type declarations

### DIFF
--- a/.github/scripts/guard-filter-covers-wire.sh
+++ b/.github/scripts/guard-filter-covers-wire.sh
@@ -21,9 +21,9 @@ check() {
   matched="$matched$hits"$'\n'
 }
 
-check HTTPDatabase 'HTTPDatabase'
-check HTTPQuery 'HTTPQuery'
-check HTTPRecord 'HTTPRecord'
+check HTTPDatabase '(struct|enum|final class|class) +HTTPDatabase\b'
+check HTTPQuery '(struct|enum|final class|class) +HTTPQuery\b'
+check HTTPRecord '(struct|enum|final class|class) +HTTPRecord\b'
 check RecordChunk '(struct|enum|final class|class) +RecordChunk\b'
 check RecordCursor '(struct|enum|final class|class) +RecordCursor\b'
 


### PR DESCRIPTION
The guard's HTTPDatabase/HTTPQuery/HTTPRecord patterns were bare substrings matched across all of Sources, so any mention outside the two watched directories tripped it: a doc comment like "Backed by HTTPDatabase" in the UI layer, or an identifier such as HTTPQueryable, hard-failed the Server workflow's changes job on every PR until the text was reworded. The three patterns now anchor to type declarations, matching how RecordChunk and RecordCursor were already written. Verified by reproduction: a doc-comment mention that previously failed the guard now passes, and the guard still exits 0 on the clean tree.