### PR TITLE
Attach early records to their lifecycle chain

### DIFF
--- a/Sources/Scout/Diagnostics/Log/Log.swift
+++ b/Sources/Scout/Diagnostics/Log/Log.swift
@@ -8,12 +8,12 @@
 import CoreData
 import Logging
 
-func log(_ event: LogEvent, date: Date, sessionID: UUID, context: NSManagedObjectContext) throws {
+func log(_ event: LogEvent, date: Date, identity: Identity.Snapshot, context: NSManagedObjectContext) throws {
     let object = context.insert(EventEntry.self)
 
     object.eventID = UUID()
     object.date = date
-    object.session = try context.existing(SessionEntry.self, key: "sessionID", id: sessionID)
+    object.session = try context.linkedSession(identity, date: date)
     object.level = event.level.rawValue
     object.name = event.message.description
 

--- a/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
+++ b/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
@@ -24,12 +24,12 @@ struct ScoutLogHandler: LogHandler {
 
     func log(event: LogEvent) {
         let date = Date()
-        let sessionID = runtime.session.current
+        let identity = runtime.identity.snapshot
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
                     context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
-                    try Scout.log(event, date: date, sessionID: sessionID, context: context)
+                    try Scout.log(event, date: date, identity: identity, context: context)
                 }
                 try await self.runtime.sync()
             } catch {

--- a/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/TelemetryHandler+LogMetrics.swift
@@ -16,22 +16,22 @@ extension TelemetryPersisting {
     func logMetrics(category: String, value: some MetricScalar) {
         let label = self.label
         let date = Date()
-        let sessionID = runtime.session.current
+        let identity = runtime.identity.snapshot
         persistMetrics { context in
-            try saveMetrics(label, date: date, category: category, value: value, sessionID: sessionID, context)
+            try saveMetrics(label, date: date, category: category, value: value, identity: identity, context)
         }
     }
 
     func logTimer(seconds: TimeInterval) {
         let label = self.label
         let date = Date()
-        let sessionID = runtime.session.current
+        let identity = runtime.identity.snapshot
         persistMetrics { context in
             try saveMetrics(
-                label, date: date, category: Telemetry.Export.timer.rawValue, value: seconds, sessionID: sessionID,
+                label, date: date, category: Telemetry.Export.timer.rawValue, value: seconds, identity: identity,
                 context)
             try saveMetrics(
-                label, date: date, category: LatencyBuckets.category(for: seconds), value: 1, sessionID: sessionID,
+                label, date: date, category: LatencyBuckets.category(for: seconds), value: 1, identity: identity,
                 context)
         }
     }
@@ -43,13 +43,13 @@ extension TelemetryPersisting {
     func logRecorder(value: Double) {
         let label = self.label
         let date = Date()
-        let sessionID = runtime.session.current
+        let identity = runtime.identity.snapshot
         persistMetrics { context in
             try saveMetrics(
-                label, date: date, category: Telemetry.Export.recorder.rawValue, value: value, sessionID: sessionID,
+                label, date: date, category: Telemetry.Export.recorder.rawValue, value: value, identity: identity,
                 context)
             try saveMetrics(
-                label, date: date, category: RecorderBuckets.category(for: value), value: 1, sessionID: sessionID,
+                label, date: date, category: RecorderBuckets.category(for: value), value: 1, identity: identity,
                 context)
         }
     }
@@ -71,7 +71,8 @@ extension TelemetryPersisting {
 }
 
 func saveMetrics<T: MetricScalar>(
-    _ name: String, date: Date, category: String, value: T, sessionID: UUID, _ context: NSManagedObjectContext
+    _ name: String, date: Date, category: String, value: T, identity: Identity.Snapshot,
+    _ context: NSManagedObjectContext
 ) throws {
     let metrics = context.insert(T.Object.self)
 
@@ -79,7 +80,7 @@ func saveMetrics<T: MetricScalar>(
     metrics.telemetry = category
     metrics.date = date
     metrics.name = name
-    metrics.session = try context.existing(SessionEntry.self, key: "sessionID", id: sessionID)
+    metrics.session = try context.linkedSession(identity, date: date)
 
     try context.save()
 }

--- a/Sources/Scout/Identity/Identity+Snapshot.swift
+++ b/Sources/Scout/Identity/Identity+Snapshot.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+extension Identity {
+    struct Snapshot: Sendable {
+        let install: UUID
+        let launch: UUID
+        let device: UUID
+        let session: UUID
+    }
+
+    var snapshot: Snapshot {
+        Snapshot(install: install, launch: launch, device: device, session: session.current)
+    }
+}

--- a/Sources/Scout/Identity/Identity+Table.swift
+++ b/Sources/Scout/Identity/Identity+Table.swift
@@ -16,6 +16,8 @@ extension Identity {
     }
 
     func enter() async throws {
+        session.current = UUID()
+
         try await persistentContainer.run(
             SessionEntry.Trigger(session: session, launchID: launch),
             VisitEntry.Trigger(launchID: launch),

--- a/Sources/Scout/Lifecycle/Base/CurrentHub.swift
+++ b/Sources/Scout/Lifecycle/Base/CurrentHub.swift
@@ -40,6 +40,16 @@ extension NSManagedObjectContext {
         }
     }
 
+    func linkedSession(_ identity: Identity.Snapshot, date: Date) throws -> SessionEntry {
+        try linkedSession(
+            deviceID: identity.device,
+            installID: identity.install,
+            launchID: identity.launch,
+            sessionID: identity.session,
+            date: date
+        )
+    }
+
     private func fetchOrCreate<T: NSManagedObject>(_ type: T.Type, key: String, id: UUID, configure: (T) -> Void) throws
         -> T
     {

--- a/Sources/Scout/Lifecycle/Session/SessionEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.Trigger.swift
@@ -14,8 +14,7 @@ extension SessionEntry {
         var bundle: Bundle = .main
 
         func execute(in context: NSManagedObjectContext) throws {
-            let sessionID = UUID()
-            session.current = sessionID
+            let sessionID = session.current
 
             let object = context.insert(SessionEntry.self)
             object.sessionID = sessionID

--- a/Sources/Scout/Setup/Runtime.swift
+++ b/Sources/Scout/Setup/Runtime.swift
@@ -8,37 +8,41 @@
 import Foundation
 
 struct Runtime: Sendable {
-    let session: Protected<UUID>
+    let identity: Identity
     let sync: Synchronize
+
+    var session: Protected<UUID> {
+        identity.session
+    }
 }
 
 extension Runtime {
     @MainActor
-    init(backends: [Backend]) async throws {
+    init(backends: [Backend]) {
         for backend in backends {
             backend.onSetup()
         }
-
-        let session = Protected(UUID())
 
         let identity = Identity(
             install: UserDefaults.standard.ensure("scout_install_id"),
             launch: UUID(),
             device: KeychainStorage.standard.ensure("scout_device_id"),
-            session: session
+            session: Protected(UUID())
         )
-
-        try await identity.bootstrap()
 
         let dispatcher = Coalescer()
 
-        @Sendable func sync() async throws {
-            try await synchronize(backends: backends, dispatcher: dispatcher)
-        }
+        self.init(
+            identity: identity,
+            sync: { try await synchronize(backends: backends, dispatcher: dispatcher) }
+        )
+    }
+
+    @MainActor
+    func start() async throws {
+        try await identity.bootstrap()
 
         identity.table.startListening(completion: sync)
-
-        self.init(session: session, sync: sync)
 
         Task {
             do {

--- a/Sources/Scout/Setup/Setup.swift
+++ b/Sources/Scout/Setup/Setup.swift
@@ -30,7 +30,7 @@ public func setup(backends: [Backend]) async throws {
         return
     }
 
-    let runtime = try await Runtime(backends: backends)
+    let runtime = Runtime(backends: backends)
 
     LoggingSystem.bootstrap {
         ScoutLogHandler(runtime: runtime, label: $0)
@@ -38,4 +38,6 @@ public func setup(backends: [Backend]) async throws {
     MetricsSystem.bootstrap(
         TelemetryFactory(runtime: runtime)
     )
+
+    try await runtime.start()
 }

--- a/Tests/ScoutTests/Diagnostics/Log/LogTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Log/LogTests.swift
@@ -29,7 +29,7 @@ private func makeEvent(
     try log(
         makeEvent("Test Event", metadata: ["key": .string("value")]),
         date: date,
-        sessionID: UUID(),
+        identity: Identity.stub.snapshot,
         context: context
     )
 
@@ -58,7 +58,8 @@ private func makeEvent(
         "tags": .array([.string("a"), .string("b"), .string("c")])
     ]
 
-    try log(makeEvent("Array Event", metadata: metadata), date: Date(), sessionID: UUID(), context: context)
+    try log(
+        makeEvent("Array Event", metadata: metadata), date: Date(), identity: Identity.stub.snapshot, context: context)
 
     let events = try context.fetchAll(EventEntry.self)
     let paramData = try #require(events.first?.params)
@@ -74,7 +75,8 @@ private func makeEvent(
         "user": .dictionary(["name": .string("Alice"), "role": .string("admin")])
     ]
 
-    try log(makeEvent("Dict Event", metadata: metadata), date: Date(), sessionID: UUID(), context: context)
+    try log(
+        makeEvent("Dict Event", metadata: metadata), date: Date(), identity: Identity.stub.snapshot, context: context)
 
     let events = try context.fetchAll(EventEntry.self)
     let paramData = try #require(events.first?.params)
@@ -92,7 +94,8 @@ private func makeEvent(
         "map": .dictionary(["key": .string("val")]),
     ]
 
-    try log(makeEvent("Mixed Event", metadata: metadata), date: Date(), sessionID: UUID(), context: context)
+    try log(
+        makeEvent("Mixed Event", metadata: metadata), date: Date(), identity: Identity.stub.snapshot, context: context)
 
     let events = try context.fetchAll(EventEntry.self)
     let paramData = try #require(events.first?.params)
@@ -102,4 +105,31 @@ private func makeEvent(
     #expect(params["list"] == "x, 42")
     #expect(params["map"] == "key: val")
     #expect(events.first?.paramCount == 3)
+}
+
+@MainActor
+@Test("An event logged before the session record exists materializes the chain") func testLogLinksSession() throws {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let identity = Identity.stub.snapshot
+
+    try log(makeEvent("Early Event"), date: Date(), identity: identity, context: context)
+
+    let event = try #require(try context.fetchAll(EventEntry.self).first)
+    let session = try #require(event.session)
+
+    #expect(session.sessionID == identity.session)
+    #expect(session.launch?.launchID == identity.launch)
+    #expect(session.launch?.install?.installID == identity.install)
+    #expect(session.launch?.install?.device?.deviceID == identity.device)
+}
+
+@MainActor
+@Test("A second event joins the session the first one created") func testLogReusesSession() throws {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let identity = Identity.stub.snapshot
+
+    try log(makeEvent("First"), date: Date(), identity: identity, context: context)
+    try log(makeEvent("Second"), date: Date(), identity: identity, context: context)
+
+    #expect(try context.fetchAll(SessionEntry.self).count == 1)
 }

--- a/Tests/ScoutTests/Diagnostics/Metrics/SaveMetricsTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Metrics/SaveMetricsTests.swift
@@ -20,7 +20,8 @@ struct SaveMetricsTests {
 
     @Test("Persists an IntMetricsEntry with correct fields")
     func persistsIntMetrics() throws {
-        try saveMetrics("api_calls", date: date, category: "counter", value: 5, sessionID: UUID(), context)
+        try saveMetrics(
+            "api_calls", date: date, category: "counter", value: 5, identity: Identity.stub.snapshot, context)
 
         let results = try context.fetchAll(IntMetricsEntry.self)
 
@@ -35,7 +36,8 @@ struct SaveMetricsTests {
 
     @Test("Persists a DoubleMetricsEntry with correct fields")
     func persistsDoubleMetrics() throws {
-        try saveMetrics("response_time", date: date, category: "timer", value: 1.5, sessionID: UUID(), context)
+        try saveMetrics(
+            "response_time", date: date, category: "timer", value: 1.5, identity: Identity.stub.snapshot, context)
 
         let results = try context.fetchAll(DoubleMetricsEntry.self)
 
@@ -49,7 +51,7 @@ struct SaveMetricsTests {
 
     @Test("Saves to the context")
     func savesToContext() throws {
-        try saveMetrics("metric", date: date, category: "counter", value: 1, sessionID: UUID(), context)
+        try saveMetrics("metric", date: date, category: "counter", value: 1, identity: Identity.stub.snapshot, context)
 
         #expect(!context.hasChanges)
     }

--- a/Tests/ScoutTests/Lifecycle/Session/SessionEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Session/SessionEntryMonitorTests.swift
@@ -82,4 +82,12 @@ struct SessionEntryMonitorTests {
             try SessionEntry.Complete(launchID: identity.launch).execute(in: context)
         }
     }
+
+    @Test("trigger records the session identifier it was handed")
+    func triggerAdoptsCurrentSession() throws {
+        try SessionEntry.Trigger(session: identity.session, launchID: identity.launch).execute(in: context)
+
+        let session = try #require(try context.fetchAll(SessionEntry.self).first)
+        #expect(session.sessionID == identity.session.current)
+    }
 }

--- a/Tests/ScoutTests/Persistence/MergePolicyTests.swift
+++ b/Tests/ScoutTests/Persistence/MergePolicyTests.swift
@@ -60,15 +60,9 @@ struct MergePolicyTests {
         defer { try? FileManager.default.removeItem(at: directory) }
         let container = try makeContainer(in: directory)
 
-        let sessionID = UUID()
+        let identity = Identity.stub.snapshot
         try await container.performBackgroundTask { @Sendable context in
-            _ = try context.linkedSession(
-                deviceID: UUID(),
-                installID: UUID(),
-                launchID: UUID(),
-                sessionID: sessionID,
-                date: Date()
-            )
+            _ = try context.linkedSession(identity, date: Date())
             try context.save()
         }
 
@@ -85,7 +79,7 @@ struct MergePolicyTests {
                                 date: Date(),
                                 category: Telemetry.Export.counter.rawValue,
                                 value: value,
-                                sessionID: sessionID,
+                                identity: identity,
                                 context
                             )
                         }
@@ -100,7 +94,8 @@ struct MergePolicyTests {
                         try await container.performBackgroundTask { context in
                             context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
 
-                            let session = try context.existing(SessionEntry.self, key: "sessionID", id: sessionID)
+                            let session = try context.existing(
+                                SessionEntry.self, key: "sessionID", id: identity.session)
                             session?.endDate = Date()
                             try context.save()
                         }

--- a/Tests/Support/Stubs/Runtime+Stub.swift
+++ b/Tests/Support/Stubs/Runtime+Stub.swift
@@ -10,5 +10,5 @@ import Foundation
 @testable import Scout
 
 extension Runtime {
-    static let stub = Runtime(session: Protected(UUID()), sync: {})
+    static let stub = Runtime(identity: .stub, sync: {})
 }


### PR DESCRIPTION
Splitting the runtime opened a window: the log handler and the metrics factory are bootstrapped before `start()` writes the lifecycle records, so anything logged in between pointed at a session that did not exist yet and was stored with no session link. This closes it from both ends.

The session identifier is now owned by whoever starts a session. `SessionEntry.Trigger` records the identifier it was handed instead of minting its own, and the rotation moves to `Identity.enter()`, where a new foreground genuinely does start a new session. The identifier the runtime holds from construction is therefore the real one, not a placeholder waiting to be overwritten.

Records written before the chain exists now materialize it themselves. `log` and `saveMetrics` take an `Identity.Snapshot` — install, launch, device, and the session captured synchronously at the call — and resolve the session through `linkedSession`, the fetch-or-create path incident logging already uses to reattach a crash from a run that never got to persist its hub. A later trigger fills in the record the writer left bare rather than inserting a second one.

Three tests come with it: an early event links to a session, launch, install, and device chain that did not exist; a second event joins the session the first one created rather than duplicating it; and the trigger records the identifier it was handed.

Stacked on #1178.