### PR TITLE
Move the scout-db pin up to the current main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(
             url: "https://github.com/kasianov-mikhail/scout-db.git",
-            revision: "8d9e62f610968a59501f0a68b61bb78e05aeac67"
+            revision: "4944af73ae7dc539e261e41692a2c2444b9dfaae"
         ),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),


### PR DESCRIPTION
The pin sat on `8d9e62f` (Read a vector's hours back as a series, scout-db#500). This moves it to `4944af7`, picking up the uuid slot the server can sort by (scout-db#501) and the one-descriptor-per-entity registry change (scout-db#502).

Both changes are internal to scout-db, so nothing on this side needed adjusting. Built the test target and ran the full bundle on an iOS 26 simulator; everything passes.