### PR TITLE
Close a launch when its sessions end, not when they start

### DIFF
--- a/Sources/Scout/Lifecycle/Session/SessionEntry.swift
+++ b/Sources/Scout/Lifecycle/Session/SessionEntry.swift
@@ -29,6 +29,13 @@ package final class SessionEntry: SyncableEntry, HasLaunch {
         Set(Array(crashes) + Array(hangs) + Array(events) + Array(metrics))
     }
 
+    // A session spans an interval, so the launch that owns it only ends once the
+    // session does — inferring a launch end from session start dates would close
+    // the launch before its own sessions.
+    override var latest: Date? {
+        endDate ?? datePrimitive
+    }
+
     override var isPurgeable: Bool {
         endDate != nil
     }

--- a/Sources/Scout/Utilities/Date/DateEntry.swift
+++ b/Sources/Scout/Utilities/Date/DateEntry.swift
@@ -27,8 +27,12 @@ package class DateEntry: NSManagedObject {
         true
     }
 
+    var latest: Date? {
+        datePrimitive
+    }
+
     var inferred: Date? {
-        (references.map(\.datePrimitive) + [datePrimitive]).compactMap(\.self).max()
+        (references.map(\.latest) + [latest]).compactMap(\.self).max()
     }
 
     var date: Date? {

--- a/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryRecoveryTests.swift
+++ b/Tests/ScoutTests/Lifecycle/Launch/LaunchEntryRecoveryTests.swift
@@ -81,4 +81,35 @@ struct LaunchEntryRecoveryTests {
 
         #expect(launch.endDate == latest)
     }
+
+    @Test("Outlives the sessions it owns")
+    func endDateFromSessionEnd() throws {
+        let launch = LaunchEntry.stub(date: date, in: context)
+        launch.launchID = UUID()
+
+        let endDate = date.addingTimeInterval(300)
+        SessionEntry.stub(date: date.addingTimeInterval(10), endDate: endDate, launch: launch, in: context)
+
+        try context.save()
+        try LaunchEntry.Recovery(launchID: identity.launch).execute(in: context)
+
+        #expect(launch.endDate == endDate)
+    }
+
+    @Test("Closes at the last session to end, not the last to start")
+    func endDateFromLatestSessionEnd() throws {
+        let launch = LaunchEntry.stub(date: date, in: context)
+        launch.launchID = UUID()
+
+        let endDate = date.addingTimeInterval(300)
+        let early = SessionEntry.stub(date: date, endDate: endDate, launch: launch, in: context)
+        early.sessionID = UUID()
+
+        SessionEntry.stub(date: date.addingTimeInterval(120), endDate: nil, launch: launch, in: context)
+
+        try context.save()
+        try LaunchEntry.Recovery(launchID: identity.launch).execute(in: context)
+
+        #expect(launch.endDate == endDate)
+    }
 }


### PR DESCRIPTION
`LaunchEntry.Recovery` is the only writer of a launch's end date, and it takes that date from `inferred`, which folds together the `datePrimitive` of every referenced entry. For a session that primitive is the start date, so a launch was closed at the moment its last session began: every completed run reported an `end_date` earlier than the `end_date` of the session it contains, and a launch holding one 40-minute session was uploaded as zero-length.

Sessions and launches span an interval while the entries a session references (events, crashes, hangs, metrics) are instantaneous, so `inferred` now folds a new `latest` — the point an entry is known to reach — which `SessionEntry` overrides with its end date. Session recovery is unaffected: its references have no end date and fall back to their own timestamp, and it still runs before launch recovery, so a session closed from its events is already in place when the launch that owns it is closed. Both new recovery tests fail on main and pass here.