### PR TITLE
Keep the record cache out of CloudKit

### DIFF
--- a/Sources/LookupIndex/RecordCacheStore.swift
+++ b/Sources/LookupIndex/RecordCacheStore.swift
@@ -122,7 +122,7 @@ enum RecordCacheStore {
 
     private static func openContainer<Row: CacheRow>(for row: Row.Type, at url: URL) -> ModelContainer? {
         let schema = Schema([Row.self, CachedSpan.self])
-        let configuration = ModelConfiguration(schema: schema, url: url)
+        let configuration = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
         return try? ModelContainer(for: schema, configurations: [configuration])
     }
 }


### PR DESCRIPTION
The record cache holds a local copy of records that already live in the backend, so it syncs nowhere — but its `ModelConfiguration` named no CloudKit database, and the default is `.automatic`, which mirrors wherever the app carries the entitlement. Mirroring demands every attribute be optional or defaulted, and `fingerprint`, `date`, `payload` and the span's bounds are none of those, so the store failed to load, the retry destroyed it and failed the same way, and `LookupIndex.enable()` left every backend uncached for the whole session.

Nothing in the package could see it: a test bundle carries no CloudKit entitlement, so `.automatic` mirrors nothing there and the store opens fine. Naming `.none` says what the cache is either way.

Verified in an app that does carry the entitlement: the pair of "Store failed to load" failures at launch, and the "CloudKit integration requires that all attributes be optional" reason under them, are gone. Built the test target and ran the full bundle on an iPhone 17 simulator; 823 tests pass.
