### PR TITLE
Charge a rejected batch's attempt to the record that caused it

### DIFF
--- a/Sources/Scout/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Database/Access/RecordSender.swift
@@ -8,6 +8,12 @@
 import CoreData
 
 struct RecordSender: Sendable {
+    // A rejected batch names no culprit, so it is halved and resent until the
+    // offending records stand alone and only they are charged. This caps the sends
+    // one pass spends on that search, so a backend rejecting everything can't turn
+    // a backlog into thousands of requests.
+    static let maxProbes = 32
+
     let id: String
     let database: any Database
     let isTransientError: @Sendable (any Error) -> Bool
@@ -40,38 +46,70 @@ extension RecordSender {
             DeliveryEntry.maxAttempts
         )
 
-        var objects: [T] = []
-        var deliveries: [DeliveryEntry] = []
-
-        for object in try context.fetch(request) {
-            if let delivery = object.delivery(for: id), delivery.isPending {
-                objects.append(object)
-                deliveries.append(delivery)
-            }
-        }
+        let objects = try context.fetch(request).filter { $0.delivery(for: id)?.isPending == true }
 
         guard objects.count > 0 else {
             return
         }
 
-        let records = objects.map(\.record)
-
         do {
-            try await database.write(records: records)
-            for (index, delivery) in deliveries.enumerated() where objects[index].record == records[index] {
-                delivery.isPending = false
-            }
+            try await send(objects)
         } catch {
-            // Only a rejection consumes the attempt budget: transient failures
-            // (offline, throttling, cancellation) must not burn the queue while
-            // the backend is unreachable.
-            if !(error is CancellationError) && !isTransientError(error) {
-                deliveries.forEach { $0.attempts += 1 }
-                try context.save()
-            }
+            try save(context)
             throw error
         }
 
-        try context.save()
+        try save(context)
+    }
+
+    private func send<T: SyncableEntry & RecordEncodable>(_ objects: [T]) async throws {
+        var batches = [objects]
+        var probes = Self.maxProbes
+        var rejection: (any Error)?
+
+        while probes > 0, let batch = batches.popLast() {
+            probes -= 1
+
+            do {
+                try await write(batch)
+            } catch {
+                // Only a rejection consumes the attempt budget: transient failures
+                // (offline, throttling, cancellation) must not burn the queue while
+                // the backend is unreachable.
+                guard !(error is CancellationError), !isTransientError(error) else {
+                    throw error
+                }
+
+                rejection = error
+
+                if batch.count > 1 {
+                    let half = batch.count / 2
+                    batches.append(Array(batch[half...]))
+                    batches.append(Array(batch[..<half]))
+                } else {
+                    batch[0].delivery(for: id)?.attempts += 1
+                }
+            }
+        }
+
+        if let rejection {
+            throw rejection
+        }
+    }
+
+    private func write<T: SyncableEntry & RecordEncodable>(_ objects: [T]) async throws {
+        let records = objects.map(\.record)
+
+        try await database.write(records: records)
+
+        for (object, record) in zip(objects, records) where object.record == record {
+            object.delivery(for: id)?.isPending = false
+        }
+    }
+
+    private func save(_ context: NSManagedObjectContext) throws {
+        if context.hasChanges {
+            try context.save()
+        }
     }
 }

--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -249,6 +249,55 @@ struct DeliverTests {
         #expect(server.records.count(of: "Event") == 0)
     }
 
+    @Test("A rejected record burns its own budget, not the whole batch")
+    func rejectionIsolatedToRecord() async throws {
+        let healthy = (0..<7).map { EventEntry.stub(name: "healthy-\($0)", in: context) }
+        let poison = EventEntry.stub(name: "poison", in: context)
+        try context.save()
+        try SyncableEntry.plan(backends: [serverBackend], in: context)
+
+        // The server refuses one malformed record and accepts everything else.
+        server.reject = { $0["name"] as String? == "poison" }
+
+        await #expect(throws: (any Error).self) {
+            try await deliver(EventEntry.self, to: serverBackend)
+        }
+
+        // The records it was batched with are delivered in the same pass...
+        #expect(server.records.count(of: "Event") == 7)
+        #expect(healthy.allSatisfy { $0.delivery(for: "server")?.isDelivered == true })
+
+        // ...and only the rejected one pays for the rejection.
+        #expect(poison.delivery(for: "server")?.attempts == 1)
+        #expect(poison.delivery(for: "server")?.isPending == true)
+    }
+
+    @Test("A backend rejecting everything stays within the probe budget")
+    func wholesaleRejectionStaysBounded() async throws {
+        for index in 0..<64 {
+            EventEntry.stub(name: "event-\(index)", in: context)
+        }
+        try context.save()
+        try SyncableEntry.plan(backends: [serverBackend], in: context)
+
+        server.reject = { _ in true }
+
+        await #expect(throws: (any Error).self) {
+            try await deliver(EventEntry.self, to: serverBackend)
+        }
+
+        // Singling out the culprits costs sends, so one pass is capped instead of
+        // fanning a backlog out into a request per record...
+        #expect(server.writeCount <= RecordSender.maxProbes)
+        #expect(server.records.count(of: "Event") == 0)
+
+        // ...while still making progress: whatever it did single out is charged.
+        let charged = try context.fetchAll(EventEntry.self).filter {
+            ($0.delivery(for: "server")?.attempts ?? 0) > 0
+        }
+        #expect(charged.count > 0)
+    }
+
     @Test("A requeue during the send survives the delivery pass")
     func requeueDuringSendStaysPending() async throws {
         let session = SessionEntry.stub(date: Date(), in: context)

--- a/Tests/Support/Transient/InMemoryDatabase.swift
+++ b/Tests/Support/Transient/InMemoryDatabase.swift
@@ -9,11 +9,21 @@ import Foundation
 
 @testable import Scout
 
+struct RejectedRecordError: Error {
+    let recordID: String
+}
+
 final class InMemoryDatabase: DatabaseReader, DatabaseWriter, @unchecked Sendable {
     var records: [Record] = []
     var errors: [Error] = []
     var writeErrors: [Error] = []
     var beforeWrite: (() async -> Void)?
+
+    /// Rejects a batch carrying any matching record, the way a backend refuses a
+    /// single malformed one while accepting everything sent alongside it.
+    var reject: ((Record) -> Bool)?
+
+    private(set) var writeCount = 0
 
     func lookup(recordName: String, fields: [String]?) async throws -> Record {
         guard let record = records.first(where: { $0.recordID == recordName }) else {
@@ -32,11 +42,16 @@ final class InMemoryDatabase: DatabaseReader, DatabaseWriter, @unchecked Sendabl
 
     func write(records: [Record]) async throws {
         await beforeWrite?()
+        writeCount += 1
+
         if let error = writeErrors.popLast() ?? errors.popLast() {
             throw error
-        } else {
-            self.records += records
         }
+        if let reject, let rejected = records.first(where: reject) {
+            throw RejectedRecordError(recordID: rejected.recordID)
+        }
+
+        self.records += records
     }
 
     func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {


### PR DESCRIPTION
A non-transient write failure charged an attempt to every delivery in the fetched cohort, including records sitting in chunks the writer never even sent, so a single record the backend refuses burned the budget of everything queued alongside it in lockstep. After ten passes those valid records reached the ceiling too, dropped out of delivery and out of `retainedIDs`, and cleanup reclaimed the lot — permanent loss of records the backend would have accepted on their own.

A rejection names no culprit, so the batch is now halved and resent until the offending records stand alone and only they are charged, and the records they were batched with deliver in the same pass instead of waiting for the next sync. Searching that way costs sends, so a pass spends at most `maxProbes` of them and a backend rejecting everything cannot fan a backlog out into a request per record, while the depth-first order still reaches single records and keeps the queue draining. Transient failures and cancellation still cost nothing, and the mid-send record re-check from #1187 now applies to each accepted sub-batch.

Two regression tests cover it: one checks a poison record is isolated while the seven records batched with it deliver, the other that a wholesale rejection stays within the probe budget and still charges what it singled out. Both were confirmed to fail without the isolation, and all 872 tests across the targets pass.

Opened as a draft so it does not merge on green CI.