### PR TITLE
Stop main pushes from evicting each other from the concurrency queue

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: server-${{ github.ref }}
+  group: server-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ios-tests-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ios-tests-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   scope:


### PR DESCRIPTION
On main the Swift workflow set `cancel-in-progress` to false so that every commit would be tested. It does the opposite: GitHub keeps at most one running and one pending run per concurrency group, and an arriving push evicts the pending one. With the iOS matrix queueing for macOS runners for the better part of an hour, three merges inside that window meant the middle one never ran a single job — the run for `2aa71ef` (#1218) was cancelled with zero jobs while #1215 was still working through its legs and #1219 took the pending slot. Nothing reports it either, since Notify only fires on a successful run.

The group key now falls back to `github.run_id` for anything that is not a pull request, which makes it unique per run and takes those events out of the shared queue; pull requests keep grouping by `github.ref` and still cancel in progress. `server.yml` had the same shape and gets the same fix — its push trigger is path-filtered so it fired less often, but the trap was identical.

This does not make the matrix any faster, it only stops commits from being dropped. The queue itself — ten macOS legs per run, ~85% of wall-clock spent waiting for a runner — is a separate change.