### PR TITLE
Show an inline error when event params fail to load

### DIFF
--- a/Sources/ScoutUI/Analytics/Event/Detail/EventView.Sections.swift
+++ b/Sources/ScoutUI/Analytics/Event/Detail/EventView.Sections.swift
@@ -14,6 +14,7 @@ extension EventView {
 
         let count: Int
 
+        @Environment(\.database) private var database
         @ObservedObject var param: ParamProvider
         @Binding var isParamPresented: Bool
 
@@ -30,6 +31,10 @@ extension EventView {
             if let items {
                 ForEach(items.prefix(Self.previewLimit)) { item in
                     ParamRow(item: item)
+                }
+            } else if let error = param.error {
+                ErrorRow(description: error.localizedDescription) {
+                    await param.fetchAgain(in: database)
                 }
             } else {
                 ForEach(0..<min(Self.previewLimit, count), id: \.self) { _ in

--- a/Sources/ScoutUI/Primitives/States/ErrorRow.swift
+++ b/Sources/ScoutUI/Primitives/States/ErrorRow.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct ErrorRow: View {
+    let description: String
+    let retry: () async -> Void
+
+    @State private var isRetrying = false
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundColor(.yellow)
+
+            Text(verbatim: description)
+                .font(.callout)
+                .lineLimit(2)
+
+            Spacer()
+
+            retryControl
+        }
+        .frame(minHeight: 44)
+        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+    }
+
+    private var retryControl: some View {
+        ZStack {
+            Button {
+                isRetrying = true
+                Task {
+                    await retry()
+                    isRetrying = false
+                }
+            } label: {
+                Text(verbatim: "Retry")
+            }
+            .buttonStyle(.borderless)
+            .opacity(isRetrying ? 0 : 1)
+            .disabled(isRetrying)
+
+            if isRetrying {
+                RingIndicator(size: 18)
+            }
+        }
+    }
+}
+
+#Preview {
+    InsetList {
+        ErrorRow(description: "The request timed out.") {}
+        ErrorRow(description: "A much longer error description that explains what exactly went wrong while loading.") {}
+    }
+}


### PR DESCRIPTION
When the params lookup failed, EventView's ParamSection kept showing redacted placeholder rows forever — a lookup error (offline, server failure) was indistinguishable from a slow load, with no retry. The rest of the event screen is valid local data, so the failure now renders as an inline ErrorRow in the section with the error text and a Retry that re-runs the fetch.

The ErrorRow primitive is the same file introduced by the device-incidents PR; whichever lands first, the other merges cleanly. Found by the silent-error audit (row 11).