### PR TITLE
Say a backend has no probe instead of probing for nothing

### DIFF
--- a/Sources/Scout/Runtime/Backend.swift
+++ b/Sources/Scout/Runtime/Backend.swift
@@ -11,13 +11,13 @@ public struct Backend: Sendable {
     package let checkAvailability: @Sendable () async -> Bool
     package let displayName: String
     package let engine: Engine
-    package let probeStatus: @Sendable () async -> Status
-    package let accountWarning: AccountWarning
+    package let probeStatus: StatusProbe?
+    package let accountWarning: AccountWarning?
 
     package init(
         id: String, database: any Database, checkAvailability: @escaping @Sendable () async -> Bool,
-        displayName: String, engine: Engine, probeStatus: @escaping @Sendable () async -> Status = { .unknown },
-        accountWarning: @escaping AccountWarning = { nil }
+        displayName: String, engine: Engine, probeStatus: StatusProbe? = nil,
+        accountWarning: AccountWarning? = nil
     ) {
         self.id = id
         self.database = database
@@ -27,40 +27,41 @@ public struct Backend: Sendable {
         self.probeStatus = probeStatus
         self.accountWarning = accountWarning
     }
-}
 
-package typealias AccountWarning = @Sendable () async throws -> Backend.AccountStatus?
-
-extension Backend {
     package enum Engine: Sendable {
         case cloudKit
         case server(ServerInfo)
         case local
     }
+}
 
-    package enum Status: Sendable {
+package typealias StatusProbe = @Sendable () async -> Backend.Status
+
+extension Backend {
+    package enum Status: Sendable, Equatable {
         case reachable
         case readOnly
         case unreachable
         case failed(any Error & Sendable)
-        case unknown
-    }
 
+        static package func == (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case (.reachable, .reachable), (.readOnly, .readOnly), (.unreachable, .unreachable):
+                true
+            default:
+                false
+            }
+        }
+    }
+}
+
+package typealias AccountWarning = @Sendable () async throws -> Backend.AccountStatus?
+
+extension Backend {
     package enum AccountStatus: Sendable {
         case noAccount
         case restricted
         case couldNotDetermine
         case temporarilyUnavailable
-    }
-}
-
-extension Backend.Status: Equatable {
-    static package func == (lhs: Self, rhs: Self) -> Bool {
-        switch (lhs, rhs) {
-        case (.reachable, .reachable), (.readOnly, .readOnly), (.unreachable, .unreachable), (.unknown, .unknown):
-            true
-        default:
-            false
-        }
     }
 }

--- a/Sources/ScoutUI/Home/Connection/Connection.swift
+++ b/Sources/ScoutUI/Home/Connection/Connection.swift
@@ -11,20 +11,20 @@ import Scout
 struct Connection: Identifiable, Sendable {
     let id: String
     let name: String
-    let status: Backend.Status
-    var probe: @Sendable () async -> Backend.Status = { .unknown }
+    let status: Backend.Status?
+    var probe: StatusProbe?
 }
 
 extension Connection {
     init(backend: Backend) {
         self.id = backend.id
         self.name = backend.displayName
-        self.status = .unknown
+        self.status = nil
         self.probe = backend.probeStatus
     }
 
     func refreshingStatus() async -> Connection {
-        Connection(id: id, name: name, status: await probe(), probe: probe)
+        Connection(id: id, name: name, status: await probe?(), probe: probe)
     }
 }
 
@@ -50,7 +50,7 @@ extension Connection: Fixture {
     static var samples: [Connection] {
         [
             Connection(id: "https://api.scout.app", name: "Production", status: .reachable, probe: { .reachable }),
-            Connection(id: "https://staging.scout.app", name: "Staging", status: .unknown, probe: { .unknown }),
+            Connection(id: "https://staging.scout.app", name: "Staging", status: nil),
             Connection(id: "http://localhost:8080", name: "Local", status: .unreachable, probe: { .unreachable }),
         ]
     }

--- a/Sources/ScoutUI/Home/Settings/Backend+Fixture.swift
+++ b/Sources/ScoutUI/Home/Settings/Backend+Fixture.swift
@@ -24,8 +24,7 @@ extension Backend: Fixture {
                 database: DefaultDatabase(),
                 checkAvailability: { true },
                 displayName: "Staging",
-                engine: .cloudKit,
-                probeStatus: { .unknown }
+                engine: .cloudKit
             ),
             Backend(
                 id: "http://localhost:8080",

--- a/Sources/ScoutUI/Home/Settings/BackendHealth.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealth.swift
@@ -18,11 +18,11 @@ struct BackendHealth: Identifiable {
     let engine: Engine
     var hasAPIKey = false
     var isSecure = true
-    var status: Backend.Status = .unknown
+    var status: Backend.Status?
     var latency: Int? = nil
     var lastChecked: Date? = nil
     var pings: [Int] = []
-    var probe: @Sendable () async -> Backend.Status = { .unknown }
+    var probe: StatusProbe?
 
     enum Engine {
         case cloudKit
@@ -97,7 +97,7 @@ extension BackendHealth.Engine {
     }
 }
 
-extension Backend.Status {
+extension Backend.Status? {
     var healthLabel: String {
         switch self {
         case .reachable:
@@ -106,7 +106,7 @@ extension Backend.Status {
             "Read-Only"
         case .unreachable, .failed:
             "Unreachable"
-        case .unknown:
+        case nil:
             "Checking"
         }
     }
@@ -119,7 +119,7 @@ extension Backend.Status {
             .orange
         case .unreachable, .failed:
             .red
-        case .unknown:
+        case nil:
             .gray
         }
     }
@@ -132,7 +132,7 @@ extension Backend.Status {
             "exclamationmark.triangle.fill"
         case .unreachable, .failed:
             "xmark.octagon.fill"
-        case .unknown:
+        case nil:
             "questionmark.circle.fill"
         }
     }
@@ -192,9 +192,7 @@ extension BackendHealth: Fixture {
                 id: "https://staging.scout.app",
                 name: "Staging",
                 endpoint: "staging.scout.app",
-                engine: .server,
-                status: .unknown,
-                probe: { .unknown }
+                engine: .server
             ),
             BackendHealth(
                 id: "http://localhost:8080",

--- a/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
@@ -24,8 +24,10 @@ final class BackendHealthProvider: ObservableObject {
     func refreshAll() async {
         await withTaskGroup(of: ProbeResult.self) { group in
             for health in backends {
+                guard let probe = health.probe else {
+                    continue
+                }
                 let id = health.id
-                let probe = health.probe
                 group.addTask {
                     await Self.measure(id: id, probe: probe)
                 }
@@ -49,7 +51,7 @@ final class BackendHealthProvider: ObservableObject {
         let latency: Int?
     }
 
-    private static func measure(id: String, probe: @Sendable () async -> Backend.Status) async -> ProbeResult {
+    private static func measure(id: String, probe: StatusProbe) async -> ProbeResult {
         let clock = ContinuousClock()
         let start = clock.now
         let status = await probe()

--- a/Sources/ScoutUI/Primitives/Platform/ICloudWarning.swift
+++ b/Sources/ScoutUI/Primitives/Platform/ICloudWarning.swift
@@ -9,13 +9,13 @@ import Scout
 import SwiftUI
 
 extension View {
-    func iCloudWarning(_ warning: @escaping AccountWarning) -> some View {
+    func iCloudWarning(_ warning: AccountWarning?) -> some View {
         modifier(ICloudWarningModifier(warning: warning))
     }
 }
 
 private struct ICloudWarningModifier: ViewModifier {
-    let warning: AccountWarning
+    let warning: AccountWarning?
 
     @State private var isAlertPresented = false
     @State private var title: String?
@@ -52,6 +52,9 @@ private struct ICloudWarningModifier: ViewModifier {
     }
 
     private func verify() async {
+        guard let warning else {
+            return
+        }
         do {
             let status = try await warning()
             title = status?.title

--- a/Tests/ScoutUITests/Home/Connection/ConnectionSwitcherTests.swift
+++ b/Tests/ScoutUITests/Home/Connection/ConnectionSwitcherTests.swift
@@ -29,18 +29,22 @@ struct ConnectionSwitcherTests {
         #expect(connections.count == 2)
         #expect(connections[0].id == primary.absoluteString)
         #expect(connections[0].name == "a.scout.app")
-        #expect(connections.allSatisfy { $0.status == .unknown })
+        #expect(connections.allSatisfy { $0.status == nil })
     }
 
     @Test("Refresh records each connection's probed status by id")
-    func refreshRecordsProbedStatus() async {
+    func refreshRecordsProbedStatus() async throws {
         let connections = [
-            Connection(id: primary.absoluteString, name: "a.scout.app", status: .unknown, probe: { .reachable }),
-            Connection(id: secondary.absoluteString, name: "b.scout.app", status: .unknown, probe: { .unreachable }),
+            Connection(id: primary.absoluteString, name: "a.scout.app", status: nil, probe: { .reachable }),
+            Connection(id: secondary.absoluteString, name: "b.scout.app", status: nil, probe: { .unreachable }),
         ]
 
         let refreshed = await connections.refreshingStatuses()
-        #expect(refreshed.first { $0.id == primary.absoluteString }?.status == .reachable)
-        #expect(refreshed.first { $0.id == secondary.absoluteString }?.status == .unreachable)
+
+        let first = try #require(refreshed.first { $0.id == primary.absoluteString })
+        let second = try #require(refreshed.first { $0.id == secondary.absoluteString })
+
+        #expect(first.status == .reachable)
+        #expect(second.status == .unreachable)
     }
 }

--- a/Tests/ScoutUITests/Home/Settings/BackendHealthProviderTests.swift
+++ b/Tests/ScoutUITests/Home/Settings/BackendHealthProviderTests.swift
@@ -38,7 +38,7 @@ struct BackendHealthProviderTests {
     }
 
     @Test("Refreshing a single backend leaves the others untouched")
-    func refreshesSingleBackend() async {
+    func refreshesSingleBackend() async throws {
         let provider = BackendHealthProvider(healths: [
             makeHealth(id: "up", probe: { .reachable }),
             makeHealth(id: "idle"),
@@ -46,9 +46,12 @@ struct BackendHealthProviderTests {
 
         await provider.refresh(id: "up")
 
-        #expect(provider.backends.first { $0.id == "up" }?.status == .reachable)
-        #expect(provider.backends.first { $0.id == "idle" }?.status == .unknown)
-        #expect(provider.backends.first { $0.id == "idle" }?.lastChecked == nil)
+        let up = try #require(provider.backends.first { $0.id == "up" })
+        let idle = try #require(provider.backends.first { $0.id == "idle" })
+
+        #expect(up.status == .reachable)
+        #expect(idle.status == nil)
+        #expect(idle.lastChecked == nil)
     }
 
     @Test("Refreshing an unknown id is a no-op")
@@ -58,7 +61,7 @@ struct BackendHealthProviderTests {
         await provider.refresh(id: "missing")
 
         #expect(provider.backends.count == 1)
-        #expect(provider.backends[0].status == .unknown)
+        #expect(provider.backends[0].status == nil)
     }
 
     @Test("Initializing from backends maps each one")
@@ -69,6 +72,6 @@ struct BackendHealthProviderTests {
         ])
 
         #expect(provider.backends.count == 2)
-        #expect(provider.backends.allSatisfy { $0.status == .unknown })
+        #expect(provider.backends.allSatisfy { $0.status == nil })
     }
 }

--- a/Tests/ScoutUITests/Home/Settings/BackendHealthTests.swift
+++ b/Tests/ScoutUITests/Home/Settings/BackendHealthTests.swift
@@ -25,7 +25,7 @@ struct BackendHealthTests {
         #expect(health.endpoint == "localhost:8080")
         #expect(health.hasAPIKey)
         #expect(!health.isSecure)
-        #expect(health.status == .unknown)
+        #expect(health.status == nil)
         #expect(health.pings.count == 0)
     }
 
@@ -90,9 +90,7 @@ struct BackendHealthTests {
     }
 }
 
-typealias StatusProbe = @Sendable () async -> Backend.Status
-
-func makeHealth(id: String = "backend", status: Backend.Status = .unknown, probe: @escaping StatusProbe = { .unknown })
+func makeHealth(id: String = "backend", status: Backend.Status? = nil, probe: StatusProbe? = nil)
     -> BackendHealth
 {
     BackendHealth(id: id, name: id, endpoint: id, engine: .server, status: status, probe: probe)

--- a/Tests/ScoutUITests/Home/Settings/GlanceSummaryTests.swift
+++ b/Tests/ScoutUITests/Home/Settings/GlanceSummaryTests.swift
@@ -31,7 +31,7 @@ struct GlanceSummaryTests {
         let summary = GlanceSummary(backends: [
             makeHealth(id: "a", status: .reachable),
             makeHealth(id: "b", status: .unreachable),
-            makeHealth(id: "c", status: .unknown),
+            makeHealth(id: "c"),
         ])
 
         #expect(!summary.allOperational)


### PR DESCRIPTION
`Status.unknown` stood for two different things: a backend nobody has asked yet, and a backend there is nothing to ask. Neither is a state a backend can actually be in, so the case is gone and each meaning is spelled out where it belongs. `probeStatus` and `accountWarning` are optional closures — absent when a backend has no such notion — while the status a screen displays is `Backend.Status?`, with nil for "not checked yet".

Two behaviour changes fall out of that. Refreshing now skips a backend with no probe instead of stamping it "checked just now, status unknown" with the current date, and the iCloud warning does no work for a server or demo backend rather than calling a closure that always answered nil on every appear and every return from background. The modifier still attaches unconditionally and bails inside — branching the view body on it would have given `HomeList` two identities and reset its state whenever the active backend changed.

Both closure types are named now, `StatusProbe` and `AccountWarning`, because the UI layer declares them in three more places; a local `StatusProbe` typealias in the tests goes away with it. Two test assertions moved to `#require`: with an optional status, `first { ... }?.status == nil` passes both when the row is missing and when it simply has no status.