### PR TITLE
Give every home section the same empty-state text style

### DIFF
--- a/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
+++ b/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
@@ -43,7 +43,7 @@ struct HomeAlertSection: View {
 
         switch alerts.result {
         case .success(let statuses) where statuses.allHealthy:
-            placeholderText("All healthy", color: .green)
+            placeholderText("All healthy").foregroundStyle(.green)
 
         case .success(let statuses) where statuses.count > 0:
             ForEach(statuses.prefix(2), id: \.rule) { status in
@@ -54,7 +54,7 @@ struct HomeAlertSection: View {
             Button {
                 isEditorPresented = true
             } label: {
-                placeholderText("New rule", color: .blue)
+                placeholderText("New rule").foregroundStyle(.blue)
             }
             .buttonStyle(.plain)
 
@@ -65,11 +65,9 @@ struct HomeAlertSection: View {
         }
     }
 
-    private func placeholderText(_ text: String, color: Color) -> some View {
+    private func placeholderText(_ text: String) -> some View {
         Text(verbatim: text)
             .font(.body)
-            .fontWeight(.medium)
-            .foregroundStyle(color.opacity(0.7))
             .frame(height: 44)
             .frame(maxWidth: .infinity)
             .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }

--- a/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
+++ b/Sources/ScoutUI/Home/Section/Release/HomeReleaseSection.swift
@@ -29,8 +29,7 @@ struct HomeReleaseSection: View {
         case .success:
             Text(verbatim: "No results")
                 .font(.body)
-                .fontWeight(.medium)
-                .foregroundStyle(.gray.opacity(0.7))
+                .foregroundStyle(.gray)
                 .frame(maxWidth: .infinity)
                 .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
 

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -61,7 +61,6 @@ struct HomeRetentionSection: View {
                 .foregroundStyle(.gray)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 20)
-                .listRowSeparator(.hidden, edges: .bottom)
 
         default:
             HomeRetentionRow(series: .placeholder) {}
@@ -91,6 +90,10 @@ struct HomeRetentionSection: View {
         InsetList {
             HomeRetentionSection(
                 retention: .init(.success(.samples)),
+                path: .constant([])
+            )
+            HomeRetentionSection(
+                retention: .init(.success([])),
                 path: .constant([])
             )
             HomeRetentionSection(


### PR DESCRIPTION
The Alerts, Releases and Retention sections each drew their own empty-state text, and they had drifted apart: Alerts and Releases used a medium weight with a 0.7 alpha on the colour, while Retention used a plain body font in solid gray. Side by side in the home list the same "No results" line looked like two different styles.

They now all use the plain body font at full colour, so the placeholders read consistently. The Alerts helper no longer takes a colour parameter — the caller applies `foregroundStyle` instead. Retention also drops its bottom-separator override and gains an empty-state preview alongside the populated and loading ones.