### PR TITLE
Merge background Core Data writes by property

### DIFF
--- a/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
+++ b/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
@@ -47,6 +47,7 @@ struct IncidentArchive<Payload: Codable & Sendable> {
             do {
                 let id = UUID(uuidString: file.deletingPathExtension().lastPathComponent) ?? UUID()
                 try await persistentContainer.performBackgroundTask { context in
+                    context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
                     try persist(payload, id, deviceID, context)
                 }
                 try FileManager.default.removeItem(at: file)

--- a/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
+++ b/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import CoreData
 import Foundation
 import Logging
 
@@ -27,6 +28,7 @@ struct ScoutLogHandler: LogHandler {
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
+                    context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
                     try Scout.log(event, date: Date(), sessionID: sessionID, context: context)
                 }
                 try await self.sync()

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -58,6 +58,7 @@ extension TelemetryPersisting {
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
+                    context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
                     try save(context)
                 }
                 try await sync()

--- a/Sources/Scout/Identity/Command.swift
+++ b/Sources/Scout/Identity/Command.swift
@@ -14,6 +14,8 @@ protocol Command: Sendable {
 extension NSPersistentContainer {
     func run(_ commands: any Command...) async throws {
         try await performBackgroundTask { context in
+            context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+
             for command in commands {
                 try command.execute(in: context)
             }

--- a/Sources/Scout/Persistence/PersistentContainer.swift
+++ b/Sources/Scout/Persistence/PersistentContainer.swift
@@ -20,12 +20,6 @@ let persistentContainer: NSPersistentContainer = {
 }()
 
 extension NSManagedObjectModel {
-    // Loading ScoutModel.momd more than once registers a duplicate
-    // NSEntityDescription per NSManagedObject subclass, and the resulting
-    // ambiguous class→entity resolution races under parallel test runs —
-    // intermittently escalating a constraint-conflict save into a fatal
-    // "Unable to recover from optimistic locking failure". Every container
-    // must share this single instance.
     nonisolated(unsafe) static let scout: NSManagedObjectModel = {
         guard let modelURL = Bundle.module.url(forResource: "ScoutModel", withExtension: "momd") else {
             fatalError("Failed to find data model")
@@ -55,12 +49,6 @@ extension NSPersistentContainer {
             throw captured
         }
 
-        // With the default NSErrorMergePolicy a uniqueness-constraint collision
-        // fails the whole save() and leaves the offending insert pending, so on
-        // the long-lived viewContext every later save() throws too. Merging by
-        // property dedupes the colliding row instead — the reason the
-        // constraints exist — and keeps a batched save (e.g. plan inserting many
-        // DeliveryEntry rows at once) from being rejected over a single duplicate.
         viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
     }
 }

--- a/Tests/ScoutTests/Persistence/MergePolicyTests.swift
+++ b/Tests/ScoutTests/Persistence/MergePolicyTests.swift
@@ -22,14 +22,8 @@ struct MergePolicyTests {
     @Test("A duplicate insert on the same natural key dedupes instead of throwing")
     func duplicateInsertDedupes() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
-
-        let container = NSPersistentContainer(named: "ScoutModel")
-        container.persistentStoreDescriptions = [
-            NSPersistentStoreDescription(url: directory.appendingPathComponent("ScoutModel.sqlite"))
-        ]
-        try container.loadStore()
+        let container = try makeContainer(in: directory)
 
         // The main-queue viewContext is off-limits here: Swift Testing runs on a
         // background thread, and mutating it there races the main run loop's own
@@ -53,5 +47,93 @@ struct MergePolicyTests {
             return try context.fetch(request)
         }
         #expect(events.count == 1)
+    }
+
+    /// Attaching a metrics row to a session enlists that session in the save's
+    /// optimistic locking, so writes racing an update of the same session fail
+    /// with "Could not merge changes" on the default policy — the burst of
+    /// "Failed to save metrics" the telemetry handler used to print.
+    ///
+    @Test("Concurrent writes touching one session merge instead of failing")
+    func concurrentSessionWritesMerge() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let container = try makeContainer(in: directory)
+
+        let sessionID = UUID()
+        try await container.performBackgroundTask { @Sendable context in
+            _ = try context.linkedSession(
+                deviceID: UUID(),
+                installID: UUID(),
+                launchID: UUID(),
+                sessionID: sessionID,
+                date: Date()
+            )
+            try context.save()
+        }
+
+        let failures = Protected<[String]>([])
+
+        await withTaskGroup(of: Void.self) { group in
+            for value in 1...20 {
+                group.addTask {
+                    do {
+                        try await container.performBackgroundTask { context in
+                            context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+                            try saveMetrics(
+                                "counter",
+                                date: Date(),
+                                category: Telemetry.Export.counter.rawValue,
+                                value: value,
+                                sessionID: sessionID,
+                                context
+                            )
+                        }
+                    } catch {
+                        failures.mutate { $0.append(error.localizedDescription) }
+                    }
+                }
+            }
+            for _ in 1...10 {
+                group.addTask {
+                    do {
+                        try await container.performBackgroundTask { context in
+                            context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+
+                            let session = try context.existing(SessionEntry.self, key: "sessionID", id: sessionID)
+                            session?.endDate = Date()
+                            try context.save()
+                        }
+                    } catch {
+                        failures.mutate { $0.append(error.localizedDescription) }
+                    }
+                }
+            }
+        }
+
+        #expect(failures.current.count == 0)
+
+        let context = container.newBackgroundContext()
+        try context.performAndWait {
+            let request = NSFetchRequest<SessionEntry>(entityName: "SessionEntry")
+            let sessions = try context.fetch(request)
+            #expect(sessions.first?.metrics.count == 20)
+        }
+    }
+
+    /// Uniqueness constraints and row versioning are only enforced by the SQLite
+    /// store, so every case here needs a real file-backed store — an in-memory
+    /// one silently allows the duplicate and never conflicts.
+    ///
+    private func makeContainer(in directory: URL) throws -> NSPersistentContainer {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let container = NSPersistentContainer(named: "ScoutModel")
+        container.persistentStoreDescriptions = [
+            NSPersistentStoreDescription(url: directory.appendingPathComponent("ScoutModel.sqlite"))
+        ]
+        try container.loadStore()
+
+        return container
     }
 }


### PR DESCRIPTION
Contexts handed out by `performBackgroundTask` start on the default `NSErrorMergePolicy`, unlike the `viewContext`. Attaching a row to a session enlists that session in the save's optimistic locking, so a metrics or log write racing any other update of the same session — a session end writing `endDate`, a neighbouring telemetry write — failed outright with "Could not merge changes" (`NSCocoaErrorDomain` 133020) and printed a burst of "Failed to save metrics". A stress run against a real SQLite store reproduced 78 such failures; with the merge policy applied it drops to zero.

Every background write now sets the same `mergeByPropertyObjectTrump` policy the `viewContext` uses, so a conflicting save merges property by property instead of throwing. The new test in `MergePolicyTests` drives concurrent metrics writes and session updates through one session and fails without the policy. This also drops two stale comments from `PersistentContainer.swift`.