### PR TITLE
Keep the device ID when the keychain cannot answer

### DIFF
--- a/Sources/Scout/Persistence/MirroredRegistry.swift
+++ b/Sources/Scout/Persistence/MirroredRegistry.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+// The keychain owns the device ID because it survives a reinstall, but it cannot
+// be read before the first unlock after a reboot — where iOS still prewarms and
+// background-launches apps. A read that fails there is indistinguishable from a
+// missing item, and minting a replacement would attribute the whole launch to a
+// device that never appears again. The mirror answers instead, and either side
+// heals the other once it can be written.
+struct MirroredRegistry: Registry {
+    let store: any Registry
+    let mirror: any Registry
+
+    func resolve(_ key: String) -> UUID? {
+        let stored = store.resolve(key)
+        let mirrored = mirror.resolve(key)
+
+        guard let id = stored ?? mirrored else {
+            return nil
+        }
+
+        if stored != id {
+            store.register(id, for: key)
+        }
+        if mirrored != id {
+            mirror.register(id, for: key)
+        }
+
+        return id
+    }
+
+    func register(_ value: UUID, for key: String) {
+        store.register(value, for: key)
+        mirror.register(value, for: key)
+    }
+}

--- a/Sources/Scout/Runtime/Runtime.swift
+++ b/Sources/Scout/Runtime/Runtime.swift
@@ -54,10 +54,12 @@ extension Runtime {
     ///   recorded or synced.
     ///
     public init(backends: [Backend]) {
+        let registry = MirroredRegistry(store: KeychainStorage.standard, mirror: UserDefaults.standard)
+
         let identity = Identity(
             install: UserDefaults.standard.ensure("scout_install_id"),
             launch: UUID(),
-            device: KeychainStorage.standard.ensure("scout_device_id"),
+            device: registry.ensure("scout_device_id"),
             session: Protected(UUID())
         )
 

--- a/Tests/ScoutTests/Persistence/MirroredRegistryTests.swift
+++ b/Tests/ScoutTests/Persistence/MirroredRegistryTests.swift
@@ -1,0 +1,62 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("MirroredRegistry")
+struct MirroredRegistryTests {
+    let store = MockRegistry()
+    let mirror = MockRegistry()
+
+    var registry: MirroredRegistry {
+        MirroredRegistry(store: store, mirror: mirror)
+    }
+
+    @Test("Prefers the store and copies what it returns into the mirror")
+    func prefersStore() {
+        let uuid = UUID()
+        store.storage["device"] = uuid
+
+        #expect(registry.resolve("device") == uuid)
+        #expect(mirror.storage["device"] == uuid)
+    }
+
+    @Test("Keeps the mirrored ID instead of minting when the store has no answer")
+    func fallsBackToMirror() {
+        let uuid = UUID()
+        mirror.storage["device"] = uuid
+
+        #expect(registry.ensure("device") == uuid)
+        #expect(store.storage["device"] == uuid)
+    }
+
+    @Test("Overwrites a stale mirror with the stored ID")
+    func healsMirror() {
+        let uuid = UUID()
+        store.storage["device"] = uuid
+        mirror.storage["device"] = UUID()
+
+        #expect(registry.resolve("device") == uuid)
+        #expect(mirror.storage["device"] == uuid)
+    }
+
+    @Test("Mints into both sides when neither knows the key")
+    func mintsIntoBoth() {
+        let uuid = registry.ensure("device")
+
+        #expect(store.storage["device"] == uuid)
+        #expect(mirror.storage["device"] == uuid)
+    }
+
+    @Test("Returns the same ID on repeated calls")
+    func idempotent() {
+        #expect(registry.ensure("device") == registry.ensure("device"))
+    }
+}


### PR DESCRIPTION
`KeychainStorage.resolve` maps every status other than `errSecSuccess` to "no item", so a read that merely failed is indistinguishable from a missing one and `Registry.ensure` mints a replacement. The item is stored as `AfterFirstUnlockThisDeviceOnly`, and iOS prewarms and background-launches apps before the first unlock after a reboot, where that read returns `errSecInteractionNotAllowed`. The whole launch then ran under a device ID that was never seen again — a fresh device row synced to the backend, sessions and crashes attributed to it — and the `SecItemAdd` that would have persisted it failed just as silently, so the real ID came back on the next launch. Device counts inflate and one device's history splits.

The device ID now resolves through `MirroredRegistry`, which keeps the keychain as the source of truth — it is what survives a reinstall — and mirrors it into defaults. When the keychain cannot answer, the mirror does, so the launch stays on the real device instead of inventing one, and whichever side is behind is healed on the next successful read. A reinstall still picks the keychain ID over the wiped mirror, so continuity across reinstalls is unchanged.