### PR TITLE
Prefer key paths and computed properties over trivial closures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,20 @@ cohorts = RetentionCohort.build(
 
 - Signatures are the exception: a declaration stays on one line no matter how long it grows.
 
+## Key paths instead of closures
+
+- A closure whose whole body is a property access on its argument is written as a key path: `map(\.name)`, never `map { $0.name }` or `map { point in point.name }`. The same holds for `compactMap`, `flatMap`, `filter`, `forEach`, `first(where:)`, `contains(where:)`, `allSatisfy`, `count(where:)`, `removeAll(where:)`, and `Dictionary(grouping:by:)`.
+- Nested properties go into one key path rather than a chain of maps: `map(\.value.doubleValue)`, not `.map(\.value).map(\.doubleValue)`; `map(\.install.installID)`, not `map { $0.install.installID }`.
+- Flatten nested closures into a chain of key-path calls: `installs.flatMap(\.launches).map(\.launch)`, not `installs.flatMap { $0.launches.map(\.launch) }`.
+- This applies to any parameter of function type `(T) -> U`, not just sequence operations — pass `label: \.label` instead of a trailing `{ $0.label }` closure, moving the argument out of trailing position when needed. `@ViewBuilder` parameters stay closures.
+- A key path can't express negation, comparison, a call, or anything using both `$0` and `$1`, so `filter { !$0.isEmpty }`, `sorted { $0.date < $1.date }` and `reduce(0) { $0 + $1.count }` stay closures.
+
+## Parameterless methods vs computed properties
+
+- A parameterless method that only projects or derives a value — no side effects, no state mutation, not throwing, not `async`, and cheap — is a computed property named as a noun: `var record: Record`, not `func toRecord() -> Record`; `var filters: [RecordQuery.Filter]`, not `func buildFilters() -> [RecordQuery.Filter]`. Besides matching the Swift API Design Guidelines, this is what makes the key-path form above available at call sites (`records.map(\.record)`).
+- Keep it a method when it has side effects or mutates state (`RecordCacheStore.cache()` creates directories, `DatabaseCacheRegistry.sharedCache()` updates a static cache, `ChartExportSheet.exportURL()` writes a file and posts a `Message`), when it throws or is `async`, when it is generic (Swift has no generic computed properties — `chartPoints<T>()`), or when it is expensive enough that a property would misrepresent the cost (`RawCrashReport.crashInfo()` symbolicates the stack trace).
+- `View` extension modifiers stay methods regardless of parameter count (`func dismissable() -> some View`) — see the `ViewModifier` rule below.
+
 ## Array extensions
 
 - Prefer `extension [Type] { ... }` over `extension Array where Element == Type { ... }` when extending a concrete element type — matches existing usage across the codebase (e.g. `Connection.swift`, `PointGroup.swift`, `ReferenceLevel.swift`).

--- a/Sources/Connectors/Hosted/HTTPRecordCoding.swift
+++ b/Sources/Connectors/Hosted/HTTPRecordCoding.swift
@@ -21,7 +21,7 @@ extension HTTPRecord {
         fields = record.fields
     }
 
-    func toRecord() -> Record {
+    var record: Record {
         Record(recordType: recordType, recordID: recordID, fields: fields)
     }
 }

--- a/Sources/Connectors/Hosted/HostedReader.swift
+++ b/Sources/Connectors/Hosted/HostedReader.swift
@@ -20,7 +20,7 @@ extension HTTPDatabase: DatabaseReader {
     private func run(query: HTTPQuery) async throws -> RecordChunk {
         let response = try await send(query, to: "api/v1/records/query", into: HTTPQueryResponse.self)
         return RecordChunk(
-            records: response.records.map { $0.toRecord() },
+            records: response.records.map(\.record),
             cursor: response.cursor.map { token in
                 RecordCursor { _ in
                     var next = HTTPQuery()
@@ -33,7 +33,7 @@ extension HTTPDatabase: DatabaseReader {
 
     func lookup(recordName: String, fields: [String]?) async throws -> Record {
         let endpoint = recordEndpoint(recordName: recordName, fields: fields)
-        return try await get(from: endpoint, reason: "Malformed record URL", as: HTTPRecord.self).toRecord()
+        return try await get(from: endpoint, reason: "Malformed record URL", as: HTTPRecord.self).record
     }
 
     private func get<T: Decodable>(from endpoint: URL?, reason: String, as type: T.Type) async throws -> T {

--- a/Sources/ScoutUI/Analytics/Event/Provider/EventProvider.swift
+++ b/Sources/ScoutUI/Analytics/Event/Provider/EventProvider.swift
@@ -38,7 +38,7 @@ final class EventProvider: FeedProvider<Event>, Refreshable {
     private func query(for filter: EventQuery) -> RecordQuery {
         RecordQuery(
             recordType: Event.self,
-            filters: filter.buildFilters(),
+            filters: filter.filters,
             sort: [RecordQuery.Sort(field: "date", ascending: false)]
         )
     }

--- a/Sources/ScoutUI/Analytics/Event/Provider/EventQuery.swift
+++ b/Sources/ScoutUI/Analytics/Event/Provider/EventQuery.swift
@@ -25,28 +25,28 @@ struct EventQuery: Hashable {
         return criteria
     }
 
-    func buildFilters() -> [RecordQuery.Filter] {
-        var filters: [RecordQuery.Filter] = []
+    var filters: [RecordQuery.Filter] {
+        var result: [RecordQuery.Filter] = []
 
         if levels != EventQuery.allLevels {
-            filters.append(RecordQuery.Filter(field: "level", op: .in, value: .strings(levels.map(\.rawValue))))
+            result.append(RecordQuery.Filter(field: "level", op: .in, value: .strings(levels.map(\.rawValue))))
         }
         if !text.isEmpty {
-            filters.append(RecordQuery.Filter(field: "name", op: .beginsWith, value: .string(text)))
+            result.append(RecordQuery.Filter(field: "name", op: .beginsWith, value: .string(text)))
         }
         if !name.isEmpty {
-            filters.append(RecordQuery.Filter(field: "name", op: .equals, value: .string(name)))
+            result.append(RecordQuery.Filter(field: "name", op: .equals, value: .string(name)))
         }
         if let sessionID {
-            filters.append(RecordQuery.Filter(field: "session_id", op: .equals, value: .string(sessionID.uuidString)))
+            result.append(RecordQuery.Filter(field: "session_id", op: .equals, value: .string(sessionID.uuidString)))
         }
         if let deviceID {
-            filters.append(RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString)))
+            result.append(RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString)))
         }
         if let dates {
-            filters.append(contentsOf: dates.dateFilters)
+            result.append(contentsOf: dates.dateFilters)
         }
 
-        return filters
+        return result
     }
 }

--- a/Sources/ScoutUI/Monitoring/Alerts/Editor/AlertEditorView.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Editor/AlertEditorView.swift
@@ -29,16 +29,18 @@ struct AlertEditorView: View {
             Header(title: "Condition")
             PillRow(
                 options: AlertDraft.Kind.allCases,
-                selection: $draft.kind
-            ) { $0.label }
+                selection: $draft.kind,
+                label: \.label
+            )
 
             valueRow
 
             Header(title: "For at least")
             PillRow(
                 options: AlertDraft.Hold.allCases,
-                selection: $draft.hold
-            ) { $0.label }
+                selection: $draft.hold,
+                label: \.label
+            )
 
             Header(title: "Delivery")
 

--- a/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentDonut.swift
+++ b/Sources/ScoutUI/Monitoring/Incident/Breakdown/IncidentDonut.swift
@@ -126,9 +126,11 @@ struct IncidentDonut<Destination: View>: View {
 #Preview("Devices") {
     if #available(iOS 17.0, macOS 14.0, *) {
         NavigationStack {
-            IncidentDonut(segments: IncidentBreakdown.sample.devices, caption: "devices") { segment in
-                segment.count
-            } destination: { segment in
+            IncidentDonut(
+                segments: IncidentBreakdown.sample.devices,
+                caption: "devices",
+                drillDownCount: \.count
+            ) { segment in
                 Text(verbatim: segment.label)
             }
             .padding()
@@ -139,9 +141,11 @@ struct IncidentDonut<Destination: View>: View {
 #Preview("OS Versions") {
     if #available(iOS 17.0, macOS 14.0, *) {
         NavigationStack {
-            IncidentDonut(segments: IncidentBreakdown.sample.osVersions, caption: "sessions") { segment in
-                segment.count
-            } destination: { segment in
+            IncidentDonut(
+                segments: IncidentBreakdown.sample.osVersions,
+                caption: "sessions",
+                drillDownCount: \.count
+            ) { segment in
                 Text(verbatim: segment.label)
             }
             .padding()

--- a/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Rail+Merged.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Timeline/Pagination/Rail+Merged.swift
@@ -31,11 +31,14 @@ extension Rail {
     )
 
     fileprivate var flattened: Flattened {
-        let installs = self.installs.map(\.install)
-        let launches = self.installs.flatMap { $0.launches.map(\.launch) }
-        let sessions = self.installs.flatMap { $0.launches.flatMap { $0.sessions.map(\.session) } }
-        let events = self.installs.flatMap { $0.launches.flatMap { $0.sessions.flatMap(\.events) } }
-        let crashes = self.installs.flatMap { $0.launches.flatMap { $0.sessions.flatMap(\.crashes) } }
-        return (installs, launches, sessions, events, crashes)
+        let launches = installs.flatMap(\.launches)
+        let sessions = launches.flatMap(\.sessions)
+        return (
+            installs: installs.map(\.install),
+            launches: launches.map(\.launch),
+            sessions: sessions.map(\.session),
+            events: sessions.flatMap(\.events),
+            crashes: sessions.flatMap(\.crashes)
+        )
     }
 }

--- a/Tests/Connectors/Hosted/HTTPRecordCodingTests.swift
+++ b/Tests/Connectors/Hosted/HTTPRecordCodingTests.swift
@@ -26,7 +26,7 @@ struct HTTPRecordCodingTests {
 
         let wire = HTTPRecord(record: record)
         let data = try JSONEncoder().encode(wire)
-        let restored = try JSONDecoder().decode(HTTPRecord.self, from: data).toRecord()
+        let restored = try JSONDecoder().decode(HTTPRecord.self, from: data).record
 
         #expect(restored.recordType == "Event")
         #expect(restored.recordID == "record-1")

--- a/Tests/ScoutUITests/Analytics/Event/Provider/EventQueryTests.swift
+++ b/Tests/ScoutUITests/Analytics/Event/Provider/EventQueryTests.swift
@@ -13,34 +13,34 @@ import Testing
 
 struct EventQueryTests {
     @Test("Empty query produces no filters") func emptyQuery() {
-        #expect(EventQuery().buildFilters().isEmpty)
+        #expect(EventQuery().filters.isEmpty)
     }
 
     @Test("Filter by levels") func levels() {
-        let filters = EventQuery(levels: [.error, .critical]).buildFilters()
+        let filters = EventQuery(levels: [.error, .critical]).filters
 
         #expect(filters.contains { $0.field == "level" && $0.op == .in })
     }
 
     @Test("All levels produces no level filter") func allLevels() {
-        #expect(EventQuery(levels: Set(EventLevel.allCases)).buildFilters().isEmpty)
+        #expect(EventQuery(levels: Set(EventLevel.allCases)).filters.isEmpty)
     }
 
     @Test("Filter by text") func text() {
-        let filters = EventQuery(text: "Search").buildFilters()
+        let filters = EventQuery(text: "Search").filters
 
         #expect(filters.contains(RecordQuery.Filter(field: "name", op: .beginsWith, value: .string("Search"))))
     }
 
     @Test("Filter by name") func name() {
-        let filters = EventQuery(name: "Login").buildFilters()
+        let filters = EventQuery(name: "Login").filters
 
         #expect(filters.contains(RecordQuery.Filter(field: "name", op: .equals, value: .string("Login"))))
     }
 
     @Test("Filter by session") func session() {
         let sessionID = UUID()
-        let filters = EventQuery(sessionID: sessionID).buildFilters()
+        let filters = EventQuery(sessionID: sessionID).filters
 
         #expect(
             filters.contains(RecordQuery.Filter(field: "session_id", op: .equals, value: .string(sessionID.uuidString)))
@@ -48,12 +48,12 @@ struct EventQueryTests {
     }
 
     @Test("No session produces no session filter") func noSession() {
-        #expect(EventQuery().buildFilters().contains { $0.field == "session_id" } == false)
+        #expect(EventQuery().filters.contains { $0.field == "session_id" } == false)
     }
 
     @Test("Filter by device") func device() {
         let deviceID = UUID()
-        let filters = EventQuery(deviceID: deviceID).buildFilters()
+        let filters = EventQuery(deviceID: deviceID).filters
 
         #expect(
             filters.contains(RecordQuery.Filter(field: "device_id", op: .equals, value: .string(deviceID.uuidString))))
@@ -62,7 +62,7 @@ struct EventQueryTests {
     @Test("Filter by date range") func dates() {
         let start = Date(timeIntervalSinceReferenceDate: 0)
         let end = Date(timeIntervalSinceReferenceDate: 86400)
-        let filters = EventQuery(dates: start..<end).buildFilters()
+        let filters = EventQuery(dates: start..<end).filters
 
         #expect(filters.contains(RecordQuery.Filter(field: "date", op: .greaterThanOrEquals, value: .date(start))))
         #expect(filters.contains(RecordQuery.Filter(field: "date", op: .lessThan, value: .date(end))))
@@ -76,7 +76,7 @@ struct EventQueryTests {
     }
 
     @Test("Multiple filters combine") func combined() {
-        let filters = EventQuery(levels: [.error], text: "Search", name: "Login").buildFilters()
+        let filters = EventQuery(levels: [.error], text: "Search", name: "Login").filters
 
         #expect(filters.contains { $0.field == "level" && $0.op == .in })
         #expect(filters.contains(RecordQuery.Filter(field: "name", op: .beginsWith, value: .string("Search"))))

--- a/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Delivery/AlertNotifierTests.swift
@@ -11,6 +11,21 @@ import UserNotifications
 
 @testable import ScoutUI
 
+// `ephemeral` is an App Clip status that UserNotifications marks unavailable on
+// macOS, and the contract job builds this target for macOS.
+private let authorizationStatuses: [(UNAuthorizationStatus, Bool)] = {
+    var statuses: [(UNAuthorizationStatus, Bool)] = [
+        (.denied, true),
+        (.authorized, false),
+        (.provisional, false),
+        (.notDetermined, false),
+    ]
+    #if !os(macOS)
+        statuses.append((.ephemeral, false))
+    #endif
+    return statuses
+}()
+
 struct AlertNotifierTests {
     @Test("Only notifying statuses become notifications")
     func delivers() async throws {
@@ -54,15 +69,7 @@ struct AlertNotifierTests {
         #expect(center.requests.count == 1)
     }
 
-    @Test(
-        "Only a denied center refuses notifications",
-        arguments: [
-            (UNAuthorizationStatus.denied, true),
-            (.authorized, false),
-            (.provisional, false),
-            (.ephemeral, false),
-            (.notDetermined, false),
-        ])
+    @Test("Only a denied center refuses notifications", arguments: authorizationStatuses)
     func refusesNotifications(status: UNAuthorizationStatus, refuses: Bool) async {
         let center = NotificationCenterStub()
         center.status = status


### PR DESCRIPTION
A sweep over every Swift file for closures whose body is nothing but a property access turned up four call sites the codebase had missed. The two `PillRow` rows in the alert editor and the two `IncidentDonut` previews now pass `label: \.label` and `drillDownCount: \.count` instead of a trailing closure, and `Rail.flattened` walks the tree with `flatMap(\.launches).flatMap(\.sessions)` rather than three levels of nested closures, which also stops it from rebuilding the same intermediate arrays four times over.

Two parameterless methods that only project a value become computed properties. `HTTPRecord.toRecord()` is now `var record`, which is what lets `HostedReader` say `records.map(\.record)` and mirrors the `init(record:)` beside it, and `EventQuery.buildFilters()` is now `var filters`, next to the `criteria` property it already had. Methods with side effects (`RecordCacheStore.cache()`, `ChartExportSheet.exportURL()`), generic ones that cannot be properties at all (`chartPoints<T>()`), and ones expensive enough that a property would misrepresent the cost (`RawCrashReport.crashInfo()`) were deliberately left as methods.

CLAUDE.md gains the two rules this follows, including the cases a key path cannot express — negation, comparison, calls, anything using both `$0` and `$1` — and the reasons to keep a parameterless method a method.

No behaviour changes. `swift-format lint --strict` is clean and the full bundle passes on the iOS 26 simulator.