### PR TITLE
Call one reusable workflow for the scope check

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -13,24 +13,7 @@ concurrency:
 
 jobs:
   scope:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          filter: blob:none
-
-      - name: Detect code changes
-        id: filter
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: .github/scripts/detect-code-changes.sh
+    uses: ./.github/workflows/scope.yml
 
   gate:
     name: gate

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,24 +16,7 @@ concurrency:
 
 jobs:
   scope:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          filter: blob:none
-
-      - name: Detect code changes
-        id: filter
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BEFORE_SHA: ${{ github.event.before }}
-        run: .github/scripts/detect-code-changes.sh
+    uses: ./.github/workflows/scope.yml
 
   build:
     needs: scope

--- a/.github/workflows/scope.yml
+++ b/.github/workflows/scope.yml
@@ -1,0 +1,33 @@
+name: Scope
+
+on:
+  workflow_call:
+    outputs:
+      code:
+        description: Whether the change touches anything the build cares about.
+        value: ${{ jobs.scope.outputs.code }}
+
+permissions:
+  contents: read
+
+jobs:
+  scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Detect code changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: .github/scripts/detect-code-changes.sh

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,25 +14,7 @@ concurrency:
 
 jobs:
   scope:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          filter: blob:none
-
-      - name: Detect code changes
-        id: filter
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          BEFORE_SHA: ${{ github.event.before }}
-        run: .github/scripts/detect-code-changes.sh
+    uses: ./.github/workflows/scope.yml
 
   lint:
     needs: scope


### PR DESCRIPTION
The Swift, API, and Docs workflows each opened with the same scope job — deep checkout, run `detect-code-changes.sh`, expose a `code` output — copied three times and already inconsistent in which SHA it passed through: only the Swift copy set both `BASE_SHA` and `BEFORE_SHA`, so the other two would have gone blind had their triggers ever widened.

The job now lives once in `.github/workflows/scope.yml` as a `workflow_call` workflow that passes both SHAs and lets the script pick by event, and the three callers are one `uses:` line each. `needs.scope.outputs.code` and `needs.scope.result` read the same as before, so the gate jobs are untouched.

A composite action would have been the smaller unit, but `uses: ./…` needs the repository already checked out, and the checkout is half of what is being shared. The one visible change is the check name, now "scope / scope" — no gate waits on it, and no branch-protection rule names it.