### PR TITLE
Document the dashboard and its TestFlight distribution options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ To add the package and set up CloudKit, see the [Installation Guide](docs/INSTAL
 
 The built-in SwiftUI dashboard lets you inspect logs, metrics, and crash reports right inside your development builds — browse charts, drill into event lists and crash details, and track activity over time without leaving the app.
 
+It ships as a separate `ScoutUI` product, so you decide which builds carry it. See the [Dashboard Guide](docs/DASHBOARD.md) for linking it, presenting it, and keeping it out of the App Store build.
+
 <img width="200" src="https://github.com/user-attachments/assets/0987c808-6d08-4e99-8ca7-1218d352e0bf"> <img width="200" src="https://github.com/user-attachments/assets/a70ae4d9-3680-48d3-8129-2febdc466030"> <img width="200" src="https://github.com/user-attachments/assets/6043911e-fd0b-4f6e-9785-c262dab1c6d7"> <img width="200" src="https://github.com/user-attachments/assets/dcec26e1-4e44-473c-b2e9-cde8ea2ffe2f">
 
 ## Roadmap

--- a/Sources/Scout/Runtime/Runtime.swift
+++ b/Sources/Scout/Runtime/Runtime.swift
@@ -14,7 +14,7 @@ import Foundation
 /// ``ScoutMetricsFactory``:
 ///
 /// ```swift
-/// let scout = Runtime(backends: [.cloudKit(container)])
+/// let scout = Runtime(backends: [try Backend.cloudKit(container: container)])
 ///
 /// LoggingSystem.bootstrap {
 ///     ScoutLogHandler(label: $0, runtime: scout)

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,0 +1,122 @@
+# Dashboard
+
+## Table of Contents
+- [Link the Product](#link-the-product)
+- [Present the Dashboard](#present-the-dashboard)
+- [Option 1: One Binary, Hidden Entry Point](#option-1-one-binary-hidden-entry-point)
+- [Option 2: A TestFlight-Only Target or Branch](#option-2-a-testflight-only-target-or-branch)
+- [Choosing](#choosing)
+
+The dashboard ships as its own product, `ScoutUI`, separate from the `Scout` runtime. Recording logs, metrics, and crashes needs only `Scout` and a connector, so linking the dashboard is a deliberate step — and one you can take in the builds your testers run without taking it in the build you release.
+
+## Link the Product
+
+In `Package.swift`, add `ScoutUI` alongside the products you already depend on:
+
+```swift
+.target(
+    name: "YourTarget",
+    dependencies: [
+        .product(name: "Scout", package: "scout"),
+        .product(name: "NativeConnector", package: "scout"),
+        .product(name: "ScoutUI", package: "scout"),
+    ]
+)
+```
+
+In an Xcode project, select the app target, open **General > Frameworks, Libraries, and Embedded Content**, and add `ScoutUI` from the Scout package.
+
+## Present the Dashboard
+
+`scoutHome(isPresented:backends:)` presents the whole dashboard as a full-screen cover on iOS (a sheet on macOS, which has no full-screen presentation). Pass the same `backends` array you gave to `Runtime` — the dashboard reads from the active one and offers a picker when there is more than one:
+
+```swift
+import ScoutUI
+import SwiftUI
+
+struct ContentView: View {
+    @State private var isScoutPresented = false
+
+    var body: some View {
+        NavigationStack {
+            InfoList()
+                .toolbar {
+                    Button {
+                        isScoutPresented = true
+                    } label: {
+                        Image(systemName: "chart.bar.xaxis")
+                    }
+                }
+                .scoutHome(isPresented: $isScoutPresented, backends: backends)
+        }
+    }
+}
+```
+
+That leaves one decision: who gets to see the button. App Store users normally shouldn't, so the two setups below both aim the dashboard at TestFlight. They differ in whether `ScoutUI` ends up in the released binary at all.
+
+## Option 1: One Binary, Hidden Entry Point
+
+Link `ScoutUI` into the app target and gate the entry point instead of the framework. Debug builds always show it; a release build shows it only when it came from TestFlight, which the sandbox receipt reveals:
+
+```swift
+struct ScoutToolbarLink: View {
+    @Binding var isPresented: Bool
+
+    private var isVisible: Bool {
+        #if DEBUG
+            return true
+        #else
+            return Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+        #endif
+    }
+
+    var body: some View {
+        if isVisible {
+            Button {
+                isPresented = true
+            } label: {
+                Image(systemName: "chart.bar.xaxis")
+            }
+            .accessibilityLabel("Scout")
+        }
+    }
+}
+```
+
+The example app ships this file as [ScoutToolbarLink.swift](https://github.com/kasianov-mikhail/scout-ip/blob/main/ScoutIP/Components/ScoutToolbarLink.swift) and drops it into its toolbar next to the regular buttons.
+
+The appeal is that a single binary goes through TestFlight and on to release, so the build your testers approved is the build your users get. The cost is that the dashboard's view code travels with it: the receipt check hides the button at runtime, it doesn't strip anything from the binary.
+
+## Option 2: A TestFlight-Only Target or Branch
+
+Keep `ScoutUI` out of the App Store build by linking it only where the dashboard is wanted, and compiling the entry point behind a flag.
+
+Duplicate the app target — say `MyApp Scout` — link `ScoutUI` in that copy only, and add `SCOUT_UI` to its **Active Compilation Conditions**. Then guard the import and wrap the presentation in a modifier that collapses to nothing without the flag:
+
+```swift
+import Scout
+import SwiftUI
+
+#if SCOUT_UI
+    import ScoutUI
+#endif
+
+extension View {
+    func scoutDashboard(isPresented: Binding<Bool>, backends: [Backend]) -> some View {
+        #if SCOUT_UI
+            scoutHome(isPresented: isPresented, backends: backends)
+        #else
+            self
+        #endif
+    }
+}
+```
+
+A dedicated branch achieves the same split without a second target: `main` builds the App Store release, and a long-lived branch adds the `ScoutUI` dependency and the entry point on top of it. Either way the App Store binary links only `Scout` and its connector, so none of the dashboard's view code is compiled into it.
+
+Two things to weigh before choosing this. First, the build you release is not the build your testers ran — it differs by everything `ScoutUI` touches, and it reaches App Review as a separate build. Second, `ScoutAlerts` lives in `ScoutUI` too ([ScoutAlerts.swift](../Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift)), so a build without the product also loses background alert evaluation; `registerBackgroundRefresh(backends:)` and `scheduleBackgroundRefresh()` have to sit behind the same flag as the dashboard.
+
+## Choosing
+
+Start with option 1. It is a few lines, it keeps one binary through the whole pipeline, and the dashboard is reachable in TestFlight the moment a tester needs it. Move to option 2 when binary size matters enough to pay for the split, or when you want a guarantee — not a runtime check — that no dashboard code ships to App Store users.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,5 +1,11 @@
 # Installation
 
+## Table of Contents
+- [Requirements](#requirements)
+- [Add the Package](#add-the-package)
+- [Enable CloudKit](#enable-cloudkit)
+- [Upload Your Database Schema](#upload-your-database-schema)
+
 ## Requirements
 
 - iOS 16.0+
@@ -20,16 +26,28 @@ Or add it to your `Package.swift`:
 .package(url: "https://github.com/kasianov-mikhail/scout.git", from: "3.3.0")
 ```
 
-Then add `Scout` as a dependency for your target:
+Then add the products your target needs. `Scout` carries the runtime and the handlers; the backend it syncs to comes from a connector, so a CloudKit setup takes `NativeConnector` too:
 
 ```swift
 .target(
     name: "YourTarget",
     dependencies: [
-        .product(name: "Scout", package: "scout")
+        .product(name: "Scout", package: "scout"),
+        .product(name: "NativeConnector", package: "scout"),
     ]
 )
 ```
+
+The package publishes these products:
+
+| Product | What it adds |
+|-|-|
+| `Scout` | The runtime, the log handler, the metrics factory, and crash reporting |
+| `NativeConnector` | `Backend.cloudKit(container:)`, syncing to your CloudKit container |
+| `HostedConnector` | `Backend.server(url:apiKey:)`, syncing to a [Scout server](https://github.com/kasianov-mikhail/scout-server) |
+| `ScoutUI` | The in-app dashboard — see the [Dashboard Guide](DASHBOARD.md) |
+| `LookupIndex` | A SwiftData record cache for the dashboard, enabled with `LookupIndex.enable()` on iOS 17+ |
+| `DemoConnector` | `Backend.demo()`, an offline backend preloaded with fabricated data for previews and screenshots |
 
 ## Enable CloudKit
 
@@ -46,4 +64,4 @@ The CloudKit backend stores everything through [scout-db](https://github.com/kas
 3. Go to the "Schema" section and use "Import Schema" to upload the schema file.
 4. Click "Deploy to Production" to apply the schema.
 
-Once CloudKit is enabled and the schema is uploaded, see the [Usage Guide](USAGE.md) for configuring `setup`, adding [Scout server](https://github.com/kasianov-mikhail/scout-server) backends, and writing logs and metrics.
+Once CloudKit is enabled and the schema is uploaded, see the [Usage Guide](USAGE.md) for creating the runtime, adding [Scout server](https://github.com/kasianov-mikhail/scout-server) backends, and writing logs and metrics.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,14 +1,25 @@
 # Usage
 
+## Table of Contents
+- [Bootstrap](#bootstrap)
+- [Multiplexing Handlers](#multiplexing-handlers)
+- [Multiple Backends](#multiple-backends)
+- [Writing Logs](#writing-logs)
+- [Recording Metrics](#recording-metrics)
+- [Dashboard](#dashboard)
+
+## Bootstrap
+
 Create a runtime once during app launch and bootstrap the two handlers built on it. That wires logging, metrics, and crash reporting:
 ```swift
 import CloudKit
 import Logging
 import Metrics
+import NativeConnector
 import Scout
 
 let container = CKContainer(identifier: "YOUR_CONTAINER_ID")
-let scout = Runtime(backends: [.cloudKit(container)])
+let scout = Runtime(backends: [try Backend.cloudKit(container: container)])
 
 LoggingSystem.bootstrap {
     ScoutLogHandler(label: $0, runtime: scout)
@@ -17,7 +28,11 @@ MetricsSystem.bootstrap(
     ScoutMetricsFactory(runtime: scout)
 )
 ```
+The runtime lives in the `Scout` product, while each backend comes from its own connector — `Backend.cloudKit(container:)` from `NativeConnector`. It throws when the container carries no identifier, which is what a default container resolves to in an app without an iCloud container entitlement.
+
 Keep it to one runtime per app and pass the same one to both — a second runtime would install the crash handlers twice and open a second session against the same store. Creating it is synchronous, so the handlers work immediately; the lifecycle records and the first sync land shortly after. Passing an empty backend list turns Scout off — nothing is recorded or synced.
+
+## Multiplexing Handlers
 
 Scout claims no exclusive hold on either system, so you can multiplex it with handlers of your own. To keep logs in the Xcode console while debugging, add the stream handler that ships with swift-log:
 ```swift
@@ -30,14 +45,20 @@ LoggingSystem.bootstrap { label in
 ```
 Metrics compose the same way through `MultiplexMetricsHandler`. Note that both systems can only be bootstrapped once per process, so every handler you want has to be named in that single call.
 
+## Multiple Backends
+
 To sync somewhere other than CloudKit — or to several destinations at once — add more backends to the list. Every raw record is uploaded to every backend, and the dashboard reads from the first one:
 ```swift
+import HostedConnector
+
 let scout = Runtime(backends: [
-    .cloudKit(container),
-    .server(url: URL(string: "https://scout.example.com")!, apiKey: "YOUR_API_KEY"),
+    try Backend.cloudKit(container: container),
+    Backend.server(url: URL(string: "https://scout.example.com")!, apiKey: "YOUR_API_KEY"),
 ])
 ```
-Every backend receives the same raw records and aggregates them on its own side — the CloudKit backend through [scout-db](https://github.com/kasianov-mikhail/scout-db) views, a [Scout server](https://github.com/kasianov-mikhail/scout-server) natively. Unlike CloudKit, a Scout server needs no schema upload.
+Every backend receives the same raw records and aggregates them on its own side — the CloudKit backend through [scout-db](https://github.com/kasianov-mikhail/scout-db) views, a [Scout server](https://github.com/kasianov-mikhail/scout-server) natively. Unlike CloudKit, a Scout server needs no schema upload, and `Backend.server(url:apiKey:)` doesn't throw.
+
+## Writing Logs
 
 Once bootstrapped, use the standard [swift-log](https://github.com/apple/swift-log) API to write logs:
 ```swift
@@ -53,6 +74,9 @@ logger.info(
     ]
 )
 ```
+Loggers created before the bootstrap keep the handler they were built with, so create them afterwards.
+
+## Recording Metrics
 
 Metrics work the same way via [swift-metrics](https://github.com/apple/swift-metrics):
 ```swift
@@ -62,4 +86,6 @@ Counter(label: "api_requests").increment()
 Timer(label: "response_time").recordSeconds(duration)
 ```
 
-Loggers created before the bootstrap keep the handler they were built with, so create them afterwards.
+## Dashboard
+
+To read the collected data back inside the app, link the `ScoutUI` product and present the dashboard — see the [Dashboard Guide](DASHBOARD.md).


### PR DESCRIPTION
Nothing in `docs/` explained how the dashboard reaches an app. The README
advertises it for development builds, but the `ScoutUI` product and
`scoutHome(isPresented:backends:)` appeared nowhere, so a reader following the
installation and usage guides ends up with logging and metrics and no way to
look at them. `docs/DASHBOARD.md` covers linking the product, presenting the
screen, and the two ways to keep it away from App Store users: ship `ScoutUI`
in the app and gate the entry point on the sandbox receipt, the way the example
app's `ScoutToolbarLink` does, or link the product only in a TestFlight-only
target or branch behind a `SCOUT_UI` compilation condition. The second keeps
the dashboard's views out of the released binary at the cost of releasing a
build the testers never ran, and it also drops `ScoutAlerts`, which lives in
`ScoutUI` and has to sit behind the same flag.

Writing it surfaced that the bootstrap snippet in the usage guide no longer
compiles. `Runtime(backends: [.cloudKit(container)])` predates the multi-target
split: the factory now throws, takes a labelled argument, and lives in
`NativeConnector`, so the snippet needs the import and `try
Backend.cloudKit(container: container)`. The same stale line sits in `Runtime`'s doc comment
and is fixed there too. The installation guide gained the connector in its
dependency list, a table of the six products the package publishes, and a fix
for the last paragraph, which still pointed at a `setup` function that no
longer exists.

Both guides also gained a table of contents like the README's. The usage guide
had no headings at all, so it is now split into sections along the seams its
prose already had, with the paragraph about loggers created before the
bootstrap moved next to the logging snippet. The branch merged `main` after
#1185 removed the exports doc.

