### PR TITLE
Declare the backend kinds once

### DIFF
--- a/Sources/ScoutUI/Home/Settings/BackendDetailView.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendDetailView.swift
@@ -74,12 +74,12 @@ struct BackendDetailView: View {
                 }
             }
 
-            if backend.engine == .server {
+            if case let .server(info) = backend.engine {
                 Header(title: "Connection")
 
-                DetailValueRow(title: "API Key", value: backend.hasAPIKey ? "Configured" : "Not set")
+                DetailValueRow(title: "API Key", value: info.hasAPIKey ? "Configured" : "Not set")
                 DetailValueRow(title: "Timeout", value: "10 s")
-                DetailValueRow(title: "Transport", value: backend.isSecure ? "HTTPS" : "HTTP")
+                DetailValueRow(title: "Transport", value: info.isSecure ? "HTTPS" : "HTTP")
             }
 
             Header(title: "Actions")

--- a/Sources/ScoutUI/Home/Settings/BackendHealth.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealth.swift
@@ -14,39 +14,29 @@ struct BackendHealth: Identifiable {
 
     let id: String
     let name: String
-    let endpoint: String
-    let engine: Engine
-    var hasAPIKey = false
-    var isSecure = true
+    let engine: Backend.Engine
     var status: Backend.Status?
     var latency: Int? = nil
     var lastChecked: Date? = nil
     var pings: [Int] = []
     var probe: StatusProbe?
-
-    enum Engine {
-        case cloudKit
-        case server
-        case local
-    }
 }
 
 extension BackendHealth {
     init(backend: Backend) {
-        var info: Backend.Engine.ServerInfo?
-        if case let .server(server) = backend.engine {
-            info = server
-        }
-
         self.init(
             id: backend.id,
             name: backend.displayName,
-            endpoint: info?.endpoint ?? backend.id,
-            engine: .init(backend.engine),
-            hasAPIKey: info?.hasAPIKey ?? false,
-            isSecure: info?.isSecure ?? true,
+            engine: backend.engine,
             probe: backend.probeStatus
         )
+    }
+
+    var endpoint: String {
+        guard case let .server(info) = engine else {
+            return id
+        }
+        return info.endpoint
     }
 
     func recording(status: Backend.Status, latency: Int?, at date: Date) -> BackendHealth {
@@ -62,18 +52,7 @@ extension BackendHealth {
     }
 }
 
-extension BackendHealth.Engine {
-    init(_ engine: Backend.Engine) {
-        switch engine {
-        case .cloudKit:
-            self = .cloudKit
-        case .server:
-            self = .server
-        case .local:
-            self = .local
-        }
-    }
-
+extension Backend.Engine {
     var label: String {
         switch self {
         case .cloudKit:
@@ -82,17 +61,6 @@ extension BackendHealth.Engine {
             "Scout Server"
         case .local:
             "On Device"
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .cloudKit:
-            "icloud"
-        case .server:
-            "server.rack"
-        case .local:
-            "internaldrive"
         }
     }
 }
@@ -162,9 +130,9 @@ extension BackendHealth: Fixture {
             BackendHealth(
                 id: "https://api.scout.app",
                 name: "Production",
-                endpoint: "api.scout.app",
-                engine: .server,
-                hasAPIKey: true,
+                engine: .server(
+                    .init(endpoint: "api.scout.app", hasAPIKey: true, isSecure: true)
+                ),
                 status: .reachable,
                 latency: 148,
                 lastChecked: Date(timeIntervalSinceNow: -12),
@@ -177,7 +145,6 @@ extension BackendHealth: Fixture {
             BackendHealth(
                 id: "iCloud.com.example.scout",
                 name: "iCloud",
-                endpoint: "iCloud.com.example.scout",
                 engine: .cloudKit,
                 status: .reachable,
                 latency: 264,
@@ -191,15 +158,16 @@ extension BackendHealth: Fixture {
             BackendHealth(
                 id: "https://staging.scout.app",
                 name: "Staging",
-                endpoint: "staging.scout.app",
-                engine: .server
+                engine: .server(
+                    .init(endpoint: "staging.scout.app", hasAPIKey: false, isSecure: true)
+                )
             ),
             BackendHealth(
                 id: "http://localhost:8080",
                 name: "Local",
-                endpoint: "localhost:8080",
-                engine: .server,
-                isSecure: false,
+                engine: .server(
+                    .init(endpoint: "localhost:8080", hasAPIKey: false, isSecure: false)
+                ),
                 status: .unreachable,
                 lastChecked: Date(timeIntervalSinceNow: -340),
                 probe: { .unreachable }

--- a/Tests/ScoutUITests/Home/Settings/BackendHealthTests.swift
+++ b/Tests/ScoutUITests/Home/Settings/BackendHealthTests.swift
@@ -21,10 +21,14 @@ struct BackendHealthTests {
         let backend = Backend.server(url: URL(string: "http://localhost:8080")!, apiKey: "secret")
         let health = BackendHealth(backend: backend)
 
-        #expect(health.engine == .server)
+        guard case let .server(info) = health.engine else {
+            Issue.record("Expected a server engine")
+            return
+        }
+
         #expect(health.endpoint == "localhost:8080")
-        #expect(health.hasAPIKey)
-        #expect(!health.isSecure)
+        #expect(info.hasAPIKey)
+        #expect(!info.isSecure)
         #expect(health.status == nil)
         #expect(health.pings.count == 0)
     }
@@ -34,8 +38,13 @@ struct BackendHealthTests {
         let backend = Backend.server(url: URL(string: "https://api.scout.app")!, apiKey: nil)
         let health = BackendHealth(backend: backend)
 
-        #expect(health.isSecure)
-        #expect(!health.hasAPIKey)
+        guard case let .server(info) = health.engine else {
+            Issue.record("Expected a server engine")
+            return
+        }
+
+        #expect(info.isSecure)
+        #expect(!info.hasAPIKey)
         #expect(health.endpoint == "api.scout.app")
     }
 
@@ -43,7 +52,7 @@ struct BackendHealthTests {
     func mapsCloudKitBackend() {
         let health = BackendHealth(backend: makeBackend(id: "iCloud.com.example"))
 
-        #expect(health.engine == .cloudKit)
+        #expect(health.engine.label == "CloudKit")
         #expect(health.endpoint == "iCloud.com.example")
     }
 
@@ -93,5 +102,5 @@ struct BackendHealthTests {
 func makeHealth(id: String = "backend", status: Backend.Status? = nil, probe: StatusProbe? = nil)
     -> BackendHealth
 {
-    BackendHealth(id: id, name: id, endpoint: id, engine: .server, status: status, probe: probe)
+    BackendHealth(id: id, name: id, engine: .local, status: status, probe: probe)
 }


### PR DESCRIPTION
`BackendHealth` kept its own copy of the three backend kinds plus an initializer that mapped `Backend.Engine` onto it case by case. The copy earned that mapping with one label and one `== .server` gate — its `icon` was never read anywhere — so the health model now holds `Backend.Engine` itself and the label is an extension on it.

Two flattened fields go the same way: `hasAPIKey` and `isSecure` are read straight from the case payload where the connection section is built, and `endpoint` is derived from the engine rather than stored alongside it.

Two test assertions switched from comparing engines to matching the case, since `Backend.Engine` has a payload and is not Equatable.

Based on #1210, which moves the nested types into their own files; GitHub retargets this as that one merges.