### PR TITLE
Make the cached lookup types a parameter and inject the clock instead of the cutoff

### DIFF
--- a/Sources/Scout/Database/Cache/CachedDatabase.swift
+++ b/Sources/Scout/Database/Cache/CachedDatabase.swift
@@ -13,13 +13,15 @@ package struct CachedDatabase: Database {
     let base: any Database
     let scope: String
     let cache: any RecordCaching
-    let settledCutoff: @Sendable () -> Date
+    let now: @Sendable () -> Date
+    let types: Set<String>
 
-    package init(base: any Database, scope: String, cache: any RecordCaching, settledCutoff: @escaping @Sendable () -> Date = { Date().startOfWeek.addingWeek(-1) }) {
+    package init(base: any Database, scope: String, cache: any RecordCaching, now: @escaping @Sendable () -> Date = { Date() }, types: Set<String> = [EventEntry.recordType]) {
         self.base = base
         self.scope = scope
         self.cache = cache
-        self.settledCutoff = settledCutoff
+        self.now = now
+        self.types = types
     }
 
     package func lookup(recordName: String, fields: [String]?) async throws -> Record {
@@ -34,7 +36,7 @@ package struct CachedDatabase: Database {
             fields: fields
         )
 
-        if record.recordType == EventEntry.recordType {
+        if types.contains(record.recordType) {
             await cache.storeLookup(record, for: fingerprint)
         }
 
@@ -42,7 +44,8 @@ package struct CachedDatabase: Database {
     }
 
     package func series(matching query: SeriesQuery) async throws -> [MetricSeries] {
-        let frozenUpper = min(query.range.upperBound, settledCutoff())
+        let settledCutoff = now().startOfWeek.addingWeek(-1)
+        let frozenUpper = min(query.range.upperBound, settledCutoff)
 
         guard query.range.lowerBound < frozenUpper else {
             return try await base.series(matching: query)

--- a/Tests/LookupIndexTests/CachePerformanceTests.swift
+++ b/Tests/LookupIndexTests/CachePerformanceTests.swift
@@ -83,12 +83,12 @@ final class CachedDatabasePerformanceTests: XCTestCase {
         // Sized so the warm-up store finishes well inside runBlocking's timeout:
         // at 40×800 the 32k-row SwiftData insert alone brushed 60s on CI runners.
         base.series = makeSeries(versions: 10, points: 400)
-        let cutoff = Date(timeIntervalSince1970: 3_000_000)
+        let now = Date(timeIntervalSince1970: 4_000_000)
         let database = CachedDatabase(
             base: base,
             scope: "perf",
             cache: try makeRecordCache(),
-            settledCutoff: { cutoff }
+            now: { now }
         )
         let query = SeriesQuery(
             name: "Session",

--- a/Tests/LookupIndexTests/CachedDatabaseTests.swift
+++ b/Tests/LookupIndexTests/CachedDatabaseTests.swift
@@ -13,18 +13,22 @@ import Testing
 
 struct CachedDatabaseTests {
     let lower = Date(timeIntervalSince1970: 0)
-    let cutoff = Date(timeIntervalSince1970: 3_000_000)
     let upper = Date(timeIntervalSince1970: 4_000_000)
 
+    var cutoff: Date {
+        upper.startOfWeek.addingWeek(-1)
+    }
+
     @available(iOS 18, macOS 15, *)
-    func makeDatabase(base: SpyDatabase) throws -> CachedDatabase {
-        let frozen = cutoff
+    func makeDatabase(base: SpyDatabase, types: Set<String> = [EventEntry.recordType]) throws -> CachedDatabase {
+        let now = upper
 
         return CachedDatabase(
             base: base,
             scope: "test",
             cache: try makeRecordCache(),
-            settledCutoff: { frozen }
+            now: { now },
+            types: types
         )
     }
 
@@ -145,6 +149,24 @@ struct CachedDatabaseTests {
         _ = try await database.lookup(recordName: "session-1", fields: nil)
 
         #expect(base.lookups == ["session-1", "session-1"])
+    }
+
+    @available(iOS 18, macOS 15, *)
+    @Test("The immutable record types decide which lookups are cached")
+    func honorsImmutableRecordTypes() async throws {
+        let base = SpyDatabase()
+        let database = try makeDatabase(base: base, types: [SessionEntry.recordType])
+        base.records = [
+            Record(recordType: SessionEntry.recordType, recordID: "session-1"),
+            Record(recordType: EventEntry.recordType, recordID: "event-1"),
+        ]
+
+        _ = try await database.lookup(recordName: "session-1", fields: nil)
+        _ = try await database.lookup(recordName: "session-1", fields: nil)
+        _ = try await database.lookup(recordName: "event-1", fields: nil)
+        _ = try await database.lookup(recordName: "event-1", fields: nil)
+
+        #expect(base.lookups == ["session-1", "event-1", "event-1"])
     }
 
     @available(iOS 18, macOS 15, *)


### PR DESCRIPTION
`CachedDatabase.lookup` used to cache only records whose type equalled `EventEntry.recordType`, with that decision hard-coded in the decorator. The set of record types considered immutable, and therefore safe to serve from the lookup cache, is now the `types` initializer parameter, defaulting to the same single Event type, and a test checks that the set is honoured in both directions.

The `settledCutoff` closure is replaced by a `now` clock injection with a `Date()` default. The settle rule itself, a week before the start of the current week, stays inside `series(matching:)` as a local, so callers can shift time for tests but can no longer rewrite the policy through the initializer. The tests derive their expected cutoff from the injected `now` with the same rule instead of hard-coding a date.