### PR TITLE
Carry a backend's server details in its engine case

### DIFF
--- a/Sources/Connectors/Hosted/HostedBackend.swift
+++ b/Sources/Connectors/Hosted/HostedBackend.swift
@@ -15,11 +15,12 @@ extension Backend {
             database: HTTPDatabase(url: url, apiKey: apiKey),
             checkAvailability: { true },
             displayName: url.host ?? url.absoluteString,
-            engine: .server,
-            serverInfo: ServerInfo(
-                endpoint: url.hostWithPort ?? url.absoluteString,
-                hasAPIKey: apiKey != nil,
-                isSecure: url.scheme?.lowercased() == "https"
+            engine: .server(
+                ServerInfo(
+                    endpoint: url.hostWithPort ?? url.absoluteString,
+                    hasAPIKey: apiKey != nil,
+                    isSecure: url.scheme?.lowercased() == "https"
+                )
             ),
             probeStatus: {
                 do {
@@ -31,13 +32,6 @@ extension Backend {
             },
             isTransientError: { error in
                 error is URLError || (error as? HTTPDatabaseError)?.isTransient == true
-            },
-            onSetup: {
-                if apiKey != nil, url.scheme?.lowercased() != "https" {
-                    print(
-                        "[Scout] The API key for '\(url)' will be sent over a non-HTTPS connection in cleartext. Use an https:// URL."
-                    )
-                }
             }
         )
     }

--- a/Sources/Connectors/Native/NativeBackend.swift
+++ b/Sources/Connectors/Native/NativeBackend.swift
@@ -44,6 +44,7 @@ extension Backend {
                 (try? await container.accountStatus()) == .available
             },
             displayName: "iCloud",
+            engine: .cloudKit,
             probeStatus: {
                 do {
                     return try await container.accountStatus().backendStatus

--- a/Sources/Scout/Runtime/Backend.ServerInfo.swift
+++ b/Sources/Scout/Runtime/Backend.ServerInfo.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+extension Backend {
+    package struct ServerInfo: Sendable {
+        package let endpoint: String
+        package let hasAPIKey: Bool
+        package let isSecure: Bool
+
+        package init(endpoint: String, hasAPIKey: Bool, isSecure: Bool) {
+            self.endpoint = endpoint
+            self.hasAPIKey = hasAPIKey
+            self.isSecure = isSecure
+        }
+
+        package var setupWarning: String? {
+            guard hasAPIKey, !isSecure else {
+                return nil
+            }
+            return """
+                [Scout] The API key for '\(endpoint)' will be sent over a non-HTTPS connection in cleartext. \
+                Use an https:// URL.
+                """
+        }
+    }
+}

--- a/Sources/Scout/Runtime/Backend.swift
+++ b/Sources/Scout/Runtime/Backend.swift
@@ -7,48 +7,43 @@
 
 import Foundation
 
-package typealias AccountWarning = @Sendable () async throws -> Backend.AccountStatus?
-
 public struct Backend: Sendable {
     package let id: String
     package let database: any Database
     package let checkAvailability: @Sendable () async -> Bool
     package let displayName: String
-
-    package var engine: Engine = .cloudKit
-    package var serverInfo: ServerInfo? = nil
-    package var probeStatus: @Sendable () async -> Status = { .unknown }
-    package var accountWarning: AccountWarning = { nil }
-    package var isTransientError: @Sendable (any Error) -> Bool = { _ in false }
-    package var onSetup: @MainActor @Sendable () -> Void = {}
+    package let engine: Engine
+    package let probeStatus: @Sendable () async -> Status
+    package let accountWarning: AccountWarning
+    package let isTransientError: @Sendable (any Error) -> Bool
 
     package init(
         id: String,
         database: any Database,
         checkAvailability: @escaping @Sendable () async -> Bool,
         displayName: String,
-        engine: Engine = .cloudKit,
-        serverInfo: ServerInfo? = nil,
+        engine: Engine,
         probeStatus: @escaping @Sendable () async -> Status = { .unknown },
         accountWarning: @escaping AccountWarning = { nil },
-        isTransientError: @escaping @Sendable (any Error) -> Bool = { _ in false },
-        onSetup: @escaping @MainActor @Sendable () -> Void = {}
+        isTransientError: @escaping @Sendable (any Error) -> Bool = { _ in false }
     ) {
         self.id = id
         self.database = database
         self.checkAvailability = checkAvailability
         self.displayName = displayName
         self.engine = engine
-        self.serverInfo = serverInfo
         self.probeStatus = probeStatus
         self.accountWarning = accountWarning
         self.isTransientError = isTransientError
-        self.onSetup = onSetup
     }
+}
 
+package typealias AccountWarning = @Sendable () async throws -> Backend.AccountStatus?
+
+extension Backend {
     package enum Engine: Sendable {
         case cloudKit
-        case server
+        case server(ServerInfo)
         case local
     }
 
@@ -65,18 +60,6 @@ public struct Backend: Sendable {
         case restricted
         case couldNotDetermine
         case temporarilyUnavailable
-    }
-
-    package struct ServerInfo: Sendable {
-        package let endpoint: String
-        package let hasAPIKey: Bool
-        package let isSecure: Bool
-
-        package init(endpoint: String, hasAPIKey: Bool, isSecure: Bool) {
-            self.endpoint = endpoint
-            self.hasAPIKey = hasAPIKey
-            self.isSecure = isSecure
-        }
     }
 }
 

--- a/Sources/Scout/Runtime/Runtime.swift
+++ b/Sources/Scout/Runtime/Runtime.swift
@@ -91,8 +91,10 @@ extension Runtime {
 
     @MainActor
     func start() async throws {
-        for backend in backends {
-            backend.onSetup()
+        for case let .server(info) in backends.map(\.engine) {
+            if let warning = info.setupWarning {
+                print(warning)
+            }
         }
 
         try await identity.bootstrap()

--- a/Sources/ScoutUI/Home/Settings/Backend+Fixture.swift
+++ b/Sources/ScoutUI/Home/Settings/Backend+Fixture.swift
@@ -16,6 +16,7 @@ extension Backend: Fixture {
                 database: DefaultDatabase(),
                 checkAvailability: { true },
                 displayName: "Production",
+                engine: .cloudKit,
                 probeStatus: { .reachable }
             ),
             Backend(
@@ -23,6 +24,7 @@ extension Backend: Fixture {
                 database: DefaultDatabase(),
                 checkAvailability: { true },
                 displayName: "Staging",
+                engine: .cloudKit,
                 probeStatus: { .unknown }
             ),
             Backend(
@@ -30,6 +32,7 @@ extension Backend: Fixture {
                 database: DefaultDatabase(),
                 checkAvailability: { false },
                 displayName: "Local",
+                engine: .cloudKit,
                 probeStatus: { .unreachable }
             ),
         ]

--- a/Sources/ScoutUI/Home/Settings/BackendHealth.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealth.swift
@@ -33,13 +33,18 @@ struct BackendHealth: Identifiable {
 
 extension BackendHealth {
     init(backend: Backend) {
+        var info: Backend.ServerInfo?
+        if case let .server(server) = backend.engine {
+            info = server
+        }
+
         self.init(
             id: backend.id,
             name: backend.displayName,
-            endpoint: backend.serverInfo?.endpoint ?? backend.id,
+            endpoint: info?.endpoint ?? backend.id,
             engine: .init(backend.engine),
-            hasAPIKey: backend.serverInfo?.hasAPIKey ?? false,
-            isSecure: backend.serverInfo?.isSecure ?? true,
+            hasAPIKey: info?.hasAPIKey ?? false,
+            isSecure: info?.isSecure ?? true,
             probe: backend.probeStatus
         )
     }

--- a/Tests/LookupIndexTests/CachedDatabaseTests.swift
+++ b/Tests/LookupIndexTests/CachedDatabaseTests.swift
@@ -186,11 +186,21 @@ struct CachedDatabaseTests {
 
         let first = DatabaseCacheRegistry.database(
             for: Backend(
-                id: "https://example.com", database: stale, checkAvailability: { true }, displayName: "example")
+                id: "https://example.com",
+                database: stale,
+                checkAvailability: { true },
+                displayName: "example",
+                engine: .cloudKit
+            )
         )
         let second = DatabaseCacheRegistry.database(
             for: Backend(
-                id: "https://example.com", database: rotated, checkAvailability: { true }, displayName: "example")
+                id: "https://example.com",
+                database: rotated,
+                checkAvailability: { true },
+                displayName: "example",
+                engine: .cloudKit
+            )
         )
 
         #expect(spyBase(of: first) === stale)

--- a/Tests/ScoutTests/Runtime/SetupWarningTests.swift
+++ b/Tests/ScoutTests/Runtime/SetupWarningTests.swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Testing
+
+@testable import Scout
+
+@Suite("Server info setup warning")
+struct SetupWarningTests {
+    @Test("An API key over plain HTTP is called out")
+    func plainHTTPWithKeyWarns() throws {
+        let info = Backend.ServerInfo(endpoint: "localhost:8080", hasAPIKey: true, isSecure: false)
+        let warning = try #require(info.setupWarning)
+
+        #expect(warning.contains("localhost:8080"))
+    }
+
+    @Test("HTTPS carries the key safely")
+    func secureTransportIsSilent() {
+        let info = Backend.ServerInfo(endpoint: "api.scout.app", hasAPIKey: true, isSecure: true)
+
+        #expect(info.setupWarning == nil)
+    }
+
+    @Test("A keyless connection has nothing to leak")
+    func missingKeyIsSilent() {
+        let info = Backend.ServerInfo(endpoint: "localhost:8080", hasAPIKey: false, isSecure: false)
+
+        #expect(info.setupWarning == nil)
+    }
+}

--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -26,7 +26,8 @@ struct DeliverTests {
             id: "cloud",
             database: cloud,
             checkAvailability: { true },
-            displayName: "cloud"
+            displayName: "cloud",
+            engine: .cloudKit
         )
     }
 
@@ -35,7 +36,8 @@ struct DeliverTests {
             id: "server",
             database: server,
             checkAvailability: { true },
-            displayName: "server"
+            displayName: "server",
+            engine: .cloudKit
         )
     }
 
@@ -173,7 +175,8 @@ struct DeliverTests {
             id: "server",
             database: server,
             checkAvailability: { false },
-            displayName: "server"
+            displayName: "server",
+            engine: .cloudKit
         )
 
         // Many sync passes fire while the backend is unreachable...
@@ -203,6 +206,7 @@ struct DeliverTests {
             database: server,
             checkAvailability: { true },
             displayName: "server",
+            engine: .cloudKit,
             isTransientError: { $0 is URLError }
         )
 

--- a/Tests/Support/Stubs/Backend+Stub.swift
+++ b/Tests/Support/Stubs/Backend+Stub.swift
@@ -15,6 +15,7 @@ func makeBackend(id: String) -> Backend {
         id: id,
         database: InMemoryDatabase(),
         checkAvailability: { true },
-        displayName: id
+        displayName: id,
+        engine: .cloudKit
     )
 }


### PR DESCRIPTION
A backend kept its server endpoint, API key flag, and transport flag in an optional `serverInfo` property sitting next to an `engine` enum that named the same thing, so nothing stopped a CloudKit backend from carrying server details or a server backend from carrying none. `Engine.server` now holds the `ServerInfo` it describes, and the pairing is enforced by the type.

The cleartext-API-key warning moves with the data. It used to be an `onSetup` closure that only the hosted backend filled in and only the runtime ever called; it is now a `setupWarning` property on `ServerInfo`, covered by tests for the first time. One user-visible change: the message names the endpoint (`localhost:8080`) rather than the full URL, since that is what `ServerInfo` carries.

While in there, every stored property became a `let` — the type is fully immutable now — with each default living in the initializer alone instead of being repeated on the property, and `engine` is spelled out at every construction site. All package-level, so the public API is unchanged.