### PR TITLE
Log the removal of an unreadable incident archive

### DIFF
--- a/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
+++ b/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
@@ -44,12 +44,20 @@ struct IncidentArchive<Payload: Codable & Sendable> {
         decoder.dateDecodingStrategy = .iso8601
 
         for file in files where file.pathExtension == pathExtension {
-            guard let data = try? Data(contentsOf: file) else {
+            let data: Data
+            do {
+                data = try Data(contentsOf: file)
+            } catch {
+                print("Failed to read \(file.lastPathComponent), removing it: \(error)")
                 try? fileManager.removeItem(at: file)
                 continue
             }
 
-            guard let payload = try? decoder.decode(Payload.self, from: data) else {
+            let payload: Payload
+            do {
+                payload = try decoder.decode(Payload.self, from: data)
+            } catch {
+                print("Failed to decode \(file.lastPathComponent), removing it: \(error)")
                 try? fileManager.removeItem(at: file)
                 continue
             }


### PR DESCRIPTION
IncidentArchive.flush deletes a crash or hang file it cannot read or decode — reasonable self-healing, but it happened with no trace at all, so a lost incident report was indistinguishable from no incident. The file removal now prints one line naming the file and the read or decode error, matching the archive's existing print diagnostics for persist failures. Found by the silent-error audit (row 8).