### PR TITLE
Log the full error when a background write fails

### DIFF
--- a/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
+++ b/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
@@ -51,7 +51,7 @@ struct IncidentArchive<Payload: Codable & Sendable> {
                 }
                 try FileManager.default.removeItem(at: file)
             } catch {
-                print("Failed to process \(pathExtension): \(error.localizedDescription)")
+                print("Failed to process \(pathExtension): \(error)")
             }
         }
     }

--- a/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
+++ b/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
@@ -31,7 +31,7 @@ struct ScoutLogHandler: LogHandler {
                 }
                 try await self.sync()
             } catch {
-                print(error.localizedDescription)
+                print("Failed to save log: \(error)")
             }
         }
     }

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -62,7 +62,7 @@ extension TelemetryPersisting {
                 }
                 try await sync()
             } catch {
-                print("Failed to save metrics: \(error.localizedDescription)")
+                print("Failed to save metrics: \(error)")
             }
         }
     }

--- a/Sources/Scout/Identity/ActionTable.swift
+++ b/Sources/Scout/Identity/ActionTable.swift
@@ -32,7 +32,7 @@ private func run(_ action: ActionTable.Action) async {
     do {
         try await action()
     } catch {
-        print(error.localizedDescription)
+        print("Failed to run action: \(error)")
     }
 }
 


### PR DESCRIPTION
Every failing background write printed only `error.localizedDescription`, which for a Core Data failure is a bare sentence like "Could not merge changes" — no domain, no code, no `conflictList`. Diagnosing the recent merge-conflict burst needed a stress harness precisely because the log said nothing about which rows collided.

Interpolating the error itself keeps the message and adds the domain, the code and the whole `userInfo`. The two sites that printed a bare unattributed line — the log handler and the lifecycle action runner — also get a prefix naming what failed.