### PR TITLE
Load home retention through the shared loading gate

### DIFF
--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -74,7 +74,7 @@ struct HomeList: View {
             }
         }
         .rotatingProviders(
-            first: [alerts, releases],
+            first: [alerts, releases, retention],
             later: [sessions, activities, logs, devices]
         )
     }

--- a/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
+++ b/Sources/ScoutUI/Home/Section/Retention/HomeRetentionSection.swift
@@ -9,8 +9,6 @@ import Scout
 import SwiftUI
 
 struct HomeRetentionSection: View {
-    @Environment(\.database) var database
-
     @ObservedObject var retention: RetentionProvider
 
     @Binding var path: [HomeDestination]
@@ -20,9 +18,6 @@ struct HomeRetentionSection: View {
             if let cohorts = try? retention.result?.get(), cohorts.count > 0 {
                 AllButton { path.append(.retention) }
             }
-        }
-        .task {
-            await retention.fetchIfNeeded(in: database)
         }
 
         switch retention.result {


### PR DESCRIPTION
The retention section fetched its own data from a `.task`, so it was the only home section outside the shared provider rotation. Its provider now sits in the `first` list of `rotatingProviders`, which means it goes through the loading gate, the periodic refresh and the shared error view with retry, and the section itself is purely presentational like the releases one.

The visible trade-off is that home shows the ring indicator until retention resolves instead of only redacting that one section; moving the provider to `later` would keep refresh and error handling shared without gating the screen, if that reads better.

Verified with `build-for-testing` for `Scout-Package` on iPhone 17 (iOS 26).