### PR TITLE
Surface an unreadable alert store instead of resetting the rules

### DIFF
--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
@@ -43,7 +43,8 @@
 
         /// Requests a background refresh, skipped while no alert rules exist.
         public static func scheduleBackgroundRefresh() {
-            guard AlertRegistry().rules.count > 0 else {
+            let rules = (try? AlertRegistry().rules()) ?? []
+            guard rules.count > 0 else {
                 return
             }
             scheduler?.schedule()

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
@@ -23,16 +23,17 @@ final class AlertEngine {
 
     func statuses(in database: DatabaseReader) async throws -> [AlertStatus] {
         let now = Date()
-        let readings = try await readings(for: Set(registry.rules.map(\.metric)), in: database)
+        let rules = try registry.rules()
+        let readings = try await readings(for: Set(rules.map(\.metric)), in: database)
 
-        return registry.rules.compactMap { rule in
+        return try rules.compactMap { rule in
             guard let reading = readings[rule.metric] else {
                 return nil
             }
             let outcome = evaluator.evaluate(
                 rule,
                 reading: reading,
-                state: registry.state(for: rule),
+                state: try registry.state(for: rule),
                 now: now
             )
             return AlertStatus(rule: rule, outcome: outcome, reading: reading)
@@ -60,7 +61,7 @@ final class AlertEngine {
         let statuses = try await statuses(in: database)
 
         for status in statuses {
-            registry.remember(status.outcome.state, for: status.rule)
+            try registry.remember(status.outcome.state, for: status.rule)
         }
 
         await notifier?.deliver(statuses)

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertRegistry.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertRegistry.swift
@@ -9,42 +9,57 @@ import Foundation
 
 @MainActor
 final class AlertRegistry {
+    struct UnreadableStoreError: LocalizedError {
+        let key: String
+        let underlying: any Error
+
+        var errorDescription: String? {
+            "The stored alert data under \"\(key)\" can't be read: \(underlying.localizedDescription)"
+        }
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
     }
 
-    var rules: [AlertRule] {
-        get {
-            decode([AlertRule].self, forKey: "scout_alert_rules") ?? []
-        }
-        set {
-            encode(newValue, forKey: "scout_alert_rules")
-            states = states.filter { newValue.contains($0.key) }
-        }
+    func rules() throws -> [AlertRule] {
+        try decode([AlertRule].self, forKey: "scout_alert_rules") ?? []
     }
 
-    func state(for rule: AlertRule) -> AlertState {
-        states[rule] ?? .armed
+    func save(_ rules: [AlertRule]) throws {
+        let states = try states()
+        try encode(rules, forKey: "scout_alert_rules")
+        try encode(states.filter { rules.contains($0.key) }, forKey: "scout_alert_states")
     }
 
-    func remember(_ state: AlertState, for rule: AlertRule) {
-        var updated = states
+    func state(for rule: AlertRule) throws -> AlertState {
+        try states()[rule] ?? .armed
+    }
+
+    func remember(_ state: AlertState, for rule: AlertRule) throws {
+        var updated = try states()
         updated[rule] = state
-        states = updated
+        try encode(updated, forKey: "scout_alert_states")
     }
 
-    private var states: [AlertRule: AlertState] {
-        get { decode([AlertRule: AlertState].self, forKey: "scout_alert_states") ?? [:] }
-        set { encode(newValue, forKey: "scout_alert_states") }
+    private func states() throws -> [AlertRule: AlertState] {
+        try decode([AlertRule: AlertState].self, forKey: "scout_alert_states") ?? [:]
     }
 
-    private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
-        defaults.data(forKey: key).flatMap { try? JSONDecoder().decode(type, from: $0) }
+    private func decode<T: Decodable>(_ type: T.Type, forKey key: String) throws -> T? {
+        guard let data = defaults.data(forKey: key) else {
+            return nil
+        }
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            throw UnreadableStoreError(key: key, underlying: error)
+        }
     }
 
-    private func encode(_ value: some Encodable, forKey key: String) {
-        defaults.set(try? JSONEncoder().encode(value), forKey: key)
+    private func encode(_ value: some Encodable, forKey key: String) throws {
+        defaults.set(try JSONEncoder().encode(value), forKey: key)
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
@@ -23,21 +23,27 @@ final class AlertProvider: ObservableObject, Provider {
         self.result = result
     }
 
-    var rules: [AlertRule] {
-        registry.rules
-    }
-
     func add(_ rule: AlertRule) async {
-        let isFirst = registry.rules.count == 0
-        registry.rules.append(rule)
+        do {
+            let rules = try registry.rules()
+            try registry.save(rules + [rule])
 
-        if isFirst, let notifier {
-            _ = await notifier.requestAuthorization()
+            if rules.count == 0, let notifier {
+                _ = await notifier.requestAuthorization()
+            }
+        } catch {
+            result = .failure(error)
         }
     }
 
     func remove(_ rule: AlertRule) {
-        registry.rules.removeAll { $0 == rule }
+        do {
+            var rules = try registry.rules()
+            rules.removeAll { $0 == rule }
+            try registry.save(rules)
+        } catch {
+            result = .failure(error)
+        }
     }
 
     func fetch(in database: DatabaseReader) async throws -> [AlertStatus] {

--- a/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertEngineTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertEngineTests.swift
@@ -21,7 +21,7 @@ struct AlertEngineTests {
         let database = DatabaseStub()
         database.add(series: makeSeries(name: "Error", counts: errorCounts))
 
-        let engine = makeEngine(rules: [errorRule])
+        let engine = try makeEngine(rules: [errorRule])
 
         let first = try await engine.run(in: database)
 
@@ -43,7 +43,7 @@ struct AlertEngineTests {
             makeSeries(name: CrashEntry.recordType, counts: [(hoursAgo: 1, count: 1), (hoursAgo: 2, count: 1)])
         )
 
-        let engine = makeEngine(rules: [crashFreeRule])
+        let engine = try makeEngine(rules: [crashFreeRule])
         let statuses = try await engine.run(in: database)
 
         #expect(statuses[0].outcome.shouldNotify)
@@ -55,7 +55,7 @@ struct AlertEngineTests {
         database.add(series: makeSeries(name: "Error", counts: errorCounts))
 
         let center = NotificationCenterStub()
-        let engine = makeEngine(rules: [errorRule], center: center)
+        let engine = try makeEngine(rules: [errorRule], center: center)
 
         _ = try await engine.run(in: database)
 
@@ -85,7 +85,7 @@ struct AlertEngineTests {
         let database = DatabaseStub()
         database.add(series: makeSeries(name: SessionEntry.recordType, counts: [(hoursAgo: 1, count: 10)]))
 
-        let engine = makeEngine(rules: [crashFreeRule])
+        let engine = try makeEngine(rules: [crashFreeRule])
         let statuses = try await engine.run(in: database)
 
         #expect(statuses[0].outcome == AlertOutcome(state: .armed, shouldNotify: false))
@@ -110,9 +110,9 @@ struct AlertEngineTests {
         (25...48).map { (hoursAgo: $0, count: 4) } + [(hoursAgo: 1, count: 20)]
     }
 
-    private func makeEngine(rules: [AlertRule], center: NotificationCenterStub? = nil) -> AlertEngine {
+    private func makeEngine(rules: [AlertRule], center: NotificationCenterStub? = nil) throws -> AlertEngine {
         let registry = AlertRegistry(defaults: defaults)
-        registry.rules = rules
+        try registry.save(rules)
         return AlertEngine(registry: registry, notifier: center.map { AlertNotifier(center: $0) })
     }
 

--- a/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertRegistryTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertRegistryTests.swift
@@ -21,37 +21,65 @@ struct AlertRegistryTests {
     )
 
     @Test("Rules survive a new registry instance")
-    func rulesPersist() {
+    func rulesPersist() throws {
         let registry = AlertRegistry(defaults: defaults)
-        registry.rules = [rule]
+        try registry.save([rule])
 
-        #expect(AlertRegistry(defaults: defaults).rules == [rule])
+        #expect(try AlertRegistry(defaults: defaults).rules() == [rule])
     }
 
     @Test("States survive a new registry instance")
-    func statesPersist() {
+    func statesPersist() throws {
         let since = Date(timeIntervalSince1970: 1_000_000)
         let registry = AlertRegistry(defaults: defaults)
-        registry.rules = [rule]
-        registry.remember(.firing(since: since), for: rule)
+        try registry.save([rule])
+        try registry.remember(.firing(since: since), for: rule)
 
-        #expect(AlertRegistry(defaults: defaults).state(for: rule) == .firing(since: since))
+        #expect(try AlertRegistry(defaults: defaults).state(for: rule) == .firing(since: since))
     }
 
     @Test("An unknown rule reads as armed")
-    func unknownRule() {
-        #expect(AlertRegistry(defaults: defaults).state(for: rule) == .armed)
+    func unknownRule() throws {
+        #expect(try AlertRegistry(defaults: defaults).state(for: rule) == .armed)
     }
 
     @Test("Removing a rule clears its state")
-    func removalClearsState() {
+    func removalClearsState() throws {
         let registry = AlertRegistry(defaults: defaults)
-        registry.rules = [rule]
-        registry.remember(.firing(since: Date(timeIntervalSince1970: 0)), for: rule)
+        try registry.save([rule])
+        try registry.remember(.firing(since: Date(timeIntervalSince1970: 0)), for: rule)
 
-        registry.rules = []
-        registry.rules = [rule]
+        try registry.save([])
+        try registry.save([rule])
 
-        #expect(registry.state(for: rule) == .armed)
+        #expect(try registry.state(for: rule) == .armed)
+    }
+
+    @Test("Unreadable stored rules surface an error instead of an empty list")
+    func unreadableRules() {
+        defaults.set(Data("garbage".utf8), forKey: "scout_alert_rules")
+
+        #expect(throws: AlertRegistry.UnreadableStoreError.self) {
+            try AlertRegistry(defaults: defaults).rules()
+        }
+    }
+
+    @Test("Unreadable stored states surface an error instead of resetting to armed")
+    func unreadableStates() {
+        defaults.set(Data("garbage".utf8), forKey: "scout_alert_states")
+
+        #expect(throws: AlertRegistry.UnreadableStoreError.self) {
+            try AlertRegistry(defaults: defaults).state(for: rule)
+        }
+    }
+
+    @Test("Saving over unreadable states fails without touching the rules")
+    func saveOverUnreadableStates() {
+        defaults.set(Data("garbage".utf8), forKey: "scout_alert_states")
+
+        #expect(throws: AlertRegistry.UnreadableStoreError.self) {
+            try AlertRegistry(defaults: defaults).save([rule])
+        }
+        #expect(defaults.data(forKey: "scout_alert_rules") == nil)
     }
 }

--- a/Tests/ScoutUITests/Monitoring/Alerts/View/AlertProviderTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/View/AlertProviderTests.swift
@@ -23,39 +23,54 @@ struct AlertProviderTests {
 
         let center = NotificationCenterStub()
         let registry = AlertRegistry(defaults: defaults)
-        registry.rules = [errorRule]
+        try registry.save([errorRule])
         let provider = AlertProvider(registry: registry, notifier: AlertNotifier(center: center))
 
         let statuses = try await provider.fetch(in: database)
 
         #expect(statuses[0].outcome.shouldNotify)
         #expect(center.requests.count == 0)
-        #expect(registry.state(for: errorRule) == .armed)
+        #expect(try registry.state(for: errorRule) == .armed)
     }
 
     @Test("Adding the first rule requests notification authorization once")
-    func firstRuleAuthorization() async {
+    func firstRuleAuthorization() async throws {
         let center = NotificationCenterStub()
-        let provider = makeProvider(rules: [], center: center)
+        let registry = AlertRegistry(defaults: defaults)
+        let provider = AlertProvider(registry: registry, notifier: AlertNotifier(center: center))
 
         await provider.add(errorRule)
 
         #expect(center.authorizationRequests == 1)
-        #expect(provider.rules == [errorRule])
+        #expect(try registry.rules() == [errorRule])
 
         await provider.add(crashFreeRule)
 
         #expect(center.authorizationRequests == 1)
-        #expect(provider.rules.count == 2)
+        #expect(try registry.rules().count == 2)
     }
 
     @Test("Removing a rule leaves the others in place")
-    func remove() async {
-        let provider = makeProvider(rules: [errorRule, crashFreeRule])
+    func remove() async throws {
+        let registry = AlertRegistry(defaults: defaults)
+        try registry.save([errorRule, crashFreeRule])
+        let provider = AlertProvider(registry: registry)
 
         provider.remove(errorRule)
 
-        #expect(provider.rules == [crashFreeRule])
+        #expect(try registry.rules() == [crashFreeRule])
+    }
+
+    @Test("Adding a rule over an unreadable store fails instead of overwriting it")
+    func addOverUnreadableStore() async {
+        let blob = Data("garbage".utf8)
+        defaults.set(blob, forKey: "scout_alert_rules")
+        let provider = AlertProvider(registry: AlertRegistry(defaults: defaults))
+
+        await provider.add(errorRule)
+
+        #expect(provider.error is AlertRegistry.UnreadableStoreError)
+        #expect(defaults.data(forKey: "scout_alert_rules") == blob)
     }
 
     private var errorRule: AlertRule {
@@ -75,12 +90,6 @@ struct AlertProviderTests {
 
     private var errorCounts: [(hoursAgo: Int, count: Int)] {
         (25...48).map { (hoursAgo: $0, count: 4) } + [(hoursAgo: 1, count: 20)]
-    }
-
-    private func makeProvider(rules: [AlertRule], center: NotificationCenterStub? = nil) -> AlertProvider {
-        let registry = AlertRegistry(defaults: defaults)
-        registry.rules = rules
-        return AlertProvider(registry: registry, notifier: center.map { AlertNotifier(center: $0) })
     }
 
     private func makeSeries(name: String, counts: [(hoursAgo: Int, count: Int)]) -> MetricSeries {


### PR DESCRIPTION
AlertRegistry silently swallowed decode failures of its UserDefaults blobs: unreadable rules read as an empty list, the Alerts screen showed "No alert rules" as if nothing had ever been saved, alert states reset to armed (re-notifying still-firing alerts), and the next add() re-encoded the empty list and overwrote the stored rules for good.

The registry API now throws an UnreadableStoreError instead: reads propagate through AlertEngine into the provider's .failure, so the existing ErrorView in AlertListView and on Home shows the problem, and AlertProvider.add/remove fail into the same error state without touching the unreadable blob. Found by the silent-error audit (row 1).