### PR TITLE
Point the installation snippet at 0.2.0

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -23,7 +23,7 @@ https://github.com/kasianov-mikhail/scout.git
 Or add it to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/kasianov-mikhail/scout.git", from: "0.1.0")
+.package(url: "https://github.com/kasianov-mikhail/scout.git", from: "0.2.0")
 ```
 
 Then add the products your target needs. `Scout` carries the runtime and the handlers; the backend it syncs to comes from a connector, so a CloudKit setup takes `NativeConnector` too:


### PR DESCRIPTION
For a 0.x package `from: "0.1.0"` resolves to ">=0.1.0 <0.2.0", so the snippet in the installation guide pinned anyone copying it below 0.2.0, which was just tagged. It now names 0.2.0. Docs-only; the snippet inside the 0.2.0 tag keeps the old number until the next tag moves past it.