### PR TITLE
Read the chart range and cohort labels in UTC

### DIFF
--- a/Sources/ScoutUI/Analytics/Retention/RetentionCohort.swift
+++ b/Sources/ScoutUI/Analytics/Retention/RetentionCohort.swift
@@ -18,6 +18,8 @@ extension RetentionCohort {
 let cohortDateFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US")
+    formatter.calendar = .utc
+    formatter.timeZone = Calendar.utc.timeZone
     formatter.dateFormat = "MMM d"
     return formatter
 }()

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Range/RangeDateFormatter.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Range/RangeDateFormatter.swift
@@ -11,6 +11,8 @@ import Scout
 let rangeDateFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US")
+    formatter.calendar = .utc
+    formatter.timeZone = Calendar.utc.timeZone
     formatter.dateStyle = .medium
     return formatter
 }()

--- a/Tests/ScoutUITests/Analytics/Retention/RetentionCohortLabelTests.swift
+++ b/Tests/ScoutUITests/Analytics/Retention/RetentionCohortLabelTests.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Testing
+
+@testable import Scout
+@testable import ScoutUI
+
+struct RetentionCohortLabelTests {
+    /// Cohort ids are UTC week starts, so the label has to read them in UTC — in any
+    /// other zone "Week of" names the wrong week boundary.
+    @Test("Reads its dates in UTC, like the cohort ids it labels") func testTimeZone() {
+        #expect(cohortDateFormatter.timeZone == Calendar.utc.timeZone)
+        #expect(cohortDateFormatter.calendar == .utc)
+    }
+
+    @Test("Labels a cohort with its UTC week start") func testLabel() {
+        // 2024-01-01T00:00:00Z is a Monday, so its UTC week starts the Sunday before.
+        let weekStart = Date(timeIntervalSince1970: 1_704_067_200).startOfWeek
+        let cohort = RetentionCohort(id: weekStart, size: 10, retention: [])
+
+        #expect(cohort.label == "Dec 31")
+    }
+}

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Range/RangeDateFormatterTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Range/RangeDateFormatterTests.swift
@@ -17,9 +17,17 @@ struct RangeDateFormatterTests {
         #expect(rangeDateFormatter.dateStyle == .medium)
     }
 
+    /// The chart domain is built from UTC day boundaries, so the label has to read
+    /// them in UTC too — in any other zone it names the day before the bars below it.
+    @Test("Reads its dates in UTC, like the chart it labels") func testTimeZone() {
+        #expect(rangeDateFormatter.timeZone == Calendar.utc.timeZone)
+        #expect(rangeDateFormatter.calendar == .utc)
+    }
+
     @Test("Formats a date in the expected style") func testFormatting() throws {
         let parser = DateFormatter()
         parser.dateFormat = "yyyy-MM-dd"
+        parser.timeZone = Calendar.utc.timeZone
         let date = try #require(parser.date(from: "2024-01-01"))
 
         #expect(rangeDateFormatter.string(from: date) == "Jan 1, 2024")


### PR DESCRIPTION
`rangeDateFormatter` set only a locale and a date style, leaving its time zone at `TimeZone.current`. The chart domain it labels is built from UTC day boundaries — `Date.startOfDay` goes through `Calendar.utc` and `ChartTimeScale.initialRange` builds the range from it — and the chart below pins UTC through `ChartFormat`. So on any device west of UTC the date range printed directly above a chart named one calendar day earlier than the bars underneath it, and on "Today" the header read yesterday. That header appears on `StatView`, `ActivityView`, `MetricsView`, and as the navigation title of `EventStatList`, where it contradicted the list it was titling.

`cohortDateFormatter` had the identical omission against cohort ids, which are UTC week starts, so "Week of …" named the wrong boundary in the same zones.

Both formatters now pin `Calendar.utc` and its time zone, the way `CalendarMonth`, `EventQuery+Chips`, `FilterPeriodView`, and `UTCTimestampText` already do. The existing `RangeDateFormatterTests` round trip was zone-blind, parsing and formatting in local time, so it passed either way; its parser now reads UTC and the suite asserts the formatter's zone and calendar directly. `RetentionCohortLabelTests` covers the cohort label the same way, including a week start whose UTC and local days differ.

Reviewer note: this only moves the label to match data that was already UTC — no bucketing, bar heights, or ordering change. Found by the critical-bug audit (finding 6); `IncidentTrendChart` has the mirror-image bug (local bucketing under a UTC axis) and is not touched here.