### PR TITLE
Remove the line length limit and keep signatures on one line

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -3,7 +3,7 @@
   "indentation": {
     "spaces": 4
   },
-  "lineLength": 120,
+  "lineLength": 1000,
   "rules": {
     "AlwaysUseLiteralForEmptyCollectionInit": true,
     "BeginDocumentationCommentWithOneLineSummary": true,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,7 @@
 
 ## Function and method signatures
 
-- Function/method **signatures** (declarations) should be written on a single line, even with many parameters or default values — do not wrap parameters onto separate lines.
-- Exception: when a single-line signature would exceed the 120-character `lineLength` limit in `.swift-format` (a CI lint gate, so the limit wins), let `swift-format` wrap it; don't fight the formatter.
+- Function/method **signatures** (declarations) are always written on a single line, however many parameters or default values they carry — never wrap parameters onto separate lines. `.swift-format` sets `lineLength` high enough that no signature is wrapped for length.
 - This applies to declarations only, not to call sites — see below.
 
 ## Function and initializer calls
@@ -63,7 +62,7 @@ cohorts = RetentionCohort.build(
 )
 ```
 
-- Never pack several arguments onto one wrapped line, even when they fit within the 120-character limit:
+- Never pack several arguments onto one wrapped line, however short they are:
 
 ```swift
 cohorts = RetentionCohort.build(
@@ -72,7 +71,7 @@ cohorts = RetentionCohort.build(
 )
 ```
 
-- Signatures are the exception: a declaration too long for one line is wrapped by `swift-format` as it sees fit, packed lines included.
+- Signatures are the exception: a declaration stays on one line no matter how long it grows.
 
 ## Array extensions
 

--- a/Sources/Connectors/Demo/DemoMetrics.swift
+++ b/Sources/Connectors/Demo/DemoMetrics.swift
@@ -95,10 +95,7 @@ struct DemoMetrics {
         self.samples = samples
     }
 
-    private static func histogram(
-        name: String, categories: [String], center ratio: Double, scale: Double, clock: DemoClock,
-        random: inout DemoRandom
-    ) -> [DemoSample] {
+    private static func histogram(name: String, categories: [String], center ratio: Double, scale: Double, clock: DemoClock, random: inout DemoRandom) -> [DemoSample] {
         var samples: [DemoSample] = []
         let center = Double(categories.count) * ratio
 

--- a/Sources/Connectors/Native/Catalog/CatalogEntry.swift
+++ b/Sources/Connectors/Native/Catalog/CatalogEntry.swift
@@ -25,10 +25,7 @@ struct CatalogEntry {
         case sum(String, by: String, at: String)
     }
 
-    init(
-        entity: String, fields: [Field], aggregates: [Aggregate] = [],
-        derive: @escaping @Sendable (Record) -> [String: ScoutDB.RecordValue] = { _ in [:] }
-    ) {
+    init(entity: String, fields: [Field], aggregates: [Aggregate] = [], derive: @escaping @Sendable (Record) -> [String: ScoutDB.RecordValue] = { _ in [:] }) {
         self.entity = entity
         self.fields = fields + Self.metadata
         self.aggregates = aggregates

--- a/Sources/Connectors/Native/NativeReads.swift
+++ b/Sources/Connectors/Native/NativeReads.swift
@@ -29,10 +29,7 @@ extension QueryBuilder {
 }
 
 extension EntityStore {
-    func page(
-        entity: String, filters: [RecordQuery.Filter], field: String, ascending: Bool, limit: Int,
-        after cursor: FieldCursor?
-    ) async throws -> RecordChunk {
+    func page(entity: String, filters: [RecordQuery.Filter], field: String, ascending: Bool, limit: Int, after cursor: FieldCursor?) async throws -> RecordChunk {
         let page = try await filters.reduce(query(entity)) { $0.filter($1) }
             .sort(field, ascending ? .forward : .reverse)
             .page(size: limit, after: cursor)
@@ -72,9 +69,7 @@ extension EntityStore {
         }
     }
 
-    func datedIDs(entity: String, dateField: String, idField: String, in range: Range<Date>) async throws
-        -> [(date: Date, id: String)]
-    {
+    func datedIDs(entity: String, dateField: String, idField: String, in range: Range<Date>) async throws -> [(date: Date, id: String)] {
         let records = try await records(
             entity: entity,
             dateField: dateField,

--- a/Sources/Connectors/Native/NativeSeries.swift
+++ b/Sources/Connectors/Native/NativeSeries.swift
@@ -57,9 +57,7 @@ struct NativeSeries {
             .sorted { ($0.name, $0.category ?? "", $0.version ?? "") < ($1.name, $1.category ?? "", $1.version ?? "") }
     }
 
-    private func collectLast(entity: String, store: EntityStore, value: (Double) -> MetricValue) async throws
-        -> [MetricSeries]
-    {
+    private func collectLast(entity: String, store: EntityStore, value: (Double) -> MetricValue) async throws -> [MetricSeries] {
         let records = try await store.records(entity: entity, dateField: "date", in: window)
 
         var latest: [GroupKey: [Date: (date: Date, sample: Double)]] = [:]
@@ -169,9 +167,7 @@ struct NativeSeries {
         }
     }
 
-    private func collectEvents(name: String?, into totals: inout [GroupKey: [Date: Double]], store: EntityStore)
-        async throws
-    {
+    private func collectEvents(name: String?, into totals: inout [GroupKey: [Date: Double]], store: EntityStore) async throws {
         let points = try await store.query(EventEntry.recordType)
             .series(metric: .sum, group: "name", in: window)
 
@@ -180,9 +176,7 @@ struct NativeSeries {
         }
     }
 
-    private func collectMetrics(entity: String, into totals: inout [GroupKey: [Date: Double]], store: EntityStore)
-        async throws
-    {
+    private func collectMetrics(entity: String, into totals: inout [GroupKey: [Date: Double]], store: EntityStore) async throws {
         let points = try await store.query(entity)
             .series("value", metric: .sum, group: EntityCatalog.metricSeriesKey, in: window)
 
@@ -213,9 +207,7 @@ struct NativeSeries {
         case sessions, crashes, hangs, installs, firstCrashes
     }
 
-    private func collectCounts(of source: Source, into totals: inout [GroupKey: [Date: Double]], store: EntityStore)
-        async throws
-    {
+    private func collectCounts(of source: Source, into totals: inout [GroupKey: [Date: Double]], store: EntityStore) async throws {
         let (entity, dateField, name) = Self.layout(of: source)
         let records = try await store.records(entity: entity, dateField: dateField, in: window)
 
@@ -265,10 +257,7 @@ struct NativeSeries {
         }
     }
 
-    private func add(
-        _ value: Double, name: String, category: String?, version: String?, date: Date,
-        to totals: inout [GroupKey: [Date: Double]]
-    ) {
+    private func add(_ value: Double, name: String, category: String?, version: String?, date: Date, to totals: inout [GroupKey: [Date: Double]]) {
         let key = GroupKey(name: name, category: category, version: version)
         totals[key, default: [:]][bucketStart(of: date), default: 0] += value
     }

--- a/Sources/Scout/Activity/MarkerEntry.Trigger.swift
+++ b/Sources/Scout/Activity/MarkerEntry.Trigger.swift
@@ -22,9 +22,7 @@ extension MarkerEntry {
         }
     }
 
-    static func mark(name: String, install: InstallEntry?, appVersion: String?, in context: NSManagedObjectContext)
-        throws
-    {
+    static func mark(name: String, install: InstallEntry?, appVersion: String?, in context: NSManagedObjectContext) throws {
         guard let appVersion, let install else {
             return
         }

--- a/Sources/Scout/Diagnostics/Incident/LogIncident.swift
+++ b/Sources/Scout/Diagnostics/Incident/LogIncident.swift
@@ -33,10 +33,7 @@ extension HangInfo: IncidentInfo {
     }
 }
 
-func logIncident<Entry: IncidentEntry, Info: IncidentInfo>(
-    _ info: Info, id: UUID, deviceID: UUID, entityName: String, idKey: String, markerName: String,
-    context: NSManagedObjectContext, configure: (Entry, SessionEntry) -> Void
-) throws {
+func logIncident<Entry: IncidentEntry, Info: IncidentInfo>(_ info: Info, id: UUID, deviceID: UUID, entityName: String, idKey: String, markerName: String, context: NSManagedObjectContext, configure: (Entry, SessionEntry) -> Void) throws {
     // The id doubles as the archive file's UUID, so a flush interrupted
     // between the save and the file removal doesn't insert a duplicate
     // on the next launch.

--- a/Sources/Scout/Diagnostics/Telemetry/Handler/TelemetryHandler+LogMetrics.swift
+++ b/Sources/Scout/Diagnostics/Telemetry/Handler/TelemetryHandler+LogMetrics.swift
@@ -83,10 +83,7 @@ extension TelemetryPersisting {
     }
 }
 
-func saveMetrics<T: MetricScalar>(
-    _ name: String, date: Date, category: String, value: T, identity: Identity.Snapshot,
-    _ context: NSManagedObjectContext
-) throws {
+func saveMetrics<T: MetricScalar>(_ name: String, date: Date, category: String, value: T, identity: Identity.Snapshot, _ context: NSManagedObjectContext) throws {
     let metrics = context.insert(T.Object.self)
 
     metrics.value = value

--- a/Sources/Scout/Lifecycle/Base/CurrentHub.swift
+++ b/Sources/Scout/Lifecycle/Base/CurrentHub.swift
@@ -16,9 +16,7 @@ extension NSManagedObjectContext {
         return try fetch(request).first
     }
 
-    func linkedSession(deviceID: UUID, installID: UUID, launchID: UUID, sessionID: UUID, date: Date) throws
-        -> SessionEntry
-    {
+    func linkedSession(deviceID: UUID, installID: UUID, launchID: UUID, sessionID: UUID, date: Date) throws -> SessionEntry {
         let device = try fetchOrCreate(DeviceEntry.self, key: "deviceID", id: deviceID) {
             $0.deviceID = deviceID
             $0.date = date
@@ -66,9 +64,7 @@ extension NSManagedObjectContext {
         }
     }
 
-    private func fetchOrCreate<T: NSManagedObject>(_ type: T.Type, key: String, id: UUID, configure: (T) -> Void) throws
-        -> T
-    {
+    private func fetchOrCreate<T: NSManagedObject>(_ type: T.Type, key: String, id: UUID, configure: (T) -> Void) throws -> T {
         if let object = try existing(type, key: key, id: id) {
             return object
         }

--- a/Sources/Scout/Persistence/MigrationDedupe.swift
+++ b/Sources/Scout/Persistence/MigrationDedupe.swift
@@ -68,11 +68,7 @@ struct MigrationDedupe {
         }
     }
 
-    private static func merge(
-        _ duplicate: NSManagedObject,
-        into survivor: NSManagedObject,
-        in context: NSManagedObjectContext
-    ) {
+    private static func merge(_ duplicate: NSManagedObject, into survivor: NSManagedObject, in context: NSManagedObjectContext) {
         for name in survivor.entity.attributesByName.keys where survivor.value(forKey: name) == nil {
             if let value = duplicate.value(forKey: name) {
                 survivor.setValue(value, forKey: name)

--- a/Sources/ScoutUI/Delivery/Releases/View/DailyCount.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/DailyCount.swift
@@ -14,9 +14,7 @@ struct DailyCount: Equatable {
 }
 
 extension DailyCount {
-    static func series(
-        from records: [some Incident], days: Int = 14, calendar: Calendar = .current, endingOn today: Date = Date()
-    ) -> [DailyCount] {
+    static func series(from records: [some Incident], days: Int = 14, calendar: Calendar = .current, endingOn today: Date = Date()) -> [DailyCount] {
         let start = calendar.startOfDay(for: today)
 
         var counts: [Date: Int] = [:]

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -17,10 +17,7 @@ struct VersionDetailView: View {
     @State private var showAllCrashes = false
     @State private var showAllHangs = false
 
-    init(
-        release: ReleaseHealth, crashes: VersionIncidentProvider<Crash>? = nil,
-        hangs: VersionIncidentProvider<Hang>? = nil
-    ) {
+    init(release: ReleaseHealth, crashes: VersionIncidentProvider<Crash>? = nil, hangs: VersionIncidentProvider<Hang>? = nil) {
         self.release = release
         self._crashes = StateObject(wrappedValue: crashes ?? VersionIncidentProvider(version: release.id))
         self._hangs = StateObject(wrappedValue: hangs ?? VersionIncidentProvider(version: release.id))

--- a/Sources/ScoutUI/Home/Search/Index/GlobalSearchIndex.swift
+++ b/Sources/ScoutUI/Home/Search/Index/GlobalSearchIndex.swift
@@ -15,10 +15,7 @@ struct GlobalSearchIndex {
     let crashes: [IncidentGroup<Crash>]
     let hangs: [IncidentGroup<Hang>]
 
-    init?(
-        series: [MetricSeries]?, devices: [DeviceSummary]?, releases: [ReleaseHealth]?,
-        crashes: [IncidentGroup<Crash>]?, hangs: [IncidentGroup<Hang>]?
-    ) {
+    init?(series: [MetricSeries]?, devices: [DeviceSummary]?, releases: [ReleaseHealth]?, crashes: [IncidentGroup<Crash>]?, hangs: [IncidentGroup<Hang>]?) {
         guard let series, let devices, let releases, let crashes, let hangs else {
             return nil
         }

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
@@ -10,10 +10,7 @@
     import Foundation
 
     protocol AlertTaskScheduler: Sendable {
-        func register(
-            forTaskWithIdentifier identifier: String, using queue: DispatchQueue?,
-            launchHandler: @escaping @Sendable (BGTask) -> Void
-        ) -> Bool
+        func register(forTaskWithIdentifier identifier: String, using queue: DispatchQueue?, launchHandler: @escaping @Sendable (BGTask) -> Void) -> Bool
         func submit(_ taskRequest: BGTaskRequest) throws
     }
 
@@ -31,10 +28,7 @@
         private let interval: TimeInterval
         private let refresh: @Sendable () async -> Void
 
-        init(
-            scheduler: AlertTaskScheduler = BGTaskScheduler.shared, interval: TimeInterval = 1800,
-            refresh: @escaping @Sendable () async -> Void
-        ) {
+        init(scheduler: AlertTaskScheduler = BGTaskScheduler.shared, interval: TimeInterval = 1800, refresh: @escaping @Sendable () async -> Void) {
             self.scheduler = scheduler
             self.interval = interval
             self.refresh = refresh

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/AlertMetric.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/AlertMetric.swift
@@ -51,9 +51,7 @@ extension AlertMetric {
         return series.flatMap { $0.chartPoints() }
     }
 
-    private func lifecyclePoints(in database: DatabaseReader, range: Range<Date>) async throws -> (
-        sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>]
-    ) {
+    private func lifecyclePoints(in database: DatabaseReader, range: Range<Date>) async throws -> (sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>]) {
         async let sessions = database.series(
             matching: SeriesQuery(name: SessionEntry.recordType, bucket: .hour, source: .lifecycle, range: range)
         )

--- a/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading+ChartPoints.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Model/MetricReading+ChartPoints.swift
@@ -28,9 +28,7 @@ extension MetricReading {
         self.init(baseline: previous.median ?? 0, recent: current)
     }
 
-    static func stabilities(
-        sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], in range: Range<Date>, component: Calendar.Component
-    ) -> [Double] {
+    static func stabilities(sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], in range: Range<Date>, component: Calendar.Component) -> [Double] {
         zip(
             sessions.bucket(in: range, component: component).reversed(),
             crashes.bucket(in: range, component: component).reversed()

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
@@ -16,11 +16,7 @@ final class AlertProvider: ObservableObject, Provider {
     private let notifier: AlertNotifier?
     private let engine: AlertEngine
 
-    init(
-        _ result: ProviderResult<Output>? = nil,
-        registry: AlertRegistry = AlertRegistry(),
-        notifier: AlertNotifier? = nil
-    ) {
+    init(_ result: ProviderResult<Output>? = nil, registry: AlertRegistry = AlertRegistry(), notifier: AlertNotifier? = nil) {
         self.registry = registry
         self.notifier = notifier
         self.engine = AlertEngine(registry: registry, notifier: notifier)

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentBreakdown.swift
@@ -15,10 +15,7 @@ struct IncidentBreakdown: Equatable {
     let modelsByDevice: [UUID: String]
     let versionsBySession: [UUID: String]
 
-    init(
-        devices: [Segment], osVersions: [Segment], modelsByDevice: [UUID: String] = [:],
-        versionsBySession: [UUID: String] = [:]
-    ) {
+    init(devices: [Segment], osVersions: [Segment], modelsByDevice: [UUID: String] = [:], versionsBySession: [UUID: String] = [:]) {
         self.devices = devices
         self.osVersions = osVersions
         self.modelsByDevice = modelsByDevice
@@ -52,9 +49,7 @@ extension IncidentBreakdown {
         case osVersions
     }
 
-    func records<Element: SessionContext>(from records: [Element], in dimension: Dimension, matching segment: Segment)
-        -> [Element]
-    {
+    func records<Element: SessionContext>(from records: [Element], in dimension: Dimension, matching segment: Segment) -> [Element] {
         guard segment.kind == .other else {
             return records.filter { label(of: $0, in: dimension) == segment.value }
         }

--- a/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/Distribution/MetricDistributionSection.swift
@@ -15,10 +15,7 @@ struct MetricDistributionSection<H: QuantileHistogram>: View {
 
     @StateObject var provider: MetricDistributionProvider<H>
 
-    init(
-        name: String, categories: [String], extent: ChartExtent<Period>, formatter: KeyPath<Double, String>,
-        provider: MetricDistributionProvider<H>? = nil
-    ) {
+    init(name: String, categories: [String], extent: ChartExtent<Period>, formatter: KeyPath<Double, String>, provider: MetricDistributionProvider<H>? = nil) {
         self.extent = extent
         self.formatter = formatter
         self._provider = StateObject(

--- a/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
+++ b/Sources/ScoutUI/Monitoring/Metrics/MetricsView.swift
@@ -20,10 +20,7 @@ struct MetricsView<T: ChartNumeric, Extra: View>: View {
 
     @StateObject private var resets: ResetMarkerProvider
 
-    init(
-        group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period, tracksResets: Bool = false,
-        @ViewBuilder extra: @escaping (ChartExtent<Period>) -> Extra
-    ) {
+    init(group: PointGroup<T>, formatter: KeyPath<T, String>, period: Period, tracksResets: Bool = false, @ViewBuilder extra: @escaping (ChartExtent<Period>) -> Extra) {
         self.group = group
         self.formatter = formatter
         self.extra = extra

--- a/Sources/ScoutUI/Monitoring/Network/Model/StatusDistribution.swift
+++ b/Sources/ScoutUI/Monitoring/Network/Model/StatusDistribution.swift
@@ -33,9 +33,7 @@ struct StatusDistribution: Equatable {
 }
 
 extension StatusDistribution {
-    static func sample(success: Int, redirect: Int = 0, clientError: Int = 0, serverError: Int = 0)
-        -> StatusDistribution
-    {
+    static func sample(success: Int, redirect: Int = 0, clientError: Int = 0, serverError: Int = 0) -> StatusDistribution {
         let noon = Calendar.current.startOfDay(for: .now).addingTimeInterval(12 * .hour)
         return StatusDistribution(breakdowns: [
             noon: .sample(success: success, redirect: redirect, clientError: clientError, serverError: serverError)

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ChartExtent+Comparison.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ChartExtent+Comparison.swift
@@ -23,9 +23,7 @@ extension ChartExtent {
     /// months differ in length), the oldest current buckets have no
     /// counterpart and are omitted; the chart draws no reference for them.
     ///
-    func referenceSegment<U: ChartNumeric>(from points: [ChartPoint<U>], alignedTo segment: [ChartPoint<U>])
-        -> [ChartPoint<U>]
-    {
+    func referenceSegment<U: ChartNumeric>(from points: [ChartPoint<U>], alignedTo segment: [ChartPoint<U>]) -> [ChartPoint<U>] {
         zip(segment, previousSegment(from: points)).map { ChartPoint(date: $0.date, count: $1.count) }
     }
 

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonPair.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonPair.swift
@@ -46,8 +46,7 @@ extension Collection {
     /// sitting on the same date; buckets missing from `reference` get a nil
     /// reference and draw no comparison marks.
     ///
-    func paired<T>(with reference: [ChartPoint<T>], unit: Calendar.Component) -> [ComparisonPair<T>]
-    where Element == ChartPoint<T> {
+    func paired<T>(with reference: [ChartPoint<T>], unit: Calendar.Component) -> [ComparisonPair<T>] where Element == ChartPoint<T> {
         let counts = Dictionary(reference.map { ($0.date, $0.count) }, uniquingKeysWith: +)
         return map { point in
             ComparisonPair(

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Session+FetchChunk.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Session+FetchChunk.swift
@@ -9,9 +9,7 @@ import Foundation
 import Scout
 
 extension Session {
-    static func fetchChunk(installIDs: [UUID], anchor: Date?, ascending: Bool, limit: Int, in database: DatabaseReader)
-        async throws -> RecordChunk
-    {
+    static func fetchChunk(installIDs: [UUID], anchor: Date?, ascending: Bool, limit: Int, in database: DatabaseReader) async throws -> RecordChunk {
         var filters = [
             RecordQuery.Filter(field: "install_id", op: .in, value: .strings(installIDs.map(\.uuidString)))
         ]

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Provider/Rail+Init.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Provider/Rail+Init.swift
@@ -9,10 +9,7 @@ import Foundation
 import Scout
 
 extension Rail {
-    init(
-        device: Device, installs: [Install], launches: [Launch], sessions: [Session] = [], events: [Event] = [],
-        crashes: [Crash] = []
-    ) {
+    init(device: Device, installs: [Install], launches: [Launch], sessions: [Session] = [], events: [Event] = [], crashes: [Crash] = []) {
         let installs = Dictionary(grouping: installs, by: \.deviceID)
         let launches = Dictionary(grouping: launches, by: \.installID)
         let sessions = Dictionary(grouping: sessions, by: \.launchID)

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Launch+Fixture.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Launch+Fixture.swift
@@ -9,9 +9,7 @@ import Foundation
 import Scout
 
 extension Launch: Fixture {
-    static func sample(minutesAgo: Double = 0, launchID: UUID = UUID(), installID: UUID = UUID(), ongoing: Bool = false)
-        -> Launch
-    {
+    static func sample(minutesAgo: Double = 0, launchID: UUID = UUID(), installID: UUID = UUID(), ongoing: Bool = false) -> Launch {
         let startDate = Date(timeIntervalSinceNow: -minutesAgo * 60)
         return Launch(
             startDate: startDate,

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Session+Fixture.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Session+Fixture.swift
@@ -9,10 +9,7 @@ import Foundation
 import Scout
 
 extension Session: Fixture {
-    static func sample(
-        minutesAgo: Double = 0, sessionID: UUID = UUID(), launchID: UUID = UUID(), installID: UUID = UUID(),
-        ongoing: Bool = false
-    ) -> Session {
+    static func sample(minutesAgo: Double = 0, sessionID: UUID = UUID(), launchID: UUID = UUID(), installID: UUID = UUID(), ongoing: Bool = false) -> Session {
         let startDate = Date(timeIntervalSinceNow: -minutesAgo * 60)
         return Session(
             startDate: startDate,

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Version+Fixture.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Rail/Version+Fixture.swift
@@ -9,9 +9,7 @@ import Foundation
 import Scout
 
 extension Version: Fixture {
-    static func sample(
-        appVersion: String = "2.4.1", buildNumber: String = "214", minutesAgo: Double = 0, launchID: UUID = UUID()
-    ) -> Version {
+    static func sample(appVersion: String = "2.4.1", buildNumber: String = "214", minutesAgo: Double = 0, launchID: UUID = UUID()) -> Version {
         Version(
             appVersion: appVersion,
             buildNumber: buildNumber,

--- a/Tests/ScoutTests/Database/Record/RecordEncodingTests.swift
+++ b/Tests/ScoutTests/Database/Record/RecordEncodingTests.swift
@@ -130,9 +130,7 @@ struct RecordEncodingTests {
 }
 
 extension IntMetricsEntry {
-    @discardableResult static func stub(name: String, telemetry: String, value: Int, in context: NSManagedObjectContext)
-        -> IntMetricsEntry
-    {
+    @discardableResult static func stub(name: String, telemetry: String, value: Int, in context: NSManagedObjectContext) -> IntMetricsEntry {
         let entity = NSEntityDescription.entity(forEntityName: "IntMetricsEntry", in: context)!
         let metric = IntMetricsEntry(entity: entity, insertInto: context)
 
@@ -146,9 +144,7 @@ extension IntMetricsEntry {
 }
 
 extension DoubleMetricsEntry {
-    @discardableResult static func stub(
-        name: String, telemetry: String, value: Double, in context: NSManagedObjectContext
-    ) -> DoubleMetricsEntry {
+    @discardableResult static func stub(name: String, telemetry: String, value: Double, in context: NSManagedObjectContext) -> DoubleMetricsEntry {
         let entity = NSEntityDescription.entity(forEntityName: "DoubleMetricsEntry", in: context)!
         let metric = DoubleMetricsEntry(entity: entity, insertInto: context)
 

--- a/Tests/ScoutTests/Diagnostics/Incident/IncidentArchiveTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Incident/IncidentArchiveTests.swift
@@ -129,20 +129,11 @@ struct IncidentArchiveTests {
         )
     }
 
-    private func makeCrash(
-        name: String = "TestException",
-        reason: String? = "Test reason",
-        stackTrace: [String] = ["frame1", "frame2"]
-    ) -> CrashInfo {
+    private func makeCrash(name: String = "TestException", reason: String? = "Test reason", stackTrace: [String] = ["frame1", "frame2"]) -> CrashInfo {
         CrashInfo(name: name, reason: reason, stackTrace: stackTrace, identity: .stub)
     }
 
-    private func makeHang(
-        name: String = "Main Thread Blocked",
-        reason: String? = "Main thread unresponsive for 4.2s",
-        stackTrace: [String] = ["frame1", "frame2"],
-        duration: TimeInterval = 4.2
-    ) -> HangInfo {
+    private func makeHang(name: String = "Main Thread Blocked", reason: String? = "Main thread unresponsive for 4.2s", stackTrace: [String] = ["frame1", "frame2"], duration: TimeInterval = 4.2) -> HangInfo {
         HangInfo(name: name, reason: reason, stackTrace: stackTrace, duration: duration, identity: .stub)
     }
 
@@ -156,9 +147,7 @@ struct IncidentArchiveTests {
 private final class TemporaryFileManager: FileManager {
     let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
 
-    override func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask)
-        -> [URL]
-    {
+    override func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
         [root]
     }
 

--- a/Tests/ScoutTests/Diagnostics/Log/LogTests.swift
+++ b/Tests/ScoutTests/Diagnostics/Log/LogTests.swift
@@ -12,9 +12,7 @@ import Testing
 @testable import Scout
 @testable import Support
 
-private func makeEvent(
-    _ message: String, level: Logger.Level = .info, metadata: Logger.Metadata? = nil
-) -> LogEvent {
+private func makeEvent(_ message: String, level: Logger.Level = .info, metadata: Logger.Metadata? = nil) -> LogEvent {
     LogEvent(
         level: level, message: "\(message)", metadata: metadata,
         source: nil, file: #file, function: #function, line: #line

--- a/Tests/ScoutUITests/Home/Search/Index/GlobalSearchIndexTests.swift
+++ b/Tests/ScoutUITests/Home/Search/Index/GlobalSearchIndexTests.swift
@@ -12,10 +12,7 @@ import Testing
 @testable import ScoutUI
 
 struct GlobalSearchIndexTests {
-    private func makeIndex(
-        series: [MetricSeries] = [], devices: [DeviceSummary] = [], releases: [ReleaseHealth] = [],
-        crashes: [IncidentGroup<Crash>] = [], hangs: [IncidentGroup<Hang>] = []
-    ) -> GlobalSearchIndex {
+    private func makeIndex(series: [MetricSeries] = [], devices: [DeviceSummary] = [], releases: [ReleaseHealth] = [], crashes: [IncidentGroup<Crash>] = [], hangs: [IncidentGroup<Hang>] = []) -> GlobalSearchIndex {
         GlobalSearchIndex(series: series, devices: devices, releases: releases, crashes: crashes, hangs: hangs)!
     }
 

--- a/Tests/ScoutUITests/Home/Section/Log/HomeLogProviderTests.swift
+++ b/Tests/ScoutUITests/Home/Section/Log/HomeLogProviderTests.swift
@@ -142,9 +142,7 @@ struct HomeLogProviderTests {
         #expect(try provider.result?.get() != nil)
     }
 
-    private func makeSeries(name: String, category: String? = nil, date: Date = Date(), value: MetricValue)
-        -> MetricSeries
-    {
+    private func makeSeries(name: String, category: String? = nil, date: Date = Date(), value: MetricValue) -> MetricSeries {
         MetricSeries(
             name: name,
             category: category,

--- a/Tests/ScoutUITests/Home/Settings/BackendHealthTests.swift
+++ b/Tests/ScoutUITests/Home/Settings/BackendHealthTests.swift
@@ -99,8 +99,6 @@ struct BackendHealthTests {
     }
 }
 
-func makeHealth(id: String = "backend", status: Backend.Status? = nil, probe: StatusProbe? = nil)
-    -> BackendHealth
-{
+func makeHealth(id: String = "backend", status: Backend.Status? = nil, probe: StatusProbe? = nil) -> BackendHealth {
     BackendHealth(id: id, name: id, engine: .local, status: status, probe: probe)
 }

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertMessageTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertMessageTests.swift
@@ -93,10 +93,7 @@ struct AlertMessageTests {
         #expect(AlertMessage(status: status) == nil)
     }
 
-    private func makeStatus(
-        metric: AlertMetric, condition: AlertCondition, recent: [Double], shouldNotify: Bool = true,
-        notifies: Bool = true
-    ) -> AlertStatus {
+    private func makeStatus(metric: AlertMetric, condition: AlertCondition, recent: [Double], shouldNotify: Bool = true, notifies: Bool = true) -> AlertStatus {
         AlertStatus(
             rule: AlertRule(metric: metric, condition: condition, notifies: notifies),
             outcome: AlertOutcome(state: .firing(since: Date(timeIntervalSince1970: 0)), shouldNotify: shouldNotify),

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertRefreshSchedulerTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertRefreshSchedulerTests.swift
@@ -54,10 +54,7 @@
             return submittedStorage
         }
 
-        func register(
-            forTaskWithIdentifier identifier: String, using queue: DispatchQueue?,
-            launchHandler: @escaping @Sendable (BGTask) -> Void
-        ) -> Bool {
+        func register(forTaskWithIdentifier identifier: String, using queue: DispatchQueue?, launchHandler: @escaping @Sendable (BGTask) -> Void) -> Bool {
             lock.lock()
             defer { lock.unlock() }
             registeredStorage.append(identifier)

--- a/Tests/ScoutUITests/Monitoring/Metrics/Series/MetricsFormattersTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Metrics/Series/MetricsFormattersTests.swift
@@ -24,8 +24,8 @@ struct MetricsFormattersTests {
             (172_800.0, "2 d"),
             (5_184_000.0, "2 mo"),
             (47_304_000.0, "1.5 y"),
-        ]) func testDuration(seconds: TimeInterval, expected: String)
-    {
+        ])
+    func testDuration(seconds: TimeInterval, expected: String) {
         #expect(seconds.duration == expected)
     }
 
@@ -36,8 +36,8 @@ struct MetricsFormattersTests {
             (119.5, "2 min 0 s"),
             (60.4, "1 min 0 s"),
             (89.5, "1 min 30 s"),
-        ]) func testDurationSecondsCarry(seconds: TimeInterval, expected: String)
-    {
+        ])
+    func testDurationSecondsCarry(seconds: TimeInterval, expected: String) {
         #expect(seconds.duration == expected)
     }
 
@@ -50,8 +50,8 @@ struct MetricsFormattersTests {
             (3599.7, "1 h"),
             (86_399.0, "1 d"),
             (2_591_999.0, "1 mo"),
-        ]) func testDurationUnitPromotion(seconds: TimeInterval, expected: String)
-    {
+        ])
+    func testDurationUnitPromotion(seconds: TimeInterval, expected: String) {
         #expect(seconds.duration == expected)
     }
 }

--- a/Tests/ScoutUITests/Stubs/Crash+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Crash+Stub.swift
@@ -11,17 +11,7 @@ import Foundation
 @testable import ScoutUI
 
 extension Crash {
-    @discardableResult static func stub(
-        name: String = "crash",
-        fingerprint: String? = nil,
-        reason: String? = nil,
-        stackTrace: [String] = [],
-        deviceID: UUID? = nil,
-        sessionID: UUID? = nil,
-        launchID: UUID? = nil,
-        installID: UUID? = nil,
-        date: Date? = Date()
-    ) -> Crash {
+    @discardableResult static func stub(name: String = "crash", fingerprint: String? = nil, reason: String? = nil, stackTrace: [String] = [], deviceID: UUID? = nil, sessionID: UUID? = nil, launchID: UUID? = nil, installID: UUID? = nil, date: Date? = Date()) -> Crash {
         Crash(
             name: name,
             fingerprint: fingerprint ?? CrashFingerprint(name: name, reason: reason, stackTrace: stackTrace).value,

--- a/Tests/ScoutUITests/Stubs/DatabaseStub.swift
+++ b/Tests/ScoutUITests/Stubs/DatabaseStub.swift
@@ -176,10 +176,7 @@ extension Record {
         return record
     }
 
-    static func sessionStub(
-        sessionID: UUID, launchID: UUID, installID: UUID, startDate: Date, osVersion: String? = nil,
-        deviceID: UUID? = nil
-    ) -> Record {
+    static func sessionStub(sessionID: UUID, launchID: UUID, installID: UUID, startDate: Date, osVersion: String? = nil, deviceID: UUID? = nil) -> Record {
         var record = Session(
             startDate: startDate,
             endDate: nil,

--- a/Tests/ScoutUITests/Stubs/Device+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Device+Stub.swift
@@ -11,10 +11,7 @@ import Foundation
 @testable import ScoutUI
 
 extension Device {
-    @discardableResult static func stub(
-        deviceID: UUID = UUID(),
-        date: Date? = Date()
-    ) -> Device {
+    @discardableResult static func stub(deviceID: UUID = UUID(), date: Date? = Date()) -> Device {
         Device(
             date: date,
             id: UUID().uuidString,

--- a/Tests/ScoutUITests/Stubs/Event+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Event+Stub.swift
@@ -11,13 +11,7 @@ import Foundation
 @testable import ScoutUI
 
 extension Event {
-    @discardableResult static func stub(
-        name: String = "event",
-        sessionID: UUID? = nil,
-        installID: UUID? = nil,
-        deviceID: UUID? = nil,
-        date: Date? = Date()
-    ) -> Event {
+    @discardableResult static func stub(name: String = "event", sessionID: UUID? = nil, installID: UUID? = nil, deviceID: UUID? = nil, date: Date? = Date()) -> Event {
         Event(
             name: name,
             level: nil,

--- a/Tests/ScoutUITests/Stubs/Hang+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Hang+Stub.swift
@@ -11,18 +11,7 @@ import Foundation
 @testable import ScoutUI
 
 extension Hang {
-    @discardableResult static func stub(
-        name: String = "hang",
-        fingerprint: String? = nil,
-        reason: String? = nil,
-        stackTrace: [String] = [],
-        duration: TimeInterval = 4,
-        deviceID: UUID? = nil,
-        sessionID: UUID? = nil,
-        launchID: UUID? = nil,
-        installID: UUID? = nil,
-        date: Date? = Date()
-    ) -> Hang {
+    @discardableResult static func stub(name: String = "hang", fingerprint: String? = nil, reason: String? = nil, stackTrace: [String] = [], duration: TimeInterval = 4, deviceID: UUID? = nil, sessionID: UUID? = nil, launchID: UUID? = nil, installID: UUID? = nil, date: Date? = Date()) -> Hang {
         Hang(
             name: name,
             fingerprint: fingerprint ?? CrashFingerprint(name: name, reason: nil, stackTrace: stackTrace).value,

--- a/Tests/ScoutUITests/Stubs/Install+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Install+Stub.swift
@@ -11,11 +11,7 @@ import Foundation
 @testable import ScoutUI
 
 extension Install {
-    @discardableResult static func stub(
-        installID: UUID = UUID(),
-        deviceID: UUID? = nil,
-        date: Date? = Date()
-    ) -> Install {
+    @discardableResult static func stub(installID: UUID = UUID(), deviceID: UUID? = nil, date: Date? = Date()) -> Install {
         Install(
             date: date,
             id: UUID().uuidString,

--- a/Tests/ScoutUITests/Stubs/Launch+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Launch+Stub.swift
@@ -11,12 +11,7 @@ import Foundation
 @testable import ScoutUI
 
 extension Launch {
-    @discardableResult static func stub(
-        launchID: UUID = UUID(),
-        installID: UUID? = nil,
-        startDate: Date? = Date(),
-        endDate: Date? = nil
-    ) -> Launch {
+    @discardableResult static func stub(launchID: UUID = UUID(), installID: UUID? = nil, startDate: Date? = Date(), endDate: Date? = nil) -> Launch {
         Launch(
             startDate: startDate,
             endDate: endDate,

--- a/Tests/ScoutUITests/Stubs/Rail+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Rail+Stub.swift
@@ -12,13 +12,7 @@ import Foundation
 @testable import Support
 
 extension Rail {
-    @discardableResult static func stub(
-        deviceID: UUID = UUID(),
-        installID: UUID = UUID(),
-        launchID: UUID = UUID(),
-        sessionID: UUID = UUID(),
-        baseDate: Date = Date()
-    ) -> Rail {
+    @discardableResult static func stub(deviceID: UUID = UUID(), installID: UUID = UUID(), launchID: UUID = UUID(), sessionID: UUID = UUID(), baseDate: Date = Date()) -> Rail {
         Rail(
             device: .stub(deviceID: deviceID, date: baseDate),
             installs: [.stub(installID: installID, deviceID: deviceID, date: baseDate)],

--- a/Tests/ScoutUITests/Stubs/Session+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Session+Stub.swift
@@ -11,13 +11,7 @@ import Foundation
 @testable import ScoutUI
 
 extension Session {
-    @discardableResult static func stub(
-        sessionID: UUID = UUID(),
-        launchID: UUID? = nil,
-        installID: UUID? = nil,
-        startDate: Date? = Date(),
-        endDate: Date? = nil
-    ) -> Session {
+    @discardableResult static func stub(sessionID: UUID = UUID(), launchID: UUID? = nil, installID: UUID? = nil, startDate: Date? = Date(), endDate: Date? = nil) -> Session {
         Session(
             startDate: startDate,
             endDate: endDate,

--- a/Tests/ScoutUITests/Stubs/Version+Stub.swift
+++ b/Tests/ScoutUITests/Stubs/Version+Stub.swift
@@ -11,12 +11,7 @@ import Foundation
 @testable import ScoutUI
 
 extension Version {
-    @discardableResult static func stub(
-        appVersion: String? = "1.0",
-        buildNumber: String? = "1",
-        launchID: UUID? = nil,
-        date: Date? = Date()
-    ) -> Version {
+    @discardableResult static func stub(appVersion: String? = "1.0", buildNumber: String? = "1", launchID: UUID? = nil, date: Date? = Date()) -> Version {
         Version(
             appVersion: appVersion,
             buildNumber: buildNumber,

--- a/Tests/Support/Stubs/Entries/DeviceEntry+Stub.swift
+++ b/Tests/Support/Stubs/Entries/DeviceEntry+Stub.swift
@@ -10,11 +10,7 @@ import CoreData
 @testable import Scout
 
 extension DeviceEntry {
-    @discardableResult static func stub(
-        date: Date,
-        synced: Bool = false,
-        in context: NSManagedObjectContext
-    ) -> DeviceEntry {
+    @discardableResult static func stub(date: Date, synced: Bool = false, in context: NSManagedObjectContext) -> DeviceEntry {
         let device = context.insert(DeviceEntry.self)
 
         device.deviceID = Identity.stub.device

--- a/Tests/Support/Stubs/Entries/EventEntry+Stub.swift
+++ b/Tests/Support/Stubs/Entries/EventEntry+Stub.swift
@@ -10,14 +10,7 @@ import CoreData
 @testable import Scout
 
 extension EventEntry {
-    @discardableResult static func stub(
-        name: String,
-        date: Date = Date(),
-        synced: Bool = false,
-        level: EventLevel = .info,
-        session: SessionEntry? = nil,
-        in context: NSManagedObjectContext
-    ) -> EventEntry {
+    @discardableResult static func stub(name: String, date: Date = Date(), synced: Bool = false, level: EventLevel = .info, session: SessionEntry? = nil, in context: NSManagedObjectContext) -> EventEntry {
         let event = context.insert(EventEntry.self)
 
         event.name = name

--- a/Tests/Support/Stubs/Entries/InstallEntry+Stub.swift
+++ b/Tests/Support/Stubs/Entries/InstallEntry+Stub.swift
@@ -10,12 +10,7 @@ import CoreData
 @testable import Scout
 
 extension InstallEntry {
-    @discardableResult static func stub(
-        date: Date,
-        synced: Bool = false,
-        device: DeviceEntry? = nil,
-        in context: NSManagedObjectContext
-    ) -> InstallEntry {
+    @discardableResult static func stub(date: Date, synced: Bool = false, device: DeviceEntry? = nil, in context: NSManagedObjectContext) -> InstallEntry {
         let install = context.insert(InstallEntry.self)
 
         install.installID = Identity.stub.install

--- a/Tests/Support/Stubs/Entries/LaunchEntry+Stub.swift
+++ b/Tests/Support/Stubs/Entries/LaunchEntry+Stub.swift
@@ -10,13 +10,7 @@ import CoreData
 @testable import Scout
 
 extension LaunchEntry {
-    @discardableResult static func stub(
-        date: Date,
-        synced: Bool = false,
-        endDate: Date? = nil,
-        install: InstallEntry? = nil,
-        in context: NSManagedObjectContext
-    ) -> LaunchEntry {
+    @discardableResult static func stub(date: Date, synced: Bool = false, endDate: Date? = nil, install: InstallEntry? = nil, in context: NSManagedObjectContext) -> LaunchEntry {
         let launch = context.insert(LaunchEntry.self)
 
         launch.launchID = Identity.stub.launch

--- a/Tests/Support/Stubs/Entries/SessionEntry+Stub.swift
+++ b/Tests/Support/Stubs/Entries/SessionEntry+Stub.swift
@@ -10,14 +10,7 @@ import CoreData
 @testable import Scout
 
 extension SessionEntry {
-    @discardableResult static func stub(
-        date: Date,
-        synced: Bool = false,
-        endDate: Date? = nil,
-        appVersion: String? = nil,
-        launch: LaunchEntry? = nil,
-        in context: NSManagedObjectContext
-    ) -> SessionEntry {
+    @discardableResult static func stub(date: Date, synced: Bool = false, endDate: Date? = nil, appVersion: String? = nil, launch: LaunchEntry? = nil, in context: NSManagedObjectContext) -> SessionEntry {
         let session = context.insert(SessionEntry.self)
 
         session.sessionID = Identity.stub.session.current

--- a/Tests/Support/Stubs/Entries/SyncableEntry+Stub.swift
+++ b/Tests/Support/Stubs/Entries/SyncableEntry+Stub.swift
@@ -11,9 +11,7 @@ import CoreData
 
 extension SyncableEntry {
     @discardableResult
-    func seedDelivery(
-        pending: Bool = true, attempts: Int16 = 0, for backendID: String, in context: NSManagedObjectContext
-    ) -> DeliveryEntry {
+    func seedDelivery(pending: Bool = true, attempts: Int16 = 0, for backendID: String, in context: NSManagedObjectContext) -> DeliveryEntry {
         let entity = NSEntityDescription.entity(forEntityName: "DeliveryEntry", in: context)!
         let row = delivery(for: backendID) ?? DeliveryEntry(entity: entity, insertInto: context)
         row.backendID = backendID

--- a/Tests/Support/Stubs/Entries/VersionEntry+Stub.swift
+++ b/Tests/Support/Stubs/Entries/VersionEntry+Stub.swift
@@ -10,14 +10,7 @@ import CoreData
 @testable import Scout
 
 extension VersionEntry {
-    @discardableResult static func stub(
-        date: Date,
-        synced: Bool = false,
-        appVersion: String = "1.0",
-        buildNumber: String? = nil,
-        launch: LaunchEntry? = nil,
-        in context: NSManagedObjectContext
-    ) -> VersionEntry {
+    @discardableResult static func stub(date: Date, synced: Bool = false, appVersion: String = "1.0", buildNumber: String? = nil, launch: LaunchEntry? = nil, in context: NSManagedObjectContext) -> VersionEntry {
         let version = context.insert(VersionEntry.self)
 
         version.date = date

--- a/Tests/Support/Transient/InMemoryContainer.swift
+++ b/Tests/Support/Transient/InMemoryContainer.swift
@@ -23,9 +23,7 @@ final class InMemoryContainer: NSPersistentContainer, @unchecked Sendable {
         self.persistentStoreDescriptions = [description]
     }
 
-    override func loadPersistentStores(
-        completionHandler block: @escaping (NSPersistentStoreDescription, Error?) -> Void
-    ) {
+    override func loadPersistentStores(completionHandler block: @escaping (NSPersistentStoreDescription, Error?) -> Void) {
         // Call completion with the injected error to simulate a failure.
         let description = persistentStoreDescriptions.first ?? NSPersistentStoreDescription()
         block(description, injectedError)


### PR DESCRIPTION
The 120-character `lineLength` in `.swift-format` was the one thing forcing declarations to wrap, so this raises it to 1000 — swift-format has no "unlimited" setting, so the practical ceiling just moves far past any real line. With that gone, the 64 signatures that had been split across lines are joined back together: the ones whose parameters sat one per line, and the ones where only the trailing `-> T` / `async throws` / `where` clause and the opening brace had spilled over. Three parameterized tests in `MetricsFormattersTests` also get their `func` pulled off the tail of a multi-line `@Test(...)` onto its own line, matching how the other argument-driven suites are written.

`CLAUDE.md` drops the three rules that existed only to describe what happens at the 120-character boundary; the signature rule is now unconditional.

The longest signature in the tree is 294 characters. `swift-format lint --strict --recursive Sources Tests` passes, and running `format --in-place` over copies of `Sources` and `Tests` produces no changes at all — `respectsExistingLineBreaks` is on by default, so multi-line call sites stay wrapped and the joined signatures stay joined. `build-for-testing` on the iOS simulator succeeds.