### PR TITLE
Collapse the remaining wrapped signatures onto one line

### DIFF
--- a/Sources/Scout/Activity/RetentionCohort+Build.swift
+++ b/Sources/Scout/Activity/RetentionCohort+Build.swift
@@ -8,9 +8,7 @@
 import Foundation
 
 extension RetentionCohort {
-    package static func build(
-        installDays: [String: Date], sessionDays: [String: Set<Date>], in range: Range<Date>, asOf: Date
-    ) -> [RetentionCohort] {
+    package static func build(installDays: [String: Date], sessionDays: [String: Set<Date>], in range: Range<Date>, asOf: Date) -> [RetentionCohort] {
         var sizes: [Date: Int] = [:]
         var counts: [Date: [Int: Int]] = [:]
 

--- a/Sources/Scout/Diagnostics/Crash/Crash.swift
+++ b/Sources/Scout/Diagnostics/Crash/Crash.swift
@@ -19,10 +19,7 @@ package struct Crash {
     package let launchID: UUID?
     package let sessionID: UUID?
 
-    package init(
-        name: String, fingerprint: String, reason: String?, stackTrace: [String], date: Date?, id: String,
-        deviceID: UUID?, installID: UUID?, launchID: UUID?, sessionID: UUID?
-    ) {
+    package init(name: String, fingerprint: String, reason: String?, stackTrace: [String], date: Date?, id: String, deviceID: UUID?, installID: UUID?, launchID: UUID?, sessionID: UUID?) {
         self.name = name
         self.fingerprint = fingerprint
         self.reason = reason

--- a/Sources/Scout/Diagnostics/Hang/Hang.swift
+++ b/Sources/Scout/Diagnostics/Hang/Hang.swift
@@ -20,10 +20,7 @@ package struct Hang {
     package let launchID: UUID?
     package let sessionID: UUID?
 
-    package init(
-        name: String, fingerprint: String, reason: String?, stackTrace: [String], duration: TimeInterval, date: Date?,
-        id: String, deviceID: UUID?, installID: UUID?, launchID: UUID?, sessionID: UUID?
-    ) {
+    package init(name: String, fingerprint: String, reason: String?, stackTrace: [String], duration: TimeInterval, date: Date?, id: String, deviceID: UUID?, installID: UUID?, launchID: UUID?, sessionID: UUID?) {
         self.name = name
         self.fingerprint = fingerprint
         self.reason = reason

--- a/Sources/Scout/Diagnostics/Log/Event.swift
+++ b/Sources/Scout/Diagnostics/Log/Event.swift
@@ -18,10 +18,7 @@ package struct Event: Identifiable {
     package let sessionID: UUID?
     package let deviceID: UUID?
 
-    package init(
-        name: String, level: EventLevel?, date: Date?, paramCount: Int?, uuid: UUID?, id: String, installID: UUID?,
-        sessionID: UUID?, deviceID: UUID?
-    ) {
+    package init(name: String, level: EventLevel?, date: Date?, paramCount: Int?, uuid: UUID?, id: String, installID: UUID?, sessionID: UUID?, deviceID: UUID?) {
         self.name = name
         self.level = level
         self.date = date

--- a/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
+++ b/Sources/Scout/Diagnostics/Metrics/MetricSeries.swift
@@ -8,9 +8,7 @@
 import Foundation
 
 extension DatabaseReader {
-    package func metricSeries<T: MetricScalar>(
-        _ valueType: T.Type, category: String, reduce: SeriesQuery.Reduce = .sum, in range: Range<Date>
-    ) async throws -> [MetricSeries] {
+    package func metricSeries<T: MetricScalar>(_ valueType: T.Type, category: String, reduce: SeriesQuery.Reduce = .sum, in range: Range<Date>) async throws -> [MetricSeries] {
         try await series(
             matching: SeriesQuery(
                 category: category,
@@ -22,9 +20,7 @@ extension DatabaseReader {
         )
     }
 
-    package func metricSeries<T: MetricScalar>(
-        _ valueType: T.Type, categories: [String], in range: Range<Date>
-    ) async throws -> [MetricSeries] {
+    package func metricSeries<T: MetricScalar>(_ valueType: T.Type, categories: [String], in range: Range<Date>) async throws -> [MetricSeries] {
         try await withThrowingTaskGroup(of: [MetricSeries].self) { group in
             for category in categories {
                 group.addTask {
@@ -66,10 +62,7 @@ package struct SeriesQuery: Sendable {
     package var reduce: Reduce = .sum
     package var range: Range<Date>
 
-    package init(
-        name: String? = nil, category: String? = nil, values: Values? = nil, bucket: Bucket = .day,
-        byVersion: Bool = false, source: Source? = nil, reduce: Reduce = .sum, range: Range<Date>
-    ) {
+    package init(name: String? = nil, category: String? = nil, values: Values? = nil, bucket: Bucket = .day, byVersion: Bool = false, source: Source? = nil, reduce: Reduce = .sum, range: Range<Date>) {
         self.name = name
         self.category = category
         self.values = values

--- a/Sources/Scout/Runtime/Backend.swift
+++ b/Sources/Scout/Runtime/Backend.swift
@@ -18,10 +18,7 @@ public struct Backend: Sendable {
     package let probeStatus: StatusProbe?
     package let accountWarning: AccountWarning?
 
-    package init(
-        id: String, database: any Database, checkAvailability: @escaping @Sendable () async -> Bool,
-        displayName: String, engine: Engine, probeStatus: StatusProbe? = nil, accountWarning: AccountWarning? = nil
-    ) {
+    package init(id: String, database: any Database, checkAvailability: @escaping @Sendable () async -> Bool, displayName: String, engine: Engine, probeStatus: StatusProbe? = nil, accountWarning: AccountWarning? = nil) {
         self.id = id
         self.database = database
         self.checkAvailability = checkAvailability


### PR DESCRIPTION
Raising `lineLength` to 1000 in #1221 stopped swift-format from wrapping declarations, but it does not undo line breaks an author already placed inside a parameter list — those are discretionary newlines the formatter preserves. Eight signatures across six files stayed wrapped and `swift-format lint --strict` still passed on them, so the rule could not be enforced by the formatter alone.

This joins those signatures by hand: `RetentionCohort.build`, the `Crash`, `Hang`, `Event`, `SeriesQuery` and `Backend` initializers, and both `DatabaseReader.metricSeries` overloads. The change is whitespace only — no call sites were reflowed and no declarations changed. Re-running `swift-format format --in-place` over Sources and Tests produces no further diff, so the result is stable under the formatter.