### PR TITLE
Tune the delivery and cleanup fetches

### DIFF
--- a/Sources/Scout/Database/Access/RecordSender.swift
+++ b/Sources/Scout/Database/Access/RecordSender.swift
@@ -40,6 +40,7 @@ package protocol TransientFailure: Error {
             id,
             DeliveryEntry.maxAttempts
         )
+        request.relationshipKeyPathsForPrefetching = ["deliveries"]
 
         let objects = try context.fetch(request).filter {
             $0.delivery(for: id)?.isPending == true

--- a/Sources/Scout/Sync/DateEntry+Cleanup.swift
+++ b/Sources/Scout/Sync/DateEntry+Cleanup.swift
@@ -15,6 +15,7 @@ extension DateEntry {
 
         let request = NSFetchRequest<DateEntry>(entityName: "DateEntry")
         request.predicate = NSPredicate(format: "datePrimitive < %@", cutoff as NSDate)
+        request.fetchBatchSize = 200
 
         for object in try context.fetch(request)
         where object.isPurgeable && object.references.count == 0 && !retained.contains(object.objectID) {


### PR DESCRIPTION
Two fetch requests that walk every object they return now tell Core Data as much.

`RecordSender.deliver` filters the fetched objects through `delivery(for:)`, which touches the `deliveries` relationship on each one. Without prefetching, every object faults that relationship in on its own round trip to the store; `relationshipKeyPathsForPrefetching` fetches them alongside the objects instead.

`DateEntry.cleanup` scans everything older than seven days, so it gets a `fetchBatchSize` of 200 rather than materializing the whole backlog in one array.

Behaviour is unchanged — same objects fetched, same objects deleted. Verified with a full `ScoutTests` run on the iOS 26 simulator: 248 tests in 56 suites pass.