### PR TITLE
Restore the runtime line in the Quick Setup snippet

### DIFF
--- a/Sources/ScoutUI/Home/Onboarding/SetupPage.swift
+++ b/Sources/ScoutUI/Home/Onboarding/SetupPage.swift
@@ -18,8 +18,15 @@ struct SetupPage: View {
                     number: 1,
                     label: "Initialize Scout in your app",
                     code: """
+                        let scout = Runtime(
+                            backends: [backend]
+                        )
+
                         LoggingSystem.bootstrap {
-                            ScoutLogHandler(label: $0, runtime: scout)
+                            ScoutLogHandler(
+                                label: $0,
+                                runtime: scout
+                            )
                         }
                         """
                 )
@@ -43,10 +50,6 @@ struct SetupPage: View {
         let label: String
         let code: String
 
-        private var lineCount: Int {
-            code.filter { $0 == "\n" }.count + 1
-        }
-
         var body: some View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 10) {
@@ -60,8 +63,7 @@ struct SetupPage: View {
                         .fontWeight(.medium)
                 }
                 Text(code.swiftSyntax)
-                    .lineLimit(lineCount)
-                    .minimumScaleFactor(0.6)
+                    .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .codeChipStyle()
                     .padding(.leading, 32)


### PR DESCRIPTION
The first onboarding snippet showed only the LoggingSystem bootstrap, leaving out the line that builds the Runtime it passes to the handler, and it leaned on minimumScaleFactor to squeeze a 46-character line into the code chip, so the first step rendered in a visibly smaller font than the others. The handler call is now wrapped one argument per line and the Runtime construction is back above it, so every line fits the chip at full size. The chip renders the code without scaling and without the line limit that was truncating the closing brace; a preview render on iPhone 17 Pro confirms the whole snippet is visible at 14pt.