### PR TITLE
Remove pull-to-refresh from the alert list

### DIFF
--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -37,9 +37,6 @@ struct AlertListView: View {
             .task {
                 await provider.fetchIfNeeded(in: database)
             }
-            .refreshable {
-                await provider.fetchAgain(in: database)
-            }
     }
 
     @ViewBuilder private var content: some View {


### PR DESCRIPTION
AlertListView was the only screen in the app carrying a `.refreshable` modifier, so pulling down on the alert list behaved differently from every other list. The modifier is gone; the list still loads through `.task`, and the remaining explicit refetches — after the editor sheet closes, after deleting a rule, and from the error view's retry — are untouched.