### PR TITLE
Fill in the lifecycle records an early write created

### DIFF
--- a/Sources/Scout/Identity/Identity+Table.swift
+++ b/Sources/Scout/Identity/Identity+Table.swift
@@ -16,10 +16,8 @@ extension Identity {
     }
 
     func enter() async throws {
-        session.current = UUID()
-
         try await persistentContainer.run(
-            SessionEntry.Trigger(session: session, launchID: launch),
+            SessionEntry.Rotation(session: session, launchID: launch),
             VisitEntry.Trigger(launchID: launch),
             MarkerEntry.Trigger(installID: install)
         )

--- a/Sources/Scout/Lifecycle/Device/DeviceEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Device/DeviceEntry.Trigger.swift
@@ -12,19 +12,21 @@ extension DeviceEntry {
         let deviceID: UUID
 
         func execute(in context: NSManagedObjectContext) throws {
-            let request = NSFetchRequest<DeviceEntry>(entityName: "DeviceEntry")
-            request.predicate = NSPredicate(format: "deviceID == %@", deviceID as CVarArg)
-            request.fetchLimit = 1
+            let existing = try context.existing(DeviceEntry.self, key: "deviceID", id: deviceID)
+            let device = existing ?? context.insert(DeviceEntry.self)
 
-            guard try context.fetch(request).isEmpty else {
-                return
+            if existing == nil {
+                device.deviceID = deviceID
+                device.date = Date()
             }
 
-            let device = context.insert(DeviceEntry.self)
-            device.deviceID = deviceID
-            device.date = Date()
-            device.model = SystemInfo.deviceModel
-            try context.save()
+            if device.model == nil {
+                device.model = SystemInfo.deviceModel
+            }
+
+            if context.hasChanges {
+                try context.save()
+            }
         }
     }
 }

--- a/Sources/Scout/Lifecycle/Install/InstallEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Install/InstallEntry.Trigger.swift
@@ -13,19 +13,21 @@ extension InstallEntry {
         let deviceID: UUID
 
         func execute(in context: NSManagedObjectContext) throws {
-            let request = NSFetchRequest<InstallEntry>(entityName: "InstallEntry")
-            request.predicate = NSPredicate(format: "installID == %@", installID as CVarArg)
-            request.fetchLimit = 1
+            let existing = try context.existing(InstallEntry.self, key: "installID", id: installID)
+            let install = existing ?? context.insert(InstallEntry.self)
 
-            guard try context.fetch(request).isEmpty else {
-                return
+            if existing == nil {
+                install.installID = installID
+                install.date = Date()
             }
 
-            let install = context.insert(InstallEntry.self)
-            install.installID = installID
-            install.date = Date()
-            install.device = try context.existing(DeviceEntry.self, key: "deviceID", id: deviceID)
-            try context.save()
+            if install.device == nil {
+                install.device = try context.existing(DeviceEntry.self, key: "deviceID", id: deviceID)
+            }
+
+            if context.hasChanges {
+                try context.save()
+            }
         }
     }
 }

--- a/Sources/Scout/Lifecycle/Launch/LaunchEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Launch/LaunchEntry.Trigger.swift
@@ -13,9 +13,14 @@ extension LaunchEntry {
         let installID: UUID
 
         func execute(in context: NSManagedObjectContext) throws {
-            let launch = context.insert(LaunchEntry.self)
-            launch.launchID = launchID
-            launch.date = Date()
+            let existing = try context.existing(LaunchEntry.self, key: "launchID", id: launchID)
+            let launch = existing ?? context.insert(LaunchEntry.self)
+
+            if existing == nil {
+                launch.launchID = launchID
+                launch.date = Date()
+            }
+
             launch.install = try context.existing(InstallEntry.self, key: "installID", id: installID)
             try context.save()
         }

--- a/Sources/Scout/Lifecycle/Session/SessionEntry.Rotation.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.Rotation.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+extension SessionEntry {
+    struct Rotation: Command {
+        let session: Protected<UUID>
+        let launchID: UUID
+
+        func execute(in context: NSManagedObjectContext) throws {
+            session.current = UUID()
+
+            try Trigger(session: session, launchID: launchID).execute(in: context)
+        }
+    }
+}

--- a/Sources/Scout/Lifecycle/Session/SessionEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.Trigger.swift
@@ -16,9 +16,14 @@ extension SessionEntry {
         func execute(in context: NSManagedObjectContext) throws {
             let sessionID = session.current
 
-            let object = context.insert(SessionEntry.self)
-            object.sessionID = sessionID
-            object.date = Date()
+            let existing = try context.existing(SessionEntry.self, key: "sessionID", id: sessionID)
+            let object = existing ?? context.insert(SessionEntry.self)
+
+            if existing == nil {
+                object.sessionID = sessionID
+                object.date = Date()
+            }
+
             object.launch = try context.existing(LaunchEntry.self, key: "launchID", id: launchID)
             object.appVersion = bundle.marketingVersion
             object.buildNumber = bundle.buildNumber

--- a/Tests/ScoutTests/Lifecycle/Device/DeviceEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Device/DeviceEntryMonitorTests.swift
@@ -33,4 +33,16 @@ struct DeviceEntryMonitorTests {
 
         #expect(try context.fetchAll(DeviceEntry.self).count == 1)
     }
+
+    @Test("trigger stamps the model onto a device an earlier record created")
+    func triggerStampsExistingDevice() throws {
+        _ = try context.linkedSession(identity.snapshot, date: Date())
+        try context.save()
+
+        try DeviceEntry.Trigger(deviceID: identity.device).execute(in: context)
+
+        let devices = try context.fetchAll(DeviceEntry.self)
+        #expect(devices.count == 1)
+        #expect(devices.first?.model == SystemInfo.deviceModel)
+    }
 }

--- a/Tests/ScoutTests/Lifecycle/Install/InstallEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Install/InstallEntryMonitorTests.swift
@@ -48,4 +48,16 @@ struct InstallEntryMonitorTests {
         #expect(installs.count == 2)
         #expect(installs.contains { $0.installID == identity.install })
     }
+
+    @Test("trigger links the device onto an install an earlier record created")
+    func triggerLinksExistingInstall() throws {
+        _ = try context.linkedSession(identity.snapshot, date: Date())
+        try context.save()
+
+        try InstallEntry.Trigger(installID: identity.install, deviceID: identity.device).execute(in: context)
+
+        let installs = try context.fetchAll(InstallEntry.self)
+        #expect(installs.count == 1)
+        #expect(installs.first?.device?.deviceID == identity.device)
+    }
 }

--- a/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryMonitorTests.swift
@@ -36,4 +36,16 @@ struct LaunchEntryMonitorTests {
         let launches = try context.fetchAll(LaunchEntry.self)
         #expect(launches.first?.endDate == nil)
     }
+
+    @Test("trigger fills in the launch an earlier record created")
+    func triggerFillsExistingLaunch() throws {
+        _ = try context.linkedSession(identity.snapshot, date: Date())
+        try context.save()
+
+        try LaunchEntry.Trigger(launchID: identity.launch, installID: identity.install).execute(in: context)
+
+        let launches = try context.fetchAll(LaunchEntry.self)
+        #expect(launches.count == 1)
+        #expect(launches.first?.install?.installID == identity.install)
+    }
 }

--- a/Tests/ScoutTests/Lifecycle/Session/SessionEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Session/SessionEntryMonitorTests.swift
@@ -90,4 +90,29 @@ struct SessionEntryMonitorTests {
         let session = try #require(try context.fetchAll(SessionEntry.self).first)
         #expect(session.sessionID == identity.session.current)
     }
+
+    @Test("trigger fills in the session an earlier record created")
+    func triggerFillsExistingSession() throws {
+        let snapshot = identity.snapshot
+        _ = try context.linkedSession(snapshot, date: Date())
+        try context.save()
+
+        try SessionEntry.Trigger(session: identity.session, launchID: identity.launch).execute(in: context)
+
+        let sessions = try context.fetchAll(SessionEntry.self)
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.sessionID == snapshot.session)
+        #expect(sessions.first?.appVersion == Bundle.main.marketingVersion)
+    }
+
+    @Test("rotation opens a session under a fresh identifier")
+    func rotationOpensNewSession() throws {
+        let session = Protected(UUID())
+        let first = session.current
+
+        try SessionEntry.Rotation(session: session, launchID: identity.launch).execute(in: context)
+
+        #expect(session.current != first)
+        #expect(try context.fetchAll(SessionEntry.self).map(\.sessionID) == [session.current])
+    }
 }


### PR DESCRIPTION
Since records started resolving their session through `linkedSession`, a log or metric written before the runtime finishes starting materializes the device, install, launch, and session chain itself. The lifecycle triggers were not ready for that. `SessionEntry.Trigger` and `LaunchEntry.Trigger` inserted unconditionally, so each of them added a second row for an identifier that already had one — and neither entity carries a uniqueness constraint, so the merge policy could not collapse the pair. `DeviceEntry.Trigger` and `InstallEntry.Trigger` had the opposite problem: they returned early when a row existed, leaving the bare one the writer created without its hardware model or its device link, and since each runs once per launch nothing filled them in later.

The window is easy to hit. `Runtime(backends:)` returns immediately and `start()` continues in the background through the crash and hang archive flush and the first Core Data writes; anything the app logs during launch lands in it. It also reopens on every foreground, because `Identity.enter()` rotated the session identifier before the row for it was written.

All four triggers now fetch-or-create: they fill in the row that is already there and insert only when there is none, keeping the date the earlier writer recorded rather than overwriting it with their own. Device and install only touch the fields that are still empty and save only when something actually changed. The session rotation moves into a `SessionEntry.Rotation` command that mints the identifier and delegates to the trigger, so the new identifier and its record are written in one transaction — `run` executes commands in order in a single background context — and `Trigger` goes back to simply recording the identifier it was handed.

Five tests cover it: the trigger fills in a session an earlier record created instead of duplicating it, rotation opens a session under a fresh identifier, and the same fill-in behavior for launch, device, and install.