### PR TITLE
Stop reporting a suspended process as a blocked main thread

### DIFF
--- a/Sources/Scout/Diagnostics/Hang/HangHandler.swift
+++ b/Sources/Scout/Diagnostics/Hang/HangHandler.swift
@@ -12,18 +12,15 @@ private let watchdogQueue = DispatchQueue(label: "scout.hang.watchdog")
 private nonisolated(unsafe) var isInstalled = false
 
 // Touched only from closures scheduled on `watchdogQueue`, which is serial —
-// that queue is the sole synchronization for these, not the `unsafe` opt-out.
-private nonisolated(unsafe) var pingDate = Date()
-private nonisolated(unsafe) var reportedWarning = false
-private nonisolated(unsafe) var reportedCritical = false
+// that queue is the sole synchronization for this, not the `unsafe` opt-out.
+private nonisolated(unsafe) var monitor = HangMonitor(now: uptime)
 
-private let pingInterval: TimeInterval = 1
-
-// In the spirit of MetricKit's hang buckets: a first report once the main
-// thread has been unresponsive for 3s, and a more severe one at 8s — around
-// where the system watchdog would otherwise kill the app.
-private let warningThreshold: TimeInterval = 3
-private let criticalThreshold: TimeInterval = 8
+// Wall-clock time counts a backgrounded process and a corrected clock as time
+// the main thread spent unresponsive; uptime stops while the device sleeps and
+// never jumps.
+private var uptime: TimeInterval {
+    ProcessInfo.processInfo.systemUptime
+}
 
 // Installs a watchdog that detects an unresponsive main thread and captures
 // its stack trace before the system watchdog can kill the app.
@@ -38,38 +35,28 @@ func installHangHandler(identity: Identity) {
 private func schedulePing() {
     DispatchQueue.main.async {
         watchdogQueue.async {
-            pingDate = Date()
-            reportedWarning = false
-            reportedCritical = false
+            monitor.ping(at: uptime)
         }
-        watchdogQueue.asyncAfter(deadline: .now() + pingInterval) {
+        watchdogQueue.asyncAfter(deadline: .now() + HangMonitor.pingInterval) {
             schedulePing()
         }
     }
 }
 
 private func scheduleCheck(identity: Identity) {
-    watchdogQueue.asyncAfter(deadline: .now() + pingInterval) {
-        checkForHang(identity: identity)
+    watchdogQueue.asyncAfter(deadline: .now() + HangMonitor.pingInterval) {
+        if let duration = monitor.check(at: uptime) {
+            reportHang(duration: duration, identity: identity)
+        }
         scheduleCheck(identity: identity)
     }
 }
 
-private func checkForHang(identity: Identity) {
-    let elapsed = Date().timeIntervalSince(pingDate)
-
-    if elapsed >= criticalThreshold, !reportedCritical {
-        reportedCritical = true
-        reportHang(duration: elapsed, identity: identity)
-    } else if elapsed >= warningThreshold, !reportedWarning {
-        reportedWarning = true
-        reportHang(duration: elapsed, identity: identity)
-    }
-}
-
 private func reportHang(duration: TimeInterval, identity: Identity) {
+    let isCritical = duration >= HangMonitor.criticalThreshold
+
     let hang = HangInfo(
-        name: duration >= criticalThreshold ? "Watchdog Termination Imminent" : "Main Thread Blocked",
+        name: isCritical ? "Watchdog Termination Imminent" : "Main Thread Blocked",
         reason: "Main thread unresponsive for \(String(format: "%.1f", duration))s",
         stackTrace: MainThreadBacktrace.capture(),
         duration: duration,

--- a/Sources/Scout/Diagnostics/Hang/HangMonitor.swift
+++ b/Sources/Scout/Diagnostics/Hang/HangMonitor.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+struct HangMonitor {
+    static let pingInterval: TimeInterval = 1
+
+    // In the spirit of MetricKit's hang buckets: a first report once the main
+    // thread has been unresponsive for 3s, and a more severe one at 8s — around
+    // where the system watchdog would otherwise kill the app.
+    static let warningThreshold: TimeInterval = 3
+    static let criticalThreshold: TimeInterval = 8
+
+    // A check arriving this late means the watchdog queue itself stopped running:
+    // the process was suspended in the background or the device slept. The gap
+    // then measures the freeze, not an unresponsive main thread.
+    static let stallThreshold = pingInterval * 1.5
+
+    private var pingDate: TimeInterval
+    private var checkDate: TimeInterval
+    private var reportedWarning = false
+    private var reportedCritical = false
+
+    init(now: TimeInterval) {
+        pingDate = now
+        checkDate = now
+    }
+
+    mutating func ping(at now: TimeInterval) {
+        pingDate = now
+        reportedWarning = false
+        reportedCritical = false
+    }
+
+    mutating func check(at now: TimeInterval) -> TimeInterval? {
+        let stall = now - checkDate
+        checkDate = now
+
+        guard stall <= Self.stallThreshold else {
+            ping(at: now)
+            return nil
+        }
+
+        let elapsed = now - pingDate
+
+        if elapsed >= Self.criticalThreshold, !reportedCritical {
+            reportedCritical = true
+            return elapsed
+        } else if elapsed >= Self.warningThreshold, !reportedWarning {
+            reportedWarning = true
+            return elapsed
+        }
+
+        return nil
+    }
+}

--- a/Tests/ScoutTests/Diagnostics/Hang/HangMonitorTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Hang/HangMonitorTests.swift
@@ -1,0 +1,66 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("HangMonitor")
+struct HangMonitorTests {
+    @Test("Reports once the main thread stops pinging")
+    func reportsWarning() {
+        var monitor = HangMonitor(now: 0)
+
+        #expect(monitor.check(at: 1) == nil)
+        #expect(monitor.check(at: 2) == nil)
+        #expect(monitor.check(at: 3) == 3)
+    }
+
+    @Test("Escalates once the hang reaches the critical threshold")
+    func escalatesToCritical() {
+        var monitor = HangMonitor(now: 0)
+
+        let durations = (1...9).compactMap { monitor.check(at: TimeInterval($0)) }
+
+        #expect(durations == [3, 8])
+    }
+
+    @Test("A ping ends the hang and re-arms both reports")
+    func pingRearmsReports() {
+        var monitor = HangMonitor(now: 0)
+
+        #expect(monitor.check(at: 1) == nil)
+        #expect(monitor.check(at: 2) == nil)
+        #expect(monitor.check(at: 3) == 3)
+
+        monitor.ping(at: 3.5)
+
+        #expect(monitor.check(at: 4) == nil)
+        #expect(monitor.check(at: 5) == nil)
+        #expect(monitor.check(at: 6.5) == 3)
+    }
+
+    @Test("Treats a frozen watchdog as a suspended process, not a hang")
+    func suspensionIsNotAHang() {
+        var monitor = HangMonitor(now: 0)
+
+        #expect(monitor.check(at: 1) == nil)
+        #expect(monitor.check(at: 301) == nil)
+        #expect(monitor.check(at: 302) == nil)
+    }
+
+    @Test("Reports a hang that starts after resuming")
+    func reportsAfterResuming() {
+        var monitor = HangMonitor(now: 0)
+
+        #expect(monitor.check(at: 301) == nil)
+        #expect(monitor.check(at: 302) == nil)
+        #expect(monitor.check(at: 303) == nil)
+        #expect(monitor.check(at: 304) == 3)
+    }
+}


### PR DESCRIPTION
The hang watchdog measured responsiveness against the wall clock and never moved its baseline when the process resumed. iOS freezes a backgrounded app, so the main-thread ping and the watchdog stop together; on the next foreground the overdue check runs before the ping round-trips through the main queue and reads a `pingDate` from before the freeze, turning the whole background stretch into a hang. Every foreground after three seconds away produced a report — usually the critical "Watchdog Termination Imminent" one, carrying the backtrace of a perfectly healthy main thread — and a forward jump of the wall clock did the same.

Timing now comes from `ProcessInfo.systemUptime`, which never jumps and stops while the device sleeps, and the watchdog also watches its own tick: a check landing more than half an interval late means the queue itself was frozen, so the baseline moves to the resume instead of firing a report. A real hang leaves the queue ticking on schedule and still reports; if a tick is merely late while the main thread is stuck, the hang is re-measured from the reset rather than lost — the duration shortens, the report survives.

The decision logic moved into `HangMonitor` so it can be driven with synthetic timestamps, including a five-minute suspension gap.