### PR TITLE
Give sheets an opaque background from the first frame

### DIFF
--- a/Sources/ScoutUI/Home/Connection/ConnectionToolbar.swift
+++ b/Sources/ScoutUI/Home/Connection/ConnectionToolbar.swift
@@ -43,6 +43,7 @@ private struct ConnectionToolbar: ViewModifier {
                 NavigationStack {
                     SettingsOverviewView(backends: backends, activeID: $activeID)
                 }
+                .opaquePresentation()
             }
     }
 }

--- a/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
+++ b/Sources/ScoutUI/Home/Section/Alert/HomeAlertSection.swift
@@ -39,6 +39,7 @@ struct HomeAlertSection: View {
             NavigationStack {
                 AlertEditorView(provider: alerts)
             }
+            .opaquePresentation()
         }
 
         switch alerts.result {

--- a/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
+++ b/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
@@ -45,7 +45,6 @@ struct SettingsOverviewView: View {
         }
         .navigationTitle(en: "Settings")
         .dismissable()
-        .opaquePresentation()
         .task {
             await provider.refreshAll()
         }

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -32,8 +32,8 @@ struct AlertListView: View {
                 NavigationStack {
                     AlertEditorView(provider: provider)
                 }
+                .opaquePresentation()
             }
-            .opaquePresentation()
             .task {
                 await provider.fetchIfNeeded(in: database)
             }

--- a/Sources/ScoutUI/Primitives/Platform/View+OpaquePresentation.swift
+++ b/Sources/ScoutUI/Primitives/Platform/View+OpaquePresentation.swift
@@ -10,9 +10,6 @@ import Scout
 import SwiftUI
 
 extension View {
-    /// Gives a sheet an opaque system background, overriding the translucent
-    /// material newer OS versions apply by default.
-    ///
     @ViewBuilder
     func opaquePresentation() -> some View {
         if #available(iOS 16.4, macOS 13.3, *) {


### PR DESCRIPTION
The New Rule and Settings sheets came up with a grey background instead of white. `opaquePresentation()` was applied deep inside the presented content, and SwiftUI only resolves the presentation background once the transition ends, so the sheet stayed translucent over the dimmed backdrop while it animated in, and the navigation bar area kept that grey afterwards.

Moving the modifier onto the root of each sheet's content — the `NavigationStack` passed to `.sheet` — makes the background white from the first frame. Verified frame by frame against a simulator recording of both sheets opening. Also drops a stray `opaquePresentation()` from the pushed alert list screen, where it never applied.