### PR TITLE
Sum the buckets for the Events row in the stats view

### DIFF
--- a/Sources/ScoutUI/Primitives/Indicators/StatView.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatView.swift
@@ -47,7 +47,7 @@ struct StatView: View {
                     Row {
                         Text(verbatim: "Events")
                         Spacer()
-                        RedactedText(count: segment.count)
+                        RedactedText(count: segment.total)
                     } destination: {
                         EventStatList(eventName: stat.eventName, range: extent.domain)
                     }


### PR DESCRIPTION
The Events row in the stats view was showing `segment.count` — the length of the bucket array the chart draws — rather than the number of events in the window. Because bucketing emits one element per interval, including empty ones, the row printed a constant that only depended on the selected period: 24 for a day, 7 for a week, 28–31 for a month, 12 for a year, whether the event fired five thousand times or never. The neighbouring `StatRow` computes `.total` over the same window, so the two screens disagreed. This restores the aggregate that was in place before #1058, which replaced the row and lost it in the rewrite.

Verified against a real run: a week whose bars sum to 26 was reporting 7.