### PR TITLE
Let a failure say whether it is worth retrying

### DIFF
--- a/Sources/Connectors/Demo/DemoDatabase.swift
+++ b/Sources/Connectors/Demo/DemoDatabase.swift
@@ -22,7 +22,6 @@ final class DemoDatabase: DatabaseReader, DatabaseWriter, Sendable {
     }
 
     func write(record: Record) async throws {}
-
     func write(records: [Record]) async throws {}
 
     func lookup(recordName: String, fields: [String]?) async throws -> Record {

--- a/Sources/Connectors/Hosted/HTTPDatabase.swift
+++ b/Sources/Connectors/Hosted/HTTPDatabase.swift
@@ -39,10 +39,6 @@ struct HTTPDatabaseError: LocalizedError {
     var errorDescription: String? {
         "Scout server returned \(status)\(reason.map { ": \($0)" } ?? "")"
     }
-
-    var isTransient: Bool {
-        status == 429 || status >= 500
-    }
 }
 
 extension HTTPDatabase {

--- a/Sources/Connectors/Hosted/HTTPTransientFailure.swift
+++ b/Sources/Connectors/Hosted/HTTPTransientFailure.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+extension HTTPDatabaseError: TransientFailure {
+    package var isTransient: Bool {
+        status == 429 || status >= 500
+    }
+}
+
+extension URLError: TransientFailure {
+    package var isTransient: Bool {
+        true
+    }
+}

--- a/Sources/Connectors/Hosted/HostedBackend.swift
+++ b/Sources/Connectors/Hosted/HostedBackend.swift
@@ -29,9 +29,6 @@ extension Backend {
                 } catch {
                     return .failed(error)
                 }
-            },
-            isTransientError: { error in
-                error is URLError || (error as? HTTPDatabaseError)?.isTransient == true
             }
         )
     }

--- a/Sources/Connectors/Hosted/HostedWriter.swift
+++ b/Sources/Connectors/Hosted/HostedWriter.swift
@@ -14,7 +14,7 @@ extension HTTPDatabase: DatabaseWriter {
     }
 
     func write(records: [Record]) async throws {
-        for chunk in records.chunked(into: Self.maxBatchSize) {
+        for chunk in records.chunked(into: 400) {
             let request = HTTPWriteRequest(records: chunk.map(HTTPRecord.init))
             try await send(request, to: "api/v1/records", into: HTTPWriteAck.self)
         }

--- a/Sources/Connectors/Native/NativeBackend.swift
+++ b/Sources/Connectors/Native/NativeBackend.swift
@@ -67,9 +67,6 @@ extension Backend {
                 @unknown default:
                     .couldNotDetermine
                 }
-            },
-            isTransientError: { error in
-                (error as? CKError)?.isTransient == true
             }
         )
     }
@@ -83,18 +80,6 @@ extension CKContainer {
         try await CatalogEntry.publishAll(into: store, registry: registry)
 
         return store
-    }
-}
-
-extension CKError {
-    var isTransient: Bool {
-        switch code {
-        case .networkUnavailable, .networkFailure, .serviceUnavailable, .requestRateLimited, .zoneBusy,
-            .accountTemporarilyUnavailable, .operationCancelled:
-            true
-        default:
-            retryAfterSeconds != nil
-        }
     }
 }
 

--- a/Sources/Connectors/Native/NativeDatabase.swift
+++ b/Sources/Connectors/Native/NativeDatabase.swift
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import CloudKit
 import Foundation
 import Scout
 import ScoutDB
@@ -133,5 +134,17 @@ extension NativeDatabase {
             in: range,
             asOf: Date()
         )
+    }
+}
+
+extension CKError: TransientFailure {
+    package var isTransient: Bool {
+        switch code {
+        case .networkUnavailable, .networkFailure, .serviceUnavailable, .requestRateLimited, .zoneBusy,
+            .accountTemporarilyUnavailable, .operationCancelled:
+            true
+        default:
+            retryAfterSeconds != nil
+        }
     }
 }

--- a/Sources/LookupIndex/CachedDatabase.swift
+++ b/Sources/LookupIndex/CachedDatabase.swift
@@ -14,9 +14,9 @@ struct CachedDatabase: Database {
     let scope: String
     let cache: any RecordCaching
 
-    // Series buckets are cut at week starts, and late uploads from offline devices can
-    // still mutate recently closed weeks, so only weeks that ended over a week ago are frozen.
-    var settledCutoff: @Sendable () -> Date = { Date().startOfWeek.addingWeek(-1) }
+    var settledCutoff: @Sendable () -> Date = {
+        Date().startOfWeek.addingWeek(-1)
+    }
 
     func read(matching query: RecordQuery, fields: [String]?) async throws -> RecordChunk {
         try await base.read(matching: query, fields: fields)

--- a/Sources/Scout/Database/Access/Database.swift
+++ b/Sources/Scout/Database/Access/Database.swift
@@ -45,14 +45,7 @@ extension DatabaseReader {
     }
 }
 
-extension DatabaseWriter {
-    // Records are written in batches no larger than this; the backends cap a single
-    // save/modify request at 400 records.
-    package static var maxBatchSize: Int { 400 }
-}
-
 package struct RecordNotFoundError: LocalizedError {
     package let errorDescription: String? = "No record found for the requested identifier"
-
     package init() {}
 }

--- a/Sources/Scout/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Database/Access/RecordSender.swift
@@ -8,45 +8,38 @@
 import CoreData
 
 struct RecordSender: Sendable {
-    // A rejected batch names no culprit, so it is halved and resent until the
-    // offending records stand alone and only they are charged. This caps the sends
-    // one pass spends on that search, so a backend rejecting everything can't turn
-    // a backlog into thousands of requests.
-    static let maxProbes = 32
-
     let id: String
     let database: any Database
-    let isTransientError: @Sendable (any Error) -> Bool
 }
 
 extension RecordSender {
     init(backend: Backend) {
         self.id = backend.id
         self.database = backend.database
-        self.isTransientError = backend.isTransientError
     }
 }
 
-@MainActor
-extension RecordSender {
-    func deliver(type syncable: any (SyncableEntry & RecordEncodable).Type, in context: NSManagedObjectContext)
-        async throws
-    {
-        try await deliver(pending: syncable, in: context)
-    }
+package protocol TransientFailure: Error {
+    var isTransient: Bool { get }
+}
 
-    private func deliver<T: SyncableEntry & RecordEncodable>(pending: T.Type, in context: NSManagedObjectContext)
-        async throws
-    {
+@MainActor extension RecordSender {
+    func deliver<T: SyncableEntry & RecordEncodable>(type: T.Type, in context: NSManagedObjectContext) async throws {
         let request = NSFetchRequest<T>(entityName: String(describing: T.self))
+
         request.predicate = NSPredicate(
-            format:
-                "SUBQUERY(deliveries, $d, $d.backendID == %@ AND $d.isPending == YES AND $d.attempts < %d).@count > 0",
+            format: """
+                SUBQUERY(deliveries, $d, \
+                $d.backendID == %@ AND $d.isPending == YES AND $d.attempts < %d\
+                ).@count > 0
+                """,
             id,
             DeliveryEntry.maxAttempts
         )
 
-        let objects = try context.fetch(request).filter { $0.delivery(for: id)?.isPending == true }
+        let objects = try context.fetch(request).filter {
+            $0.delivery(for: id)?.isPending == true
+        }
 
         guard objects.count > 0 else {
             return
@@ -55,16 +48,20 @@ extension RecordSender {
         do {
             try await send(objects)
         } catch {
-            try save(context)
+            if context.hasChanges {
+                try context.save()
+            }
             throw error
         }
 
-        try save(context)
+        if context.hasChanges {
+            try context.save()
+        }
     }
 
     private func send<T: SyncableEntry & RecordEncodable>(_ objects: [T]) async throws {
         var batches = [objects]
-        var probes = Self.maxProbes
+        var probes = 32
         var rejection: (any Error)?
 
         while probes > 0, let batch = batches.popLast() {
@@ -72,14 +69,11 @@ extension RecordSender {
 
             do {
                 try await write(batch)
+            } catch let error as CancellationError {
+                throw error
+            } catch let error as any TransientFailure where error.isTransient {
+                throw error
             } catch {
-                // Only a rejection consumes the attempt budget: transient failures
-                // (offline, throttling, cancellation) must not burn the queue while
-                // the backend is unreachable.
-                guard !(error is CancellationError), !isTransientError(error) else {
-                    throw error
-                }
-
                 rejection = error
 
                 if batch.count > 1 {
@@ -104,12 +98,6 @@ extension RecordSender {
 
         for (object, record) in zip(objects, records) where object.record == record {
             object.delivery(for: id)?.isPending = false
-        }
-    }
-
-    private func save(_ context: NSManagedObjectContext) throws {
-        if context.hasChanges {
-            try context.save()
         }
     }
 }

--- a/Sources/Scout/Runtime/Backend.swift
+++ b/Sources/Scout/Runtime/Backend.swift
@@ -5,8 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import Foundation
-
 public struct Backend: Sendable {
     package let id: String
     package let database: any Database
@@ -15,17 +13,11 @@ public struct Backend: Sendable {
     package let engine: Engine
     package let probeStatus: @Sendable () async -> Status
     package let accountWarning: AccountWarning
-    package let isTransientError: @Sendable (any Error) -> Bool
 
     package init(
-        id: String,
-        database: any Database,
-        checkAvailability: @escaping @Sendable () async -> Bool,
-        displayName: String,
-        engine: Engine,
-        probeStatus: @escaping @Sendable () async -> Status = { .unknown },
-        accountWarning: @escaping AccountWarning = { nil },
-        isTransientError: @escaping @Sendable (any Error) -> Bool = { _ in false }
+        id: String, database: any Database, checkAvailability: @escaping @Sendable () async -> Bool,
+        displayName: String, engine: Engine, probeStatus: @escaping @Sendable () async -> Status = { .unknown },
+        accountWarning: @escaping AccountWarning = { nil }
     ) {
         self.id = id
         self.database = database
@@ -34,7 +26,6 @@ public struct Backend: Sendable {
         self.engine = engine
         self.probeStatus = probeStatus
         self.accountWarning = accountWarning
-        self.isTransientError = isTransientError
     }
 }
 
@@ -68,8 +59,6 @@ extension Backend.Status: Equatable {
         switch (lhs, rhs) {
         case (.reachable, .reachable), (.readOnly, .readOnly), (.unreachable, .unreachable), (.unknown, .unknown):
             true
-        case let (.failed(lhsError), .failed(rhsError)):
-            lhsError as NSError == rhsError as NSError
         default:
             false
         }

--- a/Tests/Connectors/Hosted/TransientErrorTests.swift
+++ b/Tests/Connectors/Hosted/TransientErrorTests.swift
@@ -13,26 +13,24 @@ import Testing
 
 @Suite("Hosted transient error classification")
 struct TransientErrorTests {
-    let backend = Backend.server(url: URL(string: "https://example.com")!, apiKey: nil)
-
     @Test("Connectivity failures are transient")
     func urlErrorsAreTransient() {
-        #expect(backend.isTransientError(URLError(.notConnectedToInternet)))
-        #expect(backend.isTransientError(URLError(.timedOut)))
-        #expect(backend.isTransientError(URLError(.networkConnectionLost)))
+        #expect(URLError(.notConnectedToInternet).isTransient)
+        #expect(URLError(.timedOut).isTransient)
+        #expect(URLError(.networkConnectionLost).isTransient)
     }
 
     @Test("Server-side outages and throttling are transient")
     func serverOutagesAreTransient() {
-        #expect(backend.isTransientError(HTTPDatabaseError(status: 500, reason: nil)))
-        #expect(backend.isTransientError(HTTPDatabaseError(status: 503, reason: nil)))
-        #expect(backend.isTransientError(HTTPDatabaseError(status: 429, reason: nil)))
+        #expect(HTTPDatabaseError(status: 500, reason: nil).isTransient)
+        #expect(HTTPDatabaseError(status: 503, reason: nil).isTransient)
+        #expect(HTTPDatabaseError(status: 429, reason: nil).isTransient)
     }
 
     @Test("Rejections count against the attempt budget")
     func rejectionsAreNotTransient() {
-        #expect(!backend.isTransientError(HTTPDatabaseError(status: 400, reason: "bad record")))
-        #expect(!backend.isTransientError(HTTPDatabaseError(status: 422, reason: nil)))
-        #expect(!backend.isTransientError(NSError(domain: "Test", code: 1)))
+        #expect(!HTTPDatabaseError(status: 400, reason: "bad record").isTransient)
+        #expect(!HTTPDatabaseError(status: 422, reason: nil).isTransient)
+        #expect(!((NSError(domain: "Test", code: 1) as any Error) is any TransientFailure))
     }
 }

--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -201,21 +201,12 @@ struct DeliverTests {
         try context.save()
         try SyncableEntry.plan(backends: [serverBackend], in: context)
 
-        let flakyServer = Backend(
-            id: "server",
-            database: server,
-            checkAvailability: { true },
-            displayName: "server",
-            engine: .cloudKit,
-            isTransientError: { $0 is URLError }
-        )
-
         // The availability check passes, but every real send fails on connectivity
         // for far longer than the attempt budget would allow...
         for _ in 0..<(DeliveryEntry.maxAttempts * 2) {
-            server.writeErrors.append(URLError(.notConnectedToInternet))
+            server.writeErrors.append(TransientTestError())
             await #expect(throws: (any Error).self) {
-                try await deliver(EventEntry.self, to: flakyServer)
+                try await deliver(EventEntry.self, to: serverBackend)
             }
         }
 
@@ -225,7 +216,7 @@ struct DeliverTests {
         #expect(server.records.count(of: "Event") == 0)
 
         // Connectivity returns and the record delivers on the first real send.
-        try await deliver(EventEntry.self, to: flakyServer)
+        try await deliver(EventEntry.self, to: serverBackend)
         #expect(event.delivery(for: "server")?.isDelivered == true)
         #expect(server.records.count(of: "Event") == 1)
     }
@@ -312,7 +303,7 @@ struct DeliverTests {
 
         // Singling out the culprits costs sends, so one pass is capped instead of
         // fanning a backlog out into a request per record...
-        #expect(server.writeCount <= RecordSender.maxProbes)
+        #expect(server.writeCount <= 32)
         #expect(server.records.count(of: "Event") == 0)
 
         // ...while still making progress: whatever it did single out is charged.

--- a/Tests/Support/Transient/InMemoryDatabase.swift
+++ b/Tests/Support/Transient/InMemoryDatabase.swift
@@ -13,6 +13,11 @@ struct RejectedRecordError: Error {
     let recordID: String
 }
 
+/// A connectivity-style failure: delivery must not charge an attempt for it.
+struct TransientTestError: TransientFailure {
+    let isTransient = true
+}
+
 final class InMemoryDatabase: DatabaseReader, DatabaseWriter, @unchecked Sendable {
     var records: [Record] = []
     var errors: [Error] = []


### PR DESCRIPTION
Delivery has to tell an offline or throttled backend apart from one that refuses a record, and until now the answer came from the backend: an `isTransientError` closure that `RecordSender` carried alongside the database. That knowledge belongs to the error, so `CKError`, `HTTPDatabaseError`, and `URLError` conform to a `TransientFailure` protocol instead, and `RecordSender` matches on it in `catch` — `Backend` loses its last per-backend closure.

The move also closes a hazard the closure had: a decorator wrapping a database had to remember to forward the classification, and `CachedDatabase` needed a hand-written passthrough or every connectivity failure would have started burning the attempt budget. An error travels through a decorator by itself. The tradeoff is that nothing forces a new connector to classify its errors — an unclassified failure counts as a rejection, same as before for anything unrecognised.

The delivery tests moved with it: `InMemoryDatabase` no longer needs a configurable predicate, and the transient case throws a small `TransientFailure` stub rather than borrowing `URLError` from a connector `ScoutTests` doesn't even import.

Along the way, in the code this already touches: `deliver` is a single generic method now that the compiler opens the existential metatype at the call site, `maxProbes` and `save` are inlined at their single use sites, the fetch predicate is a multiline literal split at its logical seams instead of a 119-column line, and `Status` equality drops the `NSError` bridge for `.failed`, which nothing ever compares.