### PR TITLE
Log alert background refresh registration and scheduling failures

### DIFF
--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertRefreshScheduler.swift
@@ -49,7 +49,11 @@
         func schedule() {
             let request = BGAppRefreshTaskRequest(identifier: Self.taskIdentifier)
             request.earliestBeginDate = Date(timeIntervalSinceNow: interval)
-            try? scheduler.submit(request)
+            do {
+                try scheduler.submit(request)
+            } catch {
+                print("Failed to schedule the alert background refresh: \(error)")
+            }
         }
     }
 #endif

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/ScoutAlerts.swift
@@ -37,7 +37,9 @@
                 await refresh(engine: engine, backends: backends)
             }
 
-            refresher.register()
+            if !refresher.register() {
+                print("Failed to register the alert background refresh; list \(taskIdentifier) in BGTaskSchedulerPermittedIdentifiers and register before the app finishes launching")
+            }
             scheduler = refresher
         }
 


### PR DESCRIPTION
Both failure points of the background alert pipeline were silent: ScoutAlerts.registerBackgroundRefresh discarded the Bool from BGTaskScheduler.register (false when the identifier is missing from BGTaskSchedulerPermittedIdentifiers or registration happens too late), and AlertRefreshScheduler.schedule swallowed submit errors with try?. A host app misconfiguration meant alert notifications just never fired, with nothing in the console.

Both spots now print the failure; the registration message names the identifier and the Info.plist key to fix. Found by the silent-error audit (row 12).