### PR TITLE
Move the alert series queries onto the database reader

### DIFF
--- a/Sources/ScoutUI/Home/Section/Log/SeriesSpan.swift
+++ b/Sources/ScoutUI/Home/Section/Log/SeriesSpan.swift
@@ -25,7 +25,7 @@ struct SeriesSpan {
     private func points(matching isIncluded: (MetricSeries) -> Bool) -> [ChartPoint<Int>] {
         series
             .filter(isIncluded)
-            .flatMap { $0.chartPoints() as [ChartPoint<Int>] }
+            .flatMap { $0.chartPoints() }
             .filter { range.contains($0.date) }
     }
 

--- a/Sources/ScoutUI/Monitoring/Alerts/Metric/AlertMetric.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Metric/AlertMetric.swift
@@ -18,50 +18,79 @@ extension AlertMetric {
         let range = period.previousRange.lowerBound..<period.initialRange.upperBound
 
         switch self {
-        case .eventCount:
-            return MetricReading(points: try await eventPoints(in: database, range: range), period: period)
+        case .eventCount(let name):
+            let series = try await database.eventSeries(named: name, in: range)
+
+            return MetricReading(
+                points: series.flatMap { $0.chartPoints() },
+                period: period
+            )
+
         case .crashFreeSessions:
-            let (sessions, crashes) = try await lifecyclePoints(in: database, range: range)
-            return MetricReading(sessions: sessions, crashes: crashes, period: period)
+            async let sessions = database.sessionSeries(in: range)
+            async let crashes = database.crashSeries(in: range)
+
+            return try await MetricReading(
+                sessions: sessions.flatMap { $0.chartPoints() },
+                crashes: crashes.flatMap { $0.chartPoints() },
+                period: period
+            )
         }
     }
 
     func values(in database: DatabaseReader, range: Range<Date>) async throws -> [Double] {
         switch self {
-        case .eventCount:
-            return try await eventPoints(in: database, range: range)
+        case .eventCount(let name):
+            return try await database.eventSeries(named: name, in: range)
+                .flatMap { $0.chartPoints() as [ChartPoint<Int>] }
                 .bucket(in: range, component: .hour)
                 .reversed()
                 .map { Double($0.count) }
 
         case .crashFreeSessions:
-            let (sessions, crashes) = try await lifecyclePoints(in: database, range: range)
-            return MetricReading.stabilities(sessions: sessions, crashes: crashes, in: range, component: .hour)
+            async let sessions = database.sessionSeries(in: range)
+            async let crashes = database.crashSeries(in: range)
+
+            return try await stabilityValues(
+                sessions: sessions.flatMap { $0.chartPoints() },
+                crashes: crashes.flatMap { $0.chartPoints() },
+                in: range,
+                component: .hour
+            )
         }
     }
+}
 
-    private func eventPoints(in database: DatabaseReader, range: Range<Date>) async throws -> [ChartPoint<Int>] {
-        guard case .eventCount(let name) = self else {
-            return []
-        }
-
-        let series = try await database.series(
-            matching: SeriesQuery(name: name, bucket: .hour, range: range)
+extension DatabaseReader {
+    fileprivate func eventSeries(named name: String, in range: Range<Date>) async throws -> [MetricSeries] {
+        try await series(
+            matching: SeriesQuery(
+                name: name,
+                bucket: .hour,
+                range: range
+            )
         )
-        return series.flatMap { $0.chartPoints() }
     }
 
-    private func lifecyclePoints(in database: DatabaseReader, range: Range<Date>) async throws -> (sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>]) {
-        async let sessions = database.series(
-            matching: SeriesQuery(name: SessionEntry.recordType, bucket: .hour, source: .lifecycle, range: range)
+    fileprivate func sessionSeries(in range: Range<Date>) async throws -> [MetricSeries] {
+        try await series(
+            matching: SeriesQuery(
+                name: SessionEntry.recordType,
+                bucket: .hour,
+                source: .lifecycle,
+                range: range
+            )
         )
-        async let crashes = database.series(
-            matching: SeriesQuery(name: CrashEntry.recordType, bucket: .hour, source: .lifecycle, range: range)
-        )
+    }
 
-        return (
-            sessions: try await sessions.flatMap { $0.chartPoints() },
-            crashes: try await crashes.flatMap { $0.chartPoints() }
+    fileprivate func crashSeries(in range: Range<Date>) async throws -> [MetricSeries] {
+        try await series(
+            matching: SeriesQuery(
+                name: CrashEntry.recordType,
+                bucket: .hour,
+                source: .lifecycle,
+                range: range
+            )
         )
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Metric/MetricReading+ChartPoints.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Metric/MetricReading+ChartPoints.swift
@@ -20,19 +20,26 @@ extension MetricReading {
     }
 
     init(sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], period: some ChartTimeScale) {
-        let previous = Self.stabilities(
-            sessions: sessions, crashes: crashes, in: period.previousRange, component: period.pointComponent)
-        let current = Self.stabilities(
-            sessions: sessions, crashes: crashes, in: period.initialRange, component: period.pointComponent)
+        func stabilities(in range: Range<Date>) -> [Double] {
+            stabilityValues(
+                sessions: sessions,
+                crashes: crashes,
+                in: range,
+                component: period.pointComponent
+            )
+        }
 
-        self.init(baseline: previous.median ?? 0, recent: current)
-    }
-
-    static func stabilities(sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], in range: Range<Date>, component: Calendar.Component) -> [Double] {
-        zip(
-            sessions.bucket(in: range, component: component).reversed(),
-            crashes.bucket(in: range, component: component).reversed()
+        self.init(
+            baseline: stabilities(in: period.previousRange).median ?? 0,
+            recent: stabilities(in: period.initialRange)
         )
-        .map { Stability(of: $1.count, in: $0.count).value }
     }
+}
+
+func stabilityValues(sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], in range: Range<Date>, component: Calendar.Component) -> [Double] {
+    zip(
+        sessions.bucket(in: range, component: component).reversed(),
+        crashes.bucket(in: range, component: component).reversed()
+    )
+    .map { Stability(of: $1.count, in: $0.count).value }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Rule/AlertCondition.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Rule/AlertCondition.swift
@@ -31,11 +31,11 @@ extension AlertCondition {
             return false
         }
 
-        switch comparison {
+        return switch comparison {
         case .below:
-            return value < reference
+            value < reference
         case .above:
-            return value > reference
+            value > reference
         }
     }
 }


### PR DESCRIPTION
AlertMetric built its SeriesQuery objects inline and re-checked its own case inside a private helper that both branches already knew the answer to. The three queries now live as fileprivate methods on DatabaseReader returning raw series, the mapping to chart points happens at the call site, and the crash-free stability math is a free function shared with MetricReading. Stacked on #1252.