### PR TITLE
Create the launch before the version that links to it

### DIFF
--- a/Sources/Scout/Identity/Command.swift
+++ b/Sources/Scout/Identity/Command.swift
@@ -13,6 +13,10 @@ protocol Command: Sendable {
 
 extension NSPersistentContainer {
     func run(_ commands: any Command...) async throws {
+        try await run(commands)
+    }
+
+    func run(_ commands: [any Command]) async throws {
         try await performBackgroundTask { context in
             context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
 

--- a/Sources/Scout/Identity/Identity+Bootstrap.swift
+++ b/Sources/Scout/Identity/Identity+Bootstrap.swift
@@ -17,19 +17,26 @@ extension Identity {
         await CrashArchive.system.flush(deviceID: device)
         await HangArchive.system.flush(deviceID: device)
 
-        try await persistentContainer.run(
-            SessionEntry.Recovery(launchID: launch),
-            LaunchEntry.Recovery(launchID: launch)
-        )
+        try await persistentContainer.run(recoveryCommands)
+        try await persistentContainer.run(startupCommands())
+    }
 
-        try await persistentContainer.run(
+    private var recoveryCommands: [any Command] {
+        [
+            SessionEntry.Recovery(launchID: launch),
+            LaunchEntry.Recovery(launchID: launch),
+        ]
+    }
+
+    func startupCommands(bundle: Bundle = .main) -> [any Command] {
+        [
             DeviceEntry.Trigger(deviceID: device),
             InstallEntry.Trigger(installID: install, deviceID: device),
-            VersionEntry.Trigger(installID: install, launchID: launch),
             LaunchEntry.Trigger(launchID: launch, installID: install),
-            SessionEntry.Trigger(session: session, launchID: launch),
+            VersionEntry.Trigger(installID: install, launchID: launch, bundle: bundle),
+            SessionEntry.Trigger(session: session, launchID: launch, bundle: bundle),
             VisitEntry.Trigger(launchID: launch),
-            MarkerEntry.Trigger(installID: install)
-        )
+            MarkerEntry.Trigger(installID: install),
+        ]
     }
 }

--- a/Tests/ScoutTests/Identity/IdentityBootstrapTests.swift
+++ b/Tests/ScoutTests/Identity/IdentityBootstrapTests.swift
@@ -1,0 +1,58 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+@testable import Support
+
+@MainActor
+@Suite("Identity+Bootstrap")
+struct IdentityBootstrapTests {
+    let context = NSManagedObjectContext.inMemoryContext()
+    let identity = Identity.stub
+    let bundle = Bundle.stub(appVersion: "1.0", buildNumber: "1")
+
+    private func startup(_ identity: Identity) throws {
+        for command in identity.startupCommands(bundle: bundle) {
+            try command.execute(in: context)
+        }
+    }
+
+    @Test("startup links the whole identity chain in one pass")
+    func startupLinksChain() throws {
+        try startup(identity)
+
+        let session = try #require(try context.fetchAll(SessionEntry.self).first)
+        #expect(session.launch?.launchID == identity.launch)
+        #expect(session.launch?.install?.installID == identity.install)
+        #expect(session.launch?.install?.device?.deviceID == identity.device)
+
+        let visit = try #require(try context.fetchAll(VisitEntry.self).first)
+        #expect(visit.launch?.launchID == identity.launch)
+    }
+
+    @Test("startup links the version to the launch it was recorded in")
+    func startupLinksVersionToLaunch() throws {
+        try startup(identity)
+
+        let version = try #require(try context.fetchAll(VersionEntry.self).first)
+        #expect(version.launch?.launchID == identity.launch)
+        #expect(version.installID == identity.install)
+    }
+
+    @Test("a later launch adds no second version for an unchanged build")
+    func laterLaunchKeepsOneVersion() throws {
+        try startup(identity)
+        try startup(
+            Identity(install: identity.install, launch: UUID(), device: identity.device, session: identity.session)
+        )
+
+        #expect(try context.fetchAll(VersionEntry.self).count == 1)
+    }
+}


### PR DESCRIPTION
`VersionEntry.Trigger` ran one slot ahead of `LaunchEntry.Trigger` in the startup batch, so the launch row it resolves did not exist yet and every version was recorded with a nil `launch`. That orphaned the row twice over: the dedup predicate `launch.install.installID == %@` could no longer match it, so an unchanged build inserted a fresh `VersionEntry` on every launch — and `VersionEntry.isPurgeable` is `false`, so cleanup never reclaimed them. The record it uploads is keyed on `"\(installID)-\(appVersion)-\(buildNumber)"` and `installID` resolves through `launch`, so with a nil launch every install on the same build collided on the shared recordID `"-1.0-42"`.

Reordering alone would leave the invariant just as easy to break again, so the batch moves out of the variadic argument list into `startupCommands`, where the order is a value a test can execute. `run` gains an array overload next to the variadic one, and `recoveryCommands` follows for symmetry. The `bundle` parameter is threaded through because the test runner's `Bundle.main` carries no version, which makes `VersionEntry.Trigger` a no-op and any test built on it vacuous.

Three tests cover it: the whole device/install/launch/session chain links in one pass, the version points at the launch it was recorded in, and a second launch on an unchanged build adds no duplicate. Restoring the old order fails the last two. The full `ScoutTests` bundle passes (227 tests in 54 suites) and `swift format lint --strict` is clean.

Worth knowing for review: the fix stops the growth but does not clean up history. Stores from builds that already ran with the old order keep one orphaned `VersionEntry` per launch, and since `isPurgeable` is `false` they stay there. Removing them needs a separate one-shot pass.