### PR TITLE
Align the retention empty state and its loading placeholders

### DIFF
--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -61,6 +61,7 @@ struct HomeRetentionSection: View {
                 .foregroundStyle(.gray)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 20)
+                .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
 
         default:
             HomeRetentionRow(series: .placeholder) {}
@@ -73,7 +74,7 @@ struct HomeRetentionSection: View {
                         Text(verbatim: "Day \(day)")
                             .font(.subheadline)
                         Spacer()
-                        Text(verbatim: "—")
+                        Text(verbatim: "     ")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.green)
                     }


### PR DESCRIPTION
Two leftovers in the home retention section. The "No results" row did not pin its separator to the leading edge the way the Alerts and Releases sections do, so the divider under it started at the text inset instead of the full width. It now uses the same `listRowSeparatorLeading` alignment guide.

The loading state also redacted an em dash, which renders as a stub barely wider than a character. Widening it to a blank run gives the redaction a bar comparable to the real rate it stands in for.

Stacked on #1140 — the base flips to main once that lands.