### PR TITLE
Disable Scout when its store cannot load instead of crashing

### DIFF
--- a/Sources/Scout/Persistence/PersistentContainer.swift
+++ b/Sources/Scout/Persistence/PersistentContainer.swift
@@ -12,12 +12,18 @@ let persistentContainer: NSPersistentContainer = {
 
     do {
         try container.loadStore()
-    } catch let error as NSError {
-        fatalError("Error loading Core Data store: \(error) | \(error.userInfo)")
+    } catch {
+        print("Failed to load the Scout store: \(error)")
     }
 
     return container
 }()
+
+extension NSPersistentContainer {
+    var isStoreLoaded: Bool {
+        persistentStoreCoordinator.persistentStores.count > 0
+    }
+}
 
 extension NSManagedObjectModel {
     nonisolated(unsafe) static let scout: NSManagedObjectModel = {

--- a/Sources/Scout/Runtime/Runtime.swift
+++ b/Sources/Scout/Runtime/Runtime.swift
@@ -51,9 +51,12 @@ extension Runtime {
     ///
     /// - Parameter backends: The backends to sync to, in any combination of CloudKit
     ///   containers and Scout servers. An empty list turns Scout off: nothing is
-    ///   recorded or synced.
+    ///   recorded or synced. A store that fails to load turns Scout off the same
+    ///   way — the error is printed, and the host app keeps running without it.
     ///
     public init(backends: [Backend]) {
+        let backends = persistentContainer.isStoreLoaded ? backends : []
+
         let registry = MirroredRegistry(store: KeychainStorage.standard, mirror: UserDefaults.standard)
 
         let identity = Identity(

--- a/Tests/ScoutTests/Persistence/PersistenceLoadTests.swift
+++ b/Tests/ScoutTests/Persistence/PersistenceLoadTests.swift
@@ -24,6 +24,15 @@ struct PersistenceLoadTests {
         container.persistentStoreDescriptions = [description]
 
         try container.loadStore()
+
+        #expect(container.isStoreLoaded)
+    }
+
+    @Test("A container whose store never loaded reports it")
+    func unloadedStoreIsReported() {
+        let container = NSPersistentContainer(name: "TestModel", managedObjectModel: model)
+
+        #expect(!container.isStoreLoaded)
     }
 
     @Test("loadStores throws when loadPersistentStores reports an error")
@@ -43,5 +52,7 @@ struct PersistenceLoadTests {
             #expect(error.domain == expectedError.domain)
             #expect(error.code == expectedError.code)
         }
+
+        #expect(!container.isStoreLoaded)
     }
 }


### PR DESCRIPTION
A store that failed to load — disk full, corruption, a migration the model cannot infer — used to hit a fatalError inside the lazy persistentContainer global, putting the host app into a permanent crash loop at launch. That contradicts Scout's own stance that a logging framework which aborts app launch is worse than one that misses a session. The failure is now printed and the runtime treats an unloaded store the same as an empty backend list: Scout stays off for that launch and the app keeps running. Found while auditing Sources/Scout for critical bugs; a companion fix for the signal handler is coming separately.