### PR TITLE
Wire pull-to-refresh onto the data-driven screens

### DIFF
--- a/Sources/ScoutUI/Analytics/Event/Analytics/EventFilter.swift
+++ b/Sources/ScoutUI/Analytics/Event/Analytics/EventFilter.swift
@@ -28,7 +28,9 @@ private struct EventFilter: ViewModifier {
     func body(content: Content) -> some View {
         VStack(spacing: 0) {
             FilterChips(query: $filter)
-            content
+            content.pullToRefresh {
+                await activeProvider.fetch(for: filter, in: database)
+            }
         }
         .searchable(text: $filter.text, placement: .pinned, prompt: Text(verbatim: "Search"))
         .autocorrectionDisabled(true)

--- a/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/EventView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct EventView: View {
     let event: Event
 
-    @Environment(\.database) var database
     @StateObject var param: ParamProvider
     @StateObject var stat: StatProvider
     @State private var isParamPresented = false
@@ -46,10 +45,7 @@ struct EventView: View {
                 ParamList(items: items)
             }
         }
-        .task {
-            await param.fetchIfNeeded(in: database)
-        }
-        .fetchTask([stat])
+        .refreshes([stat, param])
     }
 }
 

--- a/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventStatList.swift
@@ -23,7 +23,7 @@ struct EventStatList: View {
     var body: some View {
         VStack {
             EventList(provider: provider)
-                .fetchTask([provider])
+                .refreshes([provider])
                 .navigationTitle(en: range.label(using: rangeDateFormatter))
                 .font(.caption)
         }

--- a/Sources/ScoutUI/Analytics/Event/Provider/EventProvider.swift
+++ b/Sources/ScoutUI/Analytics/Event/Provider/EventProvider.swift
@@ -31,6 +31,10 @@ final class EventProvider: FeedProvider<Event>, Refreshable {
         await fetchLatest(for: filter, in: database)
     }
 
+    func fetchAgain(in database: DatabaseReader) async {
+        await fetch(for: filter, in: database)
+    }
+
     private func query(for filter: EventQuery) -> RecordQuery {
         RecordQuery(
             recordType: Event.self,

--- a/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
+++ b/Sources/ScoutUI/Analytics/Session/SessionInspector.swift
@@ -28,7 +28,7 @@ struct SessionInspector: View {
                 SessionHeader(info: info)
             }
         }
-        .fetchTask([events, info])
+        .refreshes([events, info])
         .navigationTitle(en: "Session")
         .largeNavigationTitle()
     }

--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
@@ -69,7 +69,7 @@ struct DeviceDetailView: View {
             }
         }
         .navigationTitle(en: device.modelName)
-        .fetchTask([incidents])
+        .refreshes([incidents])
     }
 
     private var crashes: [Crash] {

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -81,7 +81,7 @@ struct VersionDetailView: View {
         .monospacedNavigationTitle(en: release.id)
         .message($crashes.message)
         .message($hangs.message)
-        .fetchTask([crashes, hangs])
+        .refreshes([crashes, hangs])
     }
 
     private var crashRecords: [Crash] {

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionIncidentProvider.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionIncidentProvider.swift
@@ -30,4 +30,8 @@ final class VersionIncidentProvider<Element: RecordDecodable & Incident>: FeedPr
     func fetchLatest(in database: DatabaseReader) async {
         await fetchAll(matching: query, in: database)
     }
+
+    func fetchAgain(in database: DatabaseReader) async {
+        await fetchAll(matching: query, in: database)
+    }
 }

--- a/Sources/ScoutUI/Home/HomeList.swift
+++ b/Sources/ScoutUI/Home/HomeList.swift
@@ -56,6 +56,10 @@ struct HomeList: View {
             )
         }
         .scrollContentBackground(.hidden)
+        .refreshingProviders(
+            first: [alerts, releases, retention],
+            later: [sessions, activities, logs, devices]
+        )
         .globalSearch()
         .navigationDestination(for: HomeDestination.self) { destination in
             switch destination {
@@ -73,10 +77,6 @@ struct HomeList: View {
                 AlertListView(provider: alerts)
             }
         }
-        .refreshingProviders(
-            first: [alerts, releases, retention],
-            later: [sessions, activities, logs, devices]
-        )
     }
 
     private var statView: some View {

--- a/Sources/ScoutUI/Home/Section/Log/LogView.swift
+++ b/Sources/ScoutUI/Home/Section/Log/LogView.swift
@@ -49,6 +49,7 @@ struct LogView: View {
             await log.fetchIfNeeded(in: database)
         }
         .onChange(of: visits) { log.visits = $0 }
+        .refreshOnPull([log])
         .navigationTitle(en: "Log")
     }
 

--- a/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
+++ b/Sources/ScoutUI/Home/Settings/BackendHealthProvider.swift
@@ -10,7 +10,7 @@ import Foundation
 import Scout
 
 @MainActor
-final class BackendHealthProvider: ObservableObject {
+final class BackendHealthProvider: ObservableObject, Refreshable {
     @Published private(set) var backends: [BackendHealth]
 
     init(backends: [Backend]) {
@@ -36,6 +36,14 @@ final class BackendHealthProvider: ObservableObject {
                 apply(result)
             }
         }
+    }
+
+    func fetchLatest(in database: DatabaseReader) async {
+        await refreshAll()
+    }
+
+    func fetchAgain(in database: DatabaseReader) async {
+        await refreshAll()
     }
 
     func refresh(id: String) async {

--- a/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
+++ b/Sources/ScoutUI/Home/Settings/SettingsOverviewView.swift
@@ -45,9 +45,7 @@ struct SettingsOverviewView: View {
         }
         .navigationTitle(en: "Settings")
         .dismissable()
-        .task {
-            await provider.refreshAll()
-        }
+        .refreshes([provider])
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -37,6 +37,7 @@ struct AlertListView: View {
             .task {
                 await provider.fetchIfNeeded(in: database)
             }
+            .refreshOnPull([provider])
     }
 
     @ViewBuilder private var content: some View {

--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
@@ -39,7 +39,7 @@ struct CrashListView: View {
         }
         .navigationTitle(en: "Crashes")
         .message($provider.message)
-        .fetchTask([provider])
+        .refreshes([provider])
     }
 
     private func row(for group: IncidentGroup<Crash>) -> some View {

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
@@ -41,7 +41,7 @@ struct HangListView: View {
         }
         .navigationTitle(en: "Hangs")
         .message($provider.message)
-        .fetchTask([provider])
+        .refreshes([provider])
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentProvider.swift
@@ -17,4 +17,8 @@ final class IncidentProvider<Element: RecordDecodable & Incident>: FeedProvider<
     func fetchLatest(in database: DatabaseReader) async {
         await fetchLatest(matching: Element.query(), in: database)
     }
+
+    func fetchAgain(in database: DatabaseReader) async {
+        await fetchAgain(matching: Element.query(), in: database)
+    }
 }

--- a/Sources/ScoutUI/Primitives/Fetch/FetchTask.swift
+++ b/Sources/ScoutUI/Primitives/Fetch/FetchTask.swift
@@ -11,6 +11,7 @@ import SwiftUI
 @MainActor
 protocol Refreshable {
     func fetchLatest(in database: DatabaseReader) async
+    func fetchAgain(in database: DatabaseReader) async
 }
 
 extension View {
@@ -31,24 +32,35 @@ private struct FetchTaskModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content.task {
-            await actions(for: first).fetch()
-            await actions(for: later).fetch()
-        }
-    }
-
-    private func actions(for providers: [any Refreshable]) -> [FetchAction] {
-        providers.map { provider in
-            { await provider.fetchLatest(in: database) }
+            await first.fetchLatest(in: database)
+            await later.fetchLatest(in: database)
         }
     }
 }
 
-private typealias FetchAction = @MainActor () async -> Void
+extension [any Refreshable] {
+    @MainActor
+    func fetchLatest(in database: DatabaseReader) async {
+        await fetch { provider in
+            await provider.fetchLatest(in: database)
+        }
+    }
 
-extension [FetchAction] {
-    fileprivate func fetch() async {
+    @MainActor
+    func fetchAgain(in database: DatabaseReader) async {
+        await fetch { provider in
+            await provider.fetchAgain(in: database)
+        }
+    }
+
+    @MainActor
+    private func fetch(_ operation: @escaping @MainActor (any Refreshable) async -> Void) async {
+        let actions: [@MainActor () async -> Void] = map { provider in
+            { await operation(provider) }
+        }
+
         await withTaskGroup(of: Void.self) { group in
-            for action in self {
+            for action in actions {
                 group.addTask {
                     await action()
                 }

--- a/Sources/ScoutUI/Primitives/Fetch/RefreshOnPull.swift
+++ b/Sources/ScoutUI/Primitives/Fetch/RefreshOnPull.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+extension View {
+    func refreshOnPull(_ providers: [any Refreshable]) -> some View {
+        modifier(RefreshOnPullModifier(providers: providers))
+    }
+
+    func refreshes(_ providers: [any Refreshable]) -> some View {
+        fetchTask(providers).refreshOnPull(providers)
+    }
+}
+
+private struct RefreshOnPullModifier: ViewModifier {
+    @Environment(\.database) private var database
+
+    let providers: [any Refreshable]
+
+    func body(content: Content) -> some View {
+        content.pullToRefresh {
+            await providers.fetchAgain(in: database)
+        }
+    }
+}

--- a/Sources/ScoutUI/Primitives/Fetch/RefreshingProviders.swift
+++ b/Sources/ScoutUI/Primitives/Fetch/RefreshingProviders.swift
@@ -28,7 +28,10 @@ private struct RefreshingProvidersModifier: ViewModifier {
                 }
             }
         } else {
-            content.loadingGate(first).fetchTask(first: first, later: later)
+            content
+                .loadingGate(first)
+                .fetchTask(first: first, later: later)
+                .refreshOnPull(providers)
         }
     }
 

--- a/Sources/ScoutUI/Support/Provider/FeedProvider.swift
+++ b/Sources/ScoutUI/Support/Provider/FeedProvider.swift
@@ -15,14 +15,22 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
     @Published var cursor: RecordCursor?
     @Published var message: Message?
 
+    // Bumped by `clear()` so a response that was in flight when the feed was cleared
+    // (a pull racing a filter change) cannot merge stale records or its cursor back in.
+    private var generation = 0
+
     init(_ records: [Element]? = nil) {
         self.records = records
     }
 
     @discardableResult
     func fetchLatest(matching query: RecordQuery, in database: DatabaseReader) async -> Bool {
+        let generation = generation
         do {
             let results = try await database.read(matching: query, fields: Element.desiredKeys)
+            guard generation == self.generation else {
+                return true
+            }
             if cursor == nil {
                 cursor = results.cursor
             }
@@ -40,8 +48,13 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
 
     @discardableResult
     func fetchAll(matching query: RecordQuery, in database: DatabaseReader) async -> Bool {
+        let generation = generation
         do {
-            records = try await database.readAll(matching: query, fields: Element.desiredKeys)
+            let results: [Element] = try await database.readAll(matching: query, fields: Element.desiredKeys)
+            guard generation == self.generation else {
+                return true
+            }
+            records = results
             return true
         } catch is CancellationError {
             return true
@@ -54,8 +67,12 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
     }
 
     func fetchAgain(matching query: RecordQuery, in database: DatabaseReader) async {
+        let generation = generation
         do {
             let results = try await database.read(matching: query, fields: Element.desiredKeys)
+            guard generation == self.generation else {
+                return
+            }
             cursor = results.cursor
             records = try results.records.map(Element.init)
         } catch is CancellationError {
@@ -66,8 +83,12 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
     }
 
     func fetchMore(cursor: RecordCursor, in database: DatabaseReader) async {
+        let generation = generation
         do {
             let results = try await database.readMore(from: cursor, fields: nil)
+            guard generation == self.generation else {
+                return
+            }
             self.cursor = results.cursor
             records = dedup(new: records ?? [], old: try results.records.map(Element.init))
         } catch is CancellationError {
@@ -77,6 +98,7 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
     }
 
     func clear() {
+        generation += 1
         records = nil
         cursor = nil
     }

--- a/Sources/ScoutUI/Support/Provider/ProviderView.swift
+++ b/Sources/ScoutUI/Support/Provider/ProviderView.swift
@@ -25,7 +25,7 @@ struct ProviderView<P: Provider, Content: View>: View {
                 ErrorView(description: Text(error.localizedDescription), retry: fetch)
             }
         }
-        .fetchTask([provider])
+        .refreshes([provider])
     }
 
     private func fetch() async {


### PR DESCRIPTION
Every screen that loads through `fetchTask`, `ProviderView`, or `refreshingProviders` now also refreshes the same providers on a pull: Home, Alerts, Crashes, Hangs, Events, the per-range event list, the session inspector, the version and device details, the event detail, Log, Settings, and — via `ProviderView` — Devices, Network, Releases, Active Users, Retention, Sessions/Stats, the Metrics list, and the two search detail screens. Screens that only render data passed in from a parent keep no pull handler, and `MetricsView` stays as is because its points come from the list and its scroll is mostly disabled.

The wiring lives in `Primitives/Fetch/RefreshOnPull.swift`: `refreshOnPull(_:)` reads the database from the environment and runs `fetchAgain` on a `[any Refreshable]`, and `refreshes(_:)` pairs it with `fetchTask` so a screen names its providers once. `Refreshable` gains `fetchAgain(in:)` for that — a pull is user-initiated, so unlike the appearance load it reports failures and, on feeds, replaces the records and resets the cursor instead of merging into one that pagination may already have drained. `BackendHealthProvider` conforms so Settings goes through the same path.

Two adjustments fell out of the wiring: `FeedProvider` carries a generation counter so a response in flight when `clear()` runs (a pull racing a filter change on Events) cannot merge stale records or its cursor back in, and `HomeList` applies `refreshingProviders` before `globalSearch()` and the navigation destinations so the pull belongs to the Home list rather than to the search results or pushed screens. Verified the ring and held content on Home and Devices in the simulator with a slowed-down demo database; empty and error states remain non-scrollable and so are not pullable, as before.