### PR TITLE
Show an inline error when device incidents fail to load

### DIFF
--- a/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DeviceDetailView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct DeviceDetailView: View {
     let device: DeviceSummary
 
+    @Environment(\.database) private var database
     @StateObject private var incidents: DeviceIncidentsProvider
 
     init(device: DeviceSummary, incidents: DeviceIncidentsProvider? = nil) {
@@ -32,6 +33,13 @@ struct DeviceDetailView: View {
                 Readout(title: "Sessions", value: device.sessions.plain, color: .primary)
                 Readout(title: "Crashes", value: device.crashes.plain, color: device.crashes > 0 ? .red : .primary)
                 Spacer()
+            }
+
+            if let error = incidents.error {
+                Header(title: "Incidents")
+                ErrorRow(description: error.localizedDescription) {
+                    await incidents.fetchAgain(in: database)
+                }
             }
 
             if crashes.count > 0 {

--- a/Sources/ScoutUI/Primitives/States/ErrorRow.swift
+++ b/Sources/ScoutUI/Primitives/States/ErrorRow.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct ErrorRow: View {
+    let description: String
+    let retry: () async -> Void
+
+    @State private var isRetrying = false
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundColor(.yellow)
+
+            Text(verbatim: description)
+                .font(.callout)
+                .lineLimit(2)
+
+            Spacer()
+
+            retryControl
+        }
+        .frame(minHeight: 44)
+        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+    }
+
+    private var retryControl: some View {
+        ZStack {
+            Button {
+                isRetrying = true
+                Task {
+                    await retry()
+                    isRetrying = false
+                }
+            } label: {
+                Text(verbatim: "Retry")
+            }
+            .buttonStyle(.borderless)
+            .opacity(isRetrying ? 0 : 1)
+            .disabled(isRetrying)
+
+            if isRetrying {
+                RingIndicator(size: 18)
+            }
+        }
+    }
+}
+
+#Preview {
+    InsetList {
+        ErrorRow(description: "The request timed out.") {}
+        ErrorRow(description: "A much longer error description that explains what exactly went wrong while loading.") {}
+    }
+}


### PR DESCRIPTION
DeviceDetailView collapsed a failed incidents fetch into empty crash and hang lists, so a device with real incidents looked identical to a clean one whenever the read failed (offline, server error). The device chips and readouts are local data, so a full-screen error would be too heavy here.

This adds an ErrorRow primitive — a compact inline row with the error text and a Retry control — and renders it in an Incidents section when the provider holds a failure, retrying via fetchAgain. Found by the silent-error audit (row 7).