### PR TITLE
Point the installation snippet at 0.3.0

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -23,7 +23,7 @@ https://github.com/kasianov-mikhail/scout.git
 Or add it to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/kasianov-mikhail/scout.git", from: "0.2.0")
+.package(url: "https://github.com/kasianov-mikhail/scout.git", from: "0.3.0")
 ```
 
 Then add the products your target needs. `Scout` carries the runtime and the handlers; the backend it syncs to comes from a connector, so a CloudKit setup takes `NativeConnector` too:


### PR DESCRIPTION
The installation doc still told people to depend on 0.2.0, which is now a release behind. This bumps the `Package.swift` snippet to 0.3.0, matching the release published today.