### PR TITLE
Run the whole sync pass off the main actor and coalesce it

### DIFF
--- a/Sources/Scout/Sync/DeliveryEntry.swift
+++ b/Sources/Scout/Sync/DeliveryEntry.swift
@@ -19,13 +19,15 @@ final class DeliveryEntry: NSManagedObject {
     static func retainedIDs(to backendIDs: Set<String>, in context: NSManagedObjectContext) throws -> Set<
         NSManagedObjectID
     > {
-        let request = NSFetchRequest<DeliveryEntry>(entityName: "DeliveryEntry")
+        let request = NSFetchRequest<NSDictionary>(entityName: "DeliveryEntry")
+        request.resultType = .dictionaryResultType
+        request.propertiesToFetch = ["object"]
         request.predicate = NSPredicate(
             format: "backendID IN %@ AND isPending == YES AND attempts < %d",
             backendIDs,
             DeliveryEntry.maxAttempts
         )
 
-        return Set(try context.fetch(request).map(\.object.objectID))
+        return Set(try context.fetch(request).compactMap { $0["object"] as? NSManagedObjectID })
     }
 }

--- a/Sources/Scout/Sync/Synchronize.swift
+++ b/Sources/Scout/Sync/Synchronize.swift
@@ -13,10 +13,13 @@ typealias Synchronize = @MainActor () async throws -> Void
 func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Void {
     let context = persistentContainer.viewContext
 
-    try SyncableEntry.plan(backends: backends, in: context)
-    try DateEntry.cleanup(backends: backends, in: context)
-
     try await dispatcher.performEnsuringBackground {
+        try await persistentContainer.performBackgroundTask { context in
+            context.mergePolicy = NSMergePolicy.scout
+            try SyncableEntry.plan(backends: backends, in: context)
+            try DateEntry.cleanup(backends: backends, in: context)
+        }
+
         let availability = await withTaskGroup(of: (Int, Bool).self) { group in
             for (offset, backend) in backends.enumerated() {
                 group.addTask { (offset, await backend.checkAvailability()) }
@@ -48,8 +51,11 @@ func synchronize(backends: [Backend], dispatcher: Dispatcher) async throws -> Vo
             }
         }
         try Task.checkCancellation()
-    }
 
-    try SyncableEntry.purge(to: Set(backends.map(\.id)), in: context)
-    try context.save()
+        try await persistentContainer.performBackgroundTask { context in
+            context.mergePolicy = NSMergePolicy.scout
+            try SyncableEntry.purge(to: Set(backends.map(\.id)), in: context)
+            try context.save()
+        }
+    }
 }


### PR DESCRIPTION
`synchronize()` is `@MainActor`, and only its delivery phase ran inside `dispatcher.performEnsuringBackground`. The prologue, `SyncableEntry.plan` and `DateEntry.cleanup`, and the epilogue, `SyncableEntry.purge` and the save, sat outside the coalescer on `viewContext`, so they ran in full on the main thread for every single log line and every metric emission — `ScoutLogHandler.log(event:)` and the metrics handler both await `runtime.sync()` unconditionally, with no debounce.

That work is O(store), not O(new rows): `plan` runs an unindexable SUBQUERY scan per backend, `cleanup` materializes every pending delivery row through `DeliveryEntry.retainedIDs`, and `purge` runs the same scan twice more. Online the tables stay small and it costs a few milliseconds. Once delivery stops succeeding the backlog is unbounded, because `synchronize` skips unavailable backends, so `attempts` stays at zero, `retainedIDs` retains every row, and `cleanup` never ages anything out — retention that `DateEntryCleanupTests.keepsUnsynced` pins as intended. Each log call then pays for the whole pending table on the main thread while that table grows by one row per log call, so a device with no iCloud account or a long offline stretch hitches and then stalls, and Scout's own hang detector starts reporting the freezes Scout is causing.

The pass now runs inside `performEnsuringBackground` in its entirety, so a burst of log calls coalesces into one sweep instead of N, and both Core Data phases moved into `performBackgroundTask` on a private queue with the scout merge policy, matching how `ScoutLogHandler` and `IncidentArchive` already write. Delivery keeps running on `viewContext`, which is deliberate and documented in `PersistentContainer`. `retainedIDs` switches to a dictionary fetch so it reads object IDs straight from the store instead of materializing every pending row.

Phase order within a pass is unchanged, a log arriving mid-pass still lands in the coalesced follow-up run (its record is saved locally before `sync()` is called), and `Task.checkCancellation` still skips the purge when the background window closes. The signatures of `plan`, `cleanup`, and `purge` are untouched, so their existing suites cover them as before. Found by the critical-bug audit (finding 1).