### PR TITLE
Align the retention chart with the rest of the home list

### DIFF
--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionRow.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionRow.swift
@@ -16,7 +16,6 @@ struct HomeRetentionRow: View {
         Button(action: action) {
             Sparkline(series: series, color: .green, gridlinesAtPoints: true)
                 .frame(height: 68)
-                .padding(.horizontal, 16)
                 .padding(.bottom, 12)
         }
         .buttonStyle(.plain)

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -28,7 +28,12 @@ struct HomeRetentionSection: View {
         switch retention.result {
         case .success(let cohorts) where cohorts.count > 0:
             let stats = RetentionCohort.stats(for: cohorts)
-            let series = MiniChartSeries(values: stats.map { Int(($0.average * 100).rounded()) })
+
+            let series = MiniChartSeries(
+                values: stats.map {
+                    Int(($0.average * 100).rounded())
+                }
+            )
 
             HomeRetentionRow(series: series) { path.append(.retention) }
 


### PR DESCRIPTION
The retention sparkline sat noticeably narrower than the release rows above it. `InsetList` already applies 16 pt leading/trailing insets to every row, and `HomeRetentionRow` was adding another `.padding(.horizontal, 16)` on top of that, so the chart ended up at 32 pt per side. Removing the inner padding lets it line up with the section headers and rows.

Also reformats the `MiniChartSeries` call in `HomeRetentionSection` across multiple lines to match the call-site style used elsewhere in the project; no behaviour change there.