### PR TITLE
Run the iOS test matrix in Release and fix the SwiftData predicate trap it exposes

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -91,7 +91,7 @@ jobs:
       && needs.lint.result == 'success'
       && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 40
 
     permissions:
       contents: read
@@ -164,6 +164,7 @@ jobs:
         run: |
           xcodebuild \
             -scheme Scout-Package \
+            -configuration Debug \
             -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
             -clonedSourcePackagesDirPath /tmp/spm \
             -enableCodeCoverage ${{ matrix.coverage && 'YES' || 'NO' }} \
@@ -174,6 +175,7 @@ jobs:
         run: |
           xcodebuild \
             -scheme Scout-Package \
+            -configuration Debug \
             -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
             -clonedSourcePackagesDirPath /tmp/spm \
             -enableCodeCoverage ${{ matrix.coverage && 'YES' || 'NO' }} \
@@ -181,6 +183,35 @@ jobs:
             ${{ matrix.skipTesting && format('-skip-testing:{0}', matrix.skipTesting) || '' }} \
             -parallel-testing-enabled NO \
             -resultBundlePath TestResults.xcresult \
+            test-without-building
+
+      # Optimized builds specialize generics and fold key paths, so SwiftData predicate traps and
+      # other release-only failures never show up in the Debug pass above.
+      - name: Build (Release)
+        run: |
+          xcodebuild \
+            -scheme Scout-Package \
+            -configuration Release \
+            ENABLE_TESTABILITY=YES \
+            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
+            -clonedSourcePackagesDirPath /tmp/spm \
+            -enableCodeCoverage NO \
+            -skipMacroValidation \
+            build-for-testing
+
+      - name: Test (Release)
+        run: |
+          xcodebuild \
+            -scheme Scout-Package \
+            -configuration Release \
+            ENABLE_TESTABILITY=YES \
+            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
+            -clonedSourcePackagesDirPath /tmp/spm \
+            -enableCodeCoverage NO \
+            -skipMacroValidation \
+            ${{ matrix.skipTesting && format('-skip-testing:{0}', matrix.skipTesting) || '' }} \
+            -parallel-testing-enabled NO \
+            -resultBundlePath TestResults-Release.xcresult \
             test-without-building
 
       - name: Report coverage

--- a/Sources/LookupIndex/RecordCache.swift
+++ b/Sources/LookupIndex/RecordCache.swift
@@ -29,12 +29,8 @@ actor RecordCache<Row: CacheRow> {
     }
 
     func records(for fingerprint: String, in range: Range<Date>) -> [Record]? {
-        let lower = range.lowerBound
-        let upper = range.upperBound
-        let predicate = #Predicate<Row> {
-            $0.fingerprint == fingerprint && $0.date >= lower && $0.date < upper
-        }
-        let descriptor = FetchDescriptor(predicate: predicate, sortBy: [SortDescriptor(\Row.date)])
+        let descriptor = FetchDescriptor(
+            predicate: Row.predicate(fingerprint: fingerprint, in: range), sortBy: [Row.dateSort])
         guard let entries = try? modelContext.fetch(descriptor) else {
             return nil
         }
@@ -78,8 +74,7 @@ actor RecordCache<Row: CacheRow> {
     }
 
     func lookupRecord(for fingerprint: String) -> Record? {
-        let predicate = #Predicate<Row> { $0.fingerprint == fingerprint }
-        var descriptor = FetchDescriptor(predicate: predicate)
+        var descriptor = FetchDescriptor(predicate: Row.predicate(fingerprint: fingerprint))
         descriptor.fetchLimit = 1
         guard let entry = try? modelContext.fetch(descriptor).first else {
             return nil
@@ -91,8 +86,7 @@ actor RecordCache<Row: CacheRow> {
         guard let payload = try? JSONEncoder().encode(CachedRecordPayload(record: record)) else {
             return
         }
-        let predicate = #Predicate<Row> { $0.fingerprint == fingerprint }
-        try? modelContext.delete(model: Row.self, where: predicate)
+        try? modelContext.delete(model: Row.self, where: Row.predicate(fingerprint: fingerprint))
         modelContext.insert(Row(fingerprint: fingerprint, date: .distantPast, payload: payload))
         try? modelContext.save()
     }
@@ -105,17 +99,11 @@ actor RecordCache<Row: CacheRow> {
     }
 
     private func deleteRecords(for fingerprint: String, in range: Range<Date>) {
-        let lower = range.lowerBound
-        let upper = range.upperBound
-        let predicate = #Predicate<Row> {
-            $0.fingerprint == fingerprint && $0.date >= lower && $0.date < upper
-        }
-        try? modelContext.delete(model: Row.self, where: predicate)
+        try? modelContext.delete(model: Row.self, where: Row.predicate(fingerprint: fingerprint, in: range))
     }
 
     private func deleteAll(for fingerprint: String) {
-        let recordPredicate = #Predicate<Row> { $0.fingerprint == fingerprint }
-        try? modelContext.delete(model: Row.self, where: recordPredicate)
+        try? modelContext.delete(model: Row.self, where: Row.predicate(fingerprint: fingerprint))
 
         let spanPredicate = #Predicate<CachedSpan> { $0.fingerprint == fingerprint }
         try? modelContext.delete(model: CachedSpan.self, where: spanPredicate)

--- a/Sources/LookupIndex/RecordCacheStore.swift
+++ b/Sources/LookupIndex/RecordCacheStore.swift
@@ -12,6 +12,15 @@ import SwiftData
 protocol CacheRow: PersistentModel {
     static var schemaVersion: Int { get }
 
+    // SwiftData turns a predicate key path into a column name by matching it against the metadata
+    // the `@Model` macro generates for the concrete class. A key path spelled on a generic
+    // parameter is a different key path and never matches, so an optimized build traps inside
+    // SwiftData rather than running the query. Every row type therefore builds its own predicates
+    // and sort order, where its type is concrete.
+    static func predicate(fingerprint: String) -> Predicate<Self>
+    static func predicate(fingerprint: String, in range: Range<Date>) -> Predicate<Self>
+    static var dateSort: SortDescriptor<Self> { get }
+
     var fingerprint: String { get }
     var date: Date { get }
     var payload: Data { get }
@@ -23,6 +32,22 @@ protocol CacheRow: PersistentModel {
 @Model
 final class CachedRecord: CacheRow {
     static let schemaVersion = 2
+
+    static func predicate(fingerprint: String) -> Predicate<CachedRecord> {
+        #Predicate { $0.fingerprint == fingerprint }
+    }
+
+    static func predicate(fingerprint: String, in range: Range<Date>) -> Predicate<CachedRecord> {
+        let lower = range.lowerBound
+        let upper = range.upperBound
+        return #Predicate {
+            $0.fingerprint == fingerprint && $0.date >= lower && $0.date < upper
+        }
+    }
+
+    static var dateSort: SortDescriptor<CachedRecord> {
+        SortDescriptor(\.date)
+    }
 
     var fingerprint: String
     var date: Date
@@ -41,6 +66,22 @@ final class IndexedCachedRecord: CacheRow {
     #Index<IndexedCachedRecord>([\.fingerprint, \.date])
 
     static let schemaVersion = 3
+
+    static func predicate(fingerprint: String) -> Predicate<IndexedCachedRecord> {
+        #Predicate { $0.fingerprint == fingerprint }
+    }
+
+    static func predicate(fingerprint: String, in range: Range<Date>) -> Predicate<IndexedCachedRecord> {
+        let lower = range.lowerBound
+        let upper = range.upperBound
+        return #Predicate {
+            $0.fingerprint == fingerprint && $0.date >= lower && $0.date < upper
+        }
+    }
+
+    static var dateSort: SortDescriptor<IndexedCachedRecord> {
+        SortDescriptor(\.date)
+    }
 
     var fingerprint: String
     var date: Date


### PR DESCRIPTION
## Why

A TestFlight build (5.0/399, iOS 27) crashed with `EXC_BREAKPOINT` inside SwiftData:

```
0  libswiftCore.dylib  _assertionFailure(_:_:file:line:flags:)
1  SwiftData           static PersistentModel.graph_keyPathToString(keypath:)
...
53 SwiftData           ModelContext.delete<A>(model:where:includeSubclasses:)
55 ScoutIP             RecordCache.deleteAll(for:)
56 ScoutIP             RecordCache.store(_:for:covering:)
57 ScoutIP             CachedDatabase.series(matching:)
```

`RecordCache<Row: CacheRow>` built its predicates on the generic parameter:

```swift
let predicate = #Predicate<Row> { $0.fingerprint == fingerprint }
try? modelContext.delete(model: Row.self, where: predicate)
```

SwiftData turns a predicate key path into a column name by matching it against the metadata the
`@Model` macro generates for the concrete class. A key path spelled on a generic parameter is a
different key path, so nothing matches and SwiftData traps:

```
SwiftData/DataUtilities.swift:85: Fatal error: Couldn't find \IndexedCachedRecord.<computed 0x…>
on IndexedCachedRecord with fields [PropertyMetadata(name: "fingerprint", …), …]
```

The trap is a `fatalError`, so the surrounding `try?` cannot contain it — the process dies.

Two things kept this out of CI: it only happens once the optimizer specializes the generic, and the
matrix only ever built Debug. `swift test -c release --filter RecordCacheTests` on `main`
reproduces it every time.

## What changed

- `CacheRow` now requires `predicate(fingerprint:)`, `predicate(fingerprint:in:)` and `dateSort`,
  and `CachedRecord` / `IndexedCachedRecord` implement them where their type is concrete.
  `RecordCache` no longer spells a key path on `Row` anywhere — the same trap was waiting in
  `records(for:in:)`, `lookupRecord(for:)`, `storeLookup(_:for:)`, `deleteRecords(for:in:)` and
  `SortDescriptor(\Row.date)`.
- Every cell of the iOS matrix now runs a second `build-for-testing` + `test-without-building` pass
  in Release (with `ENABLE_TESTABILITY=YES`, which `@testable import` needs), so release-only
  failures stop reaching TestFlight. The Debug pass keeps its result bundle and coverage report; the
  job timeout goes from 20 to 40 minutes to fit both passes.

An intermediate fix that passed key paths through the protocol (`$0[keyPath: Row.fingerprintKey]`)
does not work: the `#Predicate` macro rejects `subscript(keyPath:)`.

## Testing

- `swift test -c release --filter LookupIndexTests` — 27 tests pass (SIGTRAP before this change)
- `swift test --filter LookupIndexTests` — passes
- `xcodebuild -configuration Release ENABLE_TESTABILITY=YES … test-without-building` on an
  iOS 27 simulator — full suite passes
- `xcrun swift-format lint --strict --recursive Sources Tests` — clean