### PR TITLE
Keep the sync path clear of Sendable warnings

### DIFF
--- a/Sources/Scout/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Database/Access/RecordSender.swift
@@ -24,6 +24,10 @@ package protocol TransientFailure: Error {
 }
 
 @MainActor extension RecordSender {
+    func deliver(_ type: any (SyncableEntry & RecordEncodable).Type, in context: NSManagedObjectContext) async throws {
+        try await deliver(type: type, in: context)
+    }
+
     func deliver<T: SyncableEntry & RecordEncodable>(type: T.Type, in context: NSManagedObjectContext) async throws {
         let request = NSFetchRequest<T>(entityName: String(describing: T.self))
 

--- a/Sources/Scout/Persistence/MigrationDedupe.swift
+++ b/Sources/Scout/Persistence/MigrationDedupe.swift
@@ -40,9 +40,11 @@ struct MigrationDedupe {
         let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         context.persistentStoreCoordinator = coordinator
 
+        let keys = Self.uniqueKeys.filter { source.entitiesByName[$0.entity] != nil }
+
         try context.performAndWait {
-            for (entity, key) in Self.uniqueKeys where source.entitiesByName[entity] != nil {
-                try dedupe(entityName: entity, key: key, in: context)
+            for (entity, key) in keys {
+                try Self.dedupe(entityName: entity, key: key, in: context)
             }
             if context.hasChanges {
                 try context.save()
@@ -50,7 +52,7 @@ struct MigrationDedupe {
         }
     }
 
-    private func dedupe(entityName: String, key: String, in context: NSManagedObjectContext) throws {
+    private static func dedupe(entityName: String, key: String, in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
         request.sortDescriptors = [NSSortDescriptor(key: DateEntry.datePrimitiveKey, ascending: true)]
 
@@ -66,8 +68,11 @@ struct MigrationDedupe {
         }
     }
 
-    private func merge(_ duplicate: NSManagedObject, into survivor: NSManagedObject, in context: NSManagedObjectContext)
-    {
+    private static func merge(
+        _ duplicate: NSManagedObject,
+        into survivor: NSManagedObject,
+        in context: NSManagedObjectContext
+    ) {
         for name in survivor.entity.attributesByName.keys where survivor.value(forKey: name) == nil {
             if let value = duplicate.value(forKey: name) {
                 survivor.setValue(value, forKey: name)

--- a/Sources/Scout/Sync/Synchronize.swift
+++ b/Sources/Scout/Sync/Synchronize.swift
@@ -33,7 +33,7 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
                 let recordSender = RecordSender(backend: backend)
 
                 for type in SyncableEntry.deliverableTypes {
-                    group.addTask { try? await recordSender.deliver(type: type, in: context) }
+                    group.addTask { try? await recordSender.deliver(type, in: context) }
                 }
             }
         }


### PR DESCRIPTION
Xcode flagged four concurrency warnings in the sync path. Deduplication ran its work through instance methods inside the `@Sendable` block `performAndWait` takes, so the block captured both `self` and the source model; filtering the entity list before the block and making the two helpers static leaves nothing non-Sendable in the capture list. Delivery opened the existential element type of `deliverableTypes` inside a nonisolated task closure and passed the resulting conformance to a main-actor method, so `RecordSender` now takes the existential itself and opens it on the main actor. Writing the task closure as `{ @MainActor in … }` instead crashes the region-based isolation checker, hence the overload.

Behaviour is unchanged. The full test bundle passes on iOS 27 (866 passed, 25 skipped) and the target builds without compiler warnings.