### PR TITLE
Start the first sync when setup completes

### DIFF
--- a/Sources/Scout/Setup/Setup.swift
+++ b/Sources/Scout/Setup/Setup.swift
@@ -62,4 +62,12 @@ public func setup(backends: [Backend]) async throws {
     )
 
     isSetup = true
+
+    Task {
+        do {
+            try await sync()
+        } catch {
+            print("Failed to run the first sync: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
Records written during startup — the install, device, version, launch and session rows `bootstrap` creates — sat in Core Data until something else happened to trigger a sync: a log through swift-log, a metric, or a trip to the background. Switching a CloudKit container made that visible: the whole retained backlog is queued for the new backend ID and then waits for an unrelated event before it leaves, so a fresh container stays empty for a while after launch even though the schema is already published.

Kicking off one sync once initialization completes sends those rows right away. It runs detached rather than inline: delivery goes over the network and CloudKit can throttle a freshly created container for minutes, while `setup` promises the caller nothing beyond initialization — surfacing a delivery error there would read as a failed setup. A failing first sync is logged and its records stay pending for the next pass, so the retry behaviour is unchanged.