### PR TITLE
Write raw crash reports in the signal handler, symbolicate on the next launch

### DIFF
--- a/Sources/CScoutHang/CScoutHang.c
+++ b/Sources/CScoutHang/CScoutHang.c
@@ -4,8 +4,13 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+//
 
 #include "CScoutHang.h"
+
+#include <stdatomic.h>
+#include <string.h>
+#include <sys/ucontext.h>
 
 #if defined(__arm64__) || defined(__aarch64__)
 
@@ -18,3 +23,92 @@ uint64_t scout_arm_thread_state64_fp(arm_thread_state64_t state) {
 }
 
 #endif
+
+#define SCOUT_CRASH_MAX_SIGNALS 8
+
+static struct {
+    int sig;
+    struct sigaction action;
+} scout_previous_actions[SCOUT_CRASH_MAX_SIGNALS];
+
+static int scout_previous_count = 0;
+static atomic_flag scout_crash_claimed = ATOMIC_FLAG_INIT;
+
+bool scout_crash_install(const int *signals, int count, scout_crash_handler handler) {
+    if (count > SCOUT_CRASH_MAX_SIGNALS) {
+        return false;
+    }
+
+    for (int i = 0; i < count; i++) {
+        struct sigaction action;
+        memset(&action, 0, sizeof(action));
+        action.sa_sigaction = handler;
+        action.sa_flags = SA_SIGINFO;
+        sigemptyset(&action.sa_mask);
+
+        scout_previous_actions[scout_previous_count].sig = signals[i];
+        if (sigaction(signals[i], &action, &scout_previous_actions[scout_previous_count].action) == 0) {
+            scout_previous_count++;
+        }
+    }
+
+    return true;
+}
+
+void scout_crash_restore(int sig) {
+    for (int i = 0; i < scout_previous_count; i++) {
+        if (scout_previous_actions[i].sig == sig) {
+            sigaction(sig, &scout_previous_actions[i].action, NULL);
+            return;
+        }
+    }
+    signal(sig, SIG_DFL);
+}
+
+bool scout_crash_claim(void) {
+    return !atomic_flag_test_and_set(&scout_crash_claimed);
+}
+
+uint64_t scout_image_text_size(const struct mach_header *header) {
+    if (header->magic != MH_MAGIC_64) {
+        return 0;
+    }
+
+    const struct mach_header_64 *header64 = (const struct mach_header_64 *)header;
+    const struct load_command *command = (const struct load_command *)(header64 + 1);
+
+    for (uint32_t i = 0; i < header64->ncmds; i++) {
+        if (command->cmd == LC_SEGMENT_64) {
+            const struct segment_command_64 *segment = (const struct segment_command_64 *)command;
+            if (strcmp(segment->segname, SEG_TEXT) == 0) {
+                return segment->vmsize;
+            }
+        }
+        command = (const struct load_command *)((const uint8_t *)command + command->cmdsize);
+    }
+
+    return 0;
+}
+
+void scout_crash_registers(void *context, uint64_t *pc, uint64_t *fp) {
+    *pc = 0;
+    *fp = 0;
+
+    if (context == NULL) {
+        return;
+    }
+
+    ucontext_t *ucontext = (ucontext_t *)context;
+    mcontext_t mcontext = ucontext->uc_mcontext;
+    if (mcontext == NULL) {
+        return;
+    }
+
+#if defined(__arm64__) || defined(__aarch64__)
+    *pc = (uint64_t)arm_thread_state64_get_pc(mcontext->__ss);
+    *fp = (uint64_t)arm_thread_state64_get_fp(mcontext->__ss);
+#elif defined(__x86_64__)
+    *pc = (uint64_t)mcontext->__ss.__rip;
+    *fp = (uint64_t)mcontext->__ss.__rbp;
+#endif
+}

--- a/Sources/CScoutHang/include/CScoutHang.h
+++ b/Sources/CScoutHang/include/CScoutHang.h
@@ -4,11 +4,15 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+//
 
 #ifndef SCOUT_C_SCOUT_HANG_H
 #define SCOUT_C_SCOUT_HANG_H
 
+#include <mach-o/loader.h>
 #include <mach/mach.h>
+#include <signal.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 // arm_thread_state64_get_pc/get_fp are ptrauth-stripping macros, which the
@@ -18,5 +22,19 @@
 uint64_t scout_arm_thread_state64_pc(arm_thread_state64_t state);
 uint64_t scout_arm_thread_state64_fp(arm_thread_state64_t state);
 #endif
+
+// Fatal-signal bookkeeping lives in C so the handler touches no Swift
+// runtime structures: previous sigactions sit in a fixed static array
+// written once at install, and every function here is async-signal-safe.
+typedef void (*scout_crash_handler)(int, siginfo_t *_Nullable, void *_Nullable);
+
+bool scout_crash_install(const int *_Nonnull signals, int count, scout_crash_handler _Nonnull handler);
+void scout_crash_restore(int sig);
+bool scout_crash_claim(void);
+void scout_crash_registers(void *_Nullable context, uint64_t *_Nonnull pc, uint64_t *_Nonnull fp);
+
+// getsegbynamefromheader_64 has no Swift import — this wraps the __TEXT
+// segment size lookup the image table needs.
+uint64_t scout_image_text_size(const struct mach_header *_Nonnull header);
 
 #endif

--- a/Sources/Scout/Diagnostics/Backtrace/StackWalker.swift
+++ b/Sources/Scout/Diagnostics/Backtrace/StackWalker.swift
@@ -1,0 +1,81 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import MachO
+
+// Walks a frame-pointer chain into a caller-supplied buffer and renders
+// addresses into report lines. Both halves are shared by the hang watchdog
+// and the fatal-signal handler, so `walk` must stay async-signal-safe: no
+// allocation, no locks — every memory read goes through
+// `vm_read_overwrite`, which fails gracefully on an invalid address
+// instead of trapping.
+enum StackWalker {
+    static let maximumFrameCount = 64
+
+    static func walk(pc: UInt64, fp: UInt64, into buffer: UnsafeMutableBufferPointer<UInt64>) -> Int {
+        guard buffer.count > 0, pc != 0 else {
+            return 0
+        }
+
+        buffer[0] = pc
+        var count = 1
+        var fp = fp
+
+        while count < buffer.count {
+            guard fp != 0, let frame = readFrame(at: fp), frame.returnAddress != 0 else {
+                break
+            }
+            buffer[count] = frame.returnAddress
+            count += 1
+            fp = frame.previousFP
+        }
+
+        return count
+    }
+
+    private struct Frame {
+        let previousFP: UInt64
+        let returnAddress: UInt64
+    }
+
+    private static func readFrame(at fp: UInt64) -> Frame? {
+        var pair: (previousFP: UInt64, returnAddress: UInt64) = (0, 0)
+        var readCount: vm_size_t = 0
+
+        let result = withUnsafeMutableBytes(of: &pair) { rawBuffer in
+            vm_read_overwrite(
+                mach_task_self_,
+                vm_address_t(fp),
+                vm_size_t(MemoryLayout<UInt64>.size * 2),
+                vm_address_t(UInt(bitPattern: rawBuffer.baseAddress)),
+                &readCount
+            )
+        }
+
+        guard result == KERN_SUCCESS, readCount == vm_size_t(MemoryLayout<UInt64>.size * 2) else {
+            return nil
+        }
+
+        return Frame(previousFP: pair.previousFP, returnAddress: pair.returnAddress)
+    }
+
+    static func symbolicate(index: Int, address: UInt64) -> String {
+        var info = Dl_info()
+
+        guard let pointer = UnsafeRawPointer(bitPattern: UInt(address)), dladdr(pointer, &info) != 0 else {
+            return "\(index)   ???                  0x\(String(address, radix: 16))"
+        }
+
+        let image = info.dli_fname.map { String(cString: $0).components(separatedBy: "/").last ?? "???" } ?? "???"
+        let symbol = info.dli_sname.map { String(cString: $0) } ?? "0x\(String(address, radix: 16))"
+        let offset = info.dli_saddr.map { address - UInt64(UInt(bitPattern: $0)) } ?? 0
+
+        return "\(index)   \(image)   0x\(String(address, radix: 16)) \(symbol) + \(offset)"
+    }
+}

--- a/Sources/Scout/Diagnostics/Crash/CrashArchive.swift
+++ b/Sources/Scout/Diagnostics/Crash/CrashArchive.swift
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+//
 
 import Foundation
 
@@ -12,22 +13,46 @@ import Foundation
 struct CrashArchive {
     private let archive: IncidentArchive<CrashInfo>
 
+    let directory: URL
+
     init(directory: URL) {
+        self.directory = directory
         archive = IncidentArchive(directory: directory, pathExtension: "crash", persist: logCrash)
     }
 
-    static let system = CrashArchive(
-        directory: FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first!
-            .appendingPathComponent("Scout/Crashes", isDirectory: true)
-    )
+    static let systemDirectory = FileManager.default
+        .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        .first!
+        .appendingPathComponent("Scout/Crashes", isDirectory: true)
+
+    static let system = CrashArchive(directory: systemDirectory)
 
     func write(_ crash: CrashInfo) {
         archive.write(crash)
     }
 
     func flush(deviceID: UUID) async {
+        convertRawReports()
         await archive.flush(deviceID: deviceID)
+    }
+
+    // The signal handler leaves raw reports behind — symbolicating them is
+    // not signal-safe, so it happens here, on the launch that finds them.
+    // The converted file keeps the raw file's UUID stem: if the process dies
+    // between write and remove, the next launch overwrites the same crash
+    // instead of duplicating it.
+    func convertRawReports() {
+        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        else {
+            return
+        }
+
+        for file in files where file.pathExtension == RawCrashFormat.pathExtension {
+            if let data = try? Data(contentsOf: file), let report = RawCrashReport(data: data) {
+                let id = UUID(uuidString: file.deletingPathExtension().lastPathComponent) ?? UUID()
+                archive.write(report.crashInfo(), id: id)
+            }
+            try? FileManager.default.removeItem(at: file)
+        }
     }
 }

--- a/Sources/Scout/Diagnostics/Crash/CrashInfo.swift
+++ b/Sources/Scout/Diagnostics/Crash/CrashInfo.swift
@@ -18,13 +18,29 @@ struct CrashInfo: Codable {
     let appVersion: String?
 
     init(name: String, reason: String?, stackTrace: [String], identity: Identity) {
+        self.init(
+            name: name,
+            reason: reason,
+            stackTrace: stackTrace,
+            date: Date(),
+            installID: identity.install,
+            launchID: identity.launch,
+            sessionID: identity.session.raw,
+            appVersion: Bundle.main.marketingVersion
+        )
+    }
+
+    init(
+        name: String, reason: String?, stackTrace: [String], date: Date, installID: UUID, launchID: UUID,
+        sessionID: UUID, appVersion: String?
+    ) {
         self.name = name
         self.reason = reason
         self.stackTrace = stackTrace
-        self.date = Date()
-        self.installID = identity.install
-        self.launchID = identity.launch
-        self.sessionID = identity.session.raw
-        self.appVersion = Bundle.main.marketingVersion
+        self.date = date
+        self.installID = installID
+        self.launchID = launchID
+        self.sessionID = sessionID
+        self.appVersion = appVersion
     }
 }

--- a/Sources/Scout/Diagnostics/Crash/ExceptionHandler.swift
+++ b/Sources/Scout/Diagnostics/Crash/ExceptionHandler.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import CScoutHang
 import Foundation
 
 private nonisolated(unsafe) var previousExceptionHandler: NSUncaughtExceptionHandler?
@@ -29,7 +30,7 @@ func installExceptionHandler(identity: Identity) {
             CrashArchive.system.write(crash)
         }
 
-        restorePreviousSignalHandler(SIGABRT)
+        scout_crash_restore(SIGABRT)
         previousExceptionHandler?(exception)
     }
 }

--- a/Sources/Scout/Diagnostics/Crash/RawCrashReport.swift
+++ b/Sources/Scout/Diagnostics/Crash/RawCrashReport.swift
@@ -1,0 +1,252 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import CScoutHang
+import Foundation
+import MachO
+
+// A fatal-signal report as the handler leaves it on disk: raw return
+// addresses plus the image table snapshotted at install, everything else
+// pre-rendered before the signal ever fires. The next launch turns it into
+// a regular CrashInfo by rebasing each address against the same image
+// loaded in the current process and symbolicating there — dladdr can never
+// run inside a signal handler.
+struct RawCrashReport {
+    struct Image {
+        let name: String
+        let base: UInt64
+        let size: UInt64
+    }
+
+    let signal: Int32
+    let date: Date
+    let sessionID: UUID
+    let addresses: [UInt64]
+    let installID: UUID
+    let launchID: UUID
+    let deviceID: UUID
+    let appVersion: String?
+    let images: [Image]
+
+    init?(data: Data) {
+        var reader = ByteReader(data: data)
+
+        guard reader.read(UInt32.self) == RawCrashFormat.magic else {
+            return nil
+        }
+        guard reader.read(UInt32.self) == RawCrashFormat.version else {
+            return nil
+        }
+        guard let signal = reader.read(Int32.self), let time = reader.read(Int64.self) else {
+            return nil
+        }
+        guard let sessionID = reader.readUUID() else {
+            return nil
+        }
+        guard let addresses = reader.readAddresses(limit: StackWalker.maximumFrameCount) else {
+            return nil
+        }
+        guard let installID = reader.readUUID(), let launchID = reader.readUUID(), let deviceID = reader.readUUID()
+        else {
+            return nil
+        }
+        guard let appVersion = reader.readString() else {
+            return nil
+        }
+        guard let images = reader.readImages() else {
+            return nil
+        }
+
+        self.signal = signal
+        self.date = Date(timeIntervalSince1970: TimeInterval(time))
+        self.sessionID = sessionID
+        self.addresses = addresses
+        self.installID = installID
+        self.launchID = launchID
+        self.deviceID = deviceID
+        self.appVersion = appVersion.count > 0 ? appVersion : nil
+        self.images = images
+    }
+
+    func crashInfo() -> CrashInfo {
+        CrashInfo(
+            name: signalName(signal),
+            reason: "Signal \(signal) received",
+            stackTrace: symbolicatedStackTrace(),
+            date: date,
+            installID: installID,
+            launchID: launchID,
+            sessionID: sessionID,
+            appVersion: appVersion
+        )
+    }
+
+    private func symbolicatedStackTrace() -> [String] {
+        let loaded = Image.loadedBases()
+
+        return addresses.enumerated().map { index, address in
+            guard let image = images.first(where: { address >= $0.base && address < $0.base + $0.size })
+            else {
+                return "\(index)   ???                  0x\(String(address, radix: 16))"
+            }
+
+            let offset = address - image.base
+            if let base = loaded[image.name] {
+                return StackWalker.symbolicate(index: index, address: base + offset)
+            }
+            return "\(index)   \(image.name)   + 0x\(String(offset, radix: 16))"
+        }
+    }
+}
+
+extension RawCrashReport.Image {
+    // The __TEXT segment is where every return address lives, so its size is
+    // all the report needs to attribute an address to an image.
+    static func loaded() -> [RawCrashReport.Image] {
+        (0..<_dyld_image_count()).compactMap { index -> RawCrashReport.Image? in
+            guard let name = _dyld_get_image_name(index), let header = _dyld_get_image_header(index) else {
+                return nil
+            }
+
+            let path = String(cString: name)
+            return RawCrashReport.Image(
+                name: path.components(separatedBy: "/").last ?? path,
+                base: UInt64(UInt(bitPattern: header)),
+                size: scout_image_text_size(header)
+            )
+        }
+    }
+
+    fileprivate static func loadedBases() -> [String: UInt64] {
+        var bases: [String: UInt64] = [:]
+        for image in loaded() where bases[image.name] == nil {
+            bases[image.name] = image.base
+        }
+        return bases
+    }
+}
+
+enum RawCrashFormat {
+    static let magic: UInt32 = 0x5752_4353
+    static let version: UInt32 = 1
+    static let pathExtension = "rawcrash"
+
+    static func trailer(identity: Identity, appVersion: String?, images: [RawCrashReport.Image]) -> [UInt8] {
+        var bytes: [UInt8] = []
+
+        append(identity.install.uuid, to: &bytes)
+        append(identity.launch.uuid, to: &bytes)
+        append(identity.device.uuid, to: &bytes)
+
+        let version = Array((appVersion ?? "").utf8)
+        append(UInt32(version.count), to: &bytes)
+        bytes += version
+
+        append(UInt32(images.count), to: &bytes)
+        for image in images {
+            append(image.base, to: &bytes)
+            append(image.size, to: &bytes)
+
+            let name = Array(image.name.utf8)
+            append(UInt32(name.count), to: &bytes)
+            bytes += name
+        }
+
+        return bytes
+    }
+
+    // Runs inside the signal handler: nothing here may allocate or lock,
+    // only plain memory reads and write(2).
+    static func write(
+        fd: Int32, signal: Int32, time: Int64, session: uuid_t, frames: UnsafeBufferPointer<UInt64>,
+        trailer: UnsafeRawBufferPointer
+    ) {
+        writeValue(magic, to: fd)
+        writeValue(version, to: fd)
+        writeValue(signal, to: fd)
+        writeValue(time, to: fd)
+        writeValue(session, to: fd)
+        writeValue(UInt32(frames.count), to: fd)
+        _ = Darwin.write(fd, frames.baseAddress, frames.count * MemoryLayout<UInt64>.size)
+        _ = Darwin.write(fd, trailer.baseAddress, trailer.count)
+    }
+
+    private static func append<T>(_ value: T, to bytes: inout [UInt8]) {
+        withUnsafeBytes(of: value) { bytes += $0 }
+    }
+
+    private static func writeValue<T>(_ value: T, to fd: Int32) {
+        withUnsafeBytes(of: value) { _ = Darwin.write(fd, $0.baseAddress, $0.count) }
+    }
+}
+
+private struct ByteReader {
+    let data: Data
+    var offset = 0
+
+    mutating func read<T>(_ type: T.Type) -> T? {
+        let size = MemoryLayout<T>.size
+
+        guard offset + size <= data.count else {
+            return nil
+        }
+        defer { offset += size }
+
+        return data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: type) }
+    }
+
+    mutating func readUUID() -> UUID? {
+        read(uuid_t.self).map { UUID(uuid: $0) }
+    }
+
+    mutating func readString() -> String? {
+        guard let count = read(UInt32.self), let bytes = readBytes(Int(count)) else {
+            return nil
+        }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
+    mutating func readAddresses(limit: Int) -> [UInt64]? {
+        guard let count = read(UInt32.self), count <= UInt32(limit) else {
+            return nil
+        }
+
+        var addresses: [UInt64] = []
+        for _ in 0..<count {
+            guard let address = read(UInt64.self) else {
+                return nil
+            }
+            addresses.append(address)
+        }
+        return addresses
+    }
+
+    mutating func readImages() -> [RawCrashReport.Image]? {
+        guard let count = read(UInt32.self), count <= 4096 else {
+            return nil
+        }
+
+        var images: [RawCrashReport.Image] = []
+        for _ in 0..<count {
+            guard let base = read(UInt64.self), let size = read(UInt64.self), let name = readString() else {
+                return nil
+            }
+            images.append(RawCrashReport.Image(name: name, base: base, size: size))
+        }
+        return images
+    }
+
+    private mutating func readBytes(_ count: Int) -> [UInt8]? {
+        guard count >= 0, offset + count <= data.count else {
+            return nil
+        }
+        defer { offset += count }
+
+        return [UInt8](data[data.startIndex + offset..<data.startIndex + offset + count])
+    }
+}

--- a/Sources/Scout/Diagnostics/Crash/SignalHandler.swift
+++ b/Sources/Scout/Diagnostics/Crash/SignalHandler.swift
@@ -4,12 +4,25 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+//
 
+import CScoutHang
 import Foundation
 
-private nonisolated(unsafe) var previousSignalHandlers: [Int32: sig_t] = [:]
+// A fatal signal can arrive while the crashing thread holds the malloc,
+// dyld, or Objective-C runtime lock — anything the handler touches beyond
+// async-signal-safe calls can deadlock the process instead of letting it
+// die. So everything the handler needs is prepared here, in a safe context:
+// the report path, the identity and image-table trailer, and the frame
+// buffer all live in plain malloc'd memory the handler only reads. The
+// handler itself walks the frame-pointer chain and calls open/write/close —
+// nothing else.
 private nonisolated(unsafe) var isInstalled = false
-private nonisolated(unsafe) var identity: Identity?
+private nonisolated(unsafe) var reportPath: UnsafeMutablePointer<CChar>?
+private nonisolated(unsafe) var reportTrailer: UnsafeMutableRawPointer?
+private nonisolated(unsafe) var reportTrailerCount = 0
+private nonisolated(unsafe) var reportFrames: UnsafeMutablePointer<UInt64>?
+private nonisolated(unsafe) var reportSession: Protected<UUID>?
 
 private let fatalSignals: [(signal: Int32, name: String)] = [
     (SIGABRT, "SIGABRT"),
@@ -24,30 +37,73 @@ func installSignalHandler(identity: Identity) {
     guard !isInstalled else { return }
     isInstalled = true
 
-    Scout.identity = identity
+    prepareRawReport(identity: identity)
 
-    for (sig, _) in fatalSignals {
-        previousSignalHandlers[sig] = signal(sig) { sig in
-            if let identity = Scout.identity {
-                let crash = CrashInfo(
-                    name: signalName(sig),
-                    reason: "Signal \(sig) received",
-                    stackTrace: Thread.callStackSymbols,
-                    identity: identity
-                )
-                CrashArchive.system.write(crash)
-            }
-
-            restorePreviousSignalHandler(sig)
-            raise(sig)
-        }
+    let signals = fatalSignals.map(\.signal)
+    signals.withUnsafeBufferPointer { buffer in
+        _ = scout_crash_install(buffer.baseAddress!, Int32(buffer.count), handleFatalSignal)
     }
 }
 
-func restorePreviousSignalHandler(_ sig: Int32) {
-    signal(sig, previousSignalHandlers[sig] ?? SIG_DFL)
+private func prepareRawReport(identity: Identity) {
+    let directory = CrashArchive.systemDirectory
+    try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let fileName = "\(UUID().uuidString).\(RawCrashFormat.pathExtension)"
+    reportPath = strdup(directory.appendingPathComponent(fileName).path)
+
+    let trailer = RawCrashFormat.trailer(
+        identity: identity,
+        appVersion: Bundle.main.marketingVersion,
+        images: RawCrashReport.Image.loaded()
+    )
+    let pointer = UnsafeMutableRawPointer.allocate(byteCount: trailer.count, alignment: 1)
+    trailer.withUnsafeBytes { pointer.copyMemory(from: $0.baseAddress!, byteCount: $0.count) }
+    reportTrailer = pointer
+    reportTrailerCount = trailer.count
+
+    reportFrames = .allocate(capacity: StackWalker.maximumFrameCount)
+    reportSession = identity.session
 }
 
-private func signalName(_ sig: Int32) -> String {
+private func handleFatalSignal(
+    _ sig: Int32, _ info: UnsafeMutablePointer<siginfo_t>?, _ context: UnsafeMutableRawPointer?
+) {
+    writeRawReport(signal: sig, context: context)
+
+    scout_crash_restore(sig)
+    raise(sig)
+}
+
+private func writeRawReport(signal: Int32, context: UnsafeMutableRawPointer?) {
+    guard scout_crash_claim(), let path = reportPath, let trailer = reportTrailer, let frames = reportFrames else {
+        return
+    }
+
+    var pc: UInt64 = 0
+    var fp: UInt64 = 0
+    scout_crash_registers(context, &pc, &fp)
+
+    let buffer = UnsafeMutableBufferPointer(start: frames, count: StackWalker.maximumFrameCount)
+    let count = StackWalker.walk(pc: pc, fp: fp, into: buffer)
+
+    let fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0o644)
+    guard fd >= 0 else {
+        return
+    }
+
+    let session = reportSession?.raw.uuid ?? (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    RawCrashFormat.write(
+        fd: fd,
+        signal: signal,
+        time: Int64(time(nil)),
+        session: session,
+        frames: UnsafeBufferPointer(start: frames, count: count),
+        trailer: UnsafeRawBufferPointer(start: trailer, count: reportTrailerCount)
+    )
+    close(fd)
+}
+
+func signalName(_ sig: Int32) -> String {
     fatalSignals.first { $0.signal == sig }?.name ?? "SIGNAL_\(sig)"
 }

--- a/Sources/Scout/Diagnostics/Hang/MainThreadBacktrace.swift
+++ b/Sources/Scout/Diagnostics/Hang/MainThreadBacktrace.swift
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+//
 
 import CScoutHang
 import Foundation
@@ -17,8 +18,6 @@ import MachO
 /// invalid address instead of trapping.
 ///
 enum MainThreadBacktrace {
-    static let maximumFrameCount = 64
-
     static func capture() -> [String] {
         guard let mainThread = mainMachThread() else {
             return []
@@ -28,13 +27,13 @@ enum MainThreadBacktrace {
         // suspended — no malloc, no dyld lock. If the thread is suspended
         // mid-hang while holding one of those locks, symbolicating here would
         // deadlock this thread forever. So resume first, then symbolicate.
-        var buffer = [UInt64](repeating: 0, count: maximumFrameCount)
+        var buffer = [UInt64](repeating: 0, count: StackWalker.maximumFrameCount)
         let count = buffer.withUnsafeMutableBufferPointer { captureAddresses(of: mainThread, into: $0) }
         guard count > 0 else {
             return []
         }
 
-        return buffer.prefix(count).enumerated().map(symbolicate)
+        return buffer.prefix(count).enumerated().map(StackWalker.symbolicate)
     }
 
     private static func captureAddresses(of thread: thread_t, into buffer: UnsafeMutableBufferPointer<UInt64>) -> Int {
@@ -43,24 +42,11 @@ enum MainThreadBacktrace {
         }
         defer { thread_resume(thread) }
 
-        guard let (pc, initialFP) = registerState(of: thread) else {
+        guard let (pc, fp) = registerState(of: thread) else {
             return 0
         }
 
-        buffer[0] = pc
-        var count = 1
-        var fp = initialFP
-
-        while count < buffer.count {
-            guard fp != 0, let frame = readFrame(at: fp), frame.returnAddress != 0 else {
-                break
-            }
-            buffer[count] = frame.returnAddress
-            count += 1
-            fp = frame.previousFP
-        }
-
-        return count
+        return StackWalker.walk(pc: pc, fp: fp, into: buffer)
     }
 
     // task_threads returns threads in creation order and the main thread is
@@ -81,46 +67,6 @@ enum MainThreadBacktrace {
         }
 
         return threadCount > 0 ? threadList[0] : nil
-    }
-
-    private struct Frame {
-        let previousFP: UInt64
-        let returnAddress: UInt64
-    }
-
-    private static func readFrame(at fp: UInt64) -> Frame? {
-        var pair: (previousFP: UInt64, returnAddress: UInt64) = (0, 0)
-        var readCount: vm_size_t = 0
-
-        let result = withUnsafeMutableBytes(of: &pair) { rawBuffer in
-            vm_read_overwrite(
-                mach_task_self_,
-                vm_address_t(fp),
-                vm_size_t(MemoryLayout<UInt64>.size * 2),
-                vm_address_t(UInt(bitPattern: rawBuffer.baseAddress)),
-                &readCount
-            )
-        }
-
-        guard result == KERN_SUCCESS, readCount == vm_size_t(MemoryLayout<UInt64>.size * 2) else {
-            return nil
-        }
-
-        return Frame(previousFP: pair.previousFP, returnAddress: pair.returnAddress)
-    }
-
-    private static func symbolicate(index: Int, address: UInt64) -> String {
-        var info = Dl_info()
-
-        guard let pointer = UnsafeRawPointer(bitPattern: UInt(address)), dladdr(pointer, &info) != 0 else {
-            return "\(index)   ???                  0x\(String(address, radix: 16))"
-        }
-
-        let image = info.dli_fname.map { String(cString: $0).components(separatedBy: "/").last ?? "???" } ?? "???"
-        let symbol = info.dli_sname.map { String(cString: $0) } ?? "0x\(String(address, radix: 16))"
-        let offset = info.dli_saddr.map { address - UInt64(UInt(bitPattern: $0)) } ?? 0
-
-        return "\(index)   \(image)   0x\(String(address, radix: 16)) \(symbol) + \(offset)"
     }
 }
 

--- a/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
+++ b/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
@@ -12,7 +12,7 @@ struct IncidentArchive<Payload: Codable & Sendable> {
     let pathExtension: String
     let persist: @Sendable (Payload, UUID, UUID, NSManagedObjectContext) throws -> Void
 
-    func write(_ payload: Payload) {
+    func write(_ payload: Payload, id: UUID = UUID()) {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
 
@@ -22,7 +22,7 @@ struct IncidentArchive<Payload: Codable & Sendable> {
 
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
-        let fileName = "\(UUID().uuidString).\(pathExtension)"
+        let fileName = "\(id.uuidString).\(pathExtension)"
         let fileURL = directory.appendingPathComponent(fileName)
 
         try? data.write(to: fileURL, options: .atomic)

--- a/Tests/ScoutTests/Diagnostics/Backtrace/StackWalkerTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Backtrace/StackWalkerTests.swift
@@ -1,0 +1,81 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+
+@Suite("StackWalker")
+struct StackWalkerTests {
+    @Test("walks a crafted frame-pointer chain")
+    func walksCraftedChain() {
+        var storage = [UInt64](repeating: 0, count: 4)
+
+        let (count, frames) = storage.withUnsafeMutableBufferPointer { chain in
+            let base = UInt64(UInt(bitPattern: chain.baseAddress))
+
+            chain[0] = base + 16
+            chain[1] = 0x1001
+            chain[2] = 0
+            chain[3] = 0x1002
+
+            var buffer = [UInt64](repeating: 0, count: 8)
+            let count = buffer.withUnsafeMutableBufferPointer {
+                StackWalker.walk(pc: 0xABC0, fp: base, into: $0)
+            }
+            return (count, buffer)
+        }
+
+        #expect(count == 3)
+        #expect(frames[0] == 0xABC0)
+        #expect(frames[1] == 0x1001)
+        #expect(frames[2] == 0x1002)
+    }
+
+    @Test("a zero program counter produces no frames")
+    func zeroProgramCounter() {
+        var buffer = [UInt64](repeating: 0, count: 8)
+        let count = buffer.withUnsafeMutableBufferPointer {
+            StackWalker.walk(pc: 0, fp: 0x1000, into: $0)
+        }
+
+        #expect(count == 0)
+    }
+
+    @Test("a zero frame pointer keeps the program counter alone")
+    func zeroFramePointer() {
+        var buffer = [UInt64](repeating: 0, count: 8)
+        let count = buffer.withUnsafeMutableBufferPointer {
+            StackWalker.walk(pc: 0xABC0, fp: 0, into: $0)
+        }
+
+        #expect(count == 1)
+        #expect(buffer[0] == 0xABC0)
+    }
+
+    @Test("the walk stops at the buffer's capacity")
+    func walkStopsAtCapacity() {
+        var storage = [UInt64](repeating: 0, count: 2)
+
+        let count = storage.withUnsafeMutableBufferPointer { chain in
+            let base = UInt64(UInt(bitPattern: chain.baseAddress))
+
+            // The frame links back to itself: an unbounded walk would never end.
+            chain[0] = base
+            chain[1] = 0x1001
+
+            var buffer = [UInt64](repeating: 0, count: 8)
+            return buffer.withUnsafeMutableBufferPointer {
+                StackWalker.walk(pc: 0xABC0, fp: base, into: $0)
+            }
+        }
+
+        #expect(count == 8)
+    }
+}

--- a/Tests/ScoutTests/Diagnostics/Crash/RawCrashReportTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Crash/RawCrashReportTests.swift
@@ -1,0 +1,172 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+
+import Foundation
+import Testing
+
+@testable import Scout
+@testable import Support
+
+@Suite("RawCrashReport")
+struct RawCrashReportTests {
+    let identity = Identity.stub
+
+    func writeRawReport(
+        to url: URL, signal: Int32 = SIGSEGV, addresses: [UInt64] = [0x1000, 0x2000],
+        images: [RawCrashReport.Image] = []
+    ) throws {
+        let trailer = RawCrashFormat.trailer(identity: identity, appVersion: "1.2.3", images: images)
+
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        let fd = open(url.path, O_WRONLY)
+        try #require(fd >= 0)
+
+        addresses.withUnsafeBufferPointer { frames in
+            trailer.withUnsafeBytes { trailerBytes in
+                RawCrashFormat.write(
+                    fd: fd,
+                    signal: signal,
+                    time: 1_700_000_000,
+                    session: identity.session.current.uuid,
+                    frames: frames,
+                    trailer: trailerBytes
+                )
+            }
+        }
+        close(fd)
+    }
+
+    @Test("the handler's file round-trips through the parser")
+    func roundTrip() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).rawcrash")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let images = [RawCrashReport.Image(name: "Fake.dylib", base: 0x1000, size: 0x4000)]
+        try writeRawReport(to: url, addresses: [0x1010, 0x2020, 0x3030], images: images)
+
+        let data = try Data(contentsOf: url)
+        let report = try #require(RawCrashReport(data: data))
+
+        #expect(report.signal == SIGSEGV)
+        #expect(report.date == Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(report.sessionID == identity.session.current)
+        #expect(report.addresses == [0x1010, 0x2020, 0x3030])
+        #expect(report.installID == identity.install)
+        #expect(report.launchID == identity.launch)
+        #expect(report.deviceID == identity.device)
+        #expect(report.appVersion == "1.2.3")
+        #expect(report.images.count == 1)
+        #expect(report.images.first?.name == "Fake.dylib")
+        #expect(report.images.first?.base == 0x1000)
+        #expect(report.images.first?.size == 0x4000)
+    }
+
+    @Test("truncated data is rejected instead of trapping")
+    func truncatedData() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).rawcrash")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try writeRawReport(to: url)
+        let data = try Data(contentsOf: url)
+
+        for length in 0..<data.count {
+            #expect(RawCrashReport(data: data.prefix(length)) == nil)
+        }
+    }
+
+    @Test("an address in an image that is no longer loaded keeps its offset")
+    func unloadedImageKeepsOffset() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).rawcrash")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let images = [RawCrashReport.Image(name: "Gone.dylib", base: 0x1000, size: 0x4000)]
+        try writeRawReport(to: url, addresses: [0x1010, 0xDEAD_0000], images: images)
+
+        let data = try Data(contentsOf: url)
+        let report = try #require(RawCrashReport(data: data))
+        let crash = report.crashInfo()
+
+        #expect(crash.name == "SIGSEGV")
+        #expect(crash.reason == "Signal \(SIGSEGV) received")
+        #expect(crash.stackTrace.count == 2)
+        #expect(crash.stackTrace[0].contains("Gone.dylib"))
+        #expect(crash.stackTrace[0].contains("0x10"))
+        #expect(crash.stackTrace[1].contains("???"))
+    }
+
+    @Test("an address rebased into a loaded image gets symbolicated")
+    func loadedImageIsSymbolicated() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).rawcrash")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // Pretend the crashed process had every image slid up by 0x10000:
+        // rebasing must land back on the real image for dladdr to work.
+        let current = try #require(RawCrashReport.Image.loaded().first)
+        let slid = RawCrashReport.Image(name: current.name, base: current.base + 0x10000, size: current.size)
+        try writeRawReport(to: url, addresses: [slid.base + 0x100], images: [slid])
+
+        let data = try Data(contentsOf: url)
+        let report = try #require(RawCrashReport(data: data))
+        let crash = report.crashInfo()
+
+        #expect(crash.stackTrace.count == 1)
+        #expect(crash.stackTrace[0].contains(current.name))
+        #expect(!crash.stackTrace[0].contains("???"))
+    }
+
+    @Test("the archive converts a raw report into a decodable crash file")
+    func archiveConvertsRawReport() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let stem = UUID()
+        try writeRawReport(to: tempDir.appendingPathComponent("\(stem.uuidString).rawcrash"), signal: SIGABRT)
+
+        let archive = CrashArchive(directory: tempDir)
+        archive.convertRawReports()
+
+        let files = try FileManager.default.contentsOfDirectory(at: tempDir, includingPropertiesForKeys: nil)
+        #expect(files.count == 1)
+
+        let file = try #require(files.first)
+        #expect(file.pathExtension == "crash")
+        #expect(file.deletingPathExtension().lastPathComponent == stem.uuidString)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let crash = try decoder.decode(CrashInfo.self, from: Data(contentsOf: file))
+        #expect(crash.name == "SIGABRT")
+        #expect(crash.date == Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(crash.appVersion == "1.2.3")
+        #expect(crash.installID == identity.install)
+    }
+
+    @Test("a corrupt raw report is removed without producing a crash file")
+    func corruptRawReportIsRemoved() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let url = tempDir.appendingPathComponent("\(UUID().uuidString).rawcrash")
+        try Data([0xDE, 0xAD, 0xBE, 0xEF]).write(to: url)
+
+        let archive = CrashArchive(directory: tempDir)
+        archive.convertRawReports()
+
+        let files = try FileManager.default.contentsOfDirectory(at: tempDir, includingPropertiesForKeys: nil)
+        #expect(files.count == 0)
+    }
+}


### PR DESCRIPTION
The fatal-signal handler used to call Thread.callStackSymbols, Bundle.main, JSONEncoder, FileManager, and a lazily initialized global from inside the signal context — none of which is async-signal-safe. A SIGSEGV caused by heap corruption, or one landing while any thread holds the malloc, dyld, or Objective-C runtime lock, would deadlock the process instead of letting it die, and no crash report would be written.

Everything the handler needs is now prepared at install time in plain malloc'd memory: the report path, a trailer with the identity, app version, and a snapshot of the dyld image table, plus a preallocated frame buffer. The handler itself — installed via sigaction so it gets the faulting registers from ucontext — only walks the frame-pointer chain and calls open/write/close, then restores the previous disposition and re-raises. Signal bookkeeping moved into the C shim, replacing the Swift dictionary the old handler read from signal context. The next launch rebases the raw addresses against the same images loaded at their new slide, symbolicates with dladdr, and converts the report into the usual CrashInfo JSON, so the downstream pipeline is unchanged; the converted file keeps the raw file's UUID stem so a crash during conversion cannot duplicate the record. The frame walker shared with the hang watchdog now lives in StackWalker.

Found while auditing Sources/Scout for critical bugs; companion fix: #1198.