### PR TITLE
Treat a queued check run as newer than a completed one

### DIFF
--- a/.github/scripts/wait-for-checks.sh
+++ b/.github/scripts/wait-for-checks.sh
@@ -41,7 +41,7 @@ while :; do
   pending=()
   for name in "${names[@]}"; do
     run="$(echo "$runs" | jq -c --arg n "$name" \
-      '[.[] | select(.name == $n)] | sort_by(.started_at) | last')"
+      '[.[] | select(.name == $n)] | sort_by(.started_at // "~") | last')"
     if [ -z "$run" ] || [ "$run" = "null" ]; then
       pending+=("$name(absent)")
       continue


### PR DESCRIPTION
The gate picked a check run with sort_by(.started_at) | last, but a queued run carries a null started_at and jq sorts null first, so a stale completed run could win over a newer queued one — reading a re-run in progress as the old failure and killing the gate. Since runs for both the head and the merge SHA are pooled into one array, duplicate names for the same check are reachable in practice. Sorting now substitutes a value that orders after any timestamp, so a queued run is treated as the newest.