### PR TITLE
Requeue on a background context without crossing the main actor

### DIFF
--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -51,6 +51,26 @@ struct DeliverTests {
         try await RecordSender(backend: backend).deliver(type: type, in: context)
     }
 
+    /// End a session and requeue it on a private-queue sibling, the way the real
+    /// end-of-session write lands on a background context rather than on the one
+    /// the delivery engine holds.
+    ///
+    /// The work stays synchronous on purpose: before the iOS 26 SDK, `perform` is
+    /// a plain nonisolated `async` method, so awaiting it from this main-actor
+    /// suite sends the context and the closure across isolation and fails to
+    /// compile there.
+    ///
+    func endSessionInBackground(_ sessionID: NSManagedObjectID) throws {
+        let background = context.backgroundSibling()
+
+        try background.performAndWait {
+            let session = try #require(background.object(with: sessionID) as? SessionEntry)
+            session.endDate = Date()
+            session.requeue()
+            try background.save()
+        }
+    }
+
     @Test("Events go raw to every backend")
     func eventsFanOut() async throws {
         EventEntry.stub(name: "login", in: context)
@@ -333,18 +353,12 @@ struct DeliverTests {
         try context.save()
         try SyncableEntry.plan(backends: [cloudBackend], in: context)
 
-        let background = context.backgroundSibling()
         let sessionID = session.objectID
 
         // The session ends mid-send the way it really does — on a background
         // context, not the one the delivery engine holds.
-        cloud.beforeWrite = {
-            try? await background.perform {
-                let session = try #require(background.object(with: sessionID) as? SessionEntry)
-                session.endDate = Date()
-                session.requeue()
-                try background.save()
-            }
+        cloud.beforeWrite = { @MainActor in
+            try? self.endSessionInBackground(sessionID)
         }
 
         try await deliver(SessionEntry.self, to: cloudBackend)
@@ -372,17 +386,9 @@ struct DeliverTests {
         try await deliver(SessionEntry.self, to: cloudBackend)
         #expect(session.delivery(for: "cloud")?.isDelivered == true)
 
-        let background = context.backgroundSibling()
-        let sessionID = session.objectID
-
         // The session completes on a background context once the row is already
         // delivered, so only the requeue can bring it back.
-        try await background.perform {
-            let session = try #require(background.object(with: sessionID) as? SessionEntry)
-            session.endDate = Date()
-            session.requeue()
-            try background.save()
-        }
+        try endSessionInBackground(session.objectID)
 
         try await deliver(SessionEntry.self, to: cloudBackend)
 


### PR DESCRIPTION
The nightly matrix went red on every iOS 16/17/18 leg with `sending 'background' risks causing data races` in `DeliverTests`: the two background-requeue tests added in #1193 await `NSManagedObjectContext.perform` on a sibling context from a `@MainActor` suite, and before the iOS 26 SDK `perform` is a plain nonisolated `async` method, so both the context and the closure are sent across isolation and the `ScoutTests` target fails to build under Swift 6. The per-pull-request run only covers iOS 26 Debug right now, so the break landed on main unnoticed.

Both tests now share an `endSessionInBackground` helper that ends and requeues the session through the synchronous `performAndWait` — the idiom `MergePolicyTests` and `MigrationDedupeTests` already use for a foreign context — so nothing crosses the actor boundary on any SDK, and the mid-send closure is annotated `@MainActor` like its sibling test above it. The doc comment records why the call stays synchronous so it does not get modernized back into an `await perform`.

Behaviour is unchanged: the save still lands on a private-queue context during the send, and the view context still picks it up through the merge configuration #1193 added. Verified locally on Xcode 27 (`ScoutTests` green, 256 tests) — the old-SDK legs can only be confirmed by CI, so this needs a nightly run on the branch or a green full matrix after merge.