### PR TITLE
Split the iOS matrix into separate Debug and Release legs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -83,7 +83,7 @@ jobs:
         run: .github/scripts/wait-for-checks.sh
 
   tests:
-    name: test-ios-${{ matrix.ios }}
+    name: test-ios-${{ matrix.ios }} (${{ matrix.configuration }})
     needs: [scope, lint, gate]
     if: >-
       ${{ always()
@@ -99,30 +99,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Optimized builds specialize generics and fold key paths, so SwiftData predicate traps and
+        # other release-only failures never show up in a Debug-only run.
+        configuration: [Debug, Release]
+        ios: [16, 17, 18, 26, 27]
         include:
-          - os: macos-15
+          - ios: 16
+            os: macos-15
             device: iPhone 14
-            ios: 16
             runtime: "16.4"
-            coverage: false
             skipTesting: LookupIndexTests
-          - os: macos-15
+          - ios: 17
+            os: macos-15
             device: iPhone 15
-            ios: 17
             runtime: "17.5"
-            coverage: false
-          - os: macos-15
+          - ios: 18
+            os: macos-15
             device: iPhone 16
-            ios: 18
-            coverage: false
-          - os: macos-26
+          - ios: 26
+            os: macos-26
             device: iPhone 17
-            ios: 26
+          - ios: 27
+            os: xcode-27
+            device: iPhone 17
+          - ios: 26
+            configuration: Debug
             coverage: true
-          - os: xcode-27
-            device: iPhone 17
-            ios: 27
-            coverage: false
 
     steps:
       - uses: actions/checkout@v7
@@ -164,7 +166,8 @@ jobs:
         run: |
           xcodebuild \
             -scheme Scout-Package \
-            -configuration Debug \
+            -configuration ${{ matrix.configuration }} \
+            ENABLE_TESTABILITY=YES \
             -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
             -clonedSourcePackagesDirPath /tmp/spm \
             -enableCodeCoverage ${{ matrix.coverage && 'YES' || 'NO' }} \
@@ -175,7 +178,8 @@ jobs:
         run: |
           xcodebuild \
             -scheme Scout-Package \
-            -configuration Debug \
+            -configuration ${{ matrix.configuration }} \
+            ENABLE_TESTABILITY=YES \
             -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
             -clonedSourcePackagesDirPath /tmp/spm \
             -enableCodeCoverage ${{ matrix.coverage && 'YES' || 'NO' }} \
@@ -183,35 +187,6 @@ jobs:
             ${{ matrix.skipTesting && format('-skip-testing:{0}', matrix.skipTesting) || '' }} \
             -parallel-testing-enabled NO \
             -resultBundlePath TestResults.xcresult \
-            test-without-building
-
-      # Optimized builds specialize generics and fold key paths, so SwiftData predicate traps and
-      # other release-only failures never show up in the Debug pass above.
-      - name: Build (Release)
-        run: |
-          xcodebuild \
-            -scheme Scout-Package \
-            -configuration Release \
-            ENABLE_TESTABILITY=YES \
-            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
-            -clonedSourcePackagesDirPath /tmp/spm \
-            -enableCodeCoverage NO \
-            -skipMacroValidation \
-            build-for-testing
-
-      - name: Test (Release)
-        run: |
-          xcodebuild \
-            -scheme Scout-Package \
-            -configuration Release \
-            ENABLE_TESTABILITY=YES \
-            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
-            -clonedSourcePackagesDirPath /tmp/spm \
-            -enableCodeCoverage NO \
-            -skipMacroValidation \
-            ${{ matrix.skipTesting && format('-skip-testing:{0}', matrix.skipTesting) || '' }} \
-            -parallel-testing-enabled NO \
-            -resultBundlePath TestResults-Release.xcresult \
             test-without-building
 
       - name: Report coverage


### PR DESCRIPTION
The iOS matrix used to build and test Debug, then build and test Release, all inside one job, so a release-only failure was buried four steps deep in a leg named after the Debug run. This adds a `configuration` dimension to the matrix and moves the device list into `include` keyed by `ios`, so each iOS version now fans out into `test-ios-N (Debug)` and `test-ios-N (Release)`. The duplicated Release steps are gone — `Build` and `Test` are parameterized by `matrix.configuration`, and `ENABLE_TESTABILITY=YES` is passed unconditionally since it is already the Debug default. Coverage still runs exactly once: `coverage: true` moved to a combination-specific include for iOS 26 + Debug.

`tests-gate` is untouched — it aggregates every matrix leg through a single `needs.tests.result`, and it is the required check in branch protection, so renaming the legs is safe. The `Notify` workflow matches jobs by the `test-ios-` prefix, which the new names keep.

The trade-off is ten macOS runners instead of five. Total runner minutes go up a little because checkout, the simulator runtime download, and package resolution now happen twice per iOS version, but wall-clock time roughly halves and a Release regression shows up as its own red check.