### PR TITLE
Point the installation snippet at the version that exists

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -23,7 +23,7 @@ https://github.com/kasianov-mikhail/scout.git
 Or add it to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/kasianov-mikhail/scout.git", from: "3.3.0")
+.package(url: "https://github.com/kasianov-mikhail/scout.git", from: "0.1.0")
 ```
 
 Then add the products your target needs. `Scout` carries the runtime and the handlers; the backend it syncs to comes from a connector, so a CloudKit setup takes `NativeConnector` too:


### PR DESCRIPTION
The `Package.swift` snippet in the installation guide asked for `from: "3.3.0"`, a version this package never published — the repository had no tags at all until 0.1.0 was tagged today, so anyone copying that line got a dependency that cannot resolve. It now names 0.1.0, the only released version. This is a docs-only change and does not warrant its own release; the snippet in the 0.1.0 tag still shows the old number until the next tag moves past it.