### PR TITLE
Stop a transient fetch failure from republishing the schema

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(
             url: "https://github.com/kasianov-mikhail/scout-db.git",
-            revision: "a52aa3e590d79c946c9dadfdb0ceb68ef561ee06"
+            revision: "d82f7da4b1a7c7ad793c1b276c470b3dbadb7486"
         ),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),
     ],

--- a/Sources/Connectors/Native/Catalog/CatalogEntry+Publish.swift
+++ b/Sources/Connectors/Native/Catalog/CatalogEntry+Publish.swift
@@ -23,7 +23,7 @@ extension CatalogEntry {
     func publish(into store: EntityStore, registry: SchemaRegistry) async throws {
         let declaration = declaration(on: store)
 
-        guard let published = try? await registry.schema(for: entity) else {
+        guard let published = try await registry.publishedSchema(for: entity) else {
             return try await declaration.create()
         }
         guard !matches(published) else {

--- a/Tests/Connectors/Native/Catalog/CatalogPublishTests.swift
+++ b/Tests/Connectors/Native/Catalog/CatalogPublishTests.swift
@@ -40,6 +40,56 @@ struct CatalogPublishTests {
 
         #expect(await probe.peak > 1, "the catalog was published one entity at a time")
     }
+
+    @Test("A transient fetch failure never republishes over a live schema")
+    func transientFailureLeavesSchemaAlone() async throws {
+        let entry = try #require(CatalogEntry.entries.first)
+        try await store.schema(entry.entity)
+            .field("legacy", .string)
+            .create()
+
+        let outage = Outage(database: probe)
+        let registry = SchemaRegistry(database: outage)
+        let store = EntityStore(database: outage, registry: registry)
+
+        await #expect(throws: CKError.self) {
+            try await entry.publish(into: store, registry: registry)
+        }
+
+        let published = try await SchemaRegistry(database: probe).schema(for: entry.entity)
+        #expect(published.fields.map(\.name) == ["legacy"])
+    }
+}
+
+/// Forwards to another database while every record fetch fails like a network
+/// drop, so a wrongly attempted write still lands where a test can see it.
+///
+private struct Outage: CloudDatabase {
+    let database: any CloudDatabase
+
+    func records(matching query: CKQuery, resultsLimit: Int) async throws -> QueryPage {
+        try await database.records(matching: query, resultsLimit: resultsLimit)
+    }
+
+    func records(continuingMatchFrom cursor: QueryCursor, resultsLimit: Int) async throws -> QueryPage {
+        try await database.records(continuingMatchFrom: cursor, resultsLimit: resultsLimit)
+    }
+
+    func modifyRecords(saving: [CKRecord], deleting: [CKRecord.ID]) async throws {
+        try await database.modifyRecords(saving: saving, deleting: deleting)
+    }
+
+    func saveIfUnchanged(_ records: [CKRecord]) async throws -> [(CKRecord.ID, Result<CKRecord, any Error>)] {
+        try await database.saveIfUnchanged(records)
+    }
+
+    func fetchRecord(id: CKRecord.ID) async throws -> CKRecord? {
+        throw CKError(.networkUnavailable)
+    }
+
+    func fetchRecords(ids: [CKRecord.ID]) async throws -> [CKRecord] {
+        try await database.fetchRecords(ids: ids)
+    }
 }
 
 /// Forwards to an in-memory database while recording how many requests were


### PR DESCRIPTION
Catalog publishing read the registry through try?, so a transient CloudKit failure while fetching the descriptor looked identical to an entity nothing had published yet, and the fallback create() would republish version 1 with a fresh slot map over a live schema — corrupting decoding for every client. Publishing now asks publishedSchema(for:), added in kasianov-mikhail/scout-db#507, which maps only a genuinely missing descriptor to nil and rethrows everything else, so a failed fetch aborts the publish and the entry retries on the next launch.

The same finding was fixed in parallel by #1189, which pinned scout-db to the branch of the then-unmerged kasianov-mikhail/scout-db#506 — a revision identical in content to the merged #507. This PR resolves that overlap: the pin moves to the revision on scout-db main, and the two regression tests complement each other — #1189's checks that an outage during publishAll surfaces without a single save, while the one added here publishes a live schema, fails the fetch underneath, and checks the schema survives untouched.