### PR TITLE
Send a record again once it is closed

### DIFF
--- a/Sources/Scout/Lifecycle/Launch/LaunchEntry.Recovery.swift
+++ b/Sources/Scout/Lifecycle/Launch/LaunchEntry.Recovery.swift
@@ -17,6 +17,7 @@ extension LaunchEntry {
 
             for launch in try context.fetch(request) {
                 launch.endDate = launch.inferred
+                launch.requeue()
             }
 
             if context.hasChanges {

--- a/Sources/Scout/Lifecycle/Session/SessionEntry.Complete.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.Complete.swift
@@ -23,6 +23,7 @@ extension SessionEntry {
 
             if session.endDate == nil {
                 session.endDate = Date()
+                session.requeue()
                 try context.save()
             }
         }

--- a/Sources/Scout/Lifecycle/Session/SessionEntry.Recovery.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.Recovery.swift
@@ -17,6 +17,7 @@ extension SessionEntry {
 
             for session in try context.fetch(request) {
                 session.endDate = session.inferred
+                session.requeue()
             }
 
             if context.hasChanges {

--- a/Sources/Scout/Sync/SyncableEntry.swift
+++ b/Sources/Scout/Sync/SyncableEntry.swift
@@ -14,6 +14,13 @@ package class SyncableEntry: DateEntry {
     func delivery(for backendID: String) -> DeliveryEntry? {
         deliveries.first { $0.backendID == backendID }
     }
+
+    func requeue() {
+        for delivery in deliveries {
+            delivery.isPending = true
+            delivery.attempts = 0
+        }
+    }
 }
 
 extension SyncableEntry {

--- a/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryRecoveryTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryRecoveryTests.swift
@@ -29,6 +29,20 @@ struct LaunchEntryRecoveryTests {
         #expect(launch.endDate == date)
     }
 
+    @Test("Queues a closed launch for delivery again")
+    func requeuesClosed() throws {
+        let launch = LaunchEntry.stub(date: date, in: context)
+        launch.launchID = UUID()
+
+        let delivery = launch.seedDelivery(pending: false, attempts: 3, for: "cloud", in: context)
+
+        try context.save()
+        try LaunchEntry.Recovery(launchID: identity.launch).execute(in: context)
+
+        #expect(delivery.isPending)
+        #expect(delivery.attempts == 0)
+    }
+
     @Test("Does not close launches from current launch")
     func skipsCurrent() throws {
         let launch = LaunchEntry.stub(date: date, in: context)

--- a/Tests/ScoutTests/Lifecycle/Session/SessionEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Session/SessionEntryMonitorTests.swift
@@ -62,6 +62,20 @@ struct SessionEntryMonitorTests {
         #expect(session.endDate == firstEndDate)
     }
 
+    @Test("complete queues the closed session for delivery again")
+    func completeRequeuesDelivery() throws {
+        LaunchEntry.stub(date: Date(), in: context)
+        try SessionEntry.Trigger(session: identity.session, launchID: identity.launch).execute(in: context)
+
+        let session = try #require(try context.fetchAll(SessionEntry.self).first)
+        let delivery = session.seedDelivery(pending: false, attempts: 3, for: "cloud", in: context)
+
+        try SessionEntry.Complete(launchID: identity.launch).execute(in: context)
+
+        #expect(delivery.isPending)
+        #expect(delivery.attempts == 0)
+    }
+
     @Test("complete throws notFound when no session exists for the current launch")
     func completeWithoutSessionThrows() throws {
         #expect(throws: LifecycleError.notFound) {


### PR DESCRIPTION
A session and a launch are delivered while still open, and are written to afterwards: `Complete` stamps `endDate` when the app leaves the foreground, `Recovery` closes whatever the previous run left behind. Nothing ever returned the delivery row to `isPending`, so that write never travelled — every session in the store carries a null `end_date`, and no duration can be derived from it.

`requeue()` puts every delivery row of a record back in the queue and clears its attempt count, so the closing write goes out on the next pass. The attempt reset matters because a record that failed earlier for unrelated reasons would otherwise carry a nearly exhausted counter into a delivery that has a fresh chance of succeeding.

Pairs with #1172, which deletes a record once every backend has it: without this the closing write would be dropped for good rather than merely lost.