### PR TITLE
Publish the catalog entities together instead of one at a time

### DIFF
--- a/Sources/Connectors/Native/Catalog/CatalogEntry+Publish.swift
+++ b/Sources/Connectors/Native/Catalog/CatalogEntry+Publish.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+import ScoutDB
+
+extension CatalogEntry {
+    static func publishAll(into store: EntityStore, registry: SchemaRegistry) async {
+        await withTaskGroup(of: Void.self) { group in
+            for entry in entries {
+                group.addTask {
+                    try? await entry.publish(into: store, registry: registry)
+                }
+            }
+        }
+    }
+
+    func publish(into store: EntityStore, registry: SchemaRegistry) async throws {
+        let declaration = declaration(on: store)
+
+        guard let published = try? await registry.schema(for: entity) else {
+            return try await declaration.create()
+        }
+        guard !matches(published) else {
+            return
+        }
+        try await declaration.update()
+    }
+}

--- a/Sources/Connectors/Native/NativeBackend.swift
+++ b/Sources/Connectors/Native/NativeBackend.swift
@@ -76,9 +76,7 @@ extension CKContainer {
         let registry = SchemaRegistry(database: publicCloudDatabase)
         let store = EntityStore(database: publicCloudDatabase, registry: registry)
 
-        for entry in CatalogEntry.entries {
-            try? await entry.publish(into: store, registry: registry)
-        }
+        await CatalogEntry.publishAll(into: store, registry: registry)
 
         return store
     }
@@ -96,19 +94,5 @@ extension CKAccountStatus {
         @unknown default:
             .unreachable
         }
-    }
-}
-
-extension CatalogEntry {
-    func publish(into store: EntityStore, registry: SchemaRegistry) async throws {
-        let declaration = declaration(on: store)
-
-        guard let published = try? await registry.schema(for: entity) else {
-            return try await declaration.create()
-        }
-        guard !matches(published) else {
-            return
-        }
-        try await declaration.update()
     }
 }

--- a/Tests/Connectors/Native/Catalog/CatalogPublishTests.swift
+++ b/Tests/Connectors/Native/Catalog/CatalogPublishTests.swift
@@ -1,0 +1,107 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Foundation
+import ScoutDB
+import ScoutDBTesting
+import Testing
+
+@testable import NativeConnector
+
+@Suite("Catalog publishing")
+struct CatalogPublishTests {
+    let probe = ConcurrencyProbe(InMemoryDatabase())
+    let registry: SchemaRegistry
+    let store: EntityStore
+
+    init() {
+        registry = SchemaRegistry(database: probe)
+        store = EntityStore(database: probe, registry: registry)
+    }
+
+    @Test("Every declared entity ends up published as declared")
+    func publishesEveryEntity() async throws {
+        await CatalogEntry.publishAll(into: store, registry: registry)
+
+        for entry in CatalogEntry.entries {
+            let published = try await registry.schema(for: entry.entity)
+            #expect(entry.matches(published), "\(entry.entity) was published with a different shape")
+        }
+    }
+
+    @Test("Entities reconcile together rather than one after another")
+    func publishesConcurrently() async {
+        await CatalogEntry.publishAll(into: store, registry: registry)
+
+        #expect(await probe.peak > 1, "the catalog was published one entity at a time")
+    }
+}
+
+/// Forwards to an in-memory database while recording how many requests were
+/// ever in flight at once.
+final class ConcurrencyProbe: CloudDatabase, @unchecked Sendable {
+    private let database: InMemoryDatabase
+    private let flight = Flight()
+
+    init(_ database: InMemoryDatabase) {
+        self.database = database
+    }
+
+    var peak: Int {
+        get async { await flight.peak }
+    }
+
+    func records(matching query: CKQuery, resultsLimit: Int) async throws -> QueryPage {
+        try await tracked { try await database.records(matching: query, resultsLimit: resultsLimit) }
+    }
+
+    func records(continuingMatchFrom cursor: QueryCursor, resultsLimit: Int) async throws -> QueryPage {
+        try await tracked { try await database.records(continuingMatchFrom: cursor, resultsLimit: resultsLimit) }
+    }
+
+    func modifyRecords(saving: [CKRecord], deleting: [CKRecord.ID]) async throws {
+        try await tracked { try await database.modifyRecords(saving: saving, deleting: deleting) }
+    }
+
+    func saveIfUnchanged(_ records: [CKRecord]) async throws -> [(CKRecord.ID, Result<CKRecord, any Error>)] {
+        try await tracked { try await database.saveIfUnchanged(records) }
+    }
+
+    func fetchRecord(id: CKRecord.ID) async throws -> CKRecord? {
+        try await tracked { try await database.fetchRecord(id: id) }
+    }
+
+    func fetchRecords(ids: [CKRecord.ID]) async throws -> [CKRecord] {
+        try await tracked { try await database.fetchRecords(ids: ids) }
+    }
+
+    // The sleep widens the window a sequential caller would never overlap in,
+    // so the peak separates "started together" from "started in turn".
+    private func tracked<T>(_ request: () async throws -> T) async throws -> T {
+        await flight.enter()
+        defer {
+            Task { await flight.leave() }
+        }
+        try await Task.sleep(for: .milliseconds(10))
+        return try await request()
+    }
+}
+
+private actor Flight {
+    private var inFlight = 0
+    private(set) var peak = 0
+
+    func enter() {
+        inFlight += 1
+        peak = max(peak, inFlight)
+    }
+
+    func leave() {
+        inFlight = max(0, inFlight - 1)
+    }
+}

--- a/Tests/Connectors/Native/NativeDatabase+InMemory.swift
+++ b/Tests/Connectors/Native/NativeDatabase+InMemory.swift
@@ -19,17 +19,11 @@ extension NativeDatabase {
         let registry = SchemaRegistry(database: cloud)
         let store = EntityStore(database: cloud, registry: registry)
 
-        let registration = Task { await publishCatalog(into: store, registry: registry) }
+        let registration = Task { await CatalogEntry.publishAll(into: store, registry: registry) }
 
         return NativeDatabase {
             await registration.value
             return store
-        }
-    }
-
-    static func publishCatalog(into store: EntityStore, registry: SchemaRegistry) async {
-        for entry in CatalogEntry.entries {
-            try? await entry.publish(into: store, registry: registry)
         }
     }
 }

--- a/Tests/Connectors/Native/NativeDatabaseTests.swift
+++ b/Tests/Connectors/Native/NativeDatabaseTests.swift
@@ -225,7 +225,7 @@ struct SchemaBootstrapTests {
     // Built the way Backend.cloudKit builds it — the catalog is published
     // before the store is handed to a read or a write.
     private var database: NativeDatabase {
-        let registration = Task { await NativeDatabase.publishCatalog(into: store, registry: registry) }
+        let registration = Task { await CatalogEntry.publishAll(into: store, registry: registry) }
 
         return NativeDatabase {
             await registration.value


### PR DESCRIPTION
Resolving the CloudKit store reconciles every declared entity against the container, and it did so one entity at a time: eleven descriptor reads in sequence, each its own round trip. Nothing a screen reads can start until all of them land, so a cold start paid the whole sum — measured against a live container at 3.5s, each read taking around 320ms.

The entries are independent, so the reconciliation now runs them as a task group. The request gate still bounds how many reach CloudKit at once, which turns eleven sequential round trips into two gate-sized waves rather than an unbounded burst; the same measurement came back at 1.5s. Concurrent requests are individually slower than lone ones — the eight that go out together take about a second each — so the gain is smaller than the entry count suggests, and widening the gate would not buy more.

The loop moves out of NativeBackend into CatalogEntry.publishAll, which the in-memory test helpers now call as well; each of them used to carry its own copy of the same sequential loop. CatalogPublishTests covers both that every declared entity ends up published as declared, and that they go out together — a probe wraps the in-memory database and records the peak number of requests in flight. Restoring the sequential loop fails that test, so it holds the property rather than passing regardless.