### PR TITLE
Run the narrowed-away iOS matrix nightly

### DIFF
--- a/.github/actions/ios-tests/action.yml
+++ b/.github/actions/ios-tests/action.yml
@@ -1,0 +1,85 @@
+name: iOS tests
+description: Boots a simulator runtime and runs the Scout test bundle on it.
+
+inputs:
+  ios:
+    description: Major iOS version to test against.
+    required: true
+  configuration:
+    description: Xcode build configuration to build and test.
+    required: true
+  device:
+    description: Simulator device model to boot.
+    required: true
+  runtime:
+    description: Exact runtime version to download when the runner ships without one.
+    required: false
+    default: ""
+  skip-testing:
+    description: Test target to skip on this leg.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+
+  steps:
+    - name: Prepare simulator
+      id: sim
+      shell: bash
+      run: |
+        if ! xcrun simctl list runtimes | grep -q "^iOS ${{ inputs.ios }}\."; then
+          if [ -n "${{ inputs.runtime }}" ]; then
+            xcodebuild -downloadPlatform iOS -buildVersion "${{ inputs.runtime }}"
+          else
+            xcodebuild -downloadPlatform iOS
+          fi
+        fi
+        runtime=$(xcrun simctl list runtimes --json \
+          | jq -r '.runtimes[] | select(.platform == "iOS" and (.version | startswith("${{ inputs.ios }}."))) | .identifier' \
+          | tail -1)
+        if [ -z "$runtime" ]; then
+          echo "No iOS ${{ inputs.ios }} simulator runtime is available."
+          xcrun simctl list runtimes
+          exit 1
+        fi
+        udid=$(xcrun simctl list devices available --json \
+          | jq -r --arg rt "$runtime" '.devices[$rt][]? | select(.name == "${{ inputs.device }}") | .udid' \
+          | head -1)
+        if [ -z "$udid" ]; then
+          udid=$(xcrun simctl create "${{ inputs.device }}" "${{ inputs.device }}" "$runtime")
+        fi
+        echo "udid=$udid" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Swift package checkouts
+      uses: actions/cache@v6
+      with:
+        path: /tmp/spm
+        key: spm-${{ hashFiles('Package.swift') }}
+        restore-keys: spm-
+
+    - name: Build
+      shell: bash
+      run: |
+        xcodebuild \
+          -scheme Scout-Package \
+          -configuration ${{ inputs.configuration }} \
+          ENABLE_TESTABILITY=YES \
+          -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
+          -clonedSourcePackagesDirPath /tmp/spm \
+          -skipMacroValidation \
+          build-for-testing
+
+    - name: Test
+      shell: bash
+      run: |
+        xcodebuild \
+          -scheme Scout-Package \
+          -configuration ${{ inputs.configuration }} \
+          ENABLE_TESTABILITY=YES \
+          -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
+          -clonedSourcePackagesDirPath /tmp/spm \
+          -skipMacroValidation \
+          ${{ inputs.skip-testing && format('-skip-testing:{0}', inputs.skip-testing) || '' }} \
+          -parallel-testing-enabled NO \
+          test-without-building

--- a/.github/matrix/ios.json
+++ b/.github/matrix/ios.json
@@ -1,0 +1,34 @@
+{
+  "configuration": ["Debug", "Release"],
+  "ios": [16, 17, 18, 26, 27],
+  "include": [
+    {
+      "ios": 16,
+      "os": "macos-15",
+      "device": "iPhone 14",
+      "runtime": "16.4",
+      "skipTesting": "LookupIndexTests"
+    },
+    {
+      "ios": 17,
+      "os": "macos-15",
+      "device": "iPhone 15",
+      "runtime": "17.5"
+    },
+    {
+      "ios": 18,
+      "os": "macos-15",
+      "device": "iPhone 16"
+    },
+    {
+      "ios": 26,
+      "os": "macos-26",
+      "device": "iPhone 17"
+    },
+    {
+      "ios": 27,
+      "os": "xcode-27",
+      "device": "iPhone 17"
+    }
+  ]
+}

--- a/.github/scripts/ios-matrix.sh
+++ b/.github/scripts/ios-matrix.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prints .github/matrix/ios.json as a one-line strategy.matrix value. Without arguments that is the
+# full matrix; --ios and --configuration take comma-separated values and narrow it. Include entries
+# whose iOS version is narrowed away are dropped too: an include entry naming a version absent from
+# the matrix does not sit idle, it creates a job of its own.
+
+source_file="$(dirname "$0")/../matrix/ios.json"
+ios=""
+configuration=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ios)
+      ios="${2:?--ios needs a comma-separated list of versions}"
+      shift 2
+      ;;
+    --configuration)
+      configuration="${2:?--configuration needs a comma-separated list of configurations}"
+      shift 2
+      ;;
+    *)
+      echo "::error::Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+matrix="$(jq -c --arg ios "$ios" --arg configuration "$configuration" '
+  def keep($spec):
+    if $spec == "" then . else map(select(tostring as $value | $spec | split(",") | index($value))) end;
+
+  .configuration |= keep($configuration)
+  | .ios |= keep($ios)
+  | .ios as $versions
+  | .include |= map(select(.ios as $version | $versions | index($version)))
+' "$source_file")"
+
+for field in configuration ios; do
+  if [ "$(jq --arg field "$field" '.[$field] | length' <<< "$matrix")" -eq 0 ]; then
+    echo "::error::Narrowing left no $field values; check the arguments against $source_file."
+    exit 1
+  fi
+done
+
+echo "$matrix"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,96 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  matrix:
+    if: github.repository == 'kasianov-mikhail/scout'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    outputs:
+      legs: ${{ steps.legs.outputs.legs }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
+      - name: Read the iOS matrix
+        id: legs
+        # Unnarrowed on purpose: .github/workflows/swift.yml runs a single leg per pull request, and
+        # this workflow keeps the rest of .github/matrix/ios.json alive so the narrowing there stays
+        # reversible. Drop this workflow once that matrix is restored.
+        run: |
+          legs="$(.github/scripts/ios-matrix.sh)"
+          echo "$legs"
+          echo "legs=$legs" >> "$GITHUB_OUTPUT"
+
+  tests:
+    name: test-ios-${{ matrix.ios }} (${{ matrix.configuration }})
+    needs: matrix
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.legs) }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/ios-tests
+        with:
+          ios: ${{ matrix.ios }}
+          configuration: ${{ matrix.configuration }}
+          device: ${{ matrix.device }}
+          runtime: ${{ matrix.runtime }}
+          skip-testing: ${{ matrix.skipTesting }}
+
+  verdict:
+    name: verdict
+    needs: [matrix, tests]
+    if: always() && github.repository == 'kasianov-mikhail/scout'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
+      - name: Report the state of the matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          {
+            echo "### The full iOS matrix"
+            gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs" \
+              --jq '.jobs[] | select(.name | startswith("test-ios-")) | "- \(.name): \(.conclusion)"' \
+              || echo "- could not read this run's jobs"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ needs.tests.result }}" = success ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Every leg passed. Drop the narrowing arguments in .github/workflows/swift.yml to run the full matrix per pull request again." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          .github/scripts/require-results.sh \
+            "The matrix job|${{ needs.matrix.result }}" \
+            "The nightly iOS matrix|${{ needs.tests.result }}"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -65,13 +65,40 @@ jobs:
           CHECKS: model-versions changes
         run: .github/scripts/wait-for-checks.sh
 
+  matrix:
+    needs: scope
+    if: needs.scope.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    outputs:
+      legs: ${{ steps.legs.outputs.legs }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+
+      - name: Narrow the iOS matrix
+        id: legs
+        # Temporarily narrowed to iOS 26 Debug; drop the arguments to restore the full matrix from
+        # .github/matrix/ios.json. Until then that full matrix keeps running nightly in
+        # .github/workflows/nightly.yml, which reports when every leg is green again.
+        # Optimized builds specialize generics and fold key paths, so SwiftData predicate traps and
+        # other release-only failures never show up in a Debug-only run.
+        run: |
+          legs="$(.github/scripts/ios-matrix.sh --ios 26 --configuration Debug)"
+          echo "$legs"
+          echo "legs=$legs" >> "$GITHUB_OUTPUT"
+
   tests:
     name: test-ios-${{ matrix.ios }} (${{ matrix.configuration }})
-    needs: [scope, lint, gate]
+    needs: [scope, lint, gate, matrix]
     if: >-
       ${{ always()
       && needs.scope.outputs.code == 'true'
       && needs.lint.result == 'success'
+      && needs.matrix.result == 'success'
       && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
@@ -81,97 +108,22 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        # Temporarily narrowed to iOS 26 Debug; uncomment the lines below to restore the full matrix.
-        # Optimized builds specialize generics and fold key paths, so SwiftData predicate traps and
-        # other release-only failures never show up in a Debug-only run.
-        # configuration: [Debug, Release]
-        # ios: [16, 17, 18, 26, 27]
-        configuration: [Debug]
-        ios: [26]
-        include:
-          # - ios: 16
-          #   os: macos-15
-          #   device: iPhone 14
-          #   runtime: "16.4"
-          #   skipTesting: LookupIndexTests
-          # - ios: 17
-          #   os: macos-15
-          #   device: iPhone 15
-          #   runtime: "17.5"
-          # - ios: 18
-          #   os: macos-15
-          #   device: iPhone 16
-          - ios: 26
-            os: macos-26
-            device: iPhone 17
-          # - ios: 27
-          #   os: xcode-27
-          #   device: iPhone 17
+      matrix: ${{ fromJSON(needs.matrix.outputs.legs) }}
 
     steps:
       - uses: actions/checkout@v7
 
-      - name: Prepare simulator
-        id: sim
-        run: |
-          if ! xcrun simctl list runtimes | grep -q "^iOS ${{ matrix.ios }}\."; then
-            if [ -n "${{ matrix.runtime }}" ]; then
-              xcodebuild -downloadPlatform iOS -buildVersion "${{ matrix.runtime }}"
-            else
-              xcodebuild -downloadPlatform iOS
-            fi
-          fi
-          runtime=$(xcrun simctl list runtimes --json \
-            | jq -r '.runtimes[] | select(.platform == "iOS" and (.version | startswith("${{ matrix.ios }}."))) | .identifier' \
-            | tail -1)
-          if [ -z "$runtime" ]; then
-            echo "No iOS ${{ matrix.ios }} simulator runtime is available."
-            xcrun simctl list runtimes
-            exit 1
-          fi
-          udid=$(xcrun simctl list devices available --json \
-            | jq -r --arg rt "$runtime" '.devices[$rt][]? | select(.name == "${{ matrix.device }}") | .udid' \
-            | head -1)
-          if [ -z "$udid" ]; then
-            udid=$(xcrun simctl create "${{ matrix.device }}" "${{ matrix.device }}" "$runtime")
-          fi
-          echo "udid=$udid" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Swift package checkouts
-        uses: actions/cache@v6
+      - uses: ./.github/actions/ios-tests
         with:
-          path: /tmp/spm
-          key: spm-${{ hashFiles('Package.swift') }}
-          restore-keys: spm-
-
-      - name: Build
-        run: |
-          xcodebuild \
-            -scheme Scout-Package \
-            -configuration ${{ matrix.configuration }} \
-            ENABLE_TESTABILITY=YES \
-            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
-            -clonedSourcePackagesDirPath /tmp/spm \
-            -skipMacroValidation \
-            build-for-testing
-
-      - name: Test
-        run: |
-          xcodebuild \
-            -scheme Scout-Package \
-            -configuration ${{ matrix.configuration }} \
-            ENABLE_TESTABILITY=YES \
-            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
-            -clonedSourcePackagesDirPath /tmp/spm \
-            -skipMacroValidation \
-            ${{ matrix.skipTesting && format('-skip-testing:{0}', matrix.skipTesting) || '' }} \
-            -parallel-testing-enabled NO \
-            test-without-building
+          ios: ${{ matrix.ios }}
+          configuration: ${{ matrix.configuration }}
+          device: ${{ matrix.device }}
+          runtime: ${{ matrix.runtime }}
+          skip-testing: ${{ matrix.skipTesting }}
 
   tests-gate:
     name: tests-gate
-    needs: [scope, lint, gate, tests]
+    needs: [scope, lint, gate, matrix, tests]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -191,5 +143,6 @@ jobs:
           .github/scripts/require-results.sh \
             "Lint|${{ needs.lint.result }}" \
             "The fast-check gate|${{ needs.gate.result }}|success,skipped" \
+            "The matrix job|${{ needs.matrix.result }}" \
             "The iOS test matrix|${{ needs.tests.result }}"
           echo "Gate passes."


### PR DESCRIPTION
#1165 narrowed the pull request matrix to iOS 26 Debug, which leaves the other nine legs unbuilt for as long as the narrowing lasts. A nightly workflow now runs the full Debug/Release × iOS 16/17/18/26/27 matrix on `main` and summarises each leg's verdict, so the versions dropped from the pull request path keep reporting and the narrowing can be undone as soon as they are green again.

Rather than restate the matrix in two workflows, the legs move to `.github/matrix/ios.json`, and `.github/scripts/ios-matrix.sh` prints them as a `strategy.matrix` value: the nightly run takes them whole, while Swift asks for `--ios 26 --configuration Debug`. The script drops `include` entries whose iOS version was narrowed away — an `include` entry naming a version absent from the matrix creates a job of its own rather than sitting idle — and it fails outright when the arguments select nothing. Both workflows resolve the matrix in a small ubuntu job whose output feeds `strategy.matrix` through `fromJSON`.

The steps of a leg move to the `.github/actions/ios-tests` composite action so the two workflows share one copy. Job names are unchanged, so required checks such as `test-ios-26 (Debug)` and `tests-gate` keep their identities; the new `matrix` job is not required, but `tests-gate` now demands its success so a failure there cannot pass as an empty matrix.

Worth knowing for the reviewer: nightly runs ten macOS legs, and the iOS 27 leg waits on a runner labelled `xcode-27` — if that label has no runner behind it, expect that leg to sit queued until its 40 minute timeout every night. Say the word and I will drop it from the nightly set.
