### PR TITLE
Tidy the activity builders

### DIFF
--- a/Sources/Scout/Activity/ActivityPoint+Build.swift
+++ b/Sources/Scout/Activity/ActivityPoint+Build.swift
@@ -85,14 +85,11 @@ private struct UserWindow {
         guard let users else {
             return
         }
-        for user in users where counts[user] != nil {
-            let remaining = counts[user]! - 1
-
-            if remaining > 0 {
-                counts[user] = remaining
-            } else {
-                counts[user] = nil
+        for user in users {
+            guard let count = counts[user] else {
+                continue
             }
+            counts[user] = count > 1 ? count - 1 : nil
         }
     }
 }

--- a/Sources/Scout/Activity/RetentionCohort+Build.swift
+++ b/Sources/Scout/Activity/RetentionCohort+Build.swift
@@ -8,31 +8,9 @@
 import Foundation
 
 extension RetentionCohort {
-    /// Builds the weekly retention table from local lifecycle data — the
-    /// client-side twin of the server's `RetentionService`.
-    ///
-    /// Installs are grouped into acquisition cohorts by the UTC week of their
-    /// install day. For each install and milestone in `dayOffsets`, bounded
-    /// day-N retention asks whether the install was active on exactly
-    /// `install day + N` — i.e. whether `sessionDays[install]` contains that
-    /// day. A milestone whose window has not fully elapsed by `asOf` (the whole
-    /// cohort week plus the offset) is left `nil`, forming the table's
-    /// triangular gap.
-    ///
-    /// - Parameters:
-    ///   - installDays: install id → the moment that install was first seen.
-    ///   - sessionDays: install id → the set of UTC day-starts it was active on.
-    ///   - range: the install days to include, as a half-open range.
-    ///   - asOf: the maturity cutoff, normally now.
-    /// - Returns: one cohort per install week in `range`, sorted by week ascending.
-    ///
     package static func build(
         installDays: [String: Date], sessionDays: [String: Set<Date>], in range: Range<Date>, asOf: Date
-    )
-        -> [RetentionCohort]
-    {
-        let calendar = Calendar.utc
-
+    ) -> [RetentionCohort] {
         var sizes: [Date: Int] = [:]
         var counts: [Date: [Int: Int]] = [:]
 
@@ -43,7 +21,7 @@ extension RetentionCohort {
 
             let active = sessionDays[install] ?? []
             for (index, offset) in dayOffsets.enumerated() {
-                let target = calendar.date(byAdding: .day, value: offset, to: installDay)!
+                let target = installDay.addingDay(offset)
                 if active.contains(target) {
                     counts[week, default: [:]][index, default: 0] += 1
                 }
@@ -54,7 +32,7 @@ extension RetentionCohort {
             let cohortCounts = counts[week] ?? [:]
 
             let retained = dayOffsets.enumerated().map { index, offset -> Int? in
-                let matured = calendar.date(byAdding: .day, value: 7 + offset, to: week)!
+                let matured = week.addingDay(7 + offset)
                 guard matured < asOf else {
                     return nil
                 }


### PR DESCRIPTION
Two small cleanups in `Sources/Scout/Activity`, one per commit.

`UserWindow.release` filtered its loop on `counts[user] != nil` and then force-unwrapped the same key to read it. It binds the count once instead, and the if/else that stored either the decremented value or `nil` becomes the expression it was computing.

`RetentionCohort.build` held its own `Calendar.utc` to add day offsets, which is what `Date.addingDay` already does. Its doc comment goes with the change — `build` is `package`, and the project documents public API only.

No behaviour change. Verified on the iOS 26 simulator: ScoutTests (247) and ScoutUITests (491) pass.