### PR TITLE
Drive the coalescing test with signals instead of sleeps

### DIFF
--- a/Tests/ScoutTests/Utilities/Dispatcher/CoalescerTests.swift
+++ b/Tests/ScoutTests/Utilities/Dispatcher/CoalescerTests.swift
@@ -69,18 +69,22 @@ struct CoalescerTests {
     func testCoalescesPendingWork() async throws {
         let dispatcher = Coalescer()
         let box = Box([Int]())
+        let started = AsyncStream.makeStream(of: Void.self)
+        let release = AsyncStream.makeStream(of: Void.self)
 
         let first = Task {
             try await dispatcher.perform {
                 box.value.append(1)
-                try? await Task.sleep(for: .milliseconds(100))
+                started.continuation.yield()
+                // Hold the first run open until the test has piled up both submissions.
+                for await _ in release.stream { break }
             }
         }
 
-        // Let the first work item start, then pile up two submissions behind it.
-        try? await Task.sleep(for: .milliseconds(20))
+        for await _ in started.stream { break }
         try await dispatcher.perform { box.value.append(2) }
         try await dispatcher.perform { box.value.append(3) }
+        release.continuation.yield()
         try await first.value
 
         #expect(box.value == [1, 3])


### PR DESCRIPTION
The coalescing test in CoalescerTests relied on a 20 ms sleep finishing before the first work item's 100 ms sleep, which a loaded CI machine can't guarantee — when the timing inverted, each mid-run submission triggered its own follow-up run and the test failed with `[1, 2, 3]` instead of `[1, 3]` (seen on the test-ios-26 Debug leg of run 31690008588). The test now controls the interleaving with two `AsyncStream` signals: the first work item reports that it has started and stays open until the test has piled up both submissions, so they are guaranteed to arrive while the run is in flight. The assertion is unchanged — both submissions must coalesce into a single follow-up run. Verified with 50 consecutive green runs of the ScoutTests bundle on the iOS simulator, plus 900 iterations of the same logic in a standalone stress harness.