### PR TITLE
Give the Active Users controls the same side insets as the chart

### DIFF
--- a/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityView.swift
@@ -27,44 +27,39 @@ struct ActivityView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            PeriodPicker(extent: $extent, periods: ActivityPeriod.allCases)
-                .padding(.top)
+        ProviderView(provider: activity) { data in
+            let points = data.points(on: extent.period)
+            let segment = extent.segment(from: points)
+            let canCompare = extent.canCompare(points: points, segment: segment)
 
-            ProviderView(provider: activity) { data in
-                RangeControl(extent: $extent)
-                    .padding(.vertical)
-
-                InsetList {
-                    let points = data.points(on: extent.period)
-                    let segment = extent.segment(from: points)
-                    let canCompare = extent.canCompare(points: points, segment: segment)
-
-                    ComparableChart(
-                        segment: segment,
-                        points: points,
-                        extent: extent,
-                        color: .green,
-                        isComparing: isComparing
-                    )
+            InsetList {
+                PeriodPicker(extent: $extent, periods: ActivityPeriod.allCases)
                     .listRowSeparator(.hidden)
-                    .padding(.bottom)
 
-                    ComparisonToggle(isOn: $isComparing).disabled(!canCompare)
-                }
-                .scrollDisabled(true)
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        ChartExportButton(
-                            title: "Active Users",
-                            rangeLabel: extent.domain.label(using: rangeDateFormatter)
-                        ) {
-                            ChartView(
-                                segment: extent.segment(from: data.points(on: extent.period)),
-                                timing: extent
-                            )
+                RangeControl(extent: $extent)
+                    .padding(.bottom)
+                    .listRowSeparator(.hidden)
+
+                ComparableChart(
+                    segment: segment,
+                    points: points,
+                    extent: extent,
+                    color: .green,
+                    isComparing: isComparing
+                )
+                .listRowSeparator(.hidden)
+                .padding(.bottom)
+
+                ComparisonToggle(isOn: $isComparing).disabled(!canCompare)
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    ChartExportButton(
+                        title: "Active Users",
+                        rangeLabel: extent.domain.label(using: rangeDateFormatter)
+                    ) {
+                        ChartView(segment: segment, timing: extent)
                             .foregroundStyle(.green)
-                        }
                     }
                 }
             }


### PR DESCRIPTION
On the Active Users screen the period picker and the range control sat in an outer VStack, outside the InsetList, so they stretched to the screen edges while the chart and the comparison toggle kept the usual 16 pt side insets. They are now rows of the InsetList with hidden separators, exactly like the Sessions screen (StatView), so the whole screen lines up on one margin.

Since the list now carries the picker and the range control as well, scrollDisabled was dropped — with larger Dynamic Type the content could otherwise be clipped, and the Sessions screen scrolls too.

Verified by building the package for the simulator and by a full ScoutIP build; the screen was not checked visually in the simulator.