### PR TITLE
Pin the scout-db revision that heals a missing index head

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(
             url: "https://github.com/kasianov-mikhail/scout-db.git",
-            revision: "b2830cbdf4d98638085f50fedfbac743f5697eaa"
+            revision: "6e3c2d88be9527289d0c027f264922e0df999247"
         ),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),
     ],


### PR DESCRIPTION
Picks up kasianov-mikhail/scout-db#505, which stops a chart over an aggregate nothing has written from spending a failing CloudKit fetch on every read. The Scout app is where that showed: twenty misses in the first minute after launch, over the index heads for `Event by_name_at_date` and the two metric sums, and they were the only failing requests in the session — enough for CloudKit to answer with `Error rate mitigation activated due to high rate of failing operations` and slow the container down. A read that finds no head now writes the empty page, so the miss is spent once per aggregate instead of once per read.

Nothing in this repository changes beyond the revision. Seeding lives entirely behind `VectorReader`, so the catalog publishes schemas exactly as it did and no call site moves. Verified by running the app against the live container: the launch after the change ran seventy-six requests with no failure of any kind and no mitigation notice in twelve minutes.

The pin points at the head of the scout-db branch and wants a second bump to the squashed commit on `main` once #505 lands.
