### PR TITLE
Log a failed incident archive write

### DIFF
--- a/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
+++ b/Sources/Scout/Diagnostics/Incident/IncidentArchive.swift
@@ -23,16 +23,17 @@ struct IncidentArchive<Payload: Codable & Sendable> {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
 
-        guard let data = try? encoder.encode(payload) else {
-            return
+        do {
+            let data = try encoder.encode(payload)
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            let fileName = "\(UUID().uuidString).\(pathExtension)"
+            let fileURL = directory.appendingPathComponent(fileName)
+
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            print("Failed to archive \(pathExtension): \(error)")
         }
-
-        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-
-        let fileName = "\(UUID().uuidString).\(pathExtension)"
-        let fileURL = directory.appendingPathComponent(fileName)
-
-        try? data.write(to: fileURL, options: .atomic)
     }
 
     func flush(deviceID: UUID) async {


### PR DESCRIPTION
IncidentArchive.write swallowed every failure with try? — if encoding the payload, creating the archive directory, or writing the file failed (disk full, protected data before first unlock), the crash or hang report was lost without any trace. The write path now runs in a single do/catch and prints the failure, matching the archive's existing print diagnostics. Found by the silent-error audit (row 10).