### PR TITLE
Add a pull-to-refresh primitive with a ring indicator

### DIFF
--- a/Sources/ScoutUI/Primitives/Refresh/PullState.swift
+++ b/Sources/ScoutUI/Primitives/Refresh/PullState.swift
@@ -1,0 +1,94 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Scout
+
+struct PullState: Equatable {
+    enum Phase {
+        case idle
+        case refreshing
+        case retracting
+    }
+
+    // Content insets can settle a fraction of a point off their rest offset,
+    // which must not read as a lingering pull.
+    static let slack: CGFloat = 1
+
+    let threshold: CGFloat
+
+    private(set) var pull: CGFloat = 0
+    private(set) var phase: Phase = .idle
+    private(set) var isArmed = true
+
+    init(threshold: CGFloat = 58) {
+        self.threshold = threshold
+    }
+
+    var isRefreshing: Bool {
+        phase == .refreshing
+    }
+
+    var isVisible: Bool {
+        phase != .idle || (isArmed && pull > 0)
+    }
+
+    var inset: CGFloat {
+        isRefreshing ? threshold : 0
+    }
+
+    var progress: Double? {
+        phase == .idle ? min(pull / threshold, 1) : nil
+    }
+
+    // While retracting the ring follows the animated inset rather than the
+    // measured pull, which UIKit clamps to zero the moment the inset shrinks.
+    func ringOffset(size: CGFloat) -> CGFloat {
+        (phase == .retracting ? inset : pull) - (threshold + size) / 2
+    }
+
+    var ringScale: CGFloat {
+        phase == .retracting ? 0 : 1
+    }
+
+    mutating func update(pull: CGFloat, dragging: Bool = true) -> Bool {
+        self.pull = pull < Self.slack ? 0 : pull
+
+        if self.pull == 0 {
+            isArmed = true
+        }
+
+        guard dragging, self.pull >= threshold else {
+            return false
+        }
+
+        return trigger()
+    }
+
+    mutating func trigger() -> Bool {
+        guard phase == .idle, isArmed else {
+            return false
+        }
+
+        phase = .refreshing
+        isArmed = false
+        return true
+    }
+
+    mutating func finish() {
+        guard isRefreshing else { return }
+        phase = .retracting
+    }
+
+    mutating func settle() {
+        guard phase == .retracting else {
+            return
+        }
+
+        phase = .idle
+    }
+}

--- a/Sources/ScoutUI/Primitives/Refresh/PullToRefresh.swift
+++ b/Sources/ScoutUI/Primitives/Refresh/PullToRefresh.swift
@@ -1,0 +1,121 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func pullToRefresh(action: @escaping () async -> Void) -> some View {
+        if #available(iOS 18.0, macOS 15.0, *) {
+            modifier(PullToRefreshModifier(action: action))
+        } else {
+            refreshable { await action() }
+        }
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, *)
+private struct PullToRefreshModifier: ViewModifier {
+    static let ringSize: CGFloat = 22
+    static let settleFallback: Duration = .seconds(1)
+
+    let action: () async -> Void
+
+    @State private var state = PullState()
+    @State private var generation = 0
+    @State private var isDragging = false
+
+    func body(content: Content) -> some View {
+        content
+            .onScrollPhaseChange { _, phase in
+                isDragging = phase == .interacting || phase == .tracking
+            }
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                state.inset - geometry.contentOffset.y - geometry.contentInsets.top
+            } action: { _, pull in
+                var next = state
+
+                if next.update(pull: pull, dragging: isDragging) {
+                    refresh()
+                }
+                if next != state {
+                    state = next
+                }
+            }
+            .topContentMargin(state.inset)
+            .overlay(alignment: .top) {
+                ring.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top).clipped()
+            }
+            .accessibilityAction(named: Text(verbatim: "Refresh")) {
+                if state.trigger() {
+                    refresh()
+                }
+            }
+            .hapticFeedback(.impact, trigger: generation)
+    }
+
+    @ViewBuilder private var ring: some View {
+        if state.isVisible {
+            RingIndicator(size: Self.ringSize, progress: state.progress)
+                .scaleEffect(state.ringScale)
+                .offset(y: state.ringOffset(size: Self.ringSize))
+        }
+    }
+
+    // Detached from the view lifecycle on purpose: `.task(id:)` would restart
+    // the action on every reappearance and cancel it mid-flight on disappear.
+    private func refresh() {
+        generation += 1
+
+        Task {
+            await action()
+            withAnimation {
+                state.finish()
+            } completion: {
+                state.settle()
+            }
+            try? await Task.sleep(for: Self.settleFallback)
+            state.settle()
+        }
+    }
+}
+
+#Preview("Scroll") {
+    NavigationStack {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(0..<40, id: \.self) { row in
+                    Text(verbatim: "Row \(row)")
+                        .monospaced()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                }
+            }
+        }
+        .pullToRefresh {
+            try? await Task.sleep(for: .seconds(2))
+        }
+        .navigationTitle(en: "Pull to refresh")
+    }
+}
+
+#Preview("List") {
+    NavigationStack {
+        InsetList {
+            Header(title: "Rows")
+
+            ForEach(0..<40, id: \.self) { row in
+                Text(verbatim: "Row \(row)").monospaced()
+            }
+        }
+        .pullToRefresh {
+            try? await Task.sleep(for: .seconds(2))
+        }
+        .navigationTitle(en: "Pull to refresh")
+    }
+}

--- a/Sources/ScoutUI/Primitives/Refresh/TopContentMargin.swift
+++ b/Sources/ScoutUI/Primitives/Refresh/TopContentMargin.swift
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+extension View {
+    @available(iOS 17.0, macOS 14.0, *)
+    func topContentMargin(_ inset: CGFloat) -> some View {
+        modifier(TopContentMarginModifier(inset: inset))
+    }
+}
+
+// `contentMargins` is not animatable on its own; routing the inset through
+// `animatableData` lets an animation feed it frame by frame.
+@available(iOS 17.0, macOS 14.0, *)
+private struct TopContentMarginModifier: ViewModifier, Animatable {
+    var inset: CGFloat
+
+    nonisolated var animatableData: CGFloat {
+        get { inset }
+        set { inset = newValue }
+    }
+
+    func body(content: Content) -> some View {
+        content.contentMargins(.top, inset, for: .scrollContent)
+    }
+}

--- a/Tests/ScoutUITests/Primitives/Refresh/PullStateTests.swift
+++ b/Tests/ScoutUITests/Primitives/Refresh/PullStateTests.swift
@@ -1,0 +1,204 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import ScoutUI
+
+struct PullStateTests {
+    @Test("Rest is idle, hidden and without inset") func rest() {
+        let state = PullState(threshold: 60)
+
+        #expect(state.phase == .idle)
+        #expect(state.isVisible == false)
+        #expect(state.inset == 0)
+        #expect(state.progress == 0)
+    }
+
+    @Test("Pulling short of the threshold shows progress and does not trigger") func shortPull() {
+        var state = PullState(threshold: 60)
+        let triggered = state.update(pull: 30)
+
+        #expect(triggered == false)
+        #expect(state.phase == .idle)
+        #expect(state.isVisible)
+        #expect(state.progress == 0.5)
+        #expect(state.inset == 0)
+    }
+
+    @Test("Returning short of the threshold keeps showing progress") func shortReturn() {
+        var state = PullState(threshold: 60)
+        _ = state.update(pull: 45)
+        let triggered = state.update(pull: 15)
+
+        #expect(triggered == false)
+        #expect(state.phase == .idle)
+        #expect(state.progress == 0.25)
+    }
+
+    @Test("Reaching the threshold triggers once and holds the inset") func trigger() {
+        var state = PullState(threshold: 60)
+        let triggered = state.update(pull: 60)
+
+        #expect(triggered)
+        #expect(state.phase == .refreshing)
+        #expect(state.progress == nil)
+        #expect(state.inset == 60)
+        #expect(state.isVisible)
+        #expect(state.isArmed == false)
+
+        let deeper = state.update(pull: 90)
+        let settled = state.update(pull: 60)
+
+        #expect(deeper == false)
+        #expect(settled == false)
+        #expect(state.phase == .refreshing)
+    }
+
+    @Test("Progress is capped at one") func cappedProgress() {
+        var state = PullState(threshold: 60)
+        _ = state.update(pull: 90)
+
+        #expect(state.progress == nil)
+
+        state = PullState(threshold: 60)
+        _ = state.update(pull: 59)
+
+        #expect(state.progress == 59.0 / 60.0)
+    }
+
+    @Test("Finishing retracts without progress and stays visible until settled") func finish() {
+        var state = PullState(threshold: 60)
+        _ = state.update(pull: 60)
+        state.finish()
+
+        #expect(state.phase == .retracting)
+        #expect(state.inset == 0)
+        #expect(state.progress == nil)
+        #expect(state.isVisible)
+        #expect(state.ringScale == 0)
+        #expect(state.ringOffset(size: 22) == -41)
+
+        let rested = state.update(pull: 0)
+
+        #expect(rested == false)
+        #expect(state.phase == .retracting)
+        #expect(state.isVisible)
+
+        state.settle()
+
+        #expect(state.phase == .idle)
+        #expect(state.isVisible == false)
+        #expect(state.ringScale == 1)
+    }
+
+    @Test("Settling outside of retracting is a no-op") func settleIdle() {
+        var state = PullState(threshold: 60)
+        _ = state.update(pull: 60)
+        state.settle()
+
+        #expect(state.phase == .refreshing)
+    }
+
+    @Test("Finishing while idle is a no-op") func finishIdle() {
+        var state = PullState(threshold: 60)
+        _ = state.update(pull: 20)
+        state.finish()
+
+        #expect(state.phase == .idle)
+        #expect(state.progress == 20.0 / 60.0)
+    }
+
+    @Test("Retracting does not re-trigger until it has settled and rested") func noRetrigger() {
+        var state = PullState(threshold: 60)
+        _ = state.update(pull: 60)
+        state.finish()
+        let early = state.update(pull: 80)
+
+        #expect(early == false)
+        #expect(state.phase == .retracting)
+
+        state.settle()
+        let held = state.update(pull: 80)
+
+        #expect(held == false)
+        #expect(state.phase == .idle)
+        #expect(state.isArmed == false)
+        #expect(state.isVisible == false)
+
+        _ = state.update(pull: 0)
+        let again = state.update(pull: 60)
+
+        #expect(again)
+    }
+
+    @Test("A bounce that is not a drag never triggers") func bounce() {
+        var state = PullState(threshold: 60)
+        let bounced = state.update(pull: 90, dragging: false)
+
+        #expect(bounced == false)
+        #expect(state.phase == .idle)
+        #expect(state.isVisible)
+        #expect(state.progress == 1)
+    }
+
+    @Test("Trigger without a pull refreshes once and re-arms only at rest") func triggerDirectly() {
+        var state = PullState(threshold: 60)
+        let first = state.trigger()
+        let second = state.trigger()
+
+        #expect(first)
+        #expect(second == false)
+        #expect(state.phase == .refreshing)
+
+        state.finish()
+        state.settle()
+        let third = state.trigger()
+
+        #expect(third == false)
+
+        _ = state.update(pull: 0)
+        let fourth = state.trigger()
+
+        #expect(fourth)
+    }
+
+    @Test("Negative offsets clamp to rest") func negative() {
+        var state = PullState(threshold: 60)
+        _ = state.update(pull: -20)
+
+        #expect(state.pull == 0)
+        #expect(state.isVisible == false)
+    }
+
+    @Test("Ring emerges from under the bar into the centre of the held gap") func ringOffset() {
+        var state = PullState(threshold: 60)
+
+        #expect(state.ringOffset(size: 22) == -41)
+
+        _ = state.update(pull: 30)
+        #expect(state.ringOffset(size: 22) == -11)
+
+        _ = state.update(pull: 60)
+        #expect(state.ringOffset(size: 22) == 19)
+
+        _ = state.update(pull: 100)
+        #expect(state.ringOffset(size: 22) == 59)
+    }
+
+    @Test("Sub-point residue after settling reads as rest") func slack() {
+        var state = PullState(threshold: 60)
+        _ = state.update(pull: 0.67)
+
+        #expect(state.pull == 0)
+        #expect(state.isVisible == false)
+
+        _ = state.update(pull: 1)
+        #expect(state.pull == 1)
+    }
+}


### PR DESCRIPTION
Adds a `.pullToRefresh { }` modifier that replaces the system spinner with the existing `RingIndicator`: while pulling, the ring shows a static progress arc; once the pull crosses the threshold, the refresh starts, the ring spins, and the content is held with a top margin until the action completes, then everything collapses in one animation. Releasing short of the threshold returns the ring as progress, without spinning. The gesture drives `PullState`, a small phase machine (idle → refreshing → retracting) covered by unit tests; it re-arms only after the content has come back to rest, ignores rubber-band bounces that are not a drag, and exposes an accessibility action so VoiceOver can refresh too.

Measurement uses `onScrollGeometryChange` (iOS 18 / macOS 15); on older systems the modifier falls back to `.refreshable`. The held content goes through `contentMargins` rather than `safeAreaInset` so the iOS 26 large title stays put, and the margin is wrapped in an `Animatable` modifier because `contentMargins` does not animate on its own. Nothing is wired to a screen yet — the previews (ScrollView and `InsetList`) are the only call sites. When wiring screens with nested horizontal scroll views, note that `onScrollGeometryChange` observes the first scroll view in the subtree and `contentMargins` propagates to nested ones, so those hosts may need a `.contentMargins(.top, 0, for: .scrollContent)` reset on the rails.
