### PR TITLE
Move the scout-db pin up to the descriptor name fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(
             url: "https://github.com/kasianov-mikhail/scout-db.git",
-            revision: "4944af73ae7dc539e261e41692a2c2444b9dfaae"
+            revision: "b2830cbdf4d98638085f50fedfbac743f5697eaa"
         ),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),


### PR DESCRIPTION
The pin sat on `4944af7`, which named a schema descriptor `__schema@<entity>` — a record name CloudKit refuses outright, so every publish came back with "invalid id string" and nothing was ever stored. Reads and writes answered unknown entity for the rest of the session, and the next launch republished to be refused the same way; on the app side that shows up as a home screen that never leaves its loading ring.

This moves the pin to `b2830cb`, which is kasianov-mikhail/scout-db#504: a descriptor is named `schema-<digest of the entity>`, a rejected save is thrown rather than dropped along with the results it arrived in, and the in-memory double now refuses the names the server refuses so the next naming change fails offline.

The change is internal to scout-db, so nothing on this side needed adjusting. Built the test target and ran the full bundle on an iPhone 17 simulator; all 823 tests pass.