### PR TITLE
Show an error state in EventList when the first load fails

### DIFF
--- a/Sources/ScoutUI/Analytics/Event/Analytics/AnalyticsView.swift
+++ b/Sources/ScoutUI/Analytics/Event/Analytics/AnalyticsView.swift
@@ -14,16 +14,25 @@ struct AnalyticsView: View {
     @StateObject var provider = EventProvider()
     @StateObject var search = EventProvider()
 
+    @Environment(\.database) private var database
+
     var body: some View {
-        EventList(provider: activeProvider)
+        EventList(provider: activeProvider, retry: retry)
             .eventFilter($filter, provider: provider, search: search)
             .navigationTitle(en: "Events")
             .resetsTint()
-            .message($provider.message)
     }
 
     private var activeProvider: EventProvider {
         filter.text.isEmpty ? provider : search
+    }
+
+    private func retry() async {
+        if filter.text.isEmpty {
+            await provider.fetchLatest(for: filter, in: database)
+        } else {
+            await search.fetch(for: filter, in: database)
+        }
     }
 }
 

--- a/Sources/ScoutUI/Analytics/Event/List/EventList.swift
+++ b/Sources/ScoutUI/Analytics/Event/List/EventList.swift
@@ -13,26 +13,40 @@ struct EventList<Header: View>: View {
 
     @Environment(\.database) var database
     @ObservedObject var provider: EventProvider
+    var retry: (() async -> Void)? = nil
     @ViewBuilder let header: () -> Header
 
     var body: some View {
-        if let events = provider.records {
-            if events.isEmpty {
-                Placeholder(
-                    text: "No results",
-                    systemImage: "list.bullet",
-                    description: "Events will appear here once your app starts logging",
-                    code: "logger.info(\"button_tapped\")"
-                )
-            } else {
-                InsetList {
-                    header()
-                    rows(for: events)
+        Group {
+            if let events = provider.records {
+                if events.isEmpty {
+                    Placeholder(
+                        text: "No results",
+                        systemImage: "list.bullet",
+                        description: "Events will appear here once your app starts logging",
+                        code: "logger.info(\"button_tapped\")"
+                    )
+                } else {
+                    InsetList {
+                        header()
+                        rows(for: events)
+                    }
+                    .animation(nil, value: UUID())
                 }
-                .animation(nil, value: UUID())
+            } else if let error = provider.error {
+                ErrorView(description: error.localizedDescription, retry: retryLoad)
+            } else {
+                RingIndicator().frame(maxHeight: .infinity)
             }
+        }
+        .message($provider.message)
+    }
+
+    private func retryLoad() async {
+        if let retry {
+            await retry()
         } else {
-            RingIndicator().frame(maxHeight: .infinity)
+            await provider.fetchAgain(in: database)
         }
     }
 
@@ -69,8 +83,8 @@ struct EventList<Header: View>: View {
 }
 
 extension EventList where Header == EmptyView {
-    init(provider: EventProvider) {
-        self.init(provider: provider) { EmptyView() }
+    init(provider: EventProvider, retry: (() async -> Void)? = nil) {
+        self.init(provider: provider, retry: retry) { EmptyView() }
     }
 }
 

--- a/Sources/ScoutUI/Support/Provider/FeedProvider.swift
+++ b/Sources/ScoutUI/Support/Provider/FeedProvider.swift
@@ -15,6 +15,10 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
     @Published var cursor: RecordCursor?
     @Published var message: Message?
 
+    // Set when a load fails while the feed is still empty, so the owning view can
+    // render a full error state instead of an indefinite loading indicator.
+    @Published private(set) var error: Error?
+
     // Bumped by `clear()` so a response that was in flight when the feed was cleared
     // (a pull racing a filter change) cannot merge stale records or its cursor back in.
     private var generation = 0
@@ -35,11 +39,13 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
                 cursor = results.cursor
             }
             records = dedup(new: try results.records.map(Element.init), old: records ?? [])
+            error = nil
             return true
         } catch is CancellationError {
             return true
         } catch {
             if records == nil {
+                self.error = error
                 message = Message(error.localizedDescription, level: .error)
             }
             return false
@@ -55,11 +61,13 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
                 return true
             }
             records = results
+            error = nil
             return true
         } catch is CancellationError {
             return true
         } catch {
             if records == nil {
+                self.error = error
                 message = Message(error.localizedDescription, level: .error)
             }
             return false
@@ -75,9 +83,13 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
             }
             cursor = results.cursor
             records = try results.records.map(Element.init)
+            error = nil
         } catch is CancellationError {
             // A cancelled task (e.g. the view was recreated) leaves the feed untouched so it retries.
         } catch {
+            if records == nil {
+                self.error = error
+            }
             message = Message(error.localizedDescription, level: .error)
         }
     }
@@ -101,5 +113,6 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
         generation += 1
         records = nil
         cursor = nil
+        error = nil
     }
 }

--- a/Tests/ScoutUITests/Support/Provider/FeedProviderTests.swift
+++ b/Tests/ScoutUITests/Support/Provider/FeedProviderTests.swift
@@ -66,6 +66,33 @@ struct FeedProviderTests {
         #expect(succeeded == false)
         #expect(provider.records?.count == 1)
         #expect(provider.message == nil)
+        #expect(provider.error == nil)
+    }
+
+    @Test("A failed first load surfaces an error state until a load succeeds")
+    func firstLoadFailureSetsError() async throws {
+        let provider = EventProvider()
+        await provider.fetchLatest(for: EventQuery(), in: FailingDatabase())
+
+        #expect(provider.records == nil)
+        #expect(provider.error != nil)
+        #expect(provider.message != nil)
+
+        let database = DatabaseStub()
+        database.add(Record.eventStub(name: "login", sessionID: UUID(), date: Date()))
+        await provider.fetchLatest(for: EventQuery(), in: database)
+
+        #expect(provider.error == nil)
+        #expect(provider.records?.count == 1)
+    }
+
+    @Test("A failed reload of an empty feed surfaces the error state")
+    func reloadFailureOnEmptyFeedSetsError() async throws {
+        let provider = EventProvider()
+        await provider.fetch(for: EventQuery(), in: FailingDatabase())
+
+        #expect(provider.records == nil)
+        #expect(provider.error != nil)
     }
 
     @Test("A cancelled reload or page load stays quiet and keeps prior records")


### PR DESCRIPTION
When the first load of an event feed failed, EventList kept showing its loading indicator forever: FeedProvider only set a toast message, and most owners (EventStatList, SessionInspector, the search feed in AnalyticsView) never attached it, so offline or a server error looked exactly like a slow load with no retry.

FeedProvider now keeps a first-load error state (set while the feed is empty, cleared on success or clear()), and EventList renders it as the full-screen ErrorView with a Retry button. The message binding moved from AnalyticsView into EventList so every owner gets the toast for refresh and pagination failures too; AnalyticsView passes a retry closure that re-runs the active filter or search query. Found by the silent-error audit (row 6).