### PR TITLE
Report delivery failures that the next sync won't retry away

### DIFF
--- a/Sources/Scout/Sync/Synchronize.swift
+++ b/Sources/Scout/Sync/Synchronize.swift
@@ -33,7 +33,17 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
                 let recordSender = RecordSender(backend: backend)
 
                 for type in SyncableEntry.deliverableTypes {
-                    group.addTask { try? await recordSender.deliver(type, in: context) }
+                    group.addTask {
+                        do {
+                            try await recordSender.deliver(type, in: context)
+                        } catch is CancellationError {
+                            // A cancelled pass leaves the records pending for the next one.
+                        } catch let error as any TransientFailure where error.isTransient {
+                            // Offline or throttled: the next pass retries the same records.
+                        } catch {
+                            print("Failed to deliver \(type) to backend \(recordSender.id): \(error)")
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
synchronize ran every backend × record-type delivery as `try? await recordSender.deliver(...)`, so a sync reported success no matter what happened: a bad API key, a schema mismatch, a rejected payload, or a Core Data save failure all vanished. Records either sat pending forever or burned their attempt budget and were dropped a week later, with nothing in the console to explain it — the most frequently triggered swallow in the audit.

Deliveries now classify their failures the same way RecordSender.send already does. Cancelled and transient attempts stay quiet, because the records remain pending and the next pass retries them; anything else prints the record type, the backend, and the error, matching the diagnostics the SDK already emits for store loading, log persistence, and abandoned records (#1238). Control flow is unchanged — one backend's failure still doesn't block the others, and the purge and save that follow still run.

A proper diagnostics API for the SDK is a separate, larger piece of work (audit row 16). Found by the silent-error audit (row 2).