### PR TITLE
Keep a requeued delivery pending when its record changes mid-send

### DIFF
--- a/Sources/Scout/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Database/Access/RecordSender.swift
@@ -52,9 +52,13 @@ extension RecordSender {
             return
         }
 
+        let records = objects.map(\.record)
+
         do {
-            try await database.write(records: objects.map(\.record))
-            deliveries.forEach { $0.isPending = false }
+            try await database.write(records: records)
+            for (index, delivery) in deliveries.enumerated() where objects[index].record == records[index] {
+                delivery.isPending = false
+            }
         } catch {
             deliveries.forEach { $0.attempts += 1 }
             try context.save()

--- a/Sources/Scout/Database/Record/Record.swift
+++ b/Sources/Scout/Database/Record/Record.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-package struct Record: Sendable {
+package struct Record: Equatable, Sendable {
     package let recordType: String
     package let recordID: String
 

--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -200,6 +200,35 @@ struct DeliverTests {
         #expect(server.records.count(of: "Event") == 0)
     }
 
+    @Test("A requeue during the send survives the delivery pass")
+    func requeueDuringSendStaysPending() async throws {
+        let session = SessionEntry.stub(date: Date(), in: context)
+        try context.save()
+        try SyncableEntry.plan(backends: [cloudBackend], in: context)
+
+        // The session ends while its record is in flight: the completion fills in
+        // the end date and requeues the row mid-send.
+        cloud.beforeWrite = { @MainActor in
+            session.endDate = Date()
+            session.requeue()
+        }
+
+        try await deliver(SessionEntry.self, to: cloudBackend)
+        cloud.beforeWrite = nil
+
+        // The send delivered a stale record, so the row must stay pending...
+        #expect(session.delivery(for: "cloud")?.isPending == true)
+
+        // ...and the next pass delivers the completed session.
+        try await deliver(SessionEntry.self, to: cloudBackend)
+
+        #expect(session.delivery(for: "cloud")?.isDelivered == true)
+        #expect(cloud.records.count(of: "Session") == 2)
+
+        let delivered = try #require(cloud.records.last { $0.recordType == "Session" })
+        #expect(delivered["end_date"] as Date? != nil)
+    }
+
     @Test("A backend added after the first sync still receives one-shot records")
     func lateAddedBackendReceivesOneShots() async throws {
         let old = Date(timeIntervalSinceNow: -8 * 86400)

--- a/Tests/Support/Transient/InMemoryDatabase.swift
+++ b/Tests/Support/Transient/InMemoryDatabase.swift
@@ -13,6 +13,7 @@ final class InMemoryDatabase: DatabaseReader, DatabaseWriter, @unchecked Sendabl
     var records: [Record] = []
     var errors: [Error] = []
     var writeErrors: [Error] = []
+    var beforeWrite: (() async -> Void)?
 
     func lookup(recordName: String, fields: [String]?) async throws -> Record {
         guard let record = records.first(where: { $0.recordID == recordName }) else {
@@ -30,6 +31,7 @@ final class InMemoryDatabase: DatabaseReader, DatabaseWriter, @unchecked Sendabl
     }
 
     func write(records: [Record]) async throws {
+        await beforeWrite?()
         if let error = writeErrors.popLast() ?? errors.popLast() {
             throw error
         } else {


### PR DESCRIPTION
RecordSender.deliver held its fetched delivery rows across the await on database.write, so a requeue that landed during the send — most notably a session completing and filling in its end date — was clobbered by the unconditional isPending = false afterwards. The stale record counted as delivered, the end date was never uploaded, and purge could then drop the entry entirely.

The sender now snapshots each object's encoded record before the write and only clears isPending for rows whose record is unchanged when the write returns; a row whose record changed mid-send stays pending and the updated record goes out on the next pass. Record gains an Equatable conformance for the comparison, and a new DeliverTests case reproduces the interleaving through a beforeWrite hook on InMemoryDatabase — it fails on the previous behavior and passes with the fix.