### PR TITLE
Move the native connector onto scout-db's query surface

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -105,15 +105,27 @@ jobs:
           echo "Toolchain: $id"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
+      - name: Acknowledge an unbuildable baseline
+        id: baseline-ack
+        run: |
+          if ${{ contains(github.event.pull_request.labels.*.name, 'api-baseline-unbuildable') }}; then
+            echo "The api-baseline-unbuildable label is set, so the base is taken as unable to build" \
+              "and the comparison is skipped." >> "$GITHUB_STEP_SUMMARY"
+            echo "acknowledged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "acknowledged=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Cache baseline API set
         id: baseline-cache
+        if: steps.baseline-ack.outputs.acknowledged != 'true'
         uses: actions/cache@v6
         with:
           path: /tmp/baseline.set
           key: api-baseline-set-${{ github.event.pull_request.base.sha }}-${{ hashFiles('.github/scripts/dump-api-set.sh') }}-${{ steps.toolchain.outputs.id }}
 
       - name: Dump baseline API
-        if: steps.baseline-cache.outputs.cache-hit != 'true'
+        if: steps.baseline-ack.outputs.acknowledged != 'true' && steps.baseline-cache.outputs.cache-hit != 'true'
         run: |
           baseline="${{ github.event.pull_request.base.sha }}"
           if [ -z "$baseline" ]; then
@@ -137,13 +149,14 @@ jobs:
               -skipMacroValidation \
               -quiet \
               build; then
-              echo "::error::The baseline scheme $scheme does not build, so the API comparison cannot run. Dependencies resolve fresh here, so a dependency release can break a base that once built — fix the base or pin the dependency."
+              echo "::error::The baseline scheme $scheme does not build, so the API comparison cannot run. Dependencies resolve fresh here, so a dependency release can break a base that once built — fix the base or pin the dependency. Where the PR is itself that fix, add the api-baseline-unbuildable label to say the base cannot answer."
               exit 1
             fi
           done
           "$GITHUB_WORKSPACE/.github/scripts/dump-api-set.sh" /tmp/dd-baseline /tmp/baseline.set
 
       - name: Compare
+        if: steps.baseline-ack.outputs.acknowledged != 'true'
         run: |
           if [ ! -f /tmp/baseline.set ]; then
             echo "::error::No baseline API set was produced, so the comparison cannot run."

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
-        .package(url: "https://github.com/kasianov-mikhail/scout-db.git", branch: "main"),
+        .package(
+            url: "https://github.com/kasianov-mikhail/scout-db.git",
+            revision: "8d9e62f610968a59501f0a68b61bb78e05aeac67"
+        ),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),
     ],

--- a/Sources/Connectors/Native/EntityCatalog.swift
+++ b/Sources/Connectors/Native/EntityCatalog.swift
@@ -9,53 +9,118 @@ import Foundation
 import Scout
 import ScoutDB
 
-// A scout-db `EntityDefinition` paired with the derivations scout applies on
-// write. Derived fields live here because they compute over scout's `Record`,
-// which the wire-format `EntityDefinition` cannot express.
+// One entity as scout declares it: the fields it writes, the aggregates it
+// reads back as series, and the derivations it applies on write. Derived fields
+// live here because they compute over scout's `Record`, which a schema
+// declaration cannot express.
 struct CatalogEntry {
-    let definition: EntityDefinition
+    let entity: String
+    let fields: [Field]
+    let aggregates: [Aggregate]
     let derive: @Sendable (Record) -> [String: ScoutDB.RecordValue]
 
+    struct Field {
+        let name: String
+        let type: FieldType
+    }
+
+    enum Aggregate {
+        case count(by: String, at: String)
+        case sum(String, by: String, at: String)
+    }
+
     init(
-        _ definition: EntityDefinition,
+        entity: String, fields: [Field], aggregates: [Aggregate] = [],
         derive: @escaping @Sendable (Record) -> [String: ScoutDB.RecordValue] = { _ in [:] }
     ) {
-        self.definition = definition
+        self.entity = entity
+        self.fields = fields + Self.metadata
+        self.aggregates = aggregates
         self.derive = derive
+    }
+
+    // Every entity carries the same tail of bucket stamps and identifiers, so
+    // it is appended once here rather than repeated in every declaration.
+    private static let metadata: [Field] = [
+        Field(name: "hour", type: .timestamp),
+        Field(name: "day", type: .timestamp),
+        Field(name: "week", type: .timestamp),
+        Field(name: "month", type: .timestamp),
+        Field(name: "device_id", type: .string),
+        Field(name: "install_id", type: .string),
+        Field(name: "launch_id", type: .string),
+        Field(name: "version", type: .int),
+    ]
+}
+
+extension CatalogEntry {
+    // Fields are declared `.ungrouped` so a creation builds no vector of its
+    // own: every aggregate scout reads is named below, dated by the record's
+    // own timestamp rather than by the hour the write lands in.
+    func declaration(on store: EntityStore) -> SchemaBuilder {
+        var builder = store.schema(entity)
+
+        for field in fields {
+            builder = builder.field(field.name, field.type, .ungrouped)
+        }
+        for aggregate in aggregates {
+            switch aggregate {
+            case .count(let group, let date):
+                builder = builder.count(by: group, at: date)
+            case .sum(let field, let group, let date):
+                builder = builder.sum(field, by: group, at: date)
+            }
+        }
+
+        return builder
+    }
+
+    // A published schema the declaration already matches is left alone: only a
+    // drift in the field list is worth a new version, and aggregates join
+    // rather than replace, so republishing an unchanged one buys nothing.
+    func matches(_ schema: EntitySchema) -> Bool {
+        guard schema.fields.count == fields.count else {
+            return false
+        }
+        return zip(schema.fields, fields).allSatisfy {
+            $0.name == $1.name && $0.type == $1.type
+        }
     }
 }
 
-// Slot assignment follows declaration order, so the field lists below are part
-// of the stored-data contract: never reorder or retype existing fields — append
-// new ones in a new schema version instead.
 enum EntityCatalog {
-    static let eventCountView = "count"
-    static let metricSeriesView = "series"
     static let metricSeriesKey = "series_key"
 
     static let entries: [CatalogEntry] = [
-        CatalogEntry(event), CatalogEntry(session), CatalogEntry(visit), CatalogEntry(launch),
-        CatalogEntry(install), CatalogEntry(device), CatalogEntry(version), CatalogEntry(crash), CatalogEntry(hang),
+        event, session, visit, launch, install, device, version, crash, hang,
         metric(entity: IntMetricsEntry.recordType, valueType: .int),
         metric(entity: DoubleMetricsEntry.recordType, valueType: .double),
     ]
 
-    static var definitions: [EntityDefinition] {
-        entries.map(\.definition)
-    }
-
-    static func definition(for entity: String) -> EntityDefinition? {
-        entries.first { $0.definition.entity == entity }?.definition
+    static func entry(for entity: String) -> CatalogEntry? {
+        entries.first { $0.entity == entity }
     }
 
     // The writer applies every entity's declared derivations uniformly, so a new
     // computed field is a per-entity `derive` closure here rather than a special
     // case wired into the shared write path.
     static func derivedValues(for record: Record) -> [String: ScoutDB.RecordValue] {
-        entries.first { $0.definition.entity == record.recordType }?.derive(record) ?? [:]
+        entry(for: record.recordType)?.derive(record) ?? [:]
     }
 
-    // Metric series are grouped by a single grid key, so the category and name
+    // A keyset page orders by one field, and a read without a sort of its own
+    // still has to walk in some order — the entity's own timestamp is the one
+    // every record carries.
+    static func dateField(for entity: String) -> String {
+        switch entity {
+        case SessionEntry.recordType, LaunchEntry.recordType:
+            "start_date"
+        default:
+            "date"
+        }
+    }
+
+    // Metric series are grouped by a single vector key, so the category and name
     // are packed into one field on write and split on read. Each component is
     // backslash-escaped so a "|" (or "\") inside a category or name can't be
     // mistaken for the separator and scatter points across the wrong series.
@@ -115,166 +180,108 @@ enum EntityCatalog {
         return result
     }
 
-    private static let event = definition(
+    private static let event = CatalogEntry(
         entity: EventEntry.recordType,
         fields: [
-            ("name", .text),
-            ("level", .string),
-            ("session_id", .string),
-            ("params", .bytes),
-            ("param_count", .int),
-            ("date", .timestamp),
+            .init(name: "name", type: .text),
+            .init(name: "level", type: .string),
+            .init(name: "session_id", type: .string),
+            .init(name: "params", type: .bytes),
+            .init(name: "param_count", type: .int),
+            .init(name: "date", type: .timestamp),
         ],
-        views: [AggregateView(name: eventCountView, groupBy: "name", bucket: .hour)]
+        aggregates: [.count(by: "name", at: "date")]
     )
 
-    private static let session = definition(
+    private static let session = CatalogEntry(
         entity: SessionEntry.recordType,
         fields: [
-            ("start_date", .timestamp),
-            ("end_date", .timestamp),
-            ("session_id", .string),
-            ("app_version", .string),
-        ],
-        trailing: [
-            ("build_number", .string),
-            ("os_version", .string),
-            ("locale", .string),
-            ("channel", .string),
-        ],
-        envelopeDate: "start_date"
+            .init(name: "start_date", type: .timestamp),
+            .init(name: "end_date", type: .timestamp),
+            .init(name: "session_id", type: .string),
+            .init(name: "app_version", type: .string),
+            .init(name: "build_number", type: .string),
+            .init(name: "os_version", type: .string),
+            .init(name: "locale", type: .string),
+            .init(name: "channel", type: .string),
+        ]
     )
 
-    private static let visit = definition(
+    private static let visit = CatalogEntry(
         entity: VisitEntry.recordType,
-        fields: [("date", .timestamp)]
+        fields: [.init(name: "date", type: .timestamp)]
     )
 
-    private static let launch = definition(
+    private static let launch = CatalogEntry(
         entity: LaunchEntry.recordType,
         fields: [
-            ("start_date", .timestamp),
-            ("end_date", .timestamp),
-        ],
-        envelopeDate: "start_date"
+            .init(name: "start_date", type: .timestamp),
+            .init(name: "end_date", type: .timestamp),
+        ]
     )
 
-    private static let install = definition(
+    private static let install = CatalogEntry(
         entity: InstallEntry.recordType,
-        fields: [("date", .timestamp)]
+        fields: [.init(name: "date", type: .timestamp)]
     )
 
-    private static let device = definition(
+    private static let device = CatalogEntry(
         entity: DeviceEntry.recordType,
-        fields: [("date", .timestamp)],
-        trailing: [("model", .string)]
+        fields: [
+            .init(name: "date", type: .timestamp),
+            .init(name: "model", type: .string),
+        ]
     )
 
-    private static let version = definition(
+    private static let version = CatalogEntry(
         entity: VersionEntry.recordType,
         fields: [
-            ("date", .timestamp),
-            ("app_version", .string),
-            ("build_number", .string),
+            .init(name: "date", type: .timestamp),
+            .init(name: "app_version", type: .string),
+            .init(name: "build_number", type: .string),
         ]
     )
 
-    private static let crash = definition(
+    private static let crash = CatalogEntry(
         entity: CrashEntry.recordType,
         fields: [
-            ("name", .text),
-            ("fingerprint", .string),
-            ("reason", .string),
-            ("stack_trace", .bytes),
-            ("session_id", .string),
-            ("app_version", .string),
-            ("date", .timestamp),
+            .init(name: "name", type: .text),
+            .init(name: "fingerprint", type: .string),
+            .init(name: "reason", type: .string),
+            .init(name: "stack_trace", type: .bytes),
+            .init(name: "session_id", type: .string),
+            .init(name: "app_version", type: .string),
+            .init(name: "date", type: .timestamp),
         ]
     )
 
-    private static let hang = definition(
+    private static let hang = CatalogEntry(
         entity: HangEntry.recordType,
         fields: [
-            ("name", .text),
-            ("fingerprint", .string),
-            ("reason", .string),
-            ("stack_trace", .bytes),
-            ("duration", .double),
-            ("session_id", .string),
-            ("app_version", .string),
-            ("date", .timestamp),
+            .init(name: "name", type: .text),
+            .init(name: "fingerprint", type: .string),
+            .init(name: "reason", type: .string),
+            .init(name: "stack_trace", type: .bytes),
+            .init(name: "duration", type: .double),
+            .init(name: "session_id", type: .string),
+            .init(name: "app_version", type: .string),
+            .init(name: "date", type: .timestamp),
         ]
     )
 
     private static func metric(entity: String, valueType: FieldType) -> CatalogEntry {
         CatalogEntry(
-            definition(
-                entity: entity,
-                fields: [
-                    ("name", .text),
-                    ("category", .string),
-                    ("session_id", .string),
-                    (metricSeriesKey, .string),
-                    ("value", valueType),
-                    ("date", .timestamp),
-                ],
-                views: [AggregateView(name: metricSeriesView, groupBy: metricSeriesKey, bucket: .hour, sum: "value")]
-            ),
+            entity: entity,
+            fields: [
+                .init(name: "name", type: .text),
+                .init(name: "category", type: .string),
+                .init(name: "session_id", type: .string),
+                .init(name: metricSeriesKey, type: .string),
+                .init(name: "value", type: valueType),
+                .init(name: "date", type: .timestamp),
+            ],
+            aggregates: [.sum("value", by: metricSeriesKey, at: "date")],
             derive: seriesKey
         )
-    }
-
-    private typealias Spec = (String, FieldType)
-
-    private static func definition(
-        entity: String, fields: [Spec], trailing: [Spec] = [], envelopeDate: String = "date",
-        views: [AggregateView]? = nil
-    )
-        -> EntityDefinition
-    {
-        EntityDefinition(
-            entity: entity, version: 1, fields: slotted(fields + metadata + trailing), envelopeDate: envelopeDate,
-            views: views)
-    }
-
-    private static let metadata: [Spec] = [
-        ("hour", .timestamp),
-        ("day", .timestamp),
-        ("week", .timestamp),
-        ("month", .timestamp),
-        ("device_id", .string),
-        ("install_id", .string),
-        ("launch_id", .string),
-        ("version", .int),
-    ]
-
-    private static func slotted(_ specs: [Spec]) -> [FieldDefinition] {
-        var next: [Pool: Int] = [:]
-        return specs.map { name, type in
-            let pool = pool(for: type)
-            let index = next[pool, default: 0]
-            next[pool] = index + 1
-            return FieldDefinition(
-                name: name, type: type, storage: .slot(pool, String(format: "%@_%02d", pool.rawValue, index)))
-        }
-    }
-
-    private static func pool(for type: FieldType) -> Pool {
-        switch type {
-        case .string:
-            .string
-        case .text:
-            .text
-        case .int:
-            .int
-        case .double:
-            .double
-        case .timestamp:
-            .timestamp
-        case .bytes:
-            .bytes
-        default:
-            fatalError("Unsupported field type \(type)")
-        }
     }
 }

--- a/Sources/Connectors/Native/NativeBackend.swift
+++ b/Sources/Connectors/Native/NativeBackend.swift
@@ -10,16 +10,16 @@ import Scout
 import ScoutDB
 
 extension Backend {
-    /// A CloudKit backend that stores records through scout-db's frozen Item/GridItem
+    /// A CloudKit backend that stores records through scout-db's frozen Entity/Vector
     /// schema.
     ///
     /// Raw records are delivered to every entity; chart aggregates are maintained by
-    /// scout-db views on write, so no client-side matrix upload happens.
+    /// scout-db vectors on write, so no client-side matrix upload happens.
     ///
     public static func cloudKit(container: CKContainer) -> Backend {
         let registry = SchemaRegistry(database: container.publicCloudDatabase)
         let store = EntityStore(database: container.publicCloudDatabase, registry: registry)
-        let registration = Task { await EntityCatalog.register(into: registry) }
+        let registration = Task { await EntityCatalog.publish(into: store, registry: registry) }
 
         return Backend(
             id: container.containerIdentifier ?? "cloudKit",
@@ -50,11 +50,6 @@ extension Backend {
                 @unknown default:
                     return .couldNotDetermine
                 }
-            },
-            onSetup: {
-                Task {
-                    await EntityCatalog.reconcile(registry: registry, database: container.publicCloudDatabase)
-                }
             }
         )
     }
@@ -76,28 +71,27 @@ extension CKAccountStatus {
 }
 
 extension EntityCatalog {
-    static func register(into registry: SchemaRegistry) async {
-        for definition in definitions {
-            try? await registry.register(definition)
+    // The store resolves a schema by reading its published descriptor, so
+    // nothing can be written until one exists. Publishing runs once per launch
+    // ahead of the first write, and costs a read per entity — the same read the
+    // write would pay anyway — plus a write only where the declaration drifted.
+    static func publish(into store: EntityStore, registry: SchemaRegistry) async {
+        for entry in entries {
+            try? await entry.publish(into: store, registry: registry)
         }
     }
+}
 
-    static func reconcile(registry: SchemaRegistry, database: any CloudDatabase) async {
-        // Read the published schema through a throwaway registry so preload never
-        // overwrites the authoritative local definitions already in `registry`.
-        let mirror = SchemaRegistry(database: database)
-        _ = try? await mirror.preload()
-        let remote = await mirror.definitions()
+extension CatalogEntry {
+    func publish(into store: EntityStore, registry: SchemaRegistry) async throws {
+        let declaration = declaration(on: store)
 
-        for definition in definitions {
-            let published = remote.first { $0.entity == definition.entity }
-
-            if let published, published.version > definition.version {
-                continue
-            }
-            if published != definition {
-                try? await registry.publish(definition)
-            }
+        guard let published = try? await registry.schema(for: entity) else {
+            return try await declaration.create()
         }
+        guard !matches(published) else {
+            return
+        }
+        try await declaration.update()
     }
 }

--- a/Sources/Connectors/Native/NativeDatabase.swift
+++ b/Sources/Connectors/Native/NativeDatabase.swift
@@ -22,8 +22,7 @@ struct NativeDatabase: Sendable {
 
 extension NativeDatabase: DatabaseWriter {
     func write(record: Record) async throws {
-        await registration.value
-        try await store.write(Self.values(for: record), entity: record.recordType, uuid: record.recordID)
+        try await write(records: [record])
     }
 
     func write(records: [Record]) async throws {
@@ -44,25 +43,32 @@ extension NativeDatabase: DatabaseWriter {
 extension NativeDatabase: DatabaseReader {
     func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
         await registration.value
-        let records = try await store.read(
-            entity: query.recordType.recordType,
-            filters: query.filters.map(\.storeFilter),
-            sort: query.sort.map { EntityStore.Sort(field: $0.field, ascending: $0.ascending) },
-            fields: fields.map { keys in keys.filter { $0 != "uuid" } }
+        let entity = query.recordType.recordType
+        let sort = query.sort.first
+
+        // A keyset page orders by one field, and the store has no unbounded read
+        // to fall back on, so a query without a sort still walks in the order of
+        // the entity's own timestamp.
+        let records = try await builder(entity: entity, filters: query.filters).records(
+            orderedBy: sort?.field ?? EntityCatalog.dateField(for: entity),
+            ascending: sort?.ascending ?? false
         )
+
         return RecordChunk(records: records.map(Record.init(entityRecord:)), cursor: nil)
     }
 
     func read(matching query: RecordQuery, fields: [String]?, limit: Int) async throws -> RecordChunk {
         await registration.value
+        let entity = query.recordType.recordType
+
         // The keyset pager orders by a single field, so a query without a sort
         // has no page order to follow — fall back to the full read.
         guard let sort = query.sort.first else {
             return try await read(matching: query, fields: fields)
         }
         return try await page(
-            entity: query.recordType.recordType,
-            filters: query.filters.map(\.storeFilter),
+            entity: entity,
+            filters: query.filters,
             field: sort.field,
             ascending: sort.ascending,
             limit: limit,
@@ -74,13 +80,15 @@ extension NativeDatabase: DatabaseReader {
     // re-queries the store for the following bounded slice instead of retaining
     // the whole pre-fetched tail in memory.
     private func page(
-        entity: String, filters: [EntityStore.Filter], field: String, ascending: Bool, limit: Int,
+        entity: String, filters: [RecordQuery.Filter], field: String, ascending: Bool, limit: Int,
         after cursor: FieldCursor?
     ) async throws
         -> RecordChunk
     {
-        let page = try await store.read(
-            entity: entity, filters: filters, orderedBy: field, descending: !ascending, limit: limit, after: cursor)
+        let page = try await builder(entity: entity, filters: filters)
+            .sort(field, ascending ? .forward : .reverse)
+            .page(size: limit, after: cursor)
+
         return RecordChunk(
             records: page.records.map(Record.init(entityRecord:)),
             cursor: page.cursor.map { next in
@@ -90,6 +98,10 @@ extension NativeDatabase: DatabaseReader {
                 }
             }
         )
+    }
+
+    private func builder(entity: String, filters: [RecordQuery.Filter]) -> QueryBuilder {
+        filters.reduce(store.query(entity)) { $0.filter($1) }
     }
 }
 
@@ -133,18 +145,10 @@ extension NativeDatabase {
 }
 
 extension NativeDatabase {
-    static func dateFilters(_ field: String, in range: Range<Date>) -> [EntityStore.Filter] {
-        [
-            EntityStore.Filter(field: field, op: .greaterThanOrEquals, value: .date(range.lowerBound)),
-            EntityStore.Filter(field: field, op: .lessThan, value: .date(range.upperBound)),
-        ]
-    }
-
     func datedIDs(entity: String, dateField: String, idField: String, in range: Range<Date>) async throws
         -> [(date: Date, id: String)]
     {
-        let records = try await store.read(
-            entity: entity, filters: Self.dateFilters(dateField, in: range), fields: [dateField, idField])
+        let records = try await store.records(entity: entity, dateField: dateField, in: range)
 
         return records.compactMap { record -> (date: Date, id: String)? in
             guard case .date(let date)? = record.values[dateField] else {

--- a/Sources/Connectors/Native/NativeReads.swift
+++ b/Sources/Connectors/Native/NativeReads.swift
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import ScoutDB
+
+let nativePageSize = 400
+
+extension QueryBuilder {
+    // The store bounds every read it offers, so a sweep is a walk over its
+    // keyset pages: one request per page rather than one for the whole entity,
+    // stopping as soon as a page runs short.
+    func records(orderedBy field: String, ascending: Bool) async throws -> [EntityRecord] {
+        let ordered = sort(field, ascending ? .forward : .reverse)
+
+        var records: [EntityRecord] = []
+        var cursor: FieldCursor?
+
+        repeat {
+            let page = try await ordered.page(size: nativePageSize, after: cursor)
+            records += page.records
+            cursor = page.cursor
+        } while cursor != nil
+
+        return records
+    }
+}
+
+extension EntityStore {
+    func records(entity: String, dateField: String, in range: Range<Date>) async throws -> [EntityRecord] {
+        try await query(entity)
+            .filter(dateField, in: range)
+            .records(orderedBy: dateField, ascending: true)
+    }
+}

--- a/Sources/Connectors/Native/NativeSeries.swift
+++ b/Sources/Connectors/Native/NativeSeries.swift
@@ -60,12 +60,7 @@ struct NativeSeries {
     private func collectLast(entity: String, store: EntityStore, value: (Double) -> MetricValue) async throws
         -> [MetricSeries]
     {
-        let filters = [
-            EntityStore.Filter(field: "date", op: .greaterThanOrEquals, value: .date(from)),
-            EntityStore.Filter(field: "date", op: .lessThan, value: .date(query.range.upperBound)),
-        ]
-        let records = try await store.read(
-            entity: entity, filters: filters, fields: ["date", "value", "name", "category"])
+        let records = try await store.records(entity: entity, dateField: "date", in: window)
 
         var latest: [GroupKey: [Date: (date: Date, sample: Double)]] = [:]
         for record in records {
@@ -106,6 +101,10 @@ struct NativeSeries {
 
     private var from: Date {
         bucketStart(of: query.range.lowerBound)
+    }
+
+    private var window: Range<Date> {
+        from..<query.range.upperBound
     }
 
     private func bucketStart(of date: Date) -> Date {
@@ -173,21 +172,21 @@ struct NativeSeries {
     private func collectEvents(name: String?, into totals: inout [GroupKey: [Date: Double]], store: EntityStore)
         async throws
     {
-        let points = try await store.series(
-            entity: EventEntry.recordType, view: EntityCatalog.eventCountView, from: from, to: query.range.upperBound)
+        let points = try await store.query(EventEntry.recordType)
+            .series(metric: .sum, group: "name", in: window)
 
-        for point in points where point.date >= from && (name == nil || point.group == name) {
-            add(Double(point.count), name: point.group, category: nil, version: nil, date: point.date, to: &totals)
+        for point in points where name == nil || point.group == name {
+            add(point.value, name: point.group, category: nil, version: nil, date: point.date, to: &totals)
         }
     }
 
     private func collectMetrics(entity: String, into totals: inout [GroupKey: [Date: Double]], store: EntityStore)
         async throws
     {
-        let points = try await store.series(
-            entity: entity, view: EntityCatalog.metricSeriesView, from: from, to: query.range.upperBound)
+        let points = try await store.query(entity)
+            .series("value", metric: .sum, group: EntityCatalog.metricSeriesKey, in: window)
 
-        for point in points where point.date >= from {
+        for point in points {
             guard let (category, metric) = EntityCatalog.decodeSeriesKey(point.group) else {
                 continue
             }
@@ -200,7 +199,7 @@ struct NativeSeries {
             }
 
             add(
-                point.value ?? Double(point.count),
+                point.value,
                 name: metric,
                 category: category.isEmpty ? nil : category,
                 version: nil,
@@ -218,13 +217,8 @@ struct NativeSeries {
         async throws
     {
         let (entity, dateField, name) = Self.layout(of: source)
-        let filters = [
-            EntityStore.Filter(field: dateField, op: .greaterThanOrEquals, value: .date(from)),
-            EntityStore.Filter(field: dateField, op: .lessThan, value: .date(query.range.upperBound)),
-        ]
+        let records = try await store.records(entity: entity, dateField: dateField, in: window)
 
-        let records = try await store.read(
-            entity: entity, filters: filters, fields: [dateField, "app_version", "install_id"])
         var visits = records.compactMap { record -> (date: Date, version: String?, install: String?)? in
             guard case .date(let date)? = record.values[dateField] else {
                 return nil

--- a/Sources/Connectors/Native/NativeValues.swift
+++ b/Sources/Connectors/Native/NativeValues.swift
@@ -63,12 +63,19 @@ extension Record {
     }
 }
 
-extension RecordQuery.Filter {
-    var storeFilter: EntityStore.Filter {
-        EntityStore.Filter(field: field, op: storeMatch, value: value.storeValue)
+extension QueryBuilder {
+    func filter(_ filter: RecordQuery.Filter) -> QueryBuilder {
+        self.filter(filter.field, filter.storeMatch, filter.value.storeValue)
     }
 
-    private var storeMatch: EntityStore.Match {
+    func filter(_ field: String, in range: Range<Date>) -> QueryBuilder {
+        filter(field, .greaterThanOrEquals, .date(range.lowerBound))
+            .filter(field, .lessThan, .date(range.upperBound))
+    }
+}
+
+extension RecordQuery.Filter {
+    fileprivate var storeMatch: ScoutDB.Operator {
         switch op {
         case .equals:
             .equals

--- a/Tests/Connectors/Native/EntityCatalogTests.swift
+++ b/Tests/Connectors/Native/EntityCatalogTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ScoutDB
+import ScoutDBTesting
 import Testing
 
 @testable import NativeConnector
@@ -14,11 +15,32 @@ import Testing
 
 @Suite("EntityCatalog")
 struct EntityCatalogTests {
-    @Test("Every definition passes scout-db validation")
-    func validation() throws {
-        for definition in EntityCatalog.definitions {
-            try definition.validate()
+    @Test("Every declaration publishes, so every one of them validates")
+    func validation() async throws {
+        let database = InMemoryDatabase()
+        let registry = SchemaRegistry(database: database)
+        let store = EntityStore(database: database, registry: registry)
+
+        for entry in EntityCatalog.entries {
+            try await entry.publish(into: store, registry: registry)
         }
+        for entry in EntityCatalog.entries {
+            let schema = try await registry.schema(for: entry.entity)
+            #expect(entry.matches(schema))
+        }
+    }
+
+    @Test("Republishing an unchanged declaration leaves the schema where it is")
+    func idempotentPublish() async throws {
+        let database = InMemoryDatabase()
+        let registry = SchemaRegistry(database: database)
+        let store = EntityStore(database: database, registry: registry)
+        let entry = try #require(EntityCatalog.entry(for: EventEntry.recordType))
+
+        try await entry.publish(into: store, registry: registry)
+        try await entry.publish(into: store, registry: registry)
+
+        #expect(entry.matches(try await registry.schema(for: entry.entity)))
     }
 
     @Test("Definitions exist for every syncable record type")
@@ -36,7 +58,7 @@ struct EntityCatalogTests {
             DoubleMetricsEntry.recordType,
         ]
         for entity in entities {
-            #expect(EntityCatalog.definition(for: entity) != nil)
+            #expect(EntityCatalog.entry(for: entity) != nil)
         }
     }
 
@@ -53,9 +75,9 @@ struct EntityCatalogTests {
         ]
 
         for (entity, keys) in requests {
-            let definition = try #require(EntityCatalog.definition(for: entity))
-            let fields = Set(definition.fields.map(\.name))
-            // The uuid field lives in the Item envelope rather than a slot.
+            let entry = try #require(EntityCatalog.entry(for: entity))
+            let fields = Set(entry.fields.map(\.name))
+            // The uuid field lives in the record envelope rather than a slot.
             for key in keys where key != "uuid" {
                 #expect(fields.contains(key), "\(entity) is missing \(key)")
             }

--- a/Tests/Connectors/Native/NativeDatabase+InMemory.swift
+++ b/Tests/Connectors/Native/NativeDatabase+InMemory.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import ScoutDB
+import ScoutDBTesting
+
+@testable import NativeConnector
+
+extension NativeDatabase {
+    // The store resolves a schema by reading its published descriptor, so a
+    // suite has to publish the catalog before it can write anything.
+    static func inMemory() -> NativeDatabase {
+        let cloud = InMemoryDatabase()
+        let registry = SchemaRegistry(database: cloud)
+        let store = EntityStore(database: cloud, registry: registry)
+
+        return NativeDatabase(
+            store: store,
+            registration: Task { await EntityCatalog.publish(into: store, registry: registry) }
+        )
+    }
+}

--- a/Tests/Connectors/Native/NativeDatabaseTests.swift
+++ b/Tests/Connectors/Native/NativeDatabaseTests.swift
@@ -18,13 +18,8 @@ import Testing
 struct NativeDatabaseTests {
     let database: NativeDatabase
 
-    init() async throws {
-        let cloud = ScoutDBTesting.InMemoryDatabase()
-        let registry = SchemaRegistry(database: cloud)
-        for definition in EntityCatalog.definitions {
-            try await registry.register(definition)
-        }
-        database = NativeDatabase(store: EntityStore(database: cloud, registry: registry))
+    init() {
+        database = .inMemory()
     }
 
     @Test("Event records round-trip through the store")
@@ -218,61 +213,55 @@ func makeMetricRecord(id: String, name: String, value: Int64) -> Record {
 
 @Suite("Schema bootstrap healing")
 struct SchemaBootstrapTests {
-    // Simulates the schema an older app published: Device@1 without `model`.
-    private func publishStaleDeviceSchema(to cloud: ScoutDBTesting.InMemoryDatabase) async throws {
-        let current = try #require(EntityCatalog.definition(for: DeviceEntry.recordType))
-        let stale = EntityDefinition(
-            entity: current.entity,
-            version: current.version,
-            fields: current.fields.filter { $0.name != "model" },
-            envelopeDate: current.envelopeDate,
-            unique: current.unique,
-            views: current.views
-        )
-        try await SchemaRegistry(database: cloud).publish(stale)
+    let cloud = ScoutDBTesting.InMemoryDatabase()
+    let registry: SchemaRegistry
+    let store: EntityStore
+
+    init() {
+        registry = SchemaRegistry(database: cloud)
+        store = EntityStore(database: cloud, registry: registry)
     }
 
-    @Test("A stale published Device schema without model blocks reads until the local schema is registered")
-    func staleSchemaHealing() async throws {
-        let cloud = ScoutDBTesting.InMemoryDatabase()
-        try await publishStaleDeviceSchema(to: cloud)
+    // Built the way Backend.cloudKit builds it — with a registration task the
+    // reads and writes await — and never handed a setup() call.
+    private var database: NativeDatabase {
+        NativeDatabase(
+            store: store,
+            registration: Task { await EntityCatalog.publish(into: store, registry: registry) }
+        )
+    }
 
-        // A fresh launch: a new registry over the same CloudKit, before bootstrap.
-        let registry = SchemaRegistry(database: cloud)
-        let database = NativeDatabase(store: EntityStore(database: cloud, registry: registry))
+    // Simulates the schema an older app published: Device without `model`.
+    private func publishStaleDeviceSchema() async throws {
+        let entry = try #require(EntityCatalog.entry(for: DeviceEntry.recordType))
 
-        let query = RecordQuery(recordType: Device.self)
-
-        await #expect(throws: SchemaError.self) {
-            _ = try await database.read(matching: query, fields: ["device_id", "model"])
+        var stale = store.schema(entry.entity)
+        for field in entry.fields where field.name != "model" {
+            stale = stale.field(field.name, field.type, .ungrouped)
         }
+        try await stale.create()
+    }
 
-        await EntityCatalog.register(into: registry)
+    @Test("A stale published Device schema without model heals into one that carries it")
+    func staleSchemaHealing() async throws {
+        try await publishStaleDeviceSchema()
 
+        let database = database
         try await database.write(record: makeDeviceRecord(id: "d-1", model: "iPhone16,1"))
-        let chunk = try await database.read(matching: query, fields: ["device_id", "model"])
+
+        let chunk = try await database.read(
+            matching: RecordQuery(recordType: Device.self), fields: ["device_id", "model"])
         #expect(chunk.records.first?["model"] == "iPhone16,1")
 
-        // Reconcile republishes the local schema so later launches preload it clean.
-        await EntityCatalog.reconcile(registry: SchemaRegistry(database: cloud), database: cloud)
-        let republished = try await SchemaRegistry(database: cloud).definition(for: DeviceEntry.recordType)
-        #expect(republished.fields.contains { $0.name == "model" })
+        let healed = try await registry.schema(for: DeviceEntry.recordType)
+        #expect(healed.fields.contains { $0.name == "model" })
     }
 
-    @Test("A backend self-registers its schema, so reads work without setup()")
-    func selfRegistration() async throws {
-        let cloud = ScoutDBTesting.InMemoryDatabase()
-        try await publishStaleDeviceSchema(to: cloud)
-
-        // Build the backend the way Backend.cloudKit does — with a registration task —
-        // but never call setup(). The read must still resolve `model`.
-        let registry = SchemaRegistry(database: cloud)
-        let database = NativeDatabase(
-            store: EntityStore(database: cloud, registry: registry),
-            registration: Task { await EntityCatalog.register(into: registry) }
-        )
-
+    @Test("A schema nothing ever published is created on the first write")
+    func firstLaunchPublishes() async throws {
+        let database = database
         try await database.write(record: makeDeviceRecord(id: "d-1", model: "iPhone16,1"))
+
         let chunk = try await database.read(
             matching: RecordQuery(recordType: Device.self), fields: ["device_id", "model"])
         #expect(chunk.records.first?["model"] == "iPhone16,1")

--- a/Tests/Connectors/Native/NativeSeriesTests.swift
+++ b/Tests/Connectors/Native/NativeSeriesTests.swift
@@ -19,13 +19,8 @@ struct NativeSeriesTests {
     let database: NativeDatabase
     let range = TestDate.reference..<TestDate.reference.addingTimeInterval(2 * .day)
 
-    init() async throws {
-        let cloud = ScoutDBTesting.InMemoryDatabase()
-        let registry = SchemaRegistry(database: cloud)
-        for definition in EntityCatalog.definitions {
-            try await registry.register(definition)
-        }
-        database = NativeDatabase(store: EntityStore(database: cloud, registry: registry))
+    init() {
+        database = .inMemory()
     }
 
     @Test("Event counts come back as hour-bucket series")


### PR DESCRIPTION
scout-db shrank its public API to the query, schema and record surface: `EntityDefinition` and its slots went internal, the registry stopped taking a definition, the unbounded read and the field projection went away, and the view-named series read went with them. The native connector was written against all of it, so updating the dependency meant porting it.

The catalog now declares each entity through `SchemaBuilder` rather than handing over slotted definitions. Fields are marked `.ungrouped` so a creation builds no vector nobody reads, and the two aggregates scout does read — the event count by name, the metric sum by series key — are named outright, dated by the record's own timestamp now that the envelope date is gone. Publishing replaces the register-then-reconcile pair: a schema nothing published is created, one that drifted from the declaration is updated, and one that matches is left alone. Reads go through the query builder, and a sweep walks keyset pages in place of the unbounded read, ordered by the query's own sort or by the entity's timestamp when it has none.

The dependency is pinned to a commit on scout-db's main rather than to the branch, so a merge there no longer changes what scout builds against without a commit here saying so. The commit it names is kasianov-mikhail/scout-db#500, which puts the per-hour vector read back — scout's event and metric charts have nothing to read without it.

Two things worth knowing. The slot layout is declared afresh rather than reproduced, so records already in CloudKit read through the schema version they were written under and the entities move to a new version. And `fields:` no longer narrows a read: scout-db dropped the field projection, so records come back whole.