### PR TITLE
Say when alert notifications can't reach the device

### DIFF
--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
@@ -10,12 +10,17 @@ import UserNotifications
 protocol AlertNotificationCenter: Sendable {
     func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
     func add(_ request: UNNotificationRequest) async throws
+    func authorizationStatus() async -> UNAuthorizationStatus
 }
 
 // UNUserNotificationCenter is documented thread-safe but not annotated Sendable in the SDK.
 extension UNUserNotificationCenter: @retroactive @unchecked Sendable {}
 
-extension UNUserNotificationCenter: AlertNotificationCenter {}
+extension UNUserNotificationCenter: AlertNotificationCenter {
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        await notificationSettings().authorizationStatus
+    }
+}
 
 struct AlertNotifier {
     let center: AlertNotificationCenter
@@ -28,7 +33,21 @@ struct AlertNotifier {
         (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
     }
 
-    func deliver(_ statuses: [AlertStatus]) async {
+    func deliversNotifications() async -> Bool {
+        switch await center.authorizationStatus() {
+        case .authorized, .provisional, .ephemeral:
+            true
+        default:
+            false
+        }
+    }
+
+    /// Posts a notification for every status that asks for one, and reports the
+    /// rules whose notification the system refused.
+    @discardableResult
+    func deliver(_ statuses: [AlertStatus]) async -> Set<AlertRule> {
+        var undelivered: Set<AlertRule> = []
+
         for status in statuses {
             guard let message = AlertMessage(status: status) else {
                 continue
@@ -44,7 +63,14 @@ struct AlertNotifier {
                 content: content,
                 trigger: nil
             )
-            try? await center.add(request)
+
+            do {
+                try await center.add(request)
+            } catch {
+                undelivered.insert(status.rule)
+            }
         }
+
+        return undelivered
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
@@ -33,14 +33,10 @@ struct AlertNotifier {
         (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
     }
 
-    // Only an explicit denial is a refusal: a status the user has not been asked
-    // about yet still turns into a prompt when the first notifying rule is saved.
     func refusesNotifications() async -> Bool {
         await center.authorizationStatus() == .denied
     }
 
-    /// Posts a notification for every status that asks for one, and reports the
-    /// rules whose notification the system refused.
     @discardableResult
     func deliver(_ statuses: [AlertStatus]) async -> Set<AlertRule> {
         var undelivered: Set<AlertRule> = []

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
@@ -33,13 +33,10 @@ struct AlertNotifier {
         (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
     }
 
-    func deliversNotifications() async -> Bool {
-        switch await center.authorizationStatus() {
-        case .authorized, .provisional, .ephemeral:
-            true
-        default:
-            false
-        }
+    // Only an explicit denial is a refusal: a status the user has not been asked
+    // about yet still turns into a prompt when the first notifying rule is saved.
+    func refusesNotifications() async -> Bool {
+        await center.authorizationStatus() == .denied
     }
 
     /// Posts a notification for every status that asks for one, and reports the

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
@@ -59,12 +59,14 @@ final class AlertEngine {
     @discardableResult
     func run(in database: DatabaseReader) async throws -> [AlertStatus] {
         let statuses = try await statuses(in: database)
+        let undelivered = await notifier?.deliver(statuses) ?? []
 
-        for status in statuses {
+        // A notification the system refused is not recorded as sent, so the next run
+        // evaluates from the same state and gets another chance to notify.
+        for status in statuses where !undelivered.contains(status.rule) {
             try registry.remember(status.outcome.state, for: status.rule)
         }
 
-        await notifier?.deliver(statuses)
         return statuses
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
@@ -61,8 +61,6 @@ final class AlertEngine {
         let statuses = try await statuses(in: database)
         let undelivered = await notifier?.deliver(statuses) ?? []
 
-        // A notification the system refused is not recorded as sent, so the next run
-        // evaluates from the same state and gets another chance to notify.
         for status in statuses where !undelivered.contains(status.rule) {
             try registry.remember(status.outcome.state, for: status.rule)
         }

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
@@ -67,9 +67,7 @@ struct AlertEditorView: View {
                 .disabled(!draft.isValid)
             }
         }
-        .task {
-            await provider.refreshNotificationStatus()
-        }
+        .refreshingNotificationStatus(of: provider)
         .task(id: draft.metric) {
             guard draft.isValid else { return }
             guard (try? await Task.sleep(nanoseconds: 300_000_000)) != nil else {

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertEditorView.swift
@@ -47,6 +47,10 @@ struct AlertEditorView: View {
             }
             .alignmentGuide(.listRowSeparatorTrailing) { $0[.trailing] }
 
+            if draft.notifies, provider.notificationsOff {
+                NotificationsOffRow()
+            }
+
             backtestRow
         }
         .navigationTitle(en: "New Rule")
@@ -62,6 +66,9 @@ struct AlertEditorView: View {
                 }
                 .disabled(!draft.isValid)
             }
+        }
+        .task {
+            await provider.refreshNotificationStatus()
         }
         .task(id: draft.metric) {
             guard draft.isValid else { return }

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -35,12 +35,9 @@ struct AlertListView: View {
                 .opaquePresentation()
             }
             .task {
-                await provider.refreshNotificationStatus()
                 await provider.fetchIfNeeded(in: database)
             }
-            .onReceive(NotificationCenter.default.publisher(for: AppLifecycle.willEnterForeground)) { _ in
-                Task { await provider.refreshNotificationStatus() }
-            }
+            .refreshingNotificationStatus(of: provider)
             .refreshOnPull([provider])
     }
 

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertListView.swift
@@ -35,7 +35,11 @@ struct AlertListView: View {
                 .opaquePresentation()
             }
             .task {
+                await provider.refreshNotificationStatus()
                 await provider.fetchIfNeeded(in: database)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: AppLifecycle.willEnterForeground)) { _ in
+                Task { await provider.refreshNotificationStatus() }
             }
             .refreshOnPull([provider])
     }
@@ -45,6 +49,10 @@ struct AlertListView: View {
         case .success(let statuses) where statuses.count > 0:
             InsetList {
                 chips(statuses)
+
+                if provider.notificationsOff, statuses.contains(where: \.rule.notifies) {
+                    NotificationsOffRow()
+                }
 
                 Header(title: "Rules") {
                     if statuses.firingCount > 0 {

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
@@ -12,8 +12,6 @@ import SwiftUI
 final class AlertProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[AlertStatus]>?
 
-    /// Whether the system currently refuses notifications for the host app, so the
-    /// views can say that firing rules won't reach this device.
     @Published private(set) var notificationsOff = false
 
     private let registry: AlertRegistry

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
@@ -12,6 +12,10 @@ import SwiftUI
 final class AlertProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[AlertStatus]>?
 
+    /// Whether the system currently refuses notifications for the host app, so the
+    /// views can say that firing rules won't reach this device.
+    @Published private(set) var notificationsOff = false
+
     private let registry: AlertRegistry
     private let notifier: AlertNotifier?
     private let engine: AlertEngine
@@ -31,9 +35,18 @@ final class AlertProvider: ObservableObject, Provider {
             if rules.count == 0, let notifier {
                 _ = await notifier.requestAuthorization()
             }
+
+            await refreshNotificationStatus()
         } catch {
             result = .failure(error)
         }
+    }
+
+    func refreshNotificationStatus() async {
+        guard let notifier else {
+            return
+        }
+        notificationsOff = await !notifier.deliversNotifications()
     }
 
     func remove(_ rule: AlertRule) {

--- a/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/AlertProvider.swift
@@ -46,7 +46,7 @@ final class AlertProvider: ObservableObject, Provider {
         guard let notifier else {
             return
         }
-        notificationsOff = await !notifier.deliversNotifications()
+        notificationsOff = await notifier.refusesNotifications()
     }
 
     func remove(_ rule: AlertRule) {

--- a/Sources/ScoutUI/Monitoring/Alerts/View/NotificationsOffRow.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/NotificationsOffRow.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct NotificationsOffRow: View {
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "bell.slash")
+                .foregroundStyle(.orange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: "Notifications are off")
+                    .font(.callout)
+
+                Text(verbatim: "Firing rules won't reach this device.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if let settingsURL {
+                Button {
+                    openURL(settingsURL)
+                } label: {
+                    Text(verbatim: "Settings")
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .frame(minHeight: 44)
+        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+    }
+
+    private var settingsURL: URL? {
+        #if os(iOS)
+            URL(string: UIApplication.openSettingsURLString)
+        #else
+            nil
+        #endif
+    }
+}
+
+#Preview {
+    InsetList {
+        Header(title: "Rules")
+        NotificationsOffRow()
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/View/RefreshingNotificationStatus.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/View/RefreshingNotificationStatus.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+extension View {
+    func refreshingNotificationStatus(of provider: AlertProvider) -> some View {
+        modifier(RefreshingNotificationStatusModifier(provider: provider))
+    }
+}
+
+private struct RefreshingNotificationStatusModifier: ViewModifier {
+    let provider: AlertProvider
+
+    func body(content: Content) -> some View {
+        content
+            .task {
+                await provider.refreshNotificationStatus()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: AppLifecycle.willEnterForeground)) { _ in
+                Task { await provider.refreshNotificationStatus() }
+            }
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
@@ -55,19 +55,19 @@ struct AlertNotifierTests {
     }
 
     @Test(
-        "Only an authorized center delivers notifications",
+        "Only a denied center refuses notifications",
         arguments: [
-            (UNAuthorizationStatus.authorized, true),
-            (.provisional, true),
-            (.ephemeral, true),
-            (.denied, false),
+            (UNAuthorizationStatus.denied, true),
+            (.authorized, false),
+            (.provisional, false),
+            (.ephemeral, false),
             (.notDetermined, false),
         ])
-    func deliversNotifications(status: UNAuthorizationStatus, delivers: Bool) async {
+    func refusesNotifications(status: UNAuthorizationStatus, refuses: Bool) async {
         let center = NotificationCenterStub()
         center.status = status
 
-        #expect(await AlertNotifier(center: center).deliversNotifications() == delivers)
+        #expect(await AlertNotifier(center: center).refusesNotifications() == refuses)
     }
 
     @Test("Authorization passes the center's grant through")

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Testing
+import UserNotifications
 
 @testable import ScoutUI
 
@@ -27,6 +28,46 @@ struct AlertNotifierTests {
         #expect(request.content.title == "Crash-free sessions")
         #expect(request.content.body == "90.00% — below 99.50%")
         #expect(request.trigger == nil)
+    }
+
+    @Test("A refused notification is reported as undelivered")
+    func refusedDelivery() async {
+        let center = NotificationCenterStub()
+        center.addError = NSError(domain: UNErrorDomain, code: 1)
+
+        let notifier = AlertNotifier(center: center)
+        let status = makeStatus(shouldNotify: true)
+        let undelivered = await notifier.deliver([status])
+
+        #expect(undelivered == [status.rule])
+        #expect(center.requests.count == 0)
+    }
+
+    @Test("A delivered notification leaves nothing undelivered")
+    func acceptedDelivery() async {
+        let center = NotificationCenterStub()
+        let notifier = AlertNotifier(center: center)
+
+        let undelivered = await notifier.deliver([makeStatus(shouldNotify: true)])
+
+        #expect(undelivered.isEmpty)
+        #expect(center.requests.count == 1)
+    }
+
+    @Test(
+        "Only an authorized center delivers notifications",
+        arguments: [
+            (UNAuthorizationStatus.authorized, true),
+            (.provisional, true),
+            (.ephemeral, true),
+            (.denied, false),
+            (.notDetermined, false),
+        ])
+    func deliversNotifications(status: UNAuthorizationStatus, delivers: Bool) async {
+        let center = NotificationCenterStub()
+        center.status = status
+
+        #expect(await AlertNotifier(center: center).deliversNotifications() == delivers)
     }
 
     @Test("Authorization passes the center's grant through")

--- a/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertEngineTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertEngineTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Testing
+import UserNotifications
 
 @testable import Scout
 @testable import ScoutUI
@@ -64,6 +65,26 @@ struct AlertEngineTests {
 
         _ = try await engine.run(in: database)
 
+        #expect(center.requests.count == 1)
+    }
+
+    @Test("A refused notification is retried on the next run")
+    func refusedNotificationRetries() async throws {
+        let database = DatabaseStub()
+        database.add(series: makeSeries(name: "Error", counts: errorCounts))
+
+        let center = NotificationCenterStub()
+        center.addError = NSError(domain: UNErrorDomain, code: 1)
+        let engine = try makeEngine(rules: [errorRule], center: center)
+
+        _ = try await engine.run(in: database)
+
+        #expect(center.requests.count == 0)
+
+        center.addError = nil
+        let second = try await engine.run(in: database)
+
+        #expect(second[0].outcome.shouldNotify)
         #expect(center.requests.count == 1)
     }
 

--- a/Tests/ScoutUITests/Monitoring/Alerts/View/AlertProviderTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/View/AlertProviderTests.swift
@@ -61,6 +61,23 @@ struct AlertProviderTests {
         #expect(try registry.rules() == [crashFreeRule])
     }
 
+    @Test("A denied center makes the provider report that notifications are off")
+    func notificationsOffWhenDenied() async {
+        let center = NotificationCenterStub()
+        center.status = .denied
+        center.granted = false
+        let provider = AlertProvider(registry: AlertRegistry(defaults: defaults), notifier: AlertNotifier(center: center))
+
+        await provider.add(errorRule)
+
+        #expect(provider.notificationsOff)
+
+        center.status = .authorized
+        await provider.refreshNotificationStatus()
+
+        #expect(!provider.notificationsOff)
+    }
+
     @Test("Adding a rule over an unreadable store fails instead of overwriting it")
     func addOverUnreadableStore() async {
         let blob = Data("garbage".utf8)

--- a/Tests/ScoutUITests/Monitoring/Alerts/View/AlertProviderTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/View/AlertProviderTests.swift
@@ -78,6 +78,17 @@ struct AlertProviderTests {
         #expect(!provider.notificationsOff)
     }
 
+    @Test("A center that has not been asked yet doesn't claim notifications are off")
+    func notificationsOnWhenNotDetermined() async {
+        let center = NotificationCenterStub()
+        center.status = .notDetermined
+        let provider = AlertProvider(registry: AlertRegistry(defaults: defaults), notifier: AlertNotifier(center: center))
+
+        await provider.refreshNotificationStatus()
+
+        #expect(!provider.notificationsOff)
+    }
+
     @Test("Adding a rule over an unreadable store fails instead of overwriting it")
     func addOverUnreadableStore() async {
         let blob = Data("garbage".utf8)

--- a/Tests/ScoutUITests/Stubs/NotificationCenterStub.swift
+++ b/Tests/ScoutUITests/Stubs/NotificationCenterStub.swift
@@ -15,6 +15,8 @@ final class NotificationCenterStub: AlertNotificationCenter, @unchecked Sendable
     private var grantedStorage = true
     private var authorizationStorage = 0
     private var requestStorage: [UNNotificationRequest] = []
+    private var statusStorage = UNAuthorizationStatus.authorized
+    private var addErrorStorage: (any Error)?
 
     var granted: Bool {
         get {
@@ -26,6 +28,32 @@ final class NotificationCenterStub: AlertNotificationCenter, @unchecked Sendable
             lock.lock()
             defer { lock.unlock() }
             grantedStorage = newValue
+        }
+    }
+
+    var status: UNAuthorizationStatus {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return statusStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            statusStorage = newValue
+        }
+    }
+
+    var addError: (any Error)? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return addErrorStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            addErrorStorage = newValue
         }
     }
 
@@ -46,7 +74,14 @@ final class NotificationCenterStub: AlertNotificationCenter, @unchecked Sendable
     }
 
     func add(_ request: UNNotificationRequest) async throws {
+        if let addError {
+            throw addError
+        }
         record(request)
+    }
+
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        status
     }
 
     private func recordAuthorization() -> Bool {


### PR DESCRIPTION
Turning on "Notify on this device" looked like it worked no matter what the system said: AlertProvider.add discarded the result of the authorization request, AlertNotifier.deliver dropped every posting error with try?, and nothing ever read the current authorization status. A user who tapped "Don't Allow" — or who had denied notifications long ago — kept saving rules that could never notify, and only found out by noticing alerts firing in the list that never reached them.

The notifier can now report whether the system refuses to deliver, and the provider publishes that as `notificationsOff`. Only an explicit denial counts as a refusal: a status the user has not been asked about yet still turns into a prompt when the first notifying rule is saved, so a fresh install isn't told its notifications are off before the system has said anything. Both screens show a row saying notifications are off with a shortcut to Settings — the list only when a rule actually asks for notifications, the editor only while the toggle is on — and both refresh through one `refreshingNotificationStatus` modifier, on appearance and again when the app returns to the foreground, so granting permission in Settings clears the row wherever it is showing.

A refused notification also no longer counts as sent: deliver reports the rules the system rejected, and the engine skips remembering their state, so the next run evaluates from the same state and notifies again once notifications are back. Found by the silent-error audit (row 4).
