### PR TITLE
Ask a DateEntry whether it is deletable

### DIFF
--- a/Sources/Scout/Sync/DateEntry+Cleanup.swift
+++ b/Sources/Scout/Sync/DateEntry+Cleanup.swift
@@ -16,8 +16,7 @@ extension DateEntry {
         let request = NSFetchRequest<DateEntry>(entityName: "DateEntry")
         request.predicate = NSPredicate(format: "datePrimitive < %@", cutoff as NSDate)
 
-        for object in try context.fetch(request)
-        where object.isPurgeable && object.references.count == 0 && !retained.contains(object.objectID) {
+        for object in try context.fetch(request) where object.isDeletable && !retained.contains(object.objectID) {
             context.delete(object)
         }
 

--- a/Sources/Scout/Sync/SyncableEntry+Purge.swift
+++ b/Sources/Scout/Sync/SyncableEntry+Purge.swift
@@ -20,7 +20,7 @@ extension SyncableEntry {
             backendIDs.count
         )
 
-        for object in try context.fetch(request) where object.isPurgeable && object.references.count == 0 {
+        for object in try context.fetch(request) where object.isDeletable {
             context.delete(object)
         }
     }

--- a/Sources/Scout/Utilities/Date/DateEntry.swift
+++ b/Sources/Scout/Utilities/Date/DateEntry.swift
@@ -21,10 +21,12 @@ package class DateEntry: NSManagedObject {
         []
     }
 
-    // One-shot entries (device, install, version) are created once and never
-    // re-created, so cleanup must keep them for backends configured later.
     var isPurgeable: Bool {
         true
+    }
+
+    var isDeletable: Bool {
+        isPurgeable && references.count == 0
     }
 
     var latest: Date? {


### PR DESCRIPTION
`DateEntry.cleanup` and `SyncableEntry.purge` both spelled out `isPurgeable && references.count == 0` before deleting an object. That pair is a property of the entry, so it becomes `DateEntry.isDeletable` and both loops ask for it.

The comment above `isPurgeable` is dropped along the way: it explained why `DeviceEntry`, `InstallEntry` and `VersionEntry` override the property to `false`, but sat on the base declaration that returns `true`.

No behaviour change. Verified on the iOS 26 simulator: ScoutTests (247) and ScoutUITests (491) pass.