### PR TITLE
Split the runtime into construction and start

### DIFF
--- a/Sources/Scout/Setup/Runtime.swift
+++ b/Sources/Scout/Setup/Runtime.swift
@@ -8,37 +8,41 @@
 import Foundation
 
 struct Runtime: Sendable {
-    let session: Protected<UUID>
+    let identity: Identity
     let sync: Synchronize
+
+    var session: Protected<UUID> {
+        identity.session
+    }
 }
 
 extension Runtime {
     @MainActor
-    init(backends: [Backend]) async throws {
+    init(backends: [Backend]) {
         for backend in backends {
             backend.onSetup()
         }
-
-        let session = Protected(UUID())
 
         let identity = Identity(
             install: UserDefaults.standard.ensure("scout_install_id"),
             launch: UUID(),
             device: KeychainStorage.standard.ensure("scout_device_id"),
-            session: session
+            session: Protected(UUID())
         )
-
-        try await identity.bootstrap()
 
         let dispatcher = Coalescer()
 
-        @Sendable func sync() async throws {
-            try await synchronize(backends: backends, dispatcher: dispatcher)
-        }
+        self.init(
+            identity: identity,
+            sync: { try await synchronize(backends: backends, dispatcher: dispatcher) }
+        )
+    }
+
+    @MainActor
+    func start() async throws {
+        try await identity.bootstrap()
 
         identity.table.startListening(completion: sync)
-
-        self.init(session: session, sync: sync)
 
         Task {
             do {

--- a/Sources/Scout/Setup/Setup.swift
+++ b/Sources/Scout/Setup/Setup.swift
@@ -30,7 +30,7 @@ public func setup(backends: [Backend]) async throws {
         return
     }
 
-    let runtime = try await Runtime(backends: backends)
+    let runtime = Runtime(backends: backends)
 
     LoggingSystem.bootstrap {
         ScoutLogHandler(runtime: runtime, label: $0)
@@ -38,4 +38,6 @@ public func setup(backends: [Backend]) async throws {
     MetricsSystem.bootstrap(
         TelemetryFactory(runtime: runtime)
     )
+
+    try await runtime.start()
 }

--- a/Tests/Support/Stubs/Runtime+Stub.swift
+++ b/Tests/Support/Stubs/Runtime+Stub.swift
@@ -10,5 +10,5 @@ import Foundation
 @testable import Scout
 
 extension Runtime {
-    static let stub = Runtime(session: Protected(UUID()), sync: {})
+    static let stub = Runtime(identity: .stub, sync: {})
 }


### PR DESCRIPTION
`Runtime` used to be built by an async initializer that also did the work: the identity bootstrap with its crash and hang handlers, the lifecycle records, the archive flush, the table listener, and the first sync. It now splits in two. The initializer is synchronous — backend setup hooks, the identity, and the coalescing sync closure — and everything asynchronous moved into `start()`.

That lets `setup` hand a fully usable runtime to the log handler and the metrics factory before the slow part runs, which is what the public handlers in #1138 need: a handler is constructed synchronously and must have a session and a sync closure on the spot, without awaiting anything.

The runtime carries the whole `Identity` now rather than the session alone, since `start()` needs it and the record writers will need the install, launch, and device identifiers to attach an early record to its lifecycle chain. `session` stays reachable as an accessor, so the handlers are untouched.

One rough edge lands with it: anything logged between the bootstrap and the end of `start()` refers to a session record that does not exist yet, and `existing(SessionEntry:)` returns nil for it, so the event is stored with no session link. Before this change those events were not stored at all — they went to the default swift-log handler and were lost to Scout — so the window is an improvement rather than a regression. It closes in the next step, where the first session trigger adopts the identifier the runtime already holds and the writers switch to the fetch-or-create path that incident logging already uses.