### PR TITLE
Dedupe lifecycle rows with uniqueness constraints

### DIFF
--- a/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
+++ b/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
@@ -47,7 +47,7 @@ struct IncidentArchive<Payload: Codable & Sendable> {
             do {
                 let id = UUID(uuidString: file.deletingPathExtension().lastPathComponent) ?? UUID()
                 try await persistentContainer.performBackgroundTask { context in
-                    context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+                    context.mergePolicy = NSMergePolicy.scout
                     try persist(payload, id, deviceID, context)
                 }
                 try FileManager.default.removeItem(at: file)

--- a/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
+++ b/Sources/Scout/Diagnostics/Log/ScoutLogHandler.swift
@@ -63,7 +63,7 @@ public struct ScoutLogHandler: LogHandler {
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
-                    context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+                    context.mergePolicy = NSMergePolicy.scout
                     try Scout.log(event, date: date, identity: identity, context: context)
                 }
                 try await runtime.sync()

--- a/Sources/Scout/Diagnostics/Telemetry/Handler/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/Handler/TelemetryHandler+LogMetrics.swift
@@ -72,7 +72,7 @@ extension TelemetryPersisting {
         Task {
             do {
                 try await persistentContainer.performBackgroundTask { context in
-                    context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+                    context.mergePolicy = NSMergePolicy.scout
                     try save(context)
                 }
                 try await sync()

--- a/Sources/Scout/Identity/Command.swift
+++ b/Sources/Scout/Identity/Command.swift
@@ -18,7 +18,7 @@ extension NSPersistentContainer {
 
     func run(_ commands: [any Command]) async throws {
         try await performBackgroundTask { context in
-            context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+            context.mergePolicy = NSMergePolicy.scout
 
             for command in commands {
                 try command.execute(in: context)

--- a/Sources/Scout/Persistence/MigrationDedupe.swift
+++ b/Sources/Scout/Persistence/MigrationDedupe.swift
@@ -1,0 +1,98 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+// Lightweight migration fails outright when existing rows violate a uniqueness
+// constraint the destination model introduces, so stores written before the
+// constraints existed must be deduplicated with their source model before
+// `loadPersistentStores` runs.
+struct MigrationDedupe {
+    static let uniqueKeys: [(entity: String, key: String)] = [
+        ("DeviceEntry", "deviceID"),
+        ("InstallEntry", "installID"),
+        ("LaunchEntry", "launchID"),
+        ("SessionEntry", "sessionID"),
+    ]
+
+    let model: NSManagedObjectModel
+    var bundles: [Bundle] = [.module]
+
+    func prepare(_ description: NSPersistentStoreDescription) throws {
+        guard description.type == NSSQLiteStoreType else { return }
+        guard let url = description.url else { return }
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+
+        let metadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(type: .sqlite, at: url)
+        guard !model.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata) else { return }
+        guard let source = NSManagedObjectModel.mergedModel(from: bundles, forStoreMetadata: metadata) else {
+            return
+        }
+
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: source)
+        let store = try coordinator.addPersistentStore(type: .sqlite, at: url)
+        defer { try? coordinator.remove(store) }
+
+        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        context.persistentStoreCoordinator = coordinator
+
+        try context.performAndWait {
+            for (entity, key) in Self.uniqueKeys where source.entitiesByName[entity] != nil {
+                try dedupe(entityName: entity, key: key, in: context)
+            }
+            if context.hasChanges {
+                try context.save()
+            }
+        }
+    }
+
+    private func dedupe(entityName: String, key: String, in context: NSManagedObjectContext) throws {
+        let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
+        request.sortDescriptors = [NSSortDescriptor(key: DateEntry.datePrimitiveKey, ascending: true)]
+
+        var survivors: [UUID: NSManagedObject] = [:]
+        for row in try context.fetch(request) {
+            guard let id = row.value(forKey: key) as? UUID else { continue }
+
+            if let survivor = survivors[id] {
+                merge(row, into: survivor, in: context)
+            } else {
+                survivors[id] = row
+            }
+        }
+    }
+
+    private func merge(_ duplicate: NSManagedObject, into survivor: NSManagedObject, in context: NSManagedObjectContext)
+    {
+        for name in survivor.entity.attributesByName.keys where survivor.value(forKey: name) == nil {
+            if let value = duplicate.value(forKey: name) {
+                survivor.setValue(value, forKey: name)
+            }
+        }
+
+        let relationships = survivor.entity.relationshipsByName
+        for (name, relationship) in relationships where relationship.deleteRule != .cascadeDeleteRule {
+            if relationship.isToMany {
+                let children = survivor.mutableSetValue(forKey: name)
+                for child in duplicate.mutableSetValue(forKey: name).allObjects {
+                    children.add(child)
+                }
+            } else if survivor.value(forKey: name) == nil, let value = duplicate.value(forKey: name) {
+                survivor.setValue(value, forKey: name)
+            }
+        }
+
+        // The duplicate may have delivered last, leaving its bare version on
+        // the server, so the merged survivor re-sends regardless of whether
+        // the merge changed it locally.
+        if let syncable = survivor as? SyncableEntry {
+            syncable.requeue()
+        }
+
+        context.delete(duplicate)
+    }
+}

--- a/Sources/Scout/Persistence/PersistentContainer.swift
+++ b/Sources/Scout/Persistence/PersistentContainer.swift
@@ -41,6 +41,11 @@ extension NSPersistentContainer {
 
 extension NSPersistentContainer {
     func loadStore() throws {
+        let dedupe = MigrationDedupe(model: managedObjectModel)
+        for description in persistentStoreDescriptions {
+            try dedupe.prepare(description)
+        }
+
         var captured: Error?
         loadPersistentStores { _, error in
             captured = error
@@ -49,6 +54,6 @@ extension NSPersistentContainer {
             throw captured
         }
 
-        viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+        viewContext.mergePolicy = NSMergePolicy.scout
     }
 }

--- a/Sources/Scout/Persistence/ScoutMergePolicy.swift
+++ b/Sources/Scout/Persistence/ScoutMergePolicy.swift
@@ -1,0 +1,48 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+// Plain object-trump resolution lets a bare duplicate insert blank the
+// attributes it never set, so a racing `linkedSession` row would erase a
+// filled one. Backfilling nils from the other side of the conflict first
+// keeps every populated value while the trump merge still dedupes the rows.
+final class ScoutMergePolicy: NSMergePolicy {
+    init() {
+        super.init(merge: .mergeByPropertyObjectTrumpMergePolicyType)
+    }
+
+    override func resolve(constraintConflicts conflicts: [NSConstraintConflict]) throws {
+        for conflict in conflicts {
+            let donors = [conflict.databaseObject].compactMap(\.self) + conflict.conflictingObjects
+
+            for object in conflict.conflictingObjects {
+                backfill(object, from: donors)
+            }
+        }
+
+        try super.resolve(constraintConflicts: conflicts)
+    }
+
+    private func backfill(_ object: NSManagedObject, from donors: [NSManagedObject]) {
+        var keys = Array(object.entity.attributesByName.keys)
+        keys += object.entity.relationshipsByName.filter { !$0.value.isToMany }.map(\.key)
+
+        for key in keys where object.value(forKey: key) == nil {
+            for donor in donors where donor !== object {
+                if let value = donor.value(forKey: key) {
+                    object.setValue(value, forKey: key)
+                    break
+                }
+            }
+        }
+    }
+}
+
+extension NSMergePolicy {
+    nonisolated(unsafe) static let scout: NSMergePolicy = ScoutMergePolicy()
+}

--- a/Sources/Scout/Persistence/ScoutModel.xcdatamodeld/.xccurrentversion
+++ b/Sources/Scout/Persistence/ScoutModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>ScoutModel 3.xcdatamodel</string>
+	<string>ScoutModel 4.xcdatamodel</string>
 </dict>
 </plist>

--- a/Sources/Scout/Persistence/ScoutModel.xcdatamodeld/ScoutModel 4.xcdatamodel/contents
+++ b/Sources/Scout/Persistence/ScoutModel.xcdatamodeld/ScoutModel 4.xcdatamodel/contents
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="IncidentEntry" representedClassName="IncidentEntry" isAbstract="YES" parentEntity="SyncableEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="fingerprint" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="stackTrace" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="CrashEntry" representedClassName="CrashEntry" parentEntity="IncidentEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="crashID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionEntry" inverseName="crashes" inverseEntity="SessionEntry"/>
+        <fetchIndex name="bySession">
+            <fetchIndexElement property="session" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="crashID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="DateEntry" representedClassName="DateEntry" isAbstract="YES" syncable="YES" codeGenerationType="none">
+        <attribute name="datePrimitive" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="day" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="hour" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="month" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="week" attributeType="Date" usesScalarValueType="NO"/>
+        <fetchIndex name="byDatePrimitive">
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="DeliveryEntry" representedClassName="DeliveryEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="attempts" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="backendID" attributeType="String"/>
+        <attribute name="isPending" attributeType="Boolean" defaultValueString="NO" renamingIdentifier="progressPrimitive" usesScalarValueType="YES"/>
+        <relationship name="object" maxCount="1" deletionRule="Nullify" destinationEntity="SyncableEntry" inverseName="deliveries" inverseEntity="SyncableEntry"/>
+        <fetchIndex name="byBackend">
+            <fetchIndexElement property="backendID" type="Binary" order="ascending"/>
+            <fetchIndexElement property="isPending" type="Binary" order="ascending"/>
+            <fetchIndexElement property="attempts" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="object"/>
+                <constraint value="backendID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="DoubleMetricsEntry" representedClassName="DoubleMetricsEntry" parentEntity="MetricsEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="value" attributeType="Double" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="EventEntry" representedClassName="EventEntry" parentEntity="SyncableEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="eventID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="level" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="paramCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="params" optional="YES" attributeType="Binary"/>
+        <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionEntry" inverseName="events" inverseEntity="SessionEntry"/>
+        <fetchIndex name="bySession">
+            <fetchIndexElement property="session" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="eventID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="DeviceEntry" representedClassName="DeviceEntry" parentEntity="SyncableEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="deviceID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="model" optional="YES" attributeType="String"/>
+        <relationship name="installs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="InstallEntry" inverseName="device" inverseEntity="InstallEntry"/>
+        <fetchIndex name="byDeviceID">
+            <fetchIndexElement property="deviceID" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="deviceID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="HangEntry" representedClassName="HangEntry" parentEntity="IncidentEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="duration" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="hangID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionEntry" inverseName="hangs" inverseEntity="SessionEntry"/>
+        <fetchIndex name="bySession">
+            <fetchIndexElement property="session" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="hangID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="InstallEntry" representedClassName="InstallEntry" parentEntity="SyncableEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="installID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="device" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DeviceEntry" inverseName="installs" inverseEntity="DeviceEntry"/>
+        <relationship name="launches" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="LaunchEntry" inverseName="install" inverseEntity="LaunchEntry"/>
+        <relationship name="markers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MarkerEntry" inverseName="install" inverseEntity="MarkerEntry"/>
+        <fetchIndex name="byInstallID">
+            <fetchIndexElement property="installID" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byDevice">
+            <fetchIndexElement property="device" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="installID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="IntMetricsEntry" representedClassName="IntMetricsEntry" parentEntity="MetricsEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="value" attributeType="Integer 64" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="LaunchEntry" representedClassName="LaunchEntry" parentEntity="SyncableEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="launchID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="install" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="InstallEntry" inverseName="launches" inverseEntity="InstallEntry"/>
+        <relationship name="sessions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SessionEntry" inverseName="launch" inverseEntity="SessionEntry"/>
+        <relationship name="versions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="VersionEntry" inverseName="launch" inverseEntity="VersionEntry"/>
+        <relationship name="visits" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="VisitEntry" inverseName="launch" inverseEntity="VisitEntry"/>
+        <fetchIndex name="byLaunchID">
+            <fetchIndexElement property="launchID" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byInstall">
+            <fetchIndexElement property="install" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byEndDate">
+            <fetchIndexElement property="endDate" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="launchID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="MetricsEntry" representedClassName="MetricsEntry" isAbstract="YES" parentEntity="SyncableEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="telemetry" attributeType="String"/>
+        <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionEntry" inverseName="metrics" inverseEntity="SessionEntry"/>
+        <fetchIndex name="bySession">
+            <fetchIndexElement property="session" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="SessionEntry" representedClassName="SessionEntry" parentEntity="SyncableEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="buildNumber" optional="YES" attributeType="String"/>
+        <attribute name="channel" optional="YES" attributeType="String"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="locale" optional="YES" attributeType="String"/>
+        <attribute name="osVersion" optional="YES" attributeType="String"/>
+        <attribute name="sessionID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="launch" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LaunchEntry" inverseName="sessions" inverseEntity="LaunchEntry"/>
+        <relationship name="crashes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CrashEntry" inverseName="session" inverseEntity="CrashEntry"/>
+        <relationship name="hangs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="HangEntry" inverseName="session" inverseEntity="HangEntry"/>
+        <relationship name="events" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EventEntry" inverseName="session" inverseEntity="EventEntry"/>
+        <relationship name="metrics" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MetricsEntry" inverseName="session" inverseEntity="MetricsEntry"/>
+        <fetchIndex name="bySessionID">
+            <fetchIndexElement property="sessionID" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byLaunch">
+            <fetchIndexElement property="launch" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byEndDate">
+            <fetchIndexElement property="endDate" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="sessionID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="SyncableEntry" representedClassName="SyncableEntry" parentEntity="DateEntry" syncable="YES" codeGenerationType="none">
+        <relationship name="deliveries" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="DeliveryEntry" inverseName="object" inverseEntity="DeliveryEntry"/>
+    </entity>
+    <entity name="VersionEntry" representedClassName="VersionEntry" parentEntity="SyncableEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="buildNumber" optional="YES" attributeType="String"/>
+        <relationship name="launch" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LaunchEntry" inverseName="versions" inverseEntity="LaunchEntry"/>
+        <fetchIndex name="byLaunch">
+            <fetchIndexElement property="launch" type="Binary" order="ascending"/>
+            <fetchIndexElement property="datePrimitive" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="VisitEntry" representedClassName="VisitEntry" parentEntity="SyncableEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="visitID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="launch" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LaunchEntry" inverseName="visits" inverseEntity="LaunchEntry"/>
+        <fetchIndex name="byDay">
+            <fetchIndexElement property="day" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="visitID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="MarkerEntry" representedClassName="MarkerEntry" parentEntity="DateEntry" syncable="YES" codeGenerationType="none">
+        <attribute name="appVersion" optional="YES" attributeType="String"/>
+        <attribute name="markerID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <relationship name="install" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="InstallEntry" inverseName="markers" inverseEntity="InstallEntry"/>
+        <fetchIndex name="byInstallNameVersion">
+            <fetchIndexElement property="install" type="Binary" order="ascending"/>
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+            <fetchIndexElement property="appVersion" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="markerID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+</model>

--- a/Tests/ScoutTests/Lifecycle/Device/DeviceEntryTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Device/DeviceEntryTests.swift
@@ -22,8 +22,12 @@ struct DeviceEntryTests {
         let device = DeviceEntry.stub(date: week, in: context)
 
         InstallEntry.stub(date: week, device: device, in: context)
-        InstallEntry.stub(date: week.addingHour(), device: device, in: context)
-        InstallEntry.stub(date: week, in: context)
+
+        let second = InstallEntry.stub(date: week.addingHour(), device: device, in: context)
+        second.installID = UUID()
+
+        let unlinked = InstallEntry.stub(date: week, in: context)
+        unlinked.installID = UUID()
 
         try context.save()
 

--- a/Tests/ScoutTests/Lifecycle/Install/InstallEntryTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Install/InstallEntryTests.swift
@@ -26,6 +26,7 @@ struct InstallEntryTests {
         VersionEntry.stub(date: week.addingHour(), appVersion: "2.0", launch: launch, in: context)
 
         let otherLaunch = LaunchEntry.stub(date: week, in: context)
+        otherLaunch.launchID = UUID()
         VersionEntry.stub(date: week, appVersion: "3.0", launch: otherLaunch, in: context)
 
         try context.save()

--- a/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryRecoveryTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryRecoveryTests.swift
@@ -70,7 +70,8 @@ struct LaunchEntryRecoveryTests {
         let launch = LaunchEntry.stub(date: date, in: context)
         launch.launchID = UUID()
 
-        SessionEntry.stub(date: date.addingTimeInterval(10), launch: launch, in: context)
+        let early = SessionEntry.stub(date: date.addingTimeInterval(10), launch: launch, in: context)
+        early.sessionID = UUID()
 
         let latest = date.addingTimeInterval(300)
         SessionEntry.stub(date: latest, launch: launch, in: context)

--- a/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryTests.swift
@@ -22,8 +22,12 @@ struct LaunchEntryTests {
         let launch = LaunchEntry.stub(date: week, in: context)
 
         SessionEntry.stub(date: week, launch: launch, in: context)
-        SessionEntry.stub(date: week.addingHour(), launch: launch, in: context)
-        SessionEntry.stub(date: week, in: context)
+
+        let second = SessionEntry.stub(date: week.addingHour(), launch: launch, in: context)
+        second.sessionID = UUID()
+
+        let unlinked = SessionEntry.stub(date: week, in: context)
+        unlinked.sessionID = UUID()
 
         try context.save()
 

--- a/Tests/ScoutTests/Lifecycle/Session/SessionEntryTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Session/SessionEntryTests.swift
@@ -22,7 +22,8 @@ struct SessionEntryTests {
         let launch = LaunchEntry.stub(date: week, in: context)
         let session = SessionEntry.stub(date: week, launch: launch, in: context)
 
-        LaunchEntry.stub(date: week, in: context)
+        let other = LaunchEntry.stub(date: week, in: context)
+        other.launchID = UUID()
 
         try context.save()
 

--- a/Tests/ScoutTests/Persistence/MergePolicyTests.swift
+++ b/Tests/ScoutTests/Persistence/MergePolicyTests.swift
@@ -31,7 +31,7 @@ struct MergePolicyTests {
         // -[NSManagedObjectContext _processPendingUpdates:]. A private-queue
         // context confines every mutation to performAndWait instead.
         let context = container.newBackgroundContext()
-        context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+        context.mergePolicy = NSMergePolicy.scout
 
         let eventID = UUID()
         let events = try context.performAndWait {
@@ -73,7 +73,7 @@ struct MergePolicyTests {
                 group.addTask {
                     do {
                         try await container.performBackgroundTask { context in
-                            context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+                            context.mergePolicy = NSMergePolicy.scout
                             try saveMetrics(
                                 "counter",
                                 date: Date(),
@@ -92,7 +92,7 @@ struct MergePolicyTests {
                 group.addTask {
                     do {
                         try await container.performBackgroundTask { context in
-                            context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+                            context.mergePolicy = NSMergePolicy.scout
 
                             let session = try context.existing(
                                 SessionEntry.self, key: "sessionID", id: identity.session)
@@ -113,6 +113,92 @@ struct MergePolicyTests {
             let request = NSFetchRequest<SessionEntry>(entityName: "SessionEntry")
             let sessions = try context.fetch(request)
             #expect(sessions.first?.metrics.count == 20)
+        }
+    }
+
+    /// The fetch-then-insert in `linkedSession` races across background
+    /// contexts (telemetry, logs, incidents all write concurrently), so this
+    /// hammers it from many tasks and expects the uniqueness constraints to
+    /// collapse the colliding inserts to a single row per lifecycle entity.
+    ///
+    @Test("Racing linkedSession writes collapse to one row per lifecycle entity")
+    func concurrentLinkedSessionDedupes() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let container = try makeContainer(in: directory)
+
+        let identity = Identity.stub.snapshot
+        let failures = Protected<[String]>([])
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 1...20 {
+                group.addTask {
+                    do {
+                        try await container.performBackgroundTask { context in
+                            context.mergePolicy = NSMergePolicy.scout
+                            _ = try context.linkedSession(identity, date: Date())
+                            try context.save()
+                        }
+                    } catch {
+                        failures.mutate { $0.append(error.localizedDescription) }
+                    }
+                }
+            }
+        }
+
+        #expect(failures.current.count == 0)
+
+        let context = container.newBackgroundContext()
+        try context.performAndWait {
+            for entity in ["DeviceEntry", "InstallEntry", "LaunchEntry", "SessionEntry"] {
+                let request = NSFetchRequest<NSManagedObject>(entityName: entity)
+                let count = try context.count(for: request)
+                #expect(count == 1, "\(entity) deduplicated")
+            }
+        }
+    }
+
+    /// The worst interleaving behind the empty-overwrites-filled bug.
+    ///
+    /// A bare `linkedSession` row and a filled session for the same ID are
+    /// both in flight before either saves. The constraint merge must keep the
+    /// filled attributes instead of blanking them with the bare insert's nils.
+    ///
+    @Test("A bare duplicate insert keeps the filled session fields")
+    func bareDuplicateKeepsFilledFields() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let container = try makeContainer(in: directory)
+
+        let identity = Identity.stub.snapshot
+
+        let filler = container.newBackgroundContext()
+        filler.mergePolicy = NSMergePolicy.scout
+        let racer = container.newBackgroundContext()
+        racer.mergePolicy = NSMergePolicy.scout
+
+        try filler.performAndWait {
+            let session = try filler.linkedSession(identity, date: Date())
+            session.appVersion = "1.2.3"
+            session.osVersion = "26.0"
+        }
+        try racer.performAndWait {
+            _ = try racer.linkedSession(identity, date: Date())
+        }
+        try filler.performAndWait {
+            try filler.save()
+        }
+        try racer.performAndWait {
+            try racer.save()
+        }
+
+        let context = container.newBackgroundContext()
+        try context.performAndWait {
+            let request = NSFetchRequest<SessionEntry>(entityName: "SessionEntry")
+            let sessions = try context.fetch(request)
+            #expect(sessions.count == 1)
+            #expect(sessions.first?.appVersion == "1.2.3")
+            #expect(sessions.first?.osVersion == "26.0")
         }
     }
 

--- a/Tests/ScoutTests/Persistence/MigrationDedupeTests.swift
+++ b/Tests/ScoutTests/Persistence/MigrationDedupeTests.swift
@@ -1,0 +1,128 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+import Testing
+
+@testable import Scout
+
+@Suite("Migration dedupe")
+struct MigrationDedupeTests {
+    /// Stores written before ScoutModel 4 can hold duplicate lifecycle rows.
+    ///
+    /// That is exactly the data that makes the constraint-adding migration
+    /// fail. This seeds a ScoutModel 3 store with a bare chain and a filled
+    /// duplicate chain, then loads it with the current model and expects a
+    /// single merged row per entity with the filled attributes and children
+    /// preserved.
+    ///
+    @Test("A store with duplicate lifecycle rows migrates into merged singles")
+    func duplicatesMergeDuringMigration() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let storeURL = directory.appendingPathComponent("ScoutModel.sqlite")
+
+        let momdURL = try #require(Bundle.module.url(forResource: "ScoutModel", withExtension: "momd"))
+        let oldURL = momdURL.appendingPathComponent("ScoutModel 3.mom")
+        let old = try #require(NSManagedObjectModel(contentsOf: oldURL))
+
+        let deviceID = UUID()
+        let installID = UUID()
+        let launchID = UUID()
+        let sessionID = UUID()
+        let earlyDate = Date(timeIntervalSinceNow: -600)
+        let lateDate = Date(timeIntervalSinceNow: -300)
+
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: old)
+        let store = try coordinator.addPersistentStore(type: .sqlite, at: storeURL)
+        let seed = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        seed.persistentStoreCoordinator = coordinator
+
+        try seed.performAndWait {
+            let bare = try seed.linkedSession(
+                deviceID: deviceID,
+                installID: installID,
+                launchID: launchID,
+                sessionID: sessionID,
+                date: earlyDate
+            )
+
+            let delivery = seed.insert(DeliveryEntry.self)
+            delivery.backendID = "backend"
+            delivery.isPending = false
+            delivery.attempts = 3
+            delivery.object = bare
+
+            let device = seed.insert(DeviceEntry.self)
+            device.deviceID = deviceID
+            device.date = lateDate
+            device.model = "iPhone17,1"
+
+            let install = seed.insert(InstallEntry.self)
+            install.installID = installID
+            install.date = lateDate
+            install.device = device
+
+            let launch = seed.insert(LaunchEntry.self)
+            launch.launchID = launchID
+            launch.date = lateDate
+            launch.install = install
+
+            let session = seed.insert(SessionEntry.self)
+            session.sessionID = sessionID
+            session.date = lateDate
+            session.appVersion = "2.0"
+            session.osVersion = "26.0"
+            session.launch = launch
+
+            let event = seed.insert(EventEntry.self)
+            event.eventID = UUID()
+            event.name = "purchase"
+            event.level = "info"
+            event.date = lateDate
+            event.session = session
+
+            try seed.save()
+        }
+        try coordinator.remove(store)
+
+        let container = NSPersistentContainer(named: "ScoutModel")
+        container.persistentStoreDescriptions = [NSPersistentStoreDescription(url: storeURL)]
+        try container.loadStore()
+
+        let context = container.newBackgroundContext()
+        try context.performAndWait {
+            for entity in ["DeviceEntry", "InstallEntry", "LaunchEntry", "SessionEntry"] {
+                let request = NSFetchRequest<NSManagedObject>(entityName: entity)
+                let count = try context.count(for: request)
+                #expect(count == 1, "\(entity) deduplicated")
+            }
+
+            let device = try #require(try context.existing(DeviceEntry.self, key: "deviceID", id: deviceID))
+            #expect(device.model == "iPhone17,1")
+            #expect(device.date == earlyDate)
+
+            let install = try #require(try context.existing(InstallEntry.self, key: "installID", id: installID))
+            #expect(install.device == device)
+
+            let launch = try #require(try context.existing(LaunchEntry.self, key: "launchID", id: launchID))
+            #expect(launch.install == install)
+
+            let session = try #require(try context.existing(SessionEntry.self, key: "sessionID", id: sessionID))
+            #expect(session.launch == launch)
+            #expect(session.appVersion == "2.0")
+            #expect(session.osVersion == "26.0")
+            #expect(session.date == earlyDate)
+            #expect(session.events.count == 1)
+
+            let delivery = try #require(session.deliveries.first)
+            #expect(delivery.isPending)
+            #expect(delivery.attempts == 0)
+        }
+    }
+}


### PR DESCRIPTION
The fetch-then-insert in linkedSession and the lifecycle triggers races across concurrent background contexts (telemetry, logs, incidents), so Session, Launch, Install, and Device rows duplicated under load, and since the server record ID is the same UUID, a bare duplicate delivered last overwrote the filled record on the server. ScoutModel 4 adds uniqueness constraints on the four lifecycle IDs so colliding inserts collapse into one row at save. A pin test showed plain mergeByPropertyObjectTrump blanks the fields a bare insert never set, so a backfilling merge policy now fills the insert's nils from the persisted row before the trump merge, and every write context uses it. Existing stores can already hold duplicates, which makes the constraint-adding lightweight migration fail outright, so a pre-migration pass opens the store with its source model, merges duplicate rows (earliest survives, attributes backfilled, children moved), and re-queues the merged rows for delivery so the server picks up the repaired state; no store is ever reset. Verified red-green: on ScoutModel 3 the three new tests fail exactly as the bug predicts, and the full scheme (858 tests) passes with the fix. Five entity tests that unintentionally saved rows sharing the stub UUIDs now give extra rows distinct IDs.