### PR TITLE
Pin the scout-db commit that landed on main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(
             url: "https://github.com/kasianov-mikhail/scout-db.git",
-            revision: "6e3c2d88be9527289d0c027f264922e0df999247"
+            revision: "a52aa3e590d79c946c9dadfdb0ceb68ef561ee06"
         ),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),
     ],


### PR DESCRIPTION
Follow-up to #1163, which pinned scout-db at the head of the branch behind kasianov-mikhail/scout-db#505 so the two could be verified together. That PR has since landed, and squashing gave the change a new commit on `main`; the revision this repository names is now advertised only as `refs/pull/505/head`, reachable but on no branch, and it disappears if that pull request is ever pruned. The pin moves to the squashed commit, which is the same tree.

No source changes, and nothing to re-verify beyond resolution: `Scout-Package` builds against the new revision.
