### PR TITLE
Drop the repeated-setup guard

### DIFF
--- a/Sources/Scout/Setup/Setup.swift
+++ b/Sources/Scout/Setup/Setup.swift
@@ -9,8 +9,6 @@ import Foundation
 import Logging
 import Metrics
 
-@MainActor private var isSetup = false
-
 /// Initializes Scout's global infrastructure against one or more backends.
 ///
 /// Every raw record is synced to every backend. Aggregates are maintained
@@ -19,14 +17,12 @@ import Metrics
 ///
 /// - Parameter backends: The backends to sync to, in any combination of
 ///   CloudKit containers and Scout servers.
-/// - Throws: An error if initialization fails or if called more than once.
-/// - Important: Call from the main actor during app startup.
+/// - Throws: An error if initialization fails.
+/// - Important: Call from the main actor during app startup, exactly once —
+///   `swift-log` and `swift-metrics` both trap on a second bootstrap.
 ///
 @MainActor
 public func setup(backends: [Backend]) async throws {
-    guard !isSetup else {
-        throw SetupError.alreadySetup
-    }
     guard !backends.isEmpty else {
         throw SetupError.noBackends
     }
@@ -60,8 +56,6 @@ public func setup(backends: [Backend]) async throws {
     MetricsSystem.bootstrap(
         TelemetryFactory(sync: sync, session: session)
     )
-
-    isSetup = true
 
     Task {
         do {

--- a/Sources/Scout/Setup/SetupError.swift
+++ b/Sources/Scout/Setup/SetupError.swift
@@ -8,13 +8,10 @@
 import Foundation
 
 enum SetupError: LocalizedError {
-    case alreadySetup
     case noBackends
 
     var errorDescription: String? {
         switch self {
-        case .alreadySetup:
-            "Scout is already setup"
         case .noBackends:
             "Scout requires at least one backend"
         }
@@ -22,8 +19,6 @@ enum SetupError: LocalizedError {
 
     var recoverySuggestion: String? {
         switch self {
-        case .alreadySetup:
-            "Review the code to ensure setup is called only once"
         case .noBackends:
             "Pass a .cloudKit or .server backend to setup"
         }


### PR DESCRIPTION
`setup(backends:)` tracked a global `isSetup` flag and threw `SetupError.alreadySetup` on a second call. Both go away here: the flag guarded nothing that `swift-log` and `swift-metrics` don't already guard themselves — they trap on a second `bootstrap`, so a repeated setup was never survivable in the first place. The doc comment now says so instead.

This is the first step toward the public-handler interface discussed in #1138, where Scout stops owning the bootstrap and a single "already setup" flag no longer makes sense: handlers are constructed once per logger label.