### PR TITLE
Give the contract session fixture a device id

### DIFF
--- a/Tests/Connectors/Hosted/ServerContractTests.swift
+++ b/Tests/Connectors/Hosted/ServerContractTests.swift
@@ -353,10 +353,15 @@ struct ServerContractTests {
         return record
     }
 
+    // A real SessionEntry carries both ids, and the two aggregations read
+    // different ones: the active-user series counts devices, retention counts
+    // installs. The contract records reuse one id for both, so a session
+    // written here reaches either.
     private func makeSession(installID: String, startDate: Date) -> Record {
         var record = Record(recordType: "Session", recordID: "contract-\(UUID().uuidString)")
         record["session_id"] = UUID().uuidString
         record["install_id"] = installID
+        record["device_id"] = installID
         record["start_date"] = startDate
         return record
     }

--- a/Tests/Connectors/Hosted/ServerContractTests.swift
+++ b/Tests/Connectors/Hosted/ServerContractTests.swift
@@ -353,10 +353,6 @@ struct ServerContractTests {
         return record
     }
 
-    // A real SessionEntry carries both ids, and the two aggregations read
-    // different ones: the active-user series counts devices, retention counts
-    // installs. Only the install id is worth pinning from a test, so the
-    // device gets its own.
     private func makeSession(installID: String, startDate: Date) -> Record {
         var record = Record(recordType: "Session", recordID: "contract-\(UUID().uuidString)")
         record["session_id"] = UUID().uuidString

--- a/Tests/Connectors/Hosted/ServerContractTests.swift
+++ b/Tests/Connectors/Hosted/ServerContractTests.swift
@@ -107,7 +107,7 @@ struct ServerContractTests {
         let series = try await database.activity(in: day..<day.addingDay())
         let point = try #require(series.first { $0.date == Int64((day.timeIntervalSince1970 * 1000).rounded()) })
 
-        // The server forward-marks the install as active that day across all
+        // The server forward-marks the device as active that day across all
         // three windows; shared data may push the counts higher.
         #expect(point.dau >= 1)
         #expect(point.wau >= 1)
@@ -355,13 +355,13 @@ struct ServerContractTests {
 
     // A real SessionEntry carries both ids, and the two aggregations read
     // different ones: the active-user series counts devices, retention counts
-    // installs. The contract records reuse one id for both, so a session
-    // written here reaches either.
+    // installs. Only the install id is worth pinning from a test, so the
+    // device gets its own.
     private func makeSession(installID: String, startDate: Date) -> Record {
         var record = Record(recordType: "Session", recordID: "contract-\(UUID().uuidString)")
         record["session_id"] = UUID().uuidString
         record["install_id"] = installID
-        record["device_id"] = installID
+        record["device_id"] = UUID().uuidString
         record["start_date"] = startDate
         return record
     }


### PR DESCRIPTION
`ServerContractTests.makeSession` writes a session carrying `session_id`, `install_id` and `start_date`, but no `device_id`. Real sessions always carry both ids — `SessionEntry.record` sets `install_id` and `device_id` side by side — so the fixture is thinner than anything the client actually uploads.

That matters now because the two server aggregations read different ids, exactly as the native backend does: the active-user series counts distinct devices (`NativeDatabase.activity` reads `device_id` from `Visit` markers and `Session` records), while retention counts installs, since a cohort is an acquisition. A session with no `device_id` reaches retention but is invisible to the active-user series, so `activitySeries` would stop counting its own session once the server matches the client.

This gives the fixture a `device_id` of its own, minted like the `session_id` above it and like the `Visit` fixture already does. Only the install id is worth pinning from a test — `retentionCohort` ties a session back to the install it wrote — and no test correlates devices, so nothing needs to control that value. `activitySeries` now says the server marks the device active rather than the install.

Nothing else changes: the suite is unaffected against the current server, which counts installs, and correct against the server once it counts devices.

Companion to kasianov-mikhail/scout-server#56, which brings the server's active-user aggregation in line with `ActivityPoint.points`. Merge this one first — it is compatible with both servers, so landing it ahead of time keeps the contract job green through the transition.
