### PR TITLE
Show an error state in the crash and hang lists when the first load fails

### DIFF
--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
@@ -33,6 +33,10 @@ struct CrashListView: View {
                     }
                     .animation(nil, value: groups)
                 }
+            } else if let error = provider.error {
+                ErrorView(description: error.localizedDescription) {
+                    await provider.fetchAgain(in: database)
+                }
             } else {
                 RingIndicator().frame(maxHeight: .infinity)
             }

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
@@ -35,6 +35,10 @@ struct HangListView: View {
                     }
                     .animation(nil, value: groups)
                 }
+            } else if let error = provider.error {
+                ErrorView(description: error.localizedDescription) {
+                    await provider.fetchAgain(in: database)
+                }
             } else {
                 RingIndicator().frame(maxHeight: .infinity)
             }

--- a/Tests/ScoutUITests/Support/Provider/FeedProviderTests.swift
+++ b/Tests/ScoutUITests/Support/Provider/FeedProviderTests.swift
@@ -86,6 +86,22 @@ struct FeedProviderTests {
         #expect(provider.records?.count == 1)
     }
 
+    @Test("A failed first load leaves an incident feed without groups and with an error")
+    func incidentFirstLoadFailureSetsError() async throws {
+        let provider = IncidentProvider<Crash>()
+        await provider.fetchLatest(in: FailingDatabase())
+
+        #expect(provider.groups == nil)
+        #expect(provider.error != nil)
+
+        let database = DatabaseStub()
+        database.add(Crash.stub(fingerprint: "A").record)
+        await provider.fetchAgain(in: database)
+
+        #expect(provider.groups?.count == 1)
+        #expect(provider.error == nil)
+    }
+
     @Test("A failed reload of an empty feed surfaces the error state")
     func reloadFailureOnEmptyFeedSetsError() async throws {
         let provider = EventProvider()


### PR DESCRIPTION
A failed first load of the crash or hang list showed a 5-second toast and then left the screen on its loading indicator indefinitely, with no way to retry: both views branch only on `groups`, which stays nil when the read fails.

Both now render the full-screen ErrorView with a Retry button when the provider holds a first-load error, using the `FeedProvider.error` state added in #1239. A refresh that fails after a successful load still keeps the list and stays a toast, unchanged. Found by the silent-error audit (row 25).