### PR TITLE
Bucket the incident trend chart by UTC days

### DIFF
--- a/Sources/ScoutUI/Delivery/Releases/View/DailyCount.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/DailyCount.swift
@@ -14,7 +14,7 @@ struct DailyCount: Equatable {
 }
 
 extension DailyCount {
-    static func series(from records: [some Incident], days: Int = 14, calendar: Calendar = .current, endingOn today: Date = Date()) -> [DailyCount] {
+    static func series(from records: [some Incident], days: Int = 14, calendar: Calendar = .utc, endingOn today: Date = Date()) -> [DailyCount] {
         let start = calendar.startOfDay(for: today)
 
         var counts: [Date: Int] = [:]

--- a/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
+++ b/Sources/ScoutUI/Delivery/Releases/View/VersionDetailView.swift
@@ -169,6 +169,8 @@ private struct IncidentTrendChart<Element: Incident>: View {
             }
         }
         .frame(height: 170)
+        .environment(\.calendar, .utc)
+        .environment(\.timeZone, Calendar.utc.timeZone)
         .listRowSeparator(.hidden)
     }
 }

--- a/Tests/ScoutUITests/Delivery/Releases/View/DailyCountTests.swift
+++ b/Tests/ScoutUITests/Delivery/Releases/View/DailyCountTests.swift
@@ -34,6 +34,17 @@ struct DailyCountTests {
         #expect(series.dropLast(2).allSatisfy { $0.count == 0 })
     }
 
+    @Test("The default series buckets days in UTC") func testUTCByDefault() {
+        let today = Calendar.utc.startOfDay(for: Date())
+        let lateEvening = today.addingTimeInterval(23 * 3600 + 30 * 60)
+
+        let series = DailyCount.series(from: [Crash.stub(date: lateEvening)], endingOn: lateEvening)
+
+        #expect(series.allSatisfy { $0.date == Calendar.utc.startOfDay(for: $0.date) })
+        #expect(series.last?.date == today)
+        #expect(series.last?.count == 1)
+    }
+
     @Test("Records outside the window and nil dates are ignored") func testOutOfWindow() {
         let today = calendar.startOfDay(for: Date())
         let old = calendar.date(byAdding: .day, value: -30, to: today)!


### PR DESCRIPTION
The crash and hang trend chart on a release bucketed its bars with the local calendar, but the axis labels are formatted in UTC and the bars are binned by the environment calendar, so east of GMT every bar ended up labelled with the previous day and a late-evening crash landed in the wrong bar.

DailyCount.series now defaults to Calendar.utc, and the chart runs in the UTC calendar and time zone like ChartView and ComparisonChartView already do. Added a test that pins the default series to UTC day boundaries.