### PR TITLE
Extract the Scout runtime out of setup

### DIFF
--- a/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
+++ b/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
@@ -10,8 +10,7 @@ import Foundation
 import Logging
 
 struct ScoutLogHandler: LogHandler {
-    let sync: Synchronize
-    let session: Protected<UUID>
+    let runtime: Runtime
     let label: String
 
     var metadata: Logger.Metadata = [:]
@@ -24,14 +23,14 @@ struct ScoutLogHandler: LogHandler {
     }
 
     func log(event: LogEvent) {
-        let sessionID = session.current
+        let sessionID = runtime.session.current
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
                     context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
                     try Scout.log(event, date: Date(), sessionID: sessionID, context: context)
                 }
-                try await self.sync()
+                try await self.runtime.sync()
             } catch {
                 print("Failed to save log: \(error)")
             }

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryFactory.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryFactory.swift
@@ -9,28 +9,27 @@ import Foundation
 import Metrics
 
 struct TelemetryFactory: MetricsFactory {
-    let sync: Synchronize
-    let session: Protected<UUID>
+    let runtime: Runtime
 
     func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
-        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        TelemetryHandler(label: label, dimensions: dimensions, runtime: runtime)
     }
 
     func makeFloatingPointCounter(label: String, dimensions: [(String, String)]) -> FloatingPointCounterHandler {
-        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        TelemetryHandler(label: label, dimensions: dimensions, runtime: runtime)
     }
 
     func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
-        GaugeHandler(label: label, sync: sync, session: session)
+        GaugeHandler(label: label, runtime: runtime)
     }
 
     func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
-        guard aggregate else { return GaugeHandler(label: label, sync: sync, session: session) }
-        return TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        guard aggregate else { return GaugeHandler(label: label, runtime: runtime) }
+        return TelemetryHandler(label: label, dimensions: dimensions, runtime: runtime)
     }
 
     func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
-        TelemetryHandler(label: label, dimensions: dimensions, sync: sync, session: session)
+        TelemetryHandler(label: label, dimensions: dimensions, runtime: runtime)
     }
 
     func destroyCounter(_ handler: CounterHandler) {}

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -15,7 +15,7 @@ extension TelemetryPersisting {
 
     func logMetrics(category: String, value: some MetricScalar) {
         let label = self.label
-        let sessionID = session.current
+        let sessionID = runtime.session.current
         persistMetrics { context in
             try saveMetrics(label, date: Date(), category: category, value: value, sessionID: sessionID, context)
         }
@@ -23,7 +23,7 @@ extension TelemetryPersisting {
 
     func logTimer(seconds: TimeInterval) {
         let label = self.label
-        let sessionID = session.current
+        let sessionID = runtime.session.current
         persistMetrics { context in
             let date = Date()
             try saveMetrics(
@@ -41,7 +41,7 @@ extension TelemetryPersisting {
 
     func logRecorder(value: Double) {
         let label = self.label
-        let sessionID = session.current
+        let sessionID = runtime.session.current
         persistMetrics { context in
             let date = Date()
             try saveMetrics(
@@ -54,7 +54,7 @@ extension TelemetryPersisting {
     }
 
     private func persistMetrics(_ save: @escaping @Sendable (NSManagedObjectContext) throws -> Void) {
-        let sync = self.sync
+        let sync = runtime.sync
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler.swift
@@ -10,21 +10,18 @@ import Metrics
 
 protocol TelemetryPersisting {
     var label: String { get }
-    var sync: Synchronize { get }
-    var session: Protected<UUID> { get }
+    var runtime: Runtime { get }
 }
 
 final class TelemetryHandler: NSObject, TelemetryPersisting {
     let label: String
     let dimensions: [(String, String)]
-    let sync: Synchronize
-    let session: Protected<UUID>
+    let runtime: Runtime
 
-    init(label: String, dimensions: [(String, String)], sync: @escaping Synchronize, session: Protected<UUID>) {
+    init(label: String, dimensions: [(String, String)], runtime: Runtime) {
         self.label = label
         self.dimensions = dimensions
-        self.sync = sync
-        self.session = session
+        self.runtime = runtime
     }
 
     func reset() {
@@ -66,14 +63,12 @@ extension TelemetryHandler: RecorderHandler {
 
 final class GaugeHandler: NSObject, TelemetryPersisting {
     let label: String
-    let sync: Synchronize
-    let session: Protected<UUID>
+    let runtime: Runtime
     let value = Protected<Double>(0)
 
-    init(label: String, sync: @escaping Synchronize, session: Protected<UUID>) {
+    init(label: String, runtime: Runtime) {
         self.label = label
-        self.sync = sync
-        self.session = session
+        self.runtime = runtime
     }
 }
 

--- a/Sources/Scout/Setup/Runtime.swift
+++ b/Sources/Scout/Setup/Runtime.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct Runtime: Sendable {
+    let session: Protected<UUID>
+    let sync: Synchronize
+
+    @MainActor
+    init(backends: [Backend]) async throws {
+        for backend in backends {
+            backend.onSetup()
+        }
+
+        let session = Protected(UUID())
+
+        let identity = Identity(
+            install: UserDefaults.standard.ensure("scout_install_id"),
+            launch: UUID(),
+            device: KeychainStorage.standard.ensure("scout_device_id"),
+            session: session
+        )
+
+        try await identity.bootstrap()
+
+        let dispatcher = Coalescer()
+
+        @Sendable func sync() async throws {
+            try await synchronize(backends: backends, dispatcher: dispatcher)
+        }
+
+        identity.table.startListening(completion: sync)
+
+        self.session = session
+        self.sync = sync
+
+        Task {
+            do {
+                try await sync()
+            } catch {
+                print("Failed to run the first sync: \(error)")
+            }
+        }
+    }
+}

--- a/Sources/Scout/Setup/Runtime.swift
+++ b/Sources/Scout/Setup/Runtime.swift
@@ -10,7 +10,9 @@ import Foundation
 struct Runtime: Sendable {
     let session: Protected<UUID>
     let sync: Synchronize
+}
 
+extension Runtime {
     @MainActor
     init(backends: [Backend]) async throws {
         for backend in backends {
@@ -36,8 +38,7 @@ struct Runtime: Sendable {
 
         identity.table.startListening(completion: sync)
 
-        self.session = session
-        self.sync = sync
+        self.init(session: session, sync: sync)
 
         Task {
             do {

--- a/Sources/Scout/Setup/Setup.swift
+++ b/Sources/Scout/Setup/Setup.swift
@@ -30,41 +30,12 @@ public func setup(backends: [Backend]) async throws {
         return
     }
 
-    for backend in backends {
-        backend.onSetup()
-    }
-
-    let session = Protected(UUID())
-
-    let identity = Identity(
-        install: UserDefaults.standard.ensure("scout_install_id"),
-        launch: UUID(),
-        device: KeychainStorage.standard.ensure("scout_device_id"),
-        session: session
-    )
-
-    try await identity.bootstrap()
-
-    let dispatcher = Coalescer()
-
-    @Sendable func sync() async throws {
-        try await synchronize(backends: backends, dispatcher: dispatcher)
-    }
-
-    identity.table.startListening(completion: sync)
+    let runtime = try await Runtime(backends: backends)
 
     LoggingSystem.bootstrap {
-        ScoutLogHandler(sync: sync, session: session, label: $0)
+        ScoutLogHandler(sync: runtime.sync, session: runtime.session, label: $0)
     }
     MetricsSystem.bootstrap(
-        TelemetryFactory(sync: sync, session: session)
+        TelemetryFactory(sync: runtime.sync, session: runtime.session)
     )
-
-    Task {
-        do {
-            try await sync()
-        } catch {
-            print("Failed to run the first sync: \(error)")
-        }
-    }
 }

--- a/Sources/Scout/Setup/Setup.swift
+++ b/Sources/Scout/Setup/Setup.swift
@@ -33,9 +33,9 @@ public func setup(backends: [Backend]) async throws {
     let runtime = try await Runtime(backends: backends)
 
     LoggingSystem.bootstrap {
-        ScoutLogHandler(sync: runtime.sync, session: runtime.session, label: $0)
+        ScoutLogHandler(runtime: runtime, label: $0)
     }
     MetricsSystem.bootstrap(
-        TelemetryFactory(sync: runtime.sync, session: runtime.session)
+        TelemetryFactory(runtime: runtime)
     )
 }

--- a/Tests/ScoutTests/Diagnostics/Telemetry/TelemetryFactoryTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Telemetry/TelemetryFactoryTests.swift
@@ -10,9 +10,10 @@ import Metrics
 import Testing
 
 @testable import Scout
+@testable import Support
 
 struct TelemetryFactoryTests {
-    let factory = TelemetryFactory(sync: {}, session: Protected(UUID()))
+    let factory = TelemetryFactory(runtime: .stub)
 
     @Test("makeCounter returns TelemetryHandler")
     func makeCounter() {

--- a/Tests/ScoutTests/Diagnostics/Telemetry/TelemetryHandlerTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Telemetry/TelemetryHandlerTests.swift
@@ -10,18 +10,19 @@ import Metrics
 import Testing
 
 @testable import Scout
+@testable import Support
 
 struct TelemetryHandlerTests {
     @Test("TelemetryHandler stores label")
     func storesLabel() {
-        let handler = TelemetryHandler(label: "test_label", dimensions: [], sync: {}, session: Protected(UUID()))
+        let handler = TelemetryHandler(label: "test_label", dimensions: [], runtime: .stub)
         #expect(handler.label == "test_label")
     }
 
     @Test("TelemetryHandler stores dimensions")
     func storesDimensions() {
         let dims = [("key1", "value1"), ("key2", "value2")]
-        let handler = TelemetryHandler(label: "test", dimensions: dims, sync: {}, session: Protected(UUID()))
+        let handler = TelemetryHandler(label: "test", dimensions: dims, runtime: .stub)
         #expect(handler.dimensions.count == 2)
         #expect(handler.dimensions[0].0 == "key1")
         #expect(handler.dimensions[1].1 == "value2")

--- a/Tests/Support/Stubs/Runtime+Stub.swift
+++ b/Tests/Support/Stubs/Runtime+Stub.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+@testable import Scout
+
+extension Runtime {
+    static let stub = Runtime(session: Protected(UUID()), sync: {})
+}


### PR DESCRIPTION
Everything `setup` did apart from the two `bootstrap` calls now lives in a `Runtime` value: backend setup hooks, the identity bootstrap that installs the crash and hang handlers and writes the lifecycle records, the coalescing sync closure, the identity table listener, and the first sync. `setup` is left with what it is actually about — building the runtime and handing it to the log handler and the metrics factory.

The runtime travels as one value rather than as a loose session and sync pair, so `ScoutLogHandler`, `TelemetryFactory`, `TelemetryHandler`, `GaugeHandler`, and the `TelemetryPersisting` protocol all take `runtime` instead of two parameters that always arrived together. The async initializer lives in an extension, which keeps the memberwise one available for tests through a shared `Runtime.stub`.

Pure refactoring, no behavior change: the first sync still starts after the runtime is ready, and it still cannot run before setup returns, since it needs the main actor that setup holds. No new tests come with it — `Runtime(backends:)` reaches the shared Core Data container, the keychain, and the signal handlers, so there is nothing to isolate yet; the testable seam arrives with the lazy runtime store that caches this value.

Second step toward the public-handler interface in #1138, stacked on #1175.