### PR TITLE
Stop reading a cancelled job as a failed one

### DIFF
--- a/.github/scripts/require-results.sh
+++ b/.github/scripts/require-results.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+status=0
+for entry in "$@"; do
+  IFS='|' read -r label result allowed <<< "$entry"
+  : "${label:?a result entry needs a label}"
+  : "${result:?$label has no result; check the needs.<job>.result reference}"
+  allowed="${allowed:-success}"
+
+  if [[ ",$allowed," == *",$result,"* ]]; then
+    continue
+  fi
+
+  status=1
+  if [ "$result" = cancelled ]; then
+    echo "::error::$label was cancelled, so it never reached a verdict. A cancellation says the run was superseded or the runner never arrived — re-run the workflow rather than reading this as a problem with the code."
+  else
+    echo "::error::$label did not pass ($result)."
+  fi
+done
+
+exit "$status"

--- a/.github/scripts/wait-for-checks.sh
+++ b/.github/scripts/wait-for-checks.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 : "${CHECKS:?CHECKS is required}"
 timeout="${TIMEOUT:-10800}"
 absent_timeout="${ABSENT_TIMEOUT:-900}"
+cancelled_timeout="${CANCELLED_TIMEOUT:-900}"
 interval="${INTERVAL:-15}"
 max_interval="${MAX_INTERVAL:-120}"
 max_failures="${MAX_FAILURES:-10}"
@@ -19,6 +20,7 @@ back_off() {
 
 deadline=$(( SECONDS + timeout ))
 absent_deadline=$(( SECONDS + absent_timeout ))
+cancelled_deadline=0
 failures=0
 while :; do
   if ! runs="$(
@@ -41,6 +43,7 @@ while :; do
   failures=0
 
   pending=()
+  cancelled=()
   for name in "${names[@]}"; do
     run="$(echo "$runs" | jq -c --arg n "$name" \
       '[.[] | select(.name == $n)] | sort_by(.started_at // "~") | last')"
@@ -56,6 +59,10 @@ while :; do
     fi
     case "$conclusion" in
       success | skipped | neutral) ;;
+      cancelled | stale)
+        cancelled+=("$name")
+        pending+=("$name(cancelled)")
+        ;;
       *)
         echo "::error::Fast check '$name' concluded '$conclusion'; skipping the long job."
         exit 1
@@ -66,6 +73,16 @@ while :; do
   if [ "${#pending[@]}" -eq 0 ]; then
     echo "All fast checks passed: ${names[*]}"
     exit 0
+  fi
+
+  if [ "${#cancelled[@]}" -eq 0 ]; then
+    cancelled_deadline=0
+  elif [ "$cancelled_deadline" -eq 0 ]; then
+    cancelled_deadline=$(( SECONDS + cancelled_timeout ))
+    echo "::warning::Cancelled, not failed: ${cancelled[*]}. A cancellation carries no verdict, so this gate waits ${cancelled_timeout}s for a re-run to post a fresh check instead of turning the pull request red."
+  elif [ "$SECONDS" -ge "$cancelled_deadline" ]; then
+    echo "::error::Still cancelled after ${cancelled_timeout}s: ${cancelled[*]}. Nothing re-ran them, so no verdict can arrive — re-run the cancelled workflow. This is the runner, not the code under test."
+    exit 1
   fi
 
   if [ "$SECONDS" -ge "$absent_deadline" ]; then

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -197,22 +197,18 @@ jobs:
     timeout-minutes: 2
 
     steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
       - name: Require the API diff to pass
         run: |
-          if [ "${{ needs.scope.result }}" != "success" ]; then
-            echo "::error::The scope job did not succeed (${{ needs.scope.result }})."
-            exit 1
-          fi
+          .github/scripts/require-results.sh "The scope job|${{ needs.scope.result }}"
           if [ "${{ needs.scope.outputs.code }}" != "true" ]; then
             echo "Nothing outside the docs changed; the public API cannot have moved."
             exit 0
           fi
-          if [ "${{ needs.gate.result }}" != "success" ]; then
-            echo "::error::The fast-check gate did not pass (${{ needs.gate.result }})."
-            exit 1
-          fi
-          if [ "${{ needs.api-breakage.result }}" != "success" ]; then
-            echo "::error::The API breakage check did not pass (${{ needs.api-breakage.result }})."
-            exit 1
-          fi
+          .github/scripts/require-results.sh \
+            "The fast-check gate|${{ needs.gate.result }}" \
+            "The API breakage check|${{ needs.api-breakage.result }}"
           echo "Gate passes."

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -117,27 +117,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
       - name: Require the contract to pass (or be N/A)
         run: |
-          if [ "${{ needs.changes.result }}" != "success" ]; then
-            echo "::error::The changes job did not succeed (${{ needs.changes.result }})."
-            exit 1
-          fi
-          case "${{ needs.gate.result }}" in
-            success | skipped) ;;
-            *)
-              echo "::error::The fast-check gate did not pass (${{ needs.gate.result }})."
-              exit 1
-              ;;
-          esac
-          result="${{ needs.contract.result }}"
-          echo "contract job result: $result"
-          case "$result" in
-            success | skipped)
-              echo "Gate passes."
-              ;;
-            *)
-              echo "::error::The contract check did not pass (result: $result)."
-              exit 1
-              ;;
-          esac
+          .github/scripts/require-results.sh \
+            "The changes job|${{ needs.changes.result }}" \
+            "The fast-check gate|${{ needs.gate.result }}|success,skipped" \
+            "The contract check|${{ needs.contract.result }}|success,skipped"
+          echo "Gate passes."

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -207,29 +207,19 @@ jobs:
     timeout-minutes: 2
 
     steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
       - name: Require the matrix to pass
         run: |
-          if [ "${{ needs.scope.result }}" != "success" ]; then
-            echo "::error::The scope job did not succeed (${{ needs.scope.result }})."
-            exit 1
-          fi
+          .github/scripts/require-results.sh "The scope job|${{ needs.scope.result }}"
           if [ "${{ needs.scope.outputs.code }}" != "true" ]; then
             echo "Nothing outside the docs changed; the iOS matrix has nothing to build."
             exit 0
           fi
-          if [ "${{ needs.lint.result }}" != "success" ]; then
-            echo "::error::Lint did not succeed (${{ needs.lint.result }})."
-            exit 1
-          fi
-          case "${{ needs.gate.result }}" in
-            success | skipped) ;;
-            *)
-              echo "::error::The fast-check gate did not pass (${{ needs.gate.result }})."
-              exit 1
-              ;;
-          esac
-          if [ "${{ needs.tests.result }}" != "success" ]; then
-            echo "::error::The iOS test matrix did not succeed (${{ needs.tests.result }})."
-            exit 1
-          fi
+          .github/scripts/require-results.sh \
+            "Lint|${{ needs.lint.result }}" \
+            "The fast-check gate|${{ needs.gate.result }}|success,skipped" \
+            "The iOS test matrix|${{ needs.tests.result }}"
           echo "Gate passes."


### PR DESCRIPTION
Five open pull requests emptied the macOS runner pool at once, and every gate behind it turned red. The `lint` job sat queued for seventeen minutes on #1157 and #1158 before being cancelled, and on #1156 the Swift run never created a job at all. `wait-for-checks.sh` sorted `cancelled` into the same branch as `failure` and exited on the spot, and `tests-gate`, `api-gate` and `contract-gate` compared `needs.<job>.result` against `success` and reported "did not succeed" — so three pull requests read as broken code when nothing had been built.

A cancellation is the absence of a verdict, not a negative one. The wait script now returns a cancelled fast check to the pending set and holds a `CANCELLED_TIMEOUT` window (900s) open for a re-run to post a fresh check; since it already picks the latest check run per name, a re-queued `lint` is picked up and the gate passes, where before it had died long before anyone could press the button. A check still cancelled when the window closes fails with a message naming the runner rather than the code, and a genuine `failure` still short-circuits on the first poll.

The new `require-results.sh` carries the same distinction into the three aggregating gates, which until now held three copies of the same `needs.*.result` comparisons. Entries are `"label|result|allowed"` with `success` as the default, a cancelled dependency gets its own wording, and every unmet dependency is reported instead of only the first. Those three jobs gain a checkout, since they now run a script from the tree.

Worth flagging for review: cancelled deliberately does not count as success. These gates are the required checks in branch protection, so treating a cancelled `lint` as a pass would let a pull request merge that nothing had checked — the resilience here is the re-run window and the honest message, not a green light.

Exercised `require-results.sh` over all-green, all-cancelled, a failure/cancelled/skipped mix, an allowed `skipped` and an empty result. Drove `wait-for-checks.sh` against a stub `gh`: cancelled then re-run exits 0 where it used to exit 1, cancelled with no re-run fails when the window closes, and a `failure` still fails at once. `shellcheck` and `actionlint` were not available locally, so the scripts got `bash -n` and the workflows a YAML parse only.

This touches the gate jobs in `swift.yml`, `api.yml` and `server.yml`, which #1156, #1158 and #1159 also touch — #1159 in particular moves `scope` into a reusable workflow, so the merge order is worth choosing rather than leaving to chance.