### PR TITLE
Log a record delivery that runs out of attempts

### DIFF
--- a/Sources/Scout/Sync/RecordSender.swift
+++ b/Sources/Scout/Sync/RecordSender.swift
@@ -86,7 +86,12 @@ package protocol TransientFailure: Error {
                     batches.append(Array(batch[half...]))
                     batches.append(Array(batch[..<half]))
                 } else {
-                    batch[0].delivery(for: id)?.attempts += 1
+                    let delivery = batch[0].delivery(for: id)
+                    delivery?.attempts += 1
+
+                    if let delivery, delivery.attempts >= DeliveryEntry.maxAttempts {
+                        print("Giving up on a \(T.self) record for backend \(id) after \(delivery.attempts) failed attempts: \(error)")
+                    }
                 }
             }
         }


### PR DESCRIPTION
When a backend rejects a record with a non-transient error, RecordSender bisects the batch and increments the failing record's delivery attempts. Once attempts hit DeliveryEntry.maxAttempts the record silently drops out of the delivery predicate and the retention cleanup deletes it a week later — telemetry disappears without a single line anywhere, indistinguishable from the events never happening.

The sender now prints one line at the moment a record exhausts its attempts, naming the record type, the backend, and the rejection error, matching the SDK's existing print diagnostics. Found by the silent-error audit (row 3).