### PR TITLE
Keep records deliverable when the background window closes

### DIFF
--- a/Sources/Scout/Utilities/BackgroundExecutionTime.swift
+++ b/Sources/Scout/Utilities/BackgroundExecutionTime.swift
@@ -27,3 +27,11 @@ struct InsufficientBackgroundTimeError: LocalizedError {
     let helpAnchor: String? = "https://developer.apple.com/documentation/uikit/uiapplication/backgroundtimeremaining"
     let recoverySuggestion: String? = "Try again later."
 }
+
+// The window closed before the request went out, so no backend ever saw the
+// records: charging them an attempt would abandon data nothing rejected.
+extension InsufficientBackgroundTimeError: TransientFailure {
+    var isTransient: Bool {
+        true
+    }
+}

--- a/Tests/ScoutTests/Sync/DeliverTests.swift
+++ b/Tests/ScoutTests/Sync/DeliverTests.swift
@@ -221,6 +221,32 @@ struct DeliverTests {
         #expect(server.records.count(of: "Event") == 1)
     }
 
+    @Test("Running out of background time doesn't consume the attempt budget")
+    func backgroundTimeExhaustionPreservesAttempts() async throws {
+        let event = EventEntry.stub(name: "login", in: context)
+        try context.save()
+        try SyncableEntry.plan(backends: [serverBackend], in: context)
+
+        // Every pass is aborted client-side before the request goes out, for far
+        // longer than the attempt budget would allow...
+        for _ in 0..<(DeliveryEntry.maxAttempts * 2) {
+            server.writeErrors.append(InsufficientBackgroundTimeError())
+            await #expect(throws: (any Error).self) {
+                try await deliver(EventEntry.self, to: serverBackend)
+            }
+        }
+
+        // ...yet not one attempt is spent, so the record is still deliverable.
+        #expect(event.delivery(for: "server")?.attempts == 0)
+        #expect(event.delivery(for: "server")?.isPending == true)
+        #expect(server.records.count(of: "Event") == 0)
+
+        // The next pass runs with a full window and the record delivers.
+        try await deliver(EventEntry.self, to: serverBackend)
+        #expect(event.delivery(for: "server")?.isDelivered == true)
+        #expect(server.records.count(of: "Event") == 1)
+    }
+
     @Test("A cancelled send doesn't consume the attempt budget")
     func cancellationPreservesAttempts() async throws {
         let event = EventEntry.stub(name: "login", in: context)


### PR DESCRIPTION
`requireBackgroundTime` aborts a write client-side once `backgroundTimeRemaining` drops under 15 seconds, before the request ever reaches the backend. `InsufficientBackgroundTimeError` was declared `LocalizedError` only, and the only conformances to `TransientFailure` are `HTTPDatabaseError`, `URLError`, and `CKError`, so this was the one write-path error that is neither a cancellation nor transient. It fell past both escapes in `RecordSender.send` into the rejection branch, which charges the record an attempt and saves on the throwing exit — ten such passes abandoned records no backend had rejected, and `DateEntry.cleanup` deleted them once they aged past a week. The visible result was an unexplained hole in the dashboard, reported only through a `print`.

The error now conforms to `TransientFailure`, so a closed window costs nothing and the next pass retries the same records, matching how an unavailable backend and a connectivity failure already behave. `DeliverTests` pinned that rule for every other environmental failure but had no case for this one, so it gets the matching test; verified that it fails without the conformance and passes with it, with the full `ScoutTests` bundle green at 251 tests.

Found during a bug audit of the sync pipeline.