### PR TITLE
Split out RecordQuery.Filter and fold its operators

### DIFF
--- a/Sources/Scout/Database/Access/RecordQuery.Filter.swift
+++ b/Sources/Scout/Database/Access/RecordQuery.Filter.swift
@@ -1,0 +1,76 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+extension RecordQuery {
+    package struct Filter: Codable, Equatable, Sendable {
+        package enum Operator: String, Codable, Sendable {
+            case equals
+            case notEquals
+            case greaterThan
+            case greaterThanOrEquals
+            case lessThan
+            case lessThanOrEquals
+            case `in`
+            case beginsWith
+        }
+
+        package let field: String
+        package let op: Operator
+        package let value: RecordValue
+
+        package init(field: String, op: Operator, value: RecordValue) {
+            self.field = field
+            self.op = op
+            self.value = value
+        }
+    }
+}
+
+extension RecordQuery.Filter {
+    func matches(_ fields: [String: RecordValue]) -> Bool {
+        guard let value = fields[field] else {
+            return false
+        }
+
+        switch op {
+        case .equals:
+            return value == self.value
+
+        case .notEquals:
+            return value != self.value
+
+        case .in:
+            guard case .strings(let options) = self.value, case .string(let actual) = value else {
+                return false
+            }
+            return options.contains(actual)
+
+        case .beginsWith:
+            guard case .string(let prefix) = self.value, case .string(let actual) = value else {
+                return false
+            }
+            return actual.hasPrefix(prefix)
+
+        case .greaterThan, .greaterThanOrEquals, .lessThan, .lessThanOrEquals:
+            guard let lhs = value.value, let rhs = self.value.value else {
+                return false
+            }
+            switch op {
+            case .greaterThan:
+                return lhs > rhs
+            case .greaterThanOrEquals:
+                return lhs >= rhs
+            case .lessThan:
+                return lhs < rhs
+            case .lessThanOrEquals:
+                return lhs <= rhs
+            default:
+                return false
+            }
+        }
+    }
+}

--- a/Sources/Scout/Database/Query/RecordQuery.Filter.swift
+++ b/Sources/Scout/Database/Query/RecordQuery.Filter.swift
@@ -36,41 +36,37 @@ extension RecordQuery.Filter {
             return false
         }
 
-        switch op {
+        return switch op {
         case .equals:
-            return value == self.value
+            value == self.value
 
         case .notEquals:
-            return value != self.value
+            value != self.value
 
         case .in:
-            guard case .strings(let options) = self.value, case .string(let actual) = value else {
-                return false
-            }
-            return options.contains(actual)
+            match(value.string, self.value.strings) { $1.contains($0) }
 
         case .beginsWith:
-            guard case .string(let prefix) = self.value, case .string(let actual) = value else {
-                return false
-            }
-            return actual.hasPrefix(prefix)
+            match(value.string, self.value.string) { $0.hasPrefix($1) }
 
-        case .greaterThan, .greaterThanOrEquals, .lessThan, .lessThanOrEquals:
-            guard let lhs = value.value, let rhs = self.value.value else {
-                return false
-            }
-            switch op {
-            case .greaterThan:
-                return lhs > rhs
-            case .greaterThanOrEquals:
-                return lhs >= rhs
-            case .lessThan:
-                return lhs < rhs
-            case .lessThanOrEquals:
-                return lhs <= rhs
-            default:
-                return false
-            }
+        case .greaterThan:
+            match(value.value, self.value.value, using: >)
+
+        case .greaterThanOrEquals:
+            match(value.value, self.value.value, using: >=)
+
+        case .lessThan:
+            match(value.value, self.value.value, using: <)
+
+        case .lessThanOrEquals:
+            match(value.value, self.value.value, using: <=)
         }
+    }
+
+    private func match<T, U>(_ lhs: T?, _ rhs: U?, using isMatch: (T, U) -> Bool) -> Bool {
+        guard let lhs, let rhs else {
+            return false
+        }
+        return isMatch(lhs, rhs)
     }
 }

--- a/Sources/Scout/Database/Query/RecordQuery.swift
+++ b/Sources/Scout/Database/Query/RecordQuery.swift
@@ -19,29 +19,6 @@ package struct RecordQuery: Sendable {
         self.sort = sort
     }
 
-    package struct Filter: Codable, Equatable, Sendable {
-        package enum Operator: String, Codable, Sendable {
-            case equals
-            case notEquals
-            case greaterThan
-            case greaterThanOrEquals
-            case lessThan
-            case lessThanOrEquals
-            case `in`
-            case beginsWith
-        }
-
-        package let field: String
-        package let op: Operator
-        package let value: RecordValue
-
-        package init(field: String, op: Operator, value: RecordValue) {
-            self.field = field
-            self.op = op
-            self.value = value
-        }
-    }
-
     package struct Sort: Codable, Equatable, Sendable {
         package let field: String
         package let ascending: Bool
@@ -62,50 +39,5 @@ package protocol RecordDecodable: Sendable, Equatable, RecordEncodable {
 extension RecordQuery {
     package func matches(_ record: Record) -> Bool {
         record.recordType == recordType.recordType && filters.allSatisfy { $0.matches(record.fields) }
-    }
-}
-
-extension RecordQuery.Filter {
-    fileprivate func matches(_ fields: [String: RecordValue]) -> Bool {
-        guard let value = fields[field] else {
-            return false
-        }
-
-        switch op {
-        case .equals:
-            return value == self.value
-
-        case .notEquals:
-            return value != self.value
-
-        case .in:
-            guard case .strings(let options) = self.value, case .string(let actual) = value else {
-                return false
-            }
-            return options.contains(actual)
-
-        case .beginsWith:
-            guard case .string(let prefix) = self.value, case .string(let actual) = value else {
-                return false
-            }
-            return actual.hasPrefix(prefix)
-
-        case .greaterThan, .greaterThanOrEquals, .lessThan, .lessThanOrEquals:
-            guard let lhs = value.value, let rhs = self.value.value else {
-                return false
-            }
-            switch op {
-            case .greaterThan:
-                return lhs > rhs
-            case .greaterThanOrEquals:
-                return lhs >= rhs
-            case .lessThan:
-                return lhs < rhs
-            case .lessThanOrEquals:
-                return lhs <= rhs
-            default:
-                return false
-            }
-        }
     }
 }

--- a/Sources/Scout/Database/Record/RecordValue.swift
+++ b/Sources/Scout/Database/Record/RecordValue.swift
@@ -96,4 +96,12 @@ extension RecordValue {
             nil
         }
     }
+
+    var string: String? {
+        if case .string(let value) = self { value } else { nil }
+    }
+
+    var strings: [String]? {
+        if case .strings(let value) = self { value } else { nil }
+    }
 }


### PR DESCRIPTION
`RecordQuery.Filter` and the `matches(_:)` that evaluates it move to `RecordQuery.Filter.swift`, following the naming already used for nested types like `Backend.Status`. `RecordQuery.swift` keeps the query itself, `Sort` and the `RecordDecodable` protocol. The move needed one adjustment: `matches(_:)` was `fileprivate` and is called from `RecordQuery.matches(_:)` in the old file, so it becomes internal.

The second commit then simplifies the moved code. Every operator except equality unwraps both sides and applies a test, so they all go through one `match(_:_:using:)` helper and each case reads as a single line. The four ordering operators previously shared a case that unwrapped both sides and re-tested `op` in a nested switch, with a `default` branch that could never run. `RecordValue` gains `string` and `strings` accessors alongside the existing `value`.

Behaviour is unchanged. Verified on the iOS 26 simulator across ScoutTests (248), ScoutUITests (491) and the three connector targets (103), all passing.