### PR TITLE
Stamp records when they are recorded, not when they are saved

### DIFF
--- a/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
+++ b/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
@@ -23,12 +23,13 @@ struct ScoutLogHandler: LogHandler {
     }
 
     func log(event: LogEvent) {
+        let date = Date()
         let sessionID = runtime.session.current
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
                     context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
-                    try Scout.log(event, date: Date(), sessionID: sessionID, context: context)
+                    try Scout.log(event, date: date, sessionID: sessionID, context: context)
                 }
                 try await self.runtime.sync()
             } catch {

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -15,17 +15,18 @@ extension TelemetryPersisting {
 
     func logMetrics(category: String, value: some MetricScalar) {
         let label = self.label
+        let date = Date()
         let sessionID = runtime.session.current
         persistMetrics { context in
-            try saveMetrics(label, date: Date(), category: category, value: value, sessionID: sessionID, context)
+            try saveMetrics(label, date: date, category: category, value: value, sessionID: sessionID, context)
         }
     }
 
     func logTimer(seconds: TimeInterval) {
         let label = self.label
+        let date = Date()
         let sessionID = runtime.session.current
         persistMetrics { context in
-            let date = Date()
             try saveMetrics(
                 label, date: date, category: Telemetry.Export.timer.rawValue, value: seconds, sessionID: sessionID,
                 context)
@@ -41,9 +42,9 @@ extension TelemetryPersisting {
 
     func logRecorder(value: Double) {
         let label = self.label
+        let date = Date()
         let sessionID = runtime.session.current
         persistMetrics { context in
-            let date = Date()
             try saveMetrics(
                 label, date: date, category: Telemetry.Export.recorder.rawValue, value: value, sessionID: sessionID,
                 context)


### PR DESCRIPTION
A log event and a metric both took their date inside the background task that persists them, so the stored timestamp was the moment Core Data got around to the write rather than the moment the app called the logger. The session identifier was already captured synchronously; the date now joins it.

Today the gap is small — a background task hop — and shows up as events that drift past the call that produced them and as timers whose two records can straddle a second boundary. It stops being small once handlers wait for a lazily started runtime, since everything logged before the runtime is ready would otherwise collapse onto one timestamp with no order left between the events.

No new tests: both paths write through the shared Core Data container, and there is nothing to isolate until the runtime becomes injectable. Third step toward the public-handler interface in #1138.