### PR TITLE
Stop counting transient failures against the delivery attempt budget

### DIFF
--- a/Sources/Connectors/Hosted/HTTPDatabase.swift
+++ b/Sources/Connectors/Hosted/HTTPDatabase.swift
@@ -39,6 +39,10 @@ struct HTTPDatabaseError: LocalizedError {
     var errorDescription: String? {
         "Scout server returned \(status)\(reason.map { ": \($0)" } ?? "")"
     }
+
+    var isTransient: Bool {
+        status == 429 || status >= 500
+    }
 }
 
 extension HTTPDatabase {

--- a/Sources/Connectors/Hosted/HostedBackend.swift
+++ b/Sources/Connectors/Hosted/HostedBackend.swift
@@ -29,6 +29,9 @@ extension Backend {
                     return .failed(error)
                 }
             },
+            isTransientError: { error in
+                error is URLError || (error as? HTTPDatabaseError)?.isTransient == true
+            },
             onSetup: {
                 if apiKey != nil, url.scheme?.lowercased() != "https" {
                     print(

--- a/Sources/Connectors/Native/NativeBackend.swift
+++ b/Sources/Connectors/Native/NativeBackend.swift
@@ -66,6 +66,9 @@ extension Backend {
                 @unknown default:
                     .couldNotDetermine
                 }
+            },
+            isTransientError: { error in
+                (error as? CKError)?.isTransient == true
             }
         )
     }
@@ -79,6 +82,18 @@ extension CKContainer {
         await CatalogEntry.publishAll(into: store, registry: registry)
 
         return store
+    }
+}
+
+extension CKError {
+    var isTransient: Bool {
+        switch code {
+        case .networkUnavailable, .networkFailure, .serviceUnavailable, .requestRateLimited, .zoneBusy,
+            .accountTemporarilyUnavailable, .operationCancelled:
+            true
+        default:
+            retryAfterSeconds != nil
+        }
     }
 }
 

--- a/Sources/Scout/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Database/Access/RecordSender.swift
@@ -10,12 +10,14 @@ import CoreData
 struct RecordSender: Sendable {
     let id: String
     let database: any Database
+    let isTransientError: @Sendable (any Error) -> Bool
 }
 
 extension RecordSender {
     init(backend: Backend) {
         self.id = backend.id
         self.database = backend.database
+        self.isTransientError = backend.isTransientError
     }
 }
 
@@ -56,8 +58,13 @@ extension RecordSender {
             try await database.write(records: objects.map(\.record))
             deliveries.forEach { $0.isPending = false }
         } catch {
-            deliveries.forEach { $0.attempts += 1 }
-            try context.save()
+            // Only a rejection consumes the attempt budget: transient failures
+            // (offline, throttling, cancellation) must not burn the queue while
+            // the backend is unreachable.
+            if !(error is CancellationError) && !isTransientError(error) {
+                deliveries.forEach { $0.attempts += 1 }
+                try context.save()
+            }
             throw error
         }
 

--- a/Sources/Scout/Runtime/Backend.swift
+++ b/Sources/Scout/Runtime/Backend.swift
@@ -19,6 +19,7 @@ public struct Backend: Sendable {
     package var serverInfo: ServerInfo? = nil
     package var probeStatus: @Sendable () async -> Status = { .unknown }
     package var accountWarning: AccountWarning = { nil }
+    package var isTransientError: @Sendable (any Error) -> Bool = { _ in false }
     package var onSetup: @MainActor @Sendable () -> Void = {}
 
     package init(
@@ -30,6 +31,7 @@ public struct Backend: Sendable {
         serverInfo: ServerInfo? = nil,
         probeStatus: @escaping @Sendable () async -> Status = { .unknown },
         accountWarning: @escaping AccountWarning = { nil },
+        isTransientError: @escaping @Sendable (any Error) -> Bool = { _ in false },
         onSetup: @escaping @MainActor @Sendable () -> Void = {}
     ) {
         self.id = id
@@ -40,6 +42,7 @@ public struct Backend: Sendable {
         self.serverInfo = serverInfo
         self.probeStatus = probeStatus
         self.accountWarning = accountWarning
+        self.isTransientError = isTransientError
         self.onSetup = onSetup
     }
 

--- a/Tests/Connectors/Hosted/TransientErrorTests.swift
+++ b/Tests/Connectors/Hosted/TransientErrorTests.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+import Testing
+
+@testable import HostedConnector
+
+@Suite("Hosted transient error classification")
+struct TransientErrorTests {
+    let backend = Backend.server(url: URL(string: "https://example.com")!, apiKey: nil)
+
+    @Test("Connectivity failures are transient")
+    func urlErrorsAreTransient() {
+        #expect(backend.isTransientError(URLError(.notConnectedToInternet)))
+        #expect(backend.isTransientError(URLError(.timedOut)))
+        #expect(backend.isTransientError(URLError(.networkConnectionLost)))
+    }
+
+    @Test("Server-side outages and throttling are transient")
+    func serverOutagesAreTransient() {
+        #expect(backend.isTransientError(HTTPDatabaseError(status: 500, reason: nil)))
+        #expect(backend.isTransientError(HTTPDatabaseError(status: 503, reason: nil)))
+        #expect(backend.isTransientError(HTTPDatabaseError(status: 429, reason: nil)))
+    }
+
+    @Test("Rejections count against the attempt budget")
+    func rejectionsAreNotTransient() {
+        #expect(!backend.isTransientError(HTTPDatabaseError(status: 400, reason: "bad record")))
+        #expect(!backend.isTransientError(HTTPDatabaseError(status: 422, reason: nil)))
+        #expect(!backend.isTransientError(NSError(domain: "Test", code: 1)))
+    }
+}

--- a/Tests/Connectors/Native/TransientErrorTests.swift
+++ b/Tests/Connectors/Native/TransientErrorTests.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CloudKit
+import Testing
+
+@testable import NativeConnector
+
+@Suite("Native transient error classification")
+struct TransientErrorTests {
+    @Test("Connectivity and service failures are transient")
+    func connectivityIsTransient() {
+        #expect(CKError(.networkUnavailable).isTransient)
+        #expect(CKError(.networkFailure).isTransient)
+        #expect(CKError(.serviceUnavailable).isTransient)
+        #expect(CKError(.requestRateLimited).isTransient)
+        #expect(CKError(.zoneBusy).isTransient)
+        #expect(CKError(.accountTemporarilyUnavailable).isTransient)
+        #expect(CKError(.operationCancelled).isTransient)
+    }
+
+    @Test("Rejections are not transient")
+    func rejectionsAreNotTransient() {
+        #expect(!CKError(.invalidArguments).isTransient)
+        #expect(!CKError(.serverRejectedRequest).isTransient)
+        #expect(!CKError(.permissionFailure).isTransient)
+    }
+
+    @Test("A retry-after hint marks any error transient")
+    func retryAfterHintIsTransient() {
+        let error = CKError(.serverResponseLost, userInfo: [CKErrorRetryAfterKey: 30.0])
+        #expect(error.isTransient)
+    }
+}

--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -172,6 +172,55 @@ struct DeliverTests {
         #expect(server.records.count(of: "Event") == 1)
     }
 
+    @Test("Transient write failures don't consume the attempt budget")
+    func transientFailuresPreserveAttempts() async throws {
+        let event = EventEntry.stub(name: "login", in: context)
+        try context.save()
+        try SyncableEntry.plan(backends: [serverBackend], in: context)
+
+        let flakyServer = Backend(
+            id: "server",
+            database: server,
+            checkAvailability: { true },
+            displayName: "server",
+            isTransientError: { $0 is URLError }
+        )
+
+        // The availability check passes, but every real send fails on connectivity
+        // for far longer than the attempt budget would allow...
+        for _ in 0..<(DeliveryEntry.maxAttempts * 2) {
+            server.writeErrors.append(URLError(.notConnectedToInternet))
+            await #expect(throws: (any Error).self) {
+                try await deliver(EventEntry.self, to: flakyServer)
+            }
+        }
+
+        // ...yet not one attempt is spent, so the record is still deliverable.
+        #expect(event.delivery(for: "server")?.attempts == 0)
+        #expect(event.delivery(for: "server")?.isPending == true)
+        #expect(server.records.count(of: "Event") == 0)
+
+        // Connectivity returns and the record delivers on the first real send.
+        try await deliver(EventEntry.self, to: flakyServer)
+        #expect(event.delivery(for: "server")?.isDelivered == true)
+        #expect(server.records.count(of: "Event") == 1)
+    }
+
+    @Test("A cancelled send doesn't consume the attempt budget")
+    func cancellationPreservesAttempts() async throws {
+        let event = EventEntry.stub(name: "login", in: context)
+        try context.save()
+        try SyncableEntry.plan(backends: [serverBackend], in: context)
+
+        server.writeErrors.append(CancellationError())
+        await #expect(throws: (any Error).self) {
+            try await deliver(EventEntry.self, to: serverBackend)
+        }
+
+        #expect(event.delivery(for: "server")?.attempts == 0)
+        #expect(event.delivery(for: "server")?.isPending == true)
+    }
+
     @Test("A record is retried the full attempt budget before being abandoned")
     func fullAttemptBudget() async throws {
         let event = EventEntry.stub(name: "login", in: context)


### PR DESCRIPTION
Every failed write used to increment the attempts counter of the whole batch, and nothing ever reset it, so ten sync passes during an ordinary offline stretch permanently abandoned the pending queue and cleanup deleted the records a week later. The availability check doesn't guard against this: the hosted backend reports itself always available, and CloudKit's cached account status stays available without a network.

Backend now carries an isTransientError classifier, and RecordSender spends the attempt budget only on genuine rejections, skipping transient failures and cancellation. The hosted connector treats URLError and server 429/5xx responses as transient, the native one the CKError network and service codes plus any error carrying a retry-after hint. A real rejection still burns the ten-attempt budget, so a poison record keeps unblocking the queue and gets reclaimed by cleanup. Verified red-to-green: the new DeliverTests fail on the old counting behavior and pass with the fix.