### PR TITLE
Warn when notifications are off and retry undelivered alerts

### DIFF
--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotificationCenter.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotificationCenter.swift
@@ -1,0 +1,22 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import UserNotifications
+
+protocol AlertNotificationCenter: Sendable {
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
+    func add(_ request: UNNotificationRequest) async throws
+    func authorizationStatus() async -> UNAuthorizationStatus
+}
+
+extension UNUserNotificationCenter: @retroactive @unchecked Sendable {}
+
+extension UNUserNotificationCenter: AlertNotificationCenter {
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        await notificationSettings().authorizationStatus
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Delivery/AlertNotifier.swift
@@ -7,16 +7,6 @@
 
 import UserNotifications
 
-protocol AlertNotificationCenter: Sendable {
-    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
-    func add(_ request: UNNotificationRequest) async throws
-}
-
-// UNUserNotificationCenter is documented thread-safe but not annotated Sendable in the SDK.
-extension UNUserNotificationCenter: @retroactive @unchecked Sendable {}
-
-extension UNUserNotificationCenter: AlertNotificationCenter {}
-
 struct AlertNotifier {
     let center: AlertNotificationCenter
 
@@ -24,11 +14,22 @@ struct AlertNotifier {
         self.center = center
     }
 
-    func requestAuthorization() async -> Bool {
-        (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+    func needsAuthorization() async -> Bool {
+        await center.authorizationStatus() == .notDetermined
     }
 
-    func deliver(_ statuses: [AlertStatus]) async {
+    func requestAuthorization() async {
+        _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
+    }
+
+    func refusesNotifications() async -> Bool {
+        await center.authorizationStatus() == .denied
+    }
+
+    @discardableResult
+    func deliver(_ statuses: [AlertStatus]) async -> [AlertStatus] {
+        var undelivered: [AlertStatus] = []
+
         for status in statuses {
             guard let message = AlertMessage(status: status) else {
                 continue
@@ -44,7 +45,14 @@ struct AlertNotifier {
                 content: content,
                 trigger: nil
             )
-            try? await center.add(request)
+
+            do {
+                try await center.add(request)
+            } catch {
+                undelivered.append(status)
+            }
         }
+
+        return undelivered
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Editor/AlertEditorView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Editor/AlertEditorView.swift
@@ -47,6 +47,10 @@ struct AlertEditorView: View {
             }
             .alignmentGuide(.listRowSeparatorTrailing) { $0[.trailing] }
 
+            if draft.notifies, provider.notificationsDenied {
+                NotificationsDeniedRow()
+            }
+
             backtestRow
         }
         .navigationTitle(en: "New Rule")

--- a/Sources/ScoutUI/Monitoring/Alerts/Editor/AlertListView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Editor/AlertListView.swift
@@ -37,6 +37,7 @@ struct AlertListView: View {
             .task {
                 await provider.fetchIfNeeded(in: database)
             }
+            .notificationStatus(of: provider)
             .refreshOnPull([provider])
     }
 
@@ -45,6 +46,10 @@ struct AlertListView: View {
         case .success(let statuses) where statuses.count > 0:
             InsetList {
                 chips(statuses)
+
+                if provider.notificationsDenied, statuses.contains(where: \.rule.notifies) {
+                    NotificationsDeniedRow()
+                }
 
                 Header(title: "Rules") {
                     if statuses.firingCount > 0 {

--- a/Sources/ScoutUI/Monitoring/Alerts/Editor/AlertProvider.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Editor/AlertProvider.swift
@@ -12,27 +12,37 @@ import SwiftUI
 final class AlertProvider: ObservableObject, Provider {
     @Published var result: ProviderResult<[AlertStatus]>?
 
+    @Published private(set) var notificationsDenied = false
+
     private let registry: AlertRegistry
     private let notifier: AlertNotifier?
-    private let engine: AlertEngine
 
     init(_ result: ProviderResult<Output>? = nil, registry: AlertRegistry = AlertRegistry(), notifier: AlertNotifier? = nil) {
         self.registry = registry
         self.notifier = notifier
-        self.engine = AlertEngine(registry: registry, notifier: notifier)
         self.result = result
     }
 
     func add(_ rule: AlertRule) async {
         do {
             let rules = try registry.rules()
+
+            guard !rules.contains(rule) else { return }
+
             try registry.save(rules + [rule])
 
-            if rules.count == 0, let notifier {
-                _ = await notifier.requestAuthorization()
+            if let notifier, await notifier.needsAuthorization() {
+                await notifier.requestAuthorization()
+                await refreshNotificationStatus()
             }
         } catch {
             result = .failure(error)
+        }
+    }
+
+    func refreshNotificationStatus() async {
+        if let notifier {
+            notificationsDenied = await notifier.refusesNotifications()
         }
     }
 
@@ -47,6 +57,6 @@ final class AlertProvider: ObservableObject, Provider {
     }
 
     func fetch(in database: DatabaseReader) async throws -> [AlertStatus] {
-        try await engine.statuses(in: database)
+        try await AlertEngine(registry: registry, notifier: notifier).statuses(in: database)
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Engine/AlertEngine.swift
@@ -64,7 +64,10 @@ final class AlertEngine {
             try registry.remember(status.outcome.state, for: status.rule)
         }
 
-        await notifier?.deliver(statuses)
+        for status in await notifier?.deliver(statuses) ?? [] {
+            try registry.remember(.armed, for: status.rule)
+        }
+
         return statuses
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Notifications/NotificationStatus.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Notifications/NotificationStatus.swift
@@ -5,7 +5,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import Scout
 import SwiftUI
 
 extension View {
@@ -17,13 +16,14 @@ extension View {
 private struct NotificationStatusModifier: ViewModifier {
     let provider: AlertProvider
 
-    func body(content: Content) -> some View {
-        content.task {
-            await provider.refreshNotificationStatus()
+    @Environment(\.scenePhase) private var scenePhase
 
-            for await _ in NotificationCenter.default.notifications(named: AppLifecycle.willEnterForeground) {
-                await provider.refreshNotificationStatus()
+    func body(content: Content) -> some View {
+        content.task(id: scenePhase) {
+            guard scenePhase == .active else {
+                return
             }
+            await provider.refreshNotificationStatus()
         }
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Notifications/NotificationStatus.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Notifications/NotificationStatus.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+extension View {
+    func notificationStatus(of provider: AlertProvider) -> some View {
+        modifier(NotificationStatusModifier(provider: provider))
+    }
+}
+
+private struct NotificationStatusModifier: ViewModifier {
+    let provider: AlertProvider
+
+    func body(content: Content) -> some View {
+        content.task {
+            await provider.refreshNotificationStatus()
+
+            for await _ in NotificationCenter.default.notifications(named: AppLifecycle.willEnterForeground) {
+                await provider.refreshNotificationStatus()
+            }
+        }
+    }
+}

--- a/Sources/ScoutUI/Monitoring/Alerts/Notifications/NotificationsDeniedRow.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Notifications/NotificationsDeniedRow.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Scout
+import SwiftUI
+
+struct NotificationsDeniedRow: View {
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "bell.slash")
+                .foregroundStyle(.orange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: "Notifications are off")
+                    .font(.callout)
+
+                Text(verbatim: "Firing rules won't reach this device.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if let settingsURL {
+                Button {
+                    openURL(settingsURL)
+                } label: {
+                    Text(verbatim: "Settings")
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .frame(minHeight: 44)
+        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+    }
+
+    private var settingsURL: URL? {
+        #if os(iOS)
+            URL(string: UIApplication.openSettingsURLString)
+        #else
+            nil
+        #endif
+    }
+}
+
+#Preview {
+    InsetList {
+        Header(title: "Rules")
+        NotificationsDeniedRow()
+    }
+}

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Testing
+import UserNotifications
 
 @testable import ScoutUI
 
@@ -29,15 +30,52 @@ struct AlertNotifierTests {
         #expect(request.trigger == nil)
     }
 
-    @Test("Authorization passes the center's grant through")
-    func authorization() async {
+    @Test("A refused notification is reported as undelivered")
+    func refusedDelivery() async {
         let center = NotificationCenterStub()
-        center.granted = false
+        center.addError = NSError(domain: UNErrorDomain, code: 1)
 
         let notifier = AlertNotifier(center: center)
-        let granted = await notifier.requestAuthorization()
+        let status = makeStatus(shouldNotify: true)
+        let undelivered = await notifier.deliver([status])
 
-        #expect(!granted)
+        #expect(undelivered.map(\.rule) == [status.rule])
+        #expect(center.requests.count == 0)
+    }
+
+    @Test("A delivered notification leaves nothing undelivered")
+    func acceptedDelivery() async {
+        let center = NotificationCenterStub()
+        let notifier = AlertNotifier(center: center)
+
+        let undelivered = await notifier.deliver([makeStatus(shouldNotify: true)])
+
+        #expect(undelivered.count == 0)
+        #expect(center.requests.count == 1)
+    }
+
+    @Test(
+        "Only a denied center refuses notifications",
+        arguments: [
+            (UNAuthorizationStatus.denied, true),
+            (.authorized, false),
+            (.provisional, false),
+            (.ephemeral, false),
+            (.notDetermined, false),
+        ])
+    func refusesNotifications(status: UNAuthorizationStatus, refuses: Bool) async {
+        let center = NotificationCenterStub()
+        center.status = status
+
+        #expect(await AlertNotifier(center: center).refusesNotifications() == refuses)
+    }
+
+    @Test("Requesting authorization asks the center once")
+    func authorization() async {
+        let center = NotificationCenterStub()
+
+        await AlertNotifier(center: center).requestAuthorization()
+
         #expect(center.authorizationRequests == 1)
     }
 

--- a/Tests/ScoutUITests/Monitoring/Alerts/Editor/AlertProviderTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Editor/AlertProviderTests.swift
@@ -36,6 +36,7 @@ struct AlertProviderTests {
     @Test("Adding the first rule requests notification authorization once")
     func firstRuleAuthorization() async throws {
         let center = NotificationCenterStub()
+        center.status = .notDetermined
         let registry = AlertRegistry(defaults: defaults)
         let provider = AlertProvider(registry: registry, notifier: AlertNotifier(center: center))
 
@@ -50,6 +51,31 @@ struct AlertProviderTests {
         #expect(try registry.rules().count == 2)
     }
 
+    @Test("A refused prompt makes the provider report that notifications are denied")
+    func refusedPrompt() async {
+        let center = NotificationCenterStub()
+        center.status = .notDetermined
+        center.grant = false
+        let provider = AlertProvider(registry: AlertRegistry(defaults: defaults), notifier: AlertNotifier(center: center))
+
+        await provider.add(errorRule)
+
+        #expect(provider.notificationsDenied)
+    }
+
+    @Test("A rule added while authorization is still undetermined asks again")
+    func undeterminedAuthorization() async throws {
+        let center = NotificationCenterStub()
+        center.status = .notDetermined
+        let registry = AlertRegistry(defaults: defaults)
+        try registry.save([errorRule])
+        let provider = AlertProvider(registry: registry, notifier: AlertNotifier(center: center))
+
+        await provider.add(crashFreeRule)
+
+        #expect(center.authorizationRequests == 1)
+    }
+
     @Test("Removing a rule leaves the others in place")
     func remove() async throws {
         let registry = AlertRegistry(defaults: defaults)
@@ -59,6 +85,33 @@ struct AlertProviderTests {
         provider.remove(errorRule)
 
         #expect(try registry.rules() == [crashFreeRule])
+    }
+
+    @Test("A denied center makes the provider report that notifications are denied")
+    func notificationsDeniedWhenDenied() async {
+        let center = NotificationCenterStub()
+        center.status = .denied
+        let provider = AlertProvider(registry: AlertRegistry(defaults: defaults), notifier: AlertNotifier(center: center))
+
+        await provider.refreshNotificationStatus()
+
+        #expect(provider.notificationsDenied)
+
+        center.status = .authorized
+        await provider.refreshNotificationStatus()
+
+        #expect(!provider.notificationsDenied)
+    }
+
+    @Test("A center that has not been asked yet doesn't claim notifications are denied")
+    func notificationsNotDeniedWhenNotDetermined() async {
+        let center = NotificationCenterStub()
+        center.status = .notDetermined
+        let provider = AlertProvider(registry: AlertRegistry(defaults: defaults), notifier: AlertNotifier(center: center))
+
+        await provider.refreshNotificationStatus()
+
+        #expect(!provider.notificationsDenied)
     }
 
     @Test("Adding a rule over an unreadable store fails instead of overwriting it")

--- a/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertEngineTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Engine/AlertEngineTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Testing
+import UserNotifications
 
 @testable import Scout
 @testable import ScoutUI
@@ -64,6 +65,26 @@ struct AlertEngineTests {
 
         _ = try await engine.run(in: database)
 
+        #expect(center.requests.count == 1)
+    }
+
+    @Test("A refused notification is retried on the next run")
+    func refusedNotificationRetries() async throws {
+        let database = DatabaseStub()
+        database.add(series: makeSeries(name: "Error", counts: errorCounts))
+
+        let center = NotificationCenterStub()
+        center.addError = NSError(domain: UNErrorDomain, code: 1)
+        let engine = try makeEngine(rules: [errorRule], center: center)
+
+        _ = try await engine.run(in: database)
+
+        #expect(center.requests.count == 0)
+
+        center.addError = nil
+        let second = try await engine.run(in: database)
+
+        #expect(second[0].outcome.shouldNotify)
         #expect(center.requests.count == 1)
     }
 

--- a/Tests/ScoutUITests/Stubs/NotificationCenterStub.swift
+++ b/Tests/ScoutUITests/Stubs/NotificationCenterStub.swift
@@ -12,20 +12,48 @@ import UserNotifications
 
 final class NotificationCenterStub: AlertNotificationCenter, @unchecked Sendable {
     private let lock = NSLock()
-    private var grantedStorage = true
     private var authorizationStorage = 0
     private var requestStorage: [UNNotificationRequest] = []
+    private var statusStorage = UNAuthorizationStatus.authorized
+    private var grantStorage = true
+    private var addErrorStorage: (any Error)?
 
-    var granted: Bool {
+    var status: UNAuthorizationStatus {
         get {
             lock.lock()
             defer { lock.unlock() }
-            return grantedStorage
+            return statusStorage
         }
         set {
             lock.lock()
             defer { lock.unlock() }
-            grantedStorage = newValue
+            statusStorage = newValue
+        }
+    }
+
+    var grant: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return grantStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            grantStorage = newValue
+        }
+    }
+
+    var addError: (any Error)? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return addErrorStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            addErrorStorage = newValue
         }
     }
 
@@ -43,17 +71,25 @@ final class NotificationCenterStub: AlertNotificationCenter, @unchecked Sendable
 
     func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool {
         recordAuthorization()
+        return grant
     }
 
     func add(_ request: UNNotificationRequest) async throws {
+        if let addError {
+            throw addError
+        }
         record(request)
     }
 
-    private func recordAuthorization() -> Bool {
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        status
+    }
+
+    private func recordAuthorization() {
         lock.lock()
         defer { lock.unlock() }
         authorizationStorage += 1
-        return grantedStorage
+        statusStorage = grantStorage ? .authorized : .denied
     }
 
     private func record(_ request: UNNotificationRequest) {


### PR DESCRIPTION
A rule set to notify silently reached nobody when the user had denied notifications, and a notification the system refused was still recorded as delivered, so the next sync never retried it. The alert list and the editor now show a row pointing at Settings whenever notifications are denied and a notifying rule exists, the status is refreshed whenever the scene becomes active, and authorization is requested whenever it is still undetermined rather than only alongside the very first rule. AlertNotifier reports which statuses it could not deliver, and the engine persists every evaluated state before delivering and rolls the failed ones back to armed so the next run tries again. Stacked on #1253.