### PR TITLE
Retry a failed schema publish instead of caching it

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(
             url: "https://github.com/kasianov-mikhail/scout-db.git",
-            revision: "a52aa3e590d79c946c9dadfdb0ceb68ef561ee06"
+            revision: "31aef6f72bb487e46363db0dd36c7fc1c7e2fb3e"
         ),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),
     ],

--- a/Sources/Connectors/Native/Catalog/CatalogEntry+Publish.swift
+++ b/Sources/Connectors/Native/Catalog/CatalogEntry+Publish.swift
@@ -10,20 +10,21 @@ import Scout
 import ScoutDB
 
 extension CatalogEntry {
-    static func publishAll(into store: EntityStore, registry: SchemaRegistry) async {
-        await withTaskGroup(of: Void.self) { group in
+    static func publishAll(into store: EntityStore, registry: SchemaRegistry) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
             for entry in entries {
                 group.addTask {
-                    try? await entry.publish(into: store, registry: registry)
+                    try await entry.publish(into: store, registry: registry)
                 }
             }
+            try await group.waitForAll()
         }
     }
 
     func publish(into store: EntityStore, registry: SchemaRegistry) async throws {
         let declaration = declaration(on: store)
 
-        guard let published = try? await registry.schema(for: entity) else {
+        guard let published = try await registry.publishedSchema(for: entity) else {
             return try await declaration.create()
         }
         guard !matches(published) else {

--- a/Sources/Connectors/Native/LazyTable.swift
+++ b/Sources/Connectors/Native/LazyTable.swift
@@ -8,16 +8,21 @@
 import Foundation
 
 actor LazyTable<Value: Sendable> {
-    private var entries: [String: Task<Value, Never>] = [:]
+    private var entries: [String: Task<Value, any Error>] = [:]
 
-    func value(id: String, make: @escaping @Sendable () async -> Value) async -> Value {
-        if let entry = entries[id] {
-            return await entry.value
-        }
-
-        let entry = Task { await make() }
+    func value(id: String, make: @escaping @Sendable () async throws -> Value) async throws -> Value {
+        let entry = entries[id] ?? Task { try await make() }
         entries[id] = entry
 
-        return await entry.value
+        do {
+            return try await entry.value
+        } catch {
+            // Only the failed task is evicted: a concurrent caller may have
+            // already installed a fresh attempt under the same id.
+            if entries[id] == entry {
+                entries[id] = nil
+            }
+            throw error
+        }
     }
 }

--- a/Sources/Connectors/Native/NativeBackend.swift
+++ b/Sources/Connectors/Native/NativeBackend.swift
@@ -32,8 +32,8 @@ extension Backend {
         }
 
         let database = NativeDatabase {
-            await stores.value(id: id) {
-                await container.publishedStore()
+            try await stores.value(id: id) {
+                try await container.publishedStore()
             }
         }
 
@@ -72,11 +72,11 @@ extension Backend {
 }
 
 extension CKContainer {
-    fileprivate func publishedStore() async -> EntityStore {
+    fileprivate func publishedStore() async throws -> EntityStore {
         let registry = SchemaRegistry(database: publicCloudDatabase)
         let store = EntityStore(database: publicCloudDatabase, registry: registry)
 
-        await CatalogEntry.publishAll(into: store, registry: registry)
+        try await CatalogEntry.publishAll(into: store, registry: registry)
 
         return store
     }

--- a/Sources/Connectors/Native/NativeDatabase.swift
+++ b/Sources/Connectors/Native/NativeDatabase.swift
@@ -10,7 +10,7 @@ import Scout
 import ScoutDB
 
 struct NativeDatabase: Sendable {
-    let resolve: @Sendable () async -> EntityStore
+    let resolve: @Sendable () async throws -> EntityStore
 }
 
 extension NativeDatabase: DatabaseWriter {
@@ -19,7 +19,7 @@ extension NativeDatabase: DatabaseWriter {
     }
 
     func write(records: [Record]) async throws {
-        let store = await resolve()
+        let store = try await resolve()
         for (entity, group) in Dictionary(grouping: records, by: \.recordType) {
             let batch = group.map { EntityWrite(values: Self.values(for: $0), uuid: $0.recordID) }
             try await store.write(batch, entity: entity)
@@ -35,7 +35,7 @@ extension NativeDatabase: DatabaseWriter {
 
 extension NativeDatabase: DatabaseReader {
     func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
-        let store = await resolve()
+        let store = try await resolve()
         let entity = query.recordType.recordType
         let sort = query.sort.first
 
@@ -75,13 +75,13 @@ extension NativeDatabase {
 
 extension NativeDatabase {
     func series(matching query: SeriesQuery) async throws -> [MetricSeries] {
-        try await NativeSeries(query: query).series(store: await resolve())
+        try await NativeSeries(query: query).series(store: resolve())
     }
 }
 
 extension NativeDatabase {
     func activity(in range: Range<Date>) async throws -> [ActivityPoint] {
-        let store = await resolve()
+        let store = try await resolve()
         let lookback = range.lowerBound.addingTimeInterval(-30 * .day).startOfDay
         let window = lookback..<range.upperBound
 
@@ -102,7 +102,7 @@ extension NativeDatabase {
 
 extension NativeDatabase {
     func retention(in range: Range<Date>) async throws -> [RetentionCohort] {
-        let store = await resolve()
+        let store = try await resolve()
 
         async let installs = store.datedIDs(
             entity: InstallEntry.recordType,

--- a/Tests/Connectors/Native/Catalog/CatalogPublishTests.swift
+++ b/Tests/Connectors/Native/Catalog/CatalogPublishTests.swift
@@ -26,7 +26,7 @@ struct CatalogPublishTests {
 
     @Test("Every declared entity ends up published as declared")
     func publishesEveryEntity() async throws {
-        await CatalogEntry.publishAll(into: store, registry: registry)
+        try await CatalogEntry.publishAll(into: store, registry: registry)
 
         for entry in CatalogEntry.entries {
             let published = try await registry.schema(for: entry.entity)
@@ -35,10 +35,52 @@ struct CatalogPublishTests {
     }
 
     @Test("Entities reconcile together rather than one after another")
-    func publishesConcurrently() async {
-        await CatalogEntry.publishAll(into: store, registry: registry)
+    func publishesConcurrently() async throws {
+        try await CatalogEntry.publishAll(into: store, registry: registry)
 
         #expect(await probe.peak > 1, "the catalog was published one entity at a time")
+    }
+
+    @Test("An outage surfaces instead of reading as a blank slate to re-create over")
+    func outagePropagates() async {
+        let outage = Outage()
+        let registry = SchemaRegistry(database: outage)
+        let store = EntityStore(database: outage, registry: registry)
+
+        await #expect(throws: CKError.self) {
+            try await CatalogEntry.publishAll(into: store, registry: registry)
+        }
+
+        #expect(await outage.saves == 0, "a failed schema fetch was answered with a create")
+    }
+}
+
+private actor Outage: CloudDatabase {
+    private(set) var saves = 0
+
+    func records(matching query: CKQuery, resultsLimit: Int) async throws -> QueryPage {
+        throw CKError(.networkUnavailable)
+    }
+
+    func records(continuingMatchFrom cursor: QueryCursor, resultsLimit: Int) async throws -> QueryPage {
+        throw CKError(.networkUnavailable)
+    }
+
+    func modifyRecords(saving: [CKRecord], deleting: [CKRecord.ID]) async throws {
+        saves += 1
+        throw CKError(.networkUnavailable)
+    }
+
+    func saveIfUnchanged(_ records: [CKRecord]) async throws -> [(CKRecord.ID, Result<CKRecord, any Error>)] {
+        throw CKError(.networkUnavailable)
+    }
+
+    func fetchRecord(id: CKRecord.ID) async throws -> CKRecord? {
+        throw CKError(.networkUnavailable)
+    }
+
+    func fetchRecords(ids: [CKRecord.ID]) async throws -> [CKRecord] {
+        throw CKError(.networkUnavailable)
     }
 }
 

--- a/Tests/Connectors/Native/LazyTableTests.swift
+++ b/Tests/Connectors/Native/LazyTableTests.swift
@@ -29,8 +29,8 @@ struct LazyTableTests {
         let first = InMemoryDatabase()
         let second = InMemoryDatabase()
 
-        _ = await stores.value(id: "iCloud.Scout") { store(over: first) }
-        let shared = await stores.value(id: "iCloud.Scout") { store(over: second) }
+        _ = try await stores.value(id: "iCloud.Scout") { store(over: first) }
+        let shared = try await stores.value(id: "iCloud.Scout") { store(over: second) }
 
         try await publish(through: shared)
 
@@ -43,8 +43,8 @@ struct LazyTableTests {
         let first = InMemoryDatabase()
         let second = InMemoryDatabase()
 
-        let one = await stores.value(id: "iCloud.Scout") { store(over: first) }
-        let other = await stores.value(id: "iCloud.Other") { store(over: second) }
+        let one = try await stores.value(id: "iCloud.Scout") { store(over: first) }
+        let other = try await stores.value(id: "iCloud.Other") { store(over: second) }
 
         try await publish(through: one)
         try await publish(through: other)
@@ -57,12 +57,28 @@ struct LazyTableTests {
     func waitsForPreparation() async throws {
         let database = InMemoryDatabase()
 
-        _ = await stores.value(id: "iCloud.Scout") {
+        _ = try await stores.value(id: "iCloud.Scout") {
             let prepared = store(over: database)
-            try? await publish(through: prepared)
+            try await publish(through: prepared)
 
             return prepared
         }
+
+        #expect(database.records.count == 1)
+    }
+
+    @Test("A make that fails is not kept, so the next call starts over")
+    func retriesAfterFailure() async throws {
+        struct Fault: Error {}
+
+        await #expect(throws: Fault.self) {
+            try await stores.value(id: "iCloud.Scout") { throw Fault() }
+        }
+
+        let database = InMemoryDatabase()
+        let recovered = try await stores.value(id: "iCloud.Scout") { store(over: database) }
+
+        try await publish(through: recovered)
 
         #expect(database.records.count == 1)
     }

--- a/Tests/Connectors/Native/NativeDatabase+InMemory.swift
+++ b/Tests/Connectors/Native/NativeDatabase+InMemory.swift
@@ -19,10 +19,10 @@ extension NativeDatabase {
         let registry = SchemaRegistry(database: cloud)
         let store = EntityStore(database: cloud, registry: registry)
 
-        let registration = Task { await CatalogEntry.publishAll(into: store, registry: registry) }
+        let registration = Task { try await CatalogEntry.publishAll(into: store, registry: registry) }
 
         return NativeDatabase {
-            await registration.value
+            try await registration.value
             return store
         }
     }

--- a/Tests/Connectors/Native/NativeDatabaseTests.swift
+++ b/Tests/Connectors/Native/NativeDatabaseTests.swift
@@ -225,10 +225,10 @@ struct SchemaBootstrapTests {
     // Built the way Backend.cloudKit builds it — the catalog is published
     // before the store is handed to a read or a write.
     private var database: NativeDatabase {
-        let registration = Task { await CatalogEntry.publishAll(into: store, registry: registry) }
+        let registration = Task { try await CatalogEntry.publishAll(into: store, registry: registry) }
 
         return NativeDatabase {
-            await registration.value
+            try await registration.value
             return store
         }
     }


### PR DESCRIPTION
The native backend prepared its EntityStore once per process: LazyTable cached the preparation task forever and CatalogEntry.publishAll swallowed every error, so a fresh container that came up offline kept an unpublished store until the next launch while session analytics burned through their delivery attempts. Preparation failures now evict the cached task so the next resolve retries, and publish errors propagate to RecordSender, which leaves the records pending for the following sync.

The same swallowed error hid a nastier edge: a transient fetch failure read as "nothing published" and fell through to create(), whose .allKeys save would roll an already published schema back to version 1. The publisher now asks the registry's new publishedSchema(for:), which maps only a genuinely missing descriptor to nil and rethrows the rest — that API lands in companion PR kasianov-mikhail/scout-db#506, which must merge first; the scout-db pin here points at that branch and gets bumped to the merged revision before this lands.