### PR TITLE
Stop the fast-check gate from failing while runs wait for a runner

### DIFF
--- a/.github/scripts/wait-for-checks.sh
+++ b/.github/scripts/wait-for-checks.sh
@@ -17,6 +17,20 @@ back_off() {
   interval=$(( interval * 2 > max_interval ? max_interval : interval * 2 ))
 }
 
+# A run that has not been given a runner yet has no jobs, and a job that does not exist has no
+# check run, so a missing check is indistinguishable from a renamed one until the queue drains.
+undispatched_runs() {
+  for sha in "${shas[@]}"; do
+    [ -n "$sha" ] || continue
+    gh api --paginate \
+      "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$sha&per_page=100" \
+      --jq '.workflow_runs[]
+        | select(.status == "queued" or .status == "pending"
+          or .status == "waiting" or .status == "requested")
+        | .name' || return 1
+  done
+}
+
 deadline=$(( SECONDS + timeout ))
 absent_deadline=$(( SECONDS + absent_timeout ))
 failures=0
@@ -71,8 +85,13 @@ while :; do
   if [ "$SECONDS" -ge "$absent_deadline" ]; then
     absent="$(printf '%s\n' "${pending[@]}" | grep -F '(absent)' || true)"
     if [ -n "$absent" ]; then
-      echo "::error::No check run appeared within ${absent_timeout}s for: $(echo $absent) — if the job was renamed, update the CHECKS list in this workflow."
-      exit 1
+      if waiting="$(undispatched_runs)" && [ -n "$waiting" ]; then
+        echo "Still waiting for a runner: $(echo $waiting). A check run cannot appear before the run it belongs to starts, so the absence is not counted yet."
+        absent_deadline=$(( SECONDS + absent_timeout ))
+      else
+        echo "::error::No check run appeared within ${absent_timeout}s for: $(echo $absent) — if the job was renamed, update the CHECKS list in this workflow."
+        exit 1
+      fi
     fi
   fi
 

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -42,6 +42,7 @@ jobs:
     permissions:
       contents: read
       checks: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -54,6 +54,7 @@ jobs:
     permissions:
       contents: read
       checks: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -69,6 +69,7 @@ jobs:
     permissions:
       contents: read
       checks: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The gate waits for the fast checks before it starts an expensive macOS job, and gives up if an awaited check has not appeared within 15 minutes — the signal that a job was renamed and the CHECKS list went stale. But a run that has not been handed a runner yet has no jobs at all, and a job that does not exist has no check run, so a saturated macOS queue looks exactly like a rename. That happened today: the Swift run sat in `pending` for over an hour behind another branch's matrix, and every gate on every open PR went red waiting for a `lint` check that could not yet exist.

The absence is now only counted while nothing is waiting to start: before failing, the script asks the API whether any run for the same commit is still `queued`, `pending`, `waiting`, or `requested`, and if so restarts the window instead of erroring. In-progress runs deliberately do not count — the gate's own run is one — so a genuinely renamed job still fails the gate as before, and the overall three-hour timeout still caps the wait.

Listing runs needs `actions: read`, so the three gate jobs gain it.