### PR TITLE
Queue a filled-in lifecycle row for delivery again

### DIFF
--- a/Sources/Scout/Lifecycle/Device/DeviceEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Device/DeviceEntry.Trigger.swift
@@ -24,6 +24,10 @@ extension DeviceEntry {
                 device.model = SystemInfo.deviceModel
             }
 
+            if device.hasChanges {
+                device.requeue()
+            }
+
             if context.hasChanges {
                 try context.save()
             }

--- a/Sources/Scout/Lifecycle/Install/InstallEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Install/InstallEntry.Trigger.swift
@@ -25,6 +25,10 @@ extension InstallEntry {
                 install.device = try context.existing(DeviceEntry.self, key: "deviceID", id: deviceID)
             }
 
+            if install.hasChanges {
+                install.requeue()
+            }
+
             if context.hasChanges {
                 try context.save()
             }

--- a/Sources/Scout/Lifecycle/Launch/LaunchEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Launch/LaunchEntry.Trigger.swift
@@ -22,6 +22,11 @@ extension LaunchEntry {
             }
 
             launch.install = try context.existing(InstallEntry.self, key: "installID", id: installID)
+
+            if launch.hasChanges {
+                launch.requeue()
+            }
+
             try context.save()
         }
     }

--- a/Sources/Scout/Lifecycle/Session/SessionEntry.Trigger.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.Trigger.swift
@@ -30,6 +30,11 @@ extension SessionEntry {
             object.osVersion = SystemInfo.osVersion
             object.locale = SystemInfo.locale
             object.channel = SystemInfo.channel
+
+            if object.hasChanges {
+                object.requeue()
+            }
+
             try context.save()
         }
     }

--- a/Tests/ScoutTests/Lifecycle/Device/DeviceEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Device/DeviceEntryMonitorTests.swift
@@ -45,4 +45,29 @@ struct DeviceEntryMonitorTests {
         #expect(devices.count == 1)
         #expect(devices.first?.model == SystemInfo.deviceModel)
     }
+
+    @Test("trigger queues a delivered device again after stamping the model")
+    func triggerRequeuesStampedDevice() throws {
+        let device = DeviceEntry.stub(date: Date(), in: context)
+        let delivery = device.seedDelivery(pending: false, attempts: 3, for: "cloud", in: context)
+        try context.save()
+
+        try DeviceEntry.Trigger(deviceID: identity.device).execute(in: context)
+
+        #expect(delivery.isPending)
+        #expect(delivery.attempts == 0)
+    }
+
+    @Test("trigger leaves the delivery alone when the device is already stamped")
+    func triggerKeepsDeliveryForStampedDevice() throws {
+        let device = DeviceEntry.stub(date: Date(), in: context)
+        device.model = SystemInfo.deviceModel
+        let delivery = device.seedDelivery(pending: false, attempts: 3, for: "cloud", in: context)
+        try context.save()
+
+        try DeviceEntry.Trigger(deviceID: identity.device).execute(in: context)
+
+        #expect(delivery.isPending == false)
+        #expect(delivery.attempts == 3)
+    }
 }

--- a/Tests/ScoutTests/Lifecycle/Install/InstallEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Install/InstallEntryMonitorTests.swift
@@ -60,4 +60,30 @@ struct InstallEntryMonitorTests {
         #expect(installs.count == 1)
         #expect(installs.first?.device?.deviceID == identity.device)
     }
+
+    @Test("trigger queues a delivered install again after linking the device")
+    func triggerRequeuesLinkedInstall() throws {
+        DeviceEntry.stub(date: Date(), in: context)
+        let install = InstallEntry.stub(date: Date(), in: context)
+        let delivery = install.seedDelivery(pending: false, attempts: 3, for: "cloud", in: context)
+        try context.save()
+
+        try InstallEntry.Trigger(installID: identity.install, deviceID: identity.device).execute(in: context)
+
+        #expect(delivery.isPending)
+        #expect(delivery.attempts == 0)
+    }
+
+    @Test("trigger leaves the delivery alone when the install is already linked")
+    func triggerKeepsDeliveryForLinkedInstall() throws {
+        let device = DeviceEntry.stub(date: Date(), in: context)
+        let install = InstallEntry.stub(date: Date(), device: device, in: context)
+        let delivery = install.seedDelivery(pending: false, attempts: 3, for: "cloud", in: context)
+        try context.save()
+
+        try InstallEntry.Trigger(installID: identity.install, deviceID: identity.device).execute(in: context)
+
+        #expect(delivery.isPending == false)
+        #expect(delivery.attempts == 3)
+    }
 }

--- a/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryMonitorTests.swift
@@ -48,4 +48,17 @@ struct LaunchEntryMonitorTests {
         #expect(launches.count == 1)
         #expect(launches.first?.install?.installID == identity.install)
     }
+
+    @Test("trigger queues a delivered launch again after linking the install")
+    func triggerRequeuesLinkedLaunch() throws {
+        InstallEntry.stub(date: Date(), in: context)
+        let launch = LaunchEntry.stub(date: Date(), in: context)
+        let delivery = launch.seedDelivery(pending: false, attempts: 3, for: "cloud", in: context)
+        try context.save()
+
+        try LaunchEntry.Trigger(launchID: identity.launch, installID: identity.install).execute(in: context)
+
+        #expect(delivery.isPending)
+        #expect(delivery.attempts == 0)
+    }
 }

--- a/Tests/ScoutTests/Lifecycle/Session/SessionEntryMonitorTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Session/SessionEntryMonitorTests.swift
@@ -115,4 +115,17 @@ struct SessionEntryMonitorTests {
         #expect(session.current != first)
         #expect(try context.fetchAll(SessionEntry.self).map(\.sessionID) == [session.current])
     }
+
+    @Test("trigger queues a delivered session again after stamping it")
+    func triggerRequeuesStampedSession() throws {
+        let launch = LaunchEntry.stub(date: Date(), in: context)
+        let session = SessionEntry.stub(date: Date(), launch: launch, in: context)
+        let delivery = session.seedDelivery(pending: false, attempts: 3, for: "cloud", in: context)
+        try context.save()
+
+        try SessionEntry.Trigger(session: identity.session, launchID: identity.launch).execute(in: context)
+
+        #expect(delivery.isPending)
+        #expect(delivery.attempts == 0)
+    }
 }


### PR DESCRIPTION
Since the triggers became fetch-or-create they edit rows an earlier writer already persisted, and a row that was persisted early can already have been delivered: a log or metric emitted before `bootstrap()` reaches the triggers materializes the chain through `linkedSession` and then awaits `sync()` on the spot. `RecordSender` clears `isPending` on success and `plan()` only ever creates a delivery for a pair that has none, so whatever the trigger writes afterwards never leaves the device. Every other command that edits a persisted row — `SessionEntry.Complete`, `SessionEntry.Recovery`, `LaunchEntry.Recovery` — already calls `requeue()`; the four triggers did not.

All four now do, gated on the row's own `hasChanges` rather than the context's. The gate matters for device and install: their fill-in branches are guarded on a nil field, so on a normal launch nothing changes, and requeuing regardless would re-upload both rows every single launch.

Six tests cover it. Four assert that a row already handed to a backend goes back to pending with its attempt count reset once the trigger fills it in; two assert that an already-complete device or install leaves its delivery untouched. Removing the `requeue()` calls fails the four and leaves the two green, which also confirms the gate distinguishes a changed row from an untouched one. The full `ScoutTests` bundle passes (230 tests in 53 suites) and `swift format lint --strict` is clean.

Worth knowing for review: the reachable payoff is mostly `DeviceEntry.model`. A session is requeued anyway at the next backgrounding and a launch at the next start, and `install.device` is only nil on rows left by builds older than #1179, since `linkedSession` has set it on creation ever since. The change is still worth making — it closes the asymmetry with the recovery commands and covers the one field that otherwise stays wrong on the backend forever, because `DeviceEntry.isPurgeable` is `false` and nothing re-sends the row.

Independent of #1183; both branch from `main` and touch different files.