### PR TITLE
Stop the pagination footer from looping on a failed page load

### DIFF
--- a/Sources/ScoutUI/Primitives/Rows/PaginationFooter.swift
+++ b/Sources/ScoutUI/Primitives/Rows/PaginationFooter.swift
@@ -8,19 +8,51 @@
 import Scout
 import SwiftUI
 
-/// A list footer that loads the next page when it appears.
-///
 struct PaginationFooter: View {
-    let action: () async -> Void
+    let action: () async -> Bool
+
+    // Counts the pages this footer has loaded. Bumping it re-runs the task so the
+    // next page loads while the footer stays visible; leaving it alone after a
+    // failure keeps the error in place instead of re-requesting on every redraw.
+    @State private var page = 0
+    @State private var hasFailed = false
 
     var body: some View {
-        RingIndicator(size: 22)
-            .task {
-                await action()
-            }
-            .id(UUID())
+        content
             .frame(height: 68)
             .frame(maxWidth: .infinity)
             .listRowSeparator(.hidden, edges: .bottom)
+    }
+
+    @ViewBuilder private var content: some View {
+        if hasFailed {
+            ErrorRow(description: "Couldn't load more", retry: load)
+        } else {
+            RingIndicator(size: 22)
+                .task(id: page) {
+                    await load()
+                }
+        }
+    }
+
+    private func load() async {
+        if await action() {
+            hasFailed = false
+            page += 1
+        } else {
+            hasFailed = true
+        }
+    }
+}
+
+#Preview("Loading") {
+    InsetList {
+        PaginationFooter { true }
+    }
+}
+
+#Preview("Failed") {
+    InsetList {
+        PaginationFooter { false }
     }
 }

--- a/Sources/ScoutUI/Primitives/Rows/PaginationFooter.swift
+++ b/Sources/ScoutUI/Primitives/Rows/PaginationFooter.swift
@@ -47,7 +47,12 @@ struct PaginationFooter: View {
 
 #Preview("Loading") {
     InsetList {
-        PaginationFooter { true }
+        // A page that never arrives: an action that returned right away would re-arm
+        // the task on every success and spin the preview.
+        PaginationFooter {
+            try? await Task.sleep(for: .seconds(60))
+            return true
+        }
     }
 }
 

--- a/Sources/ScoutUI/Support/Provider/FeedProvider.swift
+++ b/Sources/ScoutUI/Support/Provider/FeedProvider.swift
@@ -94,18 +94,22 @@ class FeedProvider<Element: RecordDecodable & Identifiable>: ObservableObject {
         }
     }
 
-    func fetchMore(cursor: RecordCursor, in database: DatabaseReader) async {
+    @discardableResult
+    func fetchMore(cursor: RecordCursor, in database: DatabaseReader) async -> Bool {
         let generation = generation
         do {
             let results = try await database.readMore(from: cursor, fields: nil)
             guard generation == self.generation else {
-                return
+                return true
             }
             self.cursor = results.cursor
             records = dedup(new: records ?? [], old: try results.records.map(Element.init))
+            return true
         } catch is CancellationError {
+            return true
         } catch {
             message = Message(error.localizedDescription, level: .error)
+            return false
         }
     }
 

--- a/Tests/ScoutUITests/Support/Provider/FeedProviderTests.swift
+++ b/Tests/ScoutUITests/Support/Provider/FeedProviderTests.swift
@@ -95,6 +95,27 @@ struct FeedProviderTests {
         #expect(provider.error != nil)
     }
 
+    @Test("A failed page load reports the failure and keeps the loaded records")
+    func fetchMoreReportsFailure() async throws {
+        let page1 = [Record.eventStub(name: "a", sessionID: UUID(), date: Date())]
+        let database = PagingDatabase(page1: page1, page2: [])
+
+        let provider = EventProvider()
+        await provider.fetchLatest(for: EventQuery(), in: database)
+        let cursor = try #require(provider.cursor)
+
+        let failing = RecordCursor { _ in throw RefreshFailure() }
+        let loaded = await provider.fetchMore(cursor: failing, in: database)
+
+        #expect(loaded == false)
+        #expect(provider.records?.count == 1)
+        #expect(provider.message != nil)
+
+        let reloaded = await provider.fetchMore(cursor: cursor, in: database)
+
+        #expect(reloaded)
+    }
+
     @Test("A cancelled reload or page load stays quiet and keeps prior records")
     func cancellationStaysQuiet() async throws {
         let database = DatabaseStub()
@@ -108,8 +129,9 @@ struct FeedProviderTests {
         #expect(provider.records?.count == 1)
 
         let cursor = RecordCursor { _ in throw CancellationError() }
-        await provider.fetchMore(cursor: cursor, in: database)
+        let loaded = await provider.fetchMore(cursor: cursor, in: database)
 
+        #expect(loaded)
         #expect(provider.records?.count == 1)
         #expect(provider.message == nil)
     }


### PR DESCRIPTION
PaginationFooter carried `.id(UUID())`, so every redraw of the enclosing list gave it a fresh identity and re-ran its task. A failed page load set the provider's message, that published change redrew the list, and the footer immediately requested the same page again — an endless request loop behind a spinner that never resolved, with no way to retry deliberately.

The footer now owns its pagination state: `fetchMore` reports whether the page loaded, a successful load bumps a page counter that re-runs `.task(id:)` (so pages keep chaining while the footer is on screen, as before), and a failure leaves the counter alone and renders an ErrorRow with a Retry control instead of the spinner. Because the view identity is stable now, a redraw no longer cancels an in-flight load either. The toast still carries the underlying error.

That chaining needs an action that actually takes time, so the "Loading" preview drives the footer with a page that never arrives: an action returning straight away would re-arm the task on every success and spin the canvas, since nothing in a preview ever scrolls the footer out of the list. Found by the silent-error audit (row 13).
