### PR TITLE
Delete records once every backend has them

### DIFF
--- a/Sources/Scout/Lifecycle/Launch/LaunchEntry.swift
+++ b/Sources/Scout/Lifecycle/Launch/LaunchEntry.swift
@@ -22,8 +22,6 @@ package final class LaunchEntry: SyncableEntry, HasInstall {
         Set(Array(sessions) + Array(versions) + Array(visits))
     }
 
-    // The running launch has no `endDate` yet; `Recovery` stamps it on the
-    // next start, so it has to outlive the delivery that carried it.
     override var isPurgeable: Bool {
         endDate != nil
     }

--- a/Sources/Scout/Lifecycle/Launch/LaunchEntry.swift
+++ b/Sources/Scout/Lifecycle/Launch/LaunchEntry.swift
@@ -21,6 +21,12 @@ package final class LaunchEntry: SyncableEntry, HasInstall {
     override var references: Set<DateEntry> {
         Set(Array(sessions) + Array(versions) + Array(visits))
     }
+
+    // The running launch has no `endDate` yet; `Recovery` stamps it on the
+    // next start, so it has to outlive the delivery that carried it.
+    override var isPurgeable: Bool {
+        endDate != nil
+    }
 }
 
 extension LaunchEntry: RecordEncodable {

--- a/Sources/Scout/Lifecycle/Session/SessionEntry.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.swift
@@ -28,6 +28,12 @@ package final class SessionEntry: SyncableEntry, HasLaunch {
     override var references: Set<DateEntry> {
         Set(Array(crashes) + Array(hangs) + Array(events) + Array(metrics))
     }
+
+    // An open session is still being written to: `Complete` looks it up by
+    // launch to stamp `endDate`, and fails outright once it is gone.
+    override var isPurgeable: Bool {
+        endDate != nil
+    }
 }
 
 extension SessionEntry: RecordEncodable {

--- a/Sources/Scout/Lifecycle/Session/SessionEntry.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.swift
@@ -29,8 +29,6 @@ package final class SessionEntry: SyncableEntry, HasLaunch {
         Set(Array(crashes) + Array(hangs) + Array(events) + Array(metrics))
     }
 
-    // An open session is still being written to: `Complete` looks it up by
-    // launch to stamp `endDate`, and fails outright once it is gone.
     override var isPurgeable: Bool {
         endDate != nil
     }

--- a/Sources/Scout/Sync/DateEntry+Cleanup.swift
+++ b/Sources/Scout/Sync/DateEntry+Cleanup.swift
@@ -21,6 +21,8 @@ extension DateEntry {
             context.delete(object)
         }
 
+        try SyncableEntry.purgeDelivered(to: backendIDs, in: context)
+
         try context.save()
     }
 }

--- a/Sources/Scout/Sync/DateEntry+Cleanup.swift
+++ b/Sources/Scout/Sync/DateEntry+Cleanup.swift
@@ -21,7 +21,7 @@ extension DateEntry {
             context.delete(object)
         }
 
-        try SyncableEntry.purgeDelivered(to: backendIDs, in: context)
+        try SyncableEntry.purge(to: backendIDs, in: context)
 
         try context.save()
     }

--- a/Sources/Scout/Sync/SyncableEntry+Purge.swift
+++ b/Sources/Scout/Sync/SyncableEntry+Purge.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension SyncableEntry {
+    static func purgeDelivered(to backendIDs: Set<String>, in context: NSManagedObjectContext) throws {
+        guard backendIDs.count > 0 else {
+            return
+        }
+
+        let request = NSFetchRequest<SyncableEntry>(entityName: "SyncableEntry")
+        request.predicate = NSPredicate(
+            format: "SUBQUERY(deliveries, $d, $d.backendID IN %@ AND $d.isPending == NO).@count == %d",
+            backendIDs,
+            backendIDs.count
+        )
+
+        for object in try context.fetch(request) where object.isPurgeable && object.references.count == 0 {
+            context.delete(object)
+        }
+    }
+}

--- a/Sources/Scout/Sync/SyncableEntry+Purge.swift
+++ b/Sources/Scout/Sync/SyncableEntry+Purge.swift
@@ -8,7 +8,7 @@
 import CoreData
 
 extension SyncableEntry {
-    static func purgeDelivered(to backendIDs: Set<String>, in context: NSManagedObjectContext) throws {
+    static func purge(to backendIDs: Set<String>, in context: NSManagedObjectContext) throws {
         guard backendIDs.count > 0 else {
             return
         }

--- a/Sources/Scout/Sync/Synchronize.swift
+++ b/Sources/Scout/Sync/Synchronize.swift
@@ -39,4 +39,7 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
         }
         try Task.checkCancellation()
     }
+
+    try SyncableEntry.purgeDelivered(to: Set(backends.map(\.id)), in: context)
+    try context.save()
 }

--- a/Sources/Scout/Sync/Synchronize.swift
+++ b/Sources/Scout/Sync/Synchronize.swift
@@ -40,6 +40,6 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
         try Task.checkCancellation()
     }
 
-    try SyncableEntry.purgeDelivered(to: Set(backends.map(\.id)), in: context)
+    try SyncableEntry.purge(to: Set(backends.map(\.id)), in: context)
     try context.save()
 }

--- a/Tests/ScoutTests/Sync/DateEntryCleanupTests.swift
+++ b/Tests/ScoutTests/Sync/DateEntryCleanupTests.swift
@@ -30,7 +30,7 @@ struct DateEntryCleanupTests {
     @Test("Deletes synced launches older than 7 days")
     func deletesSyncedOldLaunch() throws {
         let old = Date(timeIntervalSinceNow: -8 * 86400)
-        LaunchEntry.stub(date: old, synced: true, in: context)
+        LaunchEntry.stub(date: old, synced: true, endDate: old, in: context)
         try context.save()
 
         try DateEntry.cleanup(backends: [], in: context)
@@ -89,6 +89,56 @@ struct DateEntryCleanupTests {
         try DateEntry.cleanup(backends: [makeBackend(id: "cloud")], in: context)
 
         #expect(try context.fetchAll(EventEntry.self).count == 1)
+    }
+
+    @Test("Deletes an event delivered to every backend before it ages out")
+    func deletesDeliveredEvent() throws {
+        let recent = Date(timeIntervalSinceNow: -60)
+        let event = EventEntry.stub(name: "delivered", date: recent, in: context)
+        event.seedDelivery(pending: false, for: "cloud", in: context)
+        try context.save()
+
+        try DateEntry.cleanup(backends: [makeBackend(id: "cloud")], in: context)
+
+        #expect(try context.fetchAll(EventEntry.self).isEmpty)
+    }
+
+    @Test("Keeps an event still owed to a second backend")
+    func keepsEventOwedElsewhere() throws {
+        let recent = Date(timeIntervalSinceNow: -60)
+        let event = EventEntry.stub(name: "half", date: recent, in: context)
+        event.seedDelivery(pending: false, for: "cloud", in: context)
+        event.seedDelivery(pending: true, for: "server", in: context)
+        try context.save()
+
+        let backends = [makeBackend(id: "cloud"), makeBackend(id: "server")]
+        try DateEntry.cleanup(backends: backends, in: context)
+
+        #expect(try context.fetchAll(EventEntry.self).count == 1)
+    }
+
+    @Test("Keeps a delivered session while it is still open")
+    func keepsOpenSession() throws {
+        let recent = Date(timeIntervalSinceNow: -60)
+        let session = SessionEntry.stub(date: recent, in: context)
+        session.seedDelivery(pending: false, for: "cloud", in: context)
+        try context.save()
+
+        try DateEntry.cleanup(backends: [makeBackend(id: "cloud")], in: context)
+
+        #expect(try context.fetchAll(SessionEntry.self).count == 1)
+    }
+
+    @Test("Deletes a delivered session once it is closed")
+    func deletesClosedSession() throws {
+        let recent = Date(timeIntervalSinceNow: -60)
+        let session = SessionEntry.stub(date: recent, endDate: recent, in: context)
+        session.seedDelivery(pending: false, for: "cloud", in: context)
+        try context.save()
+
+        try DateEntry.cleanup(backends: [makeBackend(id: "cloud")], in: context)
+
+        #expect(try context.fetchAll(SessionEntry.self).isEmpty)
     }
 
     @Test("Deletes local-only objects older than 7 days")


### PR DESCRIPTION
Cleanup only reclaimed rows older than seven days, so a delivered event sat on the device for a week after it was already safely stored. That backlog is what makes switching a CloudKit container expensive: `plan` queues every retained row for the new backend ID, and a week of events and metrics — thirteen thousand of them on my device — has to travel again.

A row whose configured backends have all settled has nothing left to give, so it is dropped as soon as that is true, keeping the same two guards as the age-based pass: one-shot entries stay (`isPurgeable`), and a parent waits for its children (`references`). The purge runs at the end of the sync pass, right after the delivery group closes, so records are reclaimed in the pass that delivered them rather than at the start of the next one — which may never come if the app goes quiet or is killed. Cleanup calls it too, to catch rows delivered by an earlier build or a run that ended early, since nothing else revisits them while the queue is empty. The seven-day sweep remains the ceiling for rows still owing work and for local-only entries like markers, which are never delivered at all.

Sessions and launches needed one more guard. Both are delivered while still open and are written to afterwards — `Complete` stamps `endDate` by launch, `Recovery` closes leftovers on the next start — and both fail or lose the write once the row is gone, so neither is purgeable until it carries an `endDate`. With no backends configured the rule is skipped entirely: "settled everywhere" is vacuously true against an empty set.