### PR TITLE
Debounce the events search instead of clearing the list on every keystroke

### DIFF
--- a/Sources/ScoutUI/Analytics/Event/Analytics/EventFilter.swift
+++ b/Sources/ScoutUI/Analytics/Event/Analytics/EventFilter.swift
@@ -57,26 +57,20 @@ private struct EventFilter: ViewModifier {
                     for: nil
                 )
             #endif
-
-            Task {
-                search.clear()
-                await search.fetch(for: filter, in: database)
-            }
         }
-        .onChange(of: filter.text) { _ in
+        .task(id: filter) {
+            guard !filter.text.isEmpty, (try? await Task.sleep(nanoseconds: 300_000_000)) != nil else {
+                return
+            }
+
             search.clear()
+            await search.fetch(for: filter, in: database)
         }
         .task(id: filter.criteria) {
             await provider.fetchLatest(for: filter, in: database)
         }
         .onChange(of: filter.criteria) { _ in
             provider.clear()
-            if !filter.text.isEmpty {
-                Task {
-                    search.clear()
-                    await search.fetch(for: filter, in: database)
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Typing in the Events search switched the list over to the search provider and cleared it on every keystroke, but nothing fetched until the search was submitted. A user who typed and kept reading was left with an indefinite spinner in place of the list.

The search now runs from a debounced task keyed on the whole query: 300ms after the last change it clears the search feed and fetches, the way AlertEditorView already debounces its backtest. Submitting only dismisses the keyboard, and since the task is keyed on the whole query it also covers a filter change made while searching, so the duplicate fetch in onChange(of: criteria) is gone.