### PR TITLE
Extract the shared incident list view

### DIFF
--- a/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Crash/CrashListView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2026 Mikhail Kasianov
+// Copyright 2025 Mikhail Kasianov
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
@@ -9,46 +9,21 @@ import Scout
 import SwiftUI
 
 struct CrashListView: View {
-    @Environment(\.database) var database
     @StateObject var provider = IncidentProvider<Crash>()
 
     var body: some View {
-        Group {
-            if let groups = provider.groups {
-                if groups.isEmpty {
-                    Placeholder(
-                        text: "No crashes",
-                        systemImage: "checkmark.shield",
-                        description: "No crash reports have been recorded"
-                    )
-                } else {
-                    InsetList {
-                        ForEach(groups, content: row)
-
-                        if let cursor = provider.cursor {
-                            PaginationFooter {
-                                await provider.fetchMore(cursor: cursor, in: database)
-                            }
-                        }
-                    }
-                    .animation(nil, value: groups)
-                }
-            } else if let error = provider.error {
-                ErrorView(description: error.localizedDescription) {
-                    await provider.fetchAgain(in: database)
-                }
-            } else {
-                RingIndicator().frame(maxHeight: .infinity)
+        IncidentList(
+            provider: provider,
+            title: "Crashes",
+            placeholder: Placeholder(
+                text: "No crashes",
+                systemImage: "checkmark.shield",
+                description: "No crash reports have been recorded"
+            )
+        ) { group in
+            IncidentRow(group: group) { group in
+                CrashGroupDetailView(group: group)
             }
-        }
-        .navigationTitle(en: "Crashes")
-        .message($provider.message)
-        .refreshes([provider])
-    }
-
-    private func row(for group: IncidentGroup<Crash>) -> some View {
-        IncidentRow(group: group) { group in
-            CrashGroupDetailView(group: group)
         }
     }
 }

--- a/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Hang/HangListView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2026 Mikhail Kasianov
+// Copyright 2025 Mikhail Kasianov
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
@@ -9,43 +9,20 @@ import Scout
 import SwiftUI
 
 struct HangListView: View {
-    @Environment(\.database) var database
     @StateObject var provider = IncidentProvider<Hang>()
 
     var body: some View {
-        Group {
-            if let groups = provider.groups {
-                if groups.isEmpty {
-                    Placeholder(
-                        text: "No hangs",
-                        systemImage: "checkmark.shield",
-                        description: "No unresponsive main thread has been recorded"
-                    )
-                } else {
-                    InsetList {
-                        ForEach(groups) { group in
-                            HangRow(group: group)
-                        }
-
-                        if let cursor = provider.cursor {
-                            PaginationFooter {
-                                await provider.fetchMore(cursor: cursor, in: database)
-                            }
-                        }
-                    }
-                    .animation(nil, value: groups)
-                }
-            } else if let error = provider.error {
-                ErrorView(description: error.localizedDescription) {
-                    await provider.fetchAgain(in: database)
-                }
-            } else {
-                RingIndicator().frame(maxHeight: .infinity)
-            }
+        IncidentList(
+            provider: provider,
+            title: "Hangs",
+            placeholder: Placeholder(
+                text: "No hangs",
+                systemImage: "checkmark.shield",
+                description: "No unresponsive main thread has been recorded"
+            )
+        ) { group in
+            HangRow(group: group)
         }
-        .navigationTitle(en: "Hangs")
-        .message($provider.message)
-        .refreshes([provider])
     }
 }
 

--- a/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentList.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Provider/IncidentList.swift
@@ -1,0 +1,49 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct IncidentList<Element: RecordDecodable & Incident, Row: View>: View {
+    @Environment(\.database) var database
+    @ObservedObject var provider: IncidentProvider<Element>
+
+    let title: String
+    let placeholder: Placeholder
+
+    @ViewBuilder let row: (IncidentGroup<Element>) -> Row
+
+    var body: some View {
+        Group {
+            if let groups = provider.groups {
+                if groups.isEmpty {
+                    placeholder
+                } else {
+                    InsetList {
+                        ForEach(groups, content: row)
+
+                        if let cursor = provider.cursor {
+                            PaginationFooter {
+                                await provider.fetchMore(cursor: cursor, in: database)
+                            }
+                        }
+                    }
+                    .animation(nil, value: groups)
+                }
+            } else if let error = provider.error {
+                ErrorView(description: error.localizedDescription) {
+                    await provider.fetchAgain(in: database)
+                }
+            } else {
+                RingIndicator().frame(maxHeight: .infinity)
+            }
+        }
+        .navigationTitle(en: title)
+        .message($provider.message)
+        .refreshes([provider])
+    }
+}


### PR DESCRIPTION
CrashListView and HangListView were near-identical mirrors: both walked the same four states of an IncidentProvider (content list with a PaginationFooter, empty Placeholder, first-load ErrorView, loading indicator) and attached the same message and refresh modifiers, differing only in the element type, the title, the placeholder copy, and the row.

That state machine now lives in one generic IncidentList next to IncidentProvider, parameterized by the title, the placeholder, and a row builder, so both screens shrink to a provider and their differences. No behavior change: the four rendered states, the pagination footer, the toast binding, and the pull-to-refresh wiring are the same as before, and both previews still work.

Follow-up to the audit fixes that touched these two views (#1239, #1246), which is where the duplication became worth removing.