### PR TITLE
Merge background saves into the context that delivers records

### DIFF
--- a/Sources/Scout/Persistence/PersistentContainer.swift
+++ b/Sources/Scout/Persistence/PersistentContainer.swift
@@ -55,5 +55,11 @@ extension NSPersistentContainer {
         }
 
         viewContext.mergePolicy = NSMergePolicy.scout
+
+        // Delivery runs on the view context while every record is written on a
+        // background one, so without merging those saves the sender compares
+        // stale snapshots: a record filled in mid-send counts as delivered and
+        // a requeue from a background context is never seen again.
+        viewContext.automaticallyMergesChangesFromParent = true
     }
 }

--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -278,6 +278,72 @@ struct DeliverTests {
         #expect(delivered["end_date"] as Date? != nil)
     }
 
+    @Test("A requeue on a background context during the send survives the delivery pass")
+    func backgroundRequeueDuringSendStaysPending() async throws {
+        let session = SessionEntry.stub(date: Date(), in: context)
+        try context.save()
+        try SyncableEntry.plan(backends: [cloudBackend], in: context)
+
+        let background = context.backgroundSibling()
+        let sessionID = session.objectID
+
+        // The session ends mid-send the way it really does — on a background
+        // context, not the one the delivery engine holds.
+        cloud.beforeWrite = {
+            try? await background.perform {
+                let session = try #require(background.object(with: sessionID) as? SessionEntry)
+                session.endDate = Date()
+                session.requeue()
+                try background.save()
+            }
+        }
+
+        try await deliver(SessionEntry.self, to: cloudBackend)
+        cloud.beforeWrite = nil
+
+        // The send delivered a stale record, so the row must stay pending...
+        #expect(session.delivery(for: "cloud")?.isPending == true)
+
+        // ...and the next pass delivers the completed session.
+        try await deliver(SessionEntry.self, to: cloudBackend)
+
+        #expect(session.delivery(for: "cloud")?.isDelivered == true)
+        #expect(cloud.records.count(of: "Session") == 2)
+
+        let delivered = try #require(cloud.records.last { $0.recordType == "Session" })
+        #expect(delivered["end_date"] as Date? != nil)
+    }
+
+    @Test("A requeue on a background context after delivery is picked up by the next pass")
+    func backgroundRequeueAfterDeliveryIsResent() async throws {
+        let session = SessionEntry.stub(date: Date(), in: context)
+        try context.save()
+        try SyncableEntry.plan(backends: [cloudBackend], in: context)
+
+        try await deliver(SessionEntry.self, to: cloudBackend)
+        #expect(session.delivery(for: "cloud")?.isDelivered == true)
+
+        let background = context.backgroundSibling()
+        let sessionID = session.objectID
+
+        // The session completes on a background context once the row is already
+        // delivered, so only the requeue can bring it back.
+        try await background.perform {
+            let session = try #require(background.object(with: sessionID) as? SessionEntry)
+            session.endDate = Date()
+            session.requeue()
+            try background.save()
+        }
+
+        try await deliver(SessionEntry.self, to: cloudBackend)
+
+        #expect(session.delivery(for: "cloud")?.isDelivered == true)
+        #expect(cloud.records.count(of: "Session") == 2)
+
+        let delivered = try #require(cloud.records.last { $0.recordType == "Session" })
+        #expect(delivered["end_date"] as Date? != nil)
+    }
+
     @Test("A backend added after the first sync still receives one-shot records")
     func lateAddedBackendReceivesOneShots() async throws {
         let old = Date(timeIntervalSinceNow: -8 * 86400)

--- a/Tests/Support/Transient/InMemoryContext.swift
+++ b/Tests/Support/Transient/InMemoryContext.swift
@@ -19,10 +19,13 @@ extension NSManagedObjectContext {
         description.type = NSInMemoryStoreType
 
         container.persistentStoreDescriptions = [description]
-        container.loadPersistentStores { _, error in
-            if let error {
-                fatalError("Failed to load store: \(error)")
-            }
+
+        // Load through the production path so the view context carries the same
+        // merge configuration the delivery engine depends on.
+        do {
+            try container.loadStore()
+        } catch {
+            fatalError("Failed to load store: \(error)")
         }
 
         return container.viewContext

--- a/Tests/Support/Transient/NSManagedObjectContext+Background.swift
+++ b/Tests/Support/Transient/NSManagedObjectContext+Background.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+@testable import Scout
+
+extension NSManagedObjectContext {
+    /// A private-queue sibling sharing this context's coordinator, standing in for
+    /// the background contexts `performBackgroundTask` hands every record write.
+    func backgroundSibling() -> NSManagedObjectContext {
+        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        context.persistentStoreCoordinator = persistentStoreCoordinator
+        context.mergePolicy = NSMergePolicy.scout
+        return context
+    }
+}


### PR DESCRIPTION
`RecordSender.deliver` runs on the view context while every record is written on a `performBackgroundTask` context, and the view context was never told to merge those saves — and Core Data does not refresh registered objects on a refetch either. Both guards on the delivery path were therefore reading stale snapshots: the mid-send re-check added in #1187 saw an unchanged record and cleared `isPending` on a session whose end date had just been written on another context, and the `isPending` filter kept skipping a row requeued in the background for the rest of the process lifetime. In both cases the record counted as delivered locally, the filled-in version never reached the backend, and purge could then drop the row entirely.

The view context now merges changes from its parent, so a write landing during a send is visible once the send returns, and a background requeue is picked up by the next pass. The in-memory test context is built through the production `loadStore()` so it carries the same merge configuration rather than a hand-rolled one, and a new `backgroundSibling()` helper hands tests a private-queue context on the same coordinator — the same thing `performBackgroundTask` gives production code.

Two `DeliverTests` cases cover the interleavings that were broken: a requeue arriving mid-send and a requeue arriving after the row was already delivered, both driven from a sibling background context instead of the delivery context, which is why the existing #1187 test passed against the bug. Both fail without the merge and pass with it; the full 241-test suite is green and `swift-format lint --strict` is clean.
