### PR TITLE
Narrow the iOS test matrix to iOS 26 Debug

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -82,29 +82,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Temporarily narrowed to iOS 26 Debug; uncomment the lines below to restore the full matrix.
         # Optimized builds specialize generics and fold key paths, so SwiftData predicate traps and
         # other release-only failures never show up in a Debug-only run.
-        configuration: [Debug, Release]
-        ios: [16, 17, 18, 26, 27]
+        # configuration: [Debug, Release]
+        # ios: [16, 17, 18, 26, 27]
+        configuration: [Debug]
+        ios: [26]
         include:
-          - ios: 16
-            os: macos-15
-            device: iPhone 14
-            runtime: "16.4"
-            skipTesting: LookupIndexTests
-          - ios: 17
-            os: macos-15
-            device: iPhone 15
-            runtime: "17.5"
-          - ios: 18
-            os: macos-15
-            device: iPhone 16
+          # - ios: 16
+          #   os: macos-15
+          #   device: iPhone 14
+          #   runtime: "16.4"
+          #   skipTesting: LookupIndexTests
+          # - ios: 17
+          #   os: macos-15
+          #   device: iPhone 15
+          #   runtime: "17.5"
+          # - ios: 18
+          #   os: macos-15
+          #   device: iPhone 16
           - ios: 26
             os: macos-26
             device: iPhone 17
-          - ios: 27
-            os: xcode-27
-            device: iPhone 17
+          # - ios: 27
+          #   os: xcode-27
+          #   device: iPhone 17
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Temporarily runs a single leg of the Swift test matrix — iOS 26 on macOS 26, Debug only — while the other combinations are under investigation. The values this drops are kept as comments rather than deleted, so the full Debug/Release × iOS 16/17/18/26/27 matrix comes back by uncommenting them.

The `include` entries for the other iOS versions are commented out as well, not just the `ios` list: in GitHub Actions an `include` entry that sets a matrix key to a value absent from the matrix creates a job of its own, so leaving them behind would have kept those legs running.

Worth noting for the reviewer: if branch protection lists the per-leg check names (`test-ios-16 (Debug)` and friends) as required, they will sit pending and block merges until the list is trimmed or this change is reverted. The `tests-gate` summary job is unaffected.