### PR TITLE
Name the chart point measure value instead of count

### DIFF
--- a/Sources/ScoutUI/Analytics/Activity/ActivityPoint+Points.swift
+++ b/Sources/ScoutUI/Analytics/Activity/ActivityPoint+Points.swift
@@ -23,7 +23,7 @@ extension [ActivityPoint] {
             guard count > 0 else {
                 return nil
             }
-            return ChartPoint(date: Date(millisecondsSince1970: point.date), count: count)
+            return ChartPoint(date: Date(millisecondsSince1970: point.date), value: count)
         }
     }
 }

--- a/Sources/ScoutUI/Delivery/Releases/Health/ReleaseReport.swift
+++ b/Sources/ScoutUI/Delivery/Releases/Health/ReleaseReport.swift
@@ -76,7 +76,7 @@ extension [ChartPoint<Int>] {
 
         for point in self where range.contains(point.date) {
             let index = Swift.min(slices - 1, Int(point.date.timeIntervalSince(range.lowerBound) / step))
-            values[index] += point.count
+            values[index] += point.value
         }
 
         return values

--- a/Sources/ScoutUI/Monitoring/Alerts/Metric/AlertMetric.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Metric/AlertMetric.swift
@@ -45,7 +45,7 @@ extension AlertMetric {
                 .flatMap { $0.chartPoints() as [ChartPoint<Int>] }
                 .bucket(in: range, component: .hour)
                 .reversed()
-                .map { Double($0.count) }
+                .map { Double($0.value) }
 
         case .crashFreeSessions:
             async let sessions = database.sessionSeries(in: range)

--- a/Sources/ScoutUI/Monitoring/Alerts/Metric/MetricReading+ChartPoints.swift
+++ b/Sources/ScoutUI/Monitoring/Alerts/Metric/MetricReading+ChartPoints.swift
@@ -14,8 +14,8 @@ extension MetricReading {
         let current = points.bucket(on: period)
 
         self.init(
-            baseline: previous.map { Double($0.count) }.median ?? 0,
-            recent: current.reversed().map { Double($0.count) }
+            baseline: previous.map { Double($0.value) }.median ?? 0,
+            recent: current.reversed().map { Double($0.value) }
         )
     }
 
@@ -41,5 +41,5 @@ func stabilityValues(sessions: [ChartPoint<Int>], crashes: [ChartPoint<Int>], in
         sessions.bucket(in: range, component: component).reversed(),
         crashes.bucket(in: range, component: component).reversed()
     )
-    .map { Stability(of: $1.count, in: $0.count).value }
+    .map { Stability(of: $1.value, in: $0.value).value }
 }

--- a/Sources/ScoutUI/Primitives/Indicators/StatView.swift
+++ b/Sources/ScoutUI/Primitives/Indicators/StatView.swift
@@ -47,7 +47,7 @@ struct StatView: View {
                     Row {
                         Text(verbatim: "Events")
                         Spacer()
-                        RedactedText(count: segment.count)
+                        RedactedText(count: segment.total)
                     } destination: {
                         EventStatList(eventName: stat.eventName, range: extent.domain)
                     }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ChartExtent+Comparison.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ChartExtent+Comparison.swift
@@ -24,7 +24,7 @@ extension ChartExtent {
     /// counterpart and are omitted; the chart draws no reference for them.
     ///
     func referenceSegment<U: ChartNumeric>(from points: [ChartPoint<U>], alignedTo segment: [ChartPoint<U>]) -> [ChartPoint<U>] {
-        zip(segment, previousSegment(from: points)).map { ChartPoint(date: $0.date, count: $1.count) }
+        zip(segment, previousSegment(from: points)).map { ChartPoint(date: $0.date, value: $1.value) }
     }
 
     /// Whether the comparison overlay has anything to show.

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonChartView.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonChartView.swift
@@ -57,7 +57,7 @@ struct ComparisonChartView<T: ChartNumeric>: View {
             xStart: .value("Start", pair.barStart),
             xEnd: .value("End", pair.barEnd),
             yStart: .value("Zero", T.zero),
-            yEnd: .value("Count", pair.count)
+            yEnd: .value("Count", pair.value)
         )
         .foregroundStyle(color)
         .cornerRadius(3)
@@ -74,7 +74,7 @@ struct ComparisonChartView<T: ChartNumeric>: View {
     let today = Date().startOfDay
     let counts = [14, 25, 17, 22, 9, 18, 12, 12, 16, 10, 19, 11, 15, 8]
     let points = counts.enumerated().map { i, count in
-        ChartPoint(date: today.addingDay(-i - 1), count: count)
+        ChartPoint(date: today.addingDay(-i - 1), value: count)
     }
     let segment = extent.segment(from: points)
 

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonPair.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ComparisonPair.swift
@@ -18,7 +18,7 @@ import Scout
 struct ComparisonPair<T: ChartNumeric>: Identifiable {
     let date: Date
     let bin: Range<Date>
-    let count: T
+    let value: T
     let reference: T?
 
     var id: Date { date }
@@ -47,13 +47,13 @@ extension Collection {
     /// reference and draw no comparison marks.
     ///
     func paired<T>(with reference: [ChartPoint<T>], unit: Calendar.Component) -> [ComparisonPair<T>] where Element == ChartPoint<T> {
-        let counts = Dictionary(reference.map { ($0.date, $0.count) }, uniquingKeysWith: +)
+        let values = Dictionary(reference.map { ($0.date, $0.value) }, uniquingKeysWith: +)
         return map { point in
             ComparisonPair(
                 date: point.date,
                 bin: binRange(of: point.date, unit: unit),
-                count: point.count,
-                reference: counts[point.date]
+                value: point.value,
+                reference: values[point.date]
             )
         }
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ReferenceLevel.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Comparison/ReferenceLevel.swift
@@ -14,12 +14,12 @@ import SwiftUI
 ///
 struct ReferenceLevel {
     let x: ClosedRange<CGFloat>
-    let count: CGFloat
+    let value: CGFloat
     let reference: CGFloat
     let isClamped: Bool
 
     /// Whether the previous level lies above the bar (the value dropped).
-    var isDrop: Bool { reference < count }
+    var isDrop: Bool { reference < value }
 }
 
 extension ReferenceLevel {
@@ -27,17 +27,17 @@ extension ReferenceLevel {
     /// empty in both periods, or falling outside the plot.
     ///
     init?<T: ChartNumeric>(pair: ComparisonPair<T>, proxy: ChartProxy, plotFrame: CGRect) {
-        guard let referenceCount = pair.reference else {
+        guard let referenceValue = pair.reference else {
             return nil
         }
-        guard pair.count != .zero || referenceCount != .zero else {
+        guard pair.value != .zero || referenceValue != .zero else {
             return nil
         }
         guard let barStartX = proxy.position(forX: pair.barStart), let barEndX = proxy.position(forX: pair.barEnd)
         else {
             return nil
         }
-        guard let countY = proxy.position(forY: pair.count), let referenceY = proxy.position(forY: referenceCount)
+        guard let valueY = proxy.position(forY: pair.value), let referenceY = proxy.position(forY: referenceValue)
         else {
             return nil
         }
@@ -46,7 +46,7 @@ extension ReferenceLevel {
 
         self.init(
             x: (plotFrame.minX + barStartX)...(plotFrame.minX + barEndX),
-            count: plotFrame.minY + countY,
+            value: plotFrame.minY + valueY,
             reference: max(reference, plotFrame.minY),
             isClamped: reference < plotFrame.minY
         )
@@ -64,8 +64,8 @@ extension [ReferenceLevel] {
     var slices: Path {
         Path { path in
             for level in self {
-                let top = Swift.min(level.count, level.reference)
-                let bottom = Swift.max(level.count, level.reference)
+                let top = Swift.min(level.value, level.reference)
+                let bottom = Swift.max(level.value, level.reference)
                 path.addRect(
                     CGRect(
                         x: level.x.lowerBound,
@@ -99,14 +99,14 @@ extension [ReferenceLevel] {
     var contours: Path {
         Path { path in
             for level in self {
-                path.move(to: CGPoint(x: level.x.lowerBound, y: level.count))
+                path.move(to: CGPoint(x: level.x.lowerBound, y: level.value))
                 path.addLine(to: CGPoint(x: level.x.lowerBound, y: level.reference))
                 if level.isClamped {
                     path.move(to: CGPoint(x: level.x.upperBound, y: level.reference))
                 } else {
                     path.addLine(to: CGPoint(x: level.x.upperBound, y: level.reference))
                 }
-                path.addLine(to: CGPoint(x: level.x.upperBound, y: level.count))
+                path.addLine(to: CGPoint(x: level.x.upperBound, y: level.value))
             }
         }
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Model/ChartPoint.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Model/ChartPoint.swift
@@ -13,7 +13,7 @@ typealias ChartNumeric = Plottable & MetricScalar
 
 struct ChartPoint<T: ChartNumeric>: ChartSeries {
     let date: Date
-    let count: T
+    let value: T
 }
 
 extension ChartPoint: Comparable {
@@ -28,7 +28,7 @@ extension ChartPoint: Fixture where T == Int {
         return (1...372).map { day in
             ChartPoint(
                 date: base.addingTimeInterval(TimeInterval(day - 1) * .day + 12 * .hour),
-                count: 12 + day % 40 + (day / 9) % 18
+                value: 12 + day % 40 + (day / 9) % 18
             )
         }
     }
@@ -36,7 +36,7 @@ extension ChartPoint: Fixture where T == Int {
 
 extension ChartPoint {
     static func + (lhs: ChartPoint, rhs: ChartPoint) -> ChartPoint {
-        ChartPoint(date: lhs.date, count: lhs.count + rhs.count)
+        ChartPoint(date: lhs.date, value: lhs.value + rhs.value)
     }
 
     static func += (lhs: inout ChartPoint, rhs: ChartPoint) {
@@ -51,7 +51,7 @@ extension [ChartPoint<Int>] {
         let end = Date()
         return (0..<168).compactMap { i in
             Calendar.utc.date(byAdding: .hour, value: -i, to: end).map {
-                ChartPoint(date: $0, count: .random(in: 0...20))
+                ChartPoint(date: $0, value: .random(in: 0...20))
             }
         }
         .sorted()

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Model/ChartSeries+Bucket.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Model/ChartSeries+Bucket.swift
@@ -23,7 +23,7 @@ extension Collection where Element: ChartSeries {
             let points = filter {
                 newDate..<date ~= $0.date
             }
-            result.append(Element(date: newDate, count: points.total))
+            result.append(Element(date: newDate, value: points.total))
             date = newDate
         }
 

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Model/ChartSeries.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Model/ChartSeries.swift
@@ -8,31 +8,31 @@
 import Foundation
 import Scout
 
-protocol ChartSeries: HasCount {
+protocol ChartSeries: HasValue {
     var date: Date { get }
-    init(date: Date, count: Count)
+    init(date: Date, value: Value)
 }
 
-protocol HasCount {
-    associatedtype Count: AdditiveArithmetic
-    var count: Count { get }
+protocol HasValue {
+    associatedtype Value: AdditiveArithmetic
+    var value: Value { get }
 }
 
-extension Collection where Element: HasCount {
-    var total: Element.Count {
-        reduce(.zero) { $0 + $1.count }
+extension Collection where Element: HasValue {
+    var total: Element.Value {
+        reduce(.zero) { $0 + $1.value }
     }
 }
 
 extension Collection where Element: ChartSeries {
-    func total(in range: Range<Date>) -> Element.Count {
+    func total(in range: Range<Date>) -> Element.Value {
         filter { range.contains($0.date) }
             .total
     }
 
-    func latest(in range: Range<Date>) -> Element.Count {
+    func latest(in range: Range<Date>) -> Element.Value {
         filter { range.contains($0.date) }
             .max { $0.date < $1.date }?
-            .count ?? .zero
+            .value ?? .zero
     }
 }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Model/MetricSeries+ChartPoints.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Model/MetricSeries+ChartPoints.swift
@@ -13,7 +13,7 @@ extension MetricSeries {
         points.map { point in
             ChartPoint(
                 date: Date(millisecondsSince1970: point.date),
-                count: T(point.value.doubleValue)
+                value: T(point.value.doubleValue)
             )
         }
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/Model/MiniChartSeries.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/Model/MiniChartSeries.swift
@@ -41,7 +41,7 @@ extension MiniChartSeries {
             case .total:
                 slice.total
             case .latest:
-                slice.max()?.count ?? .zero
+                slice.max()?.value ?? .zero
             }
         }
     }

--- a/Sources/ScoutUI/Primitives/Visualization/Chart/View/ChartView.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Chart/View/ChartView.swift
@@ -21,7 +21,7 @@ struct ChartView<T: ChartNumeric>: View {
             ForEach(segment, id: \.date) { point in
                 BarMark(
                     x: .value("X", point.date, unit: timing.unit),
-                    y: .value("Y", point.count),
+                    y: .value("Y", point.value),
                     width: .ratio(ChartGeometry.barRatio)
                 )
             }

--- a/Sources/ScoutUI/Primitives/Visualization/Heatmap/HeatmapGrid.swift
+++ b/Sources/ScoutUI/Primitives/Visualization/Heatmap/HeatmapGrid.swift
@@ -22,7 +22,7 @@ struct HeatmapGrid {
 
         for point in points where range.contains(point.date) {
             let hour = calendar.component(.hour, from: point.date)
-            counts[calendar.mondayBasedWeekday(from: point.date)][hour] += point.count
+            counts[calendar.mondayBasedWeekday(from: point.date)][hour] += point.value
         }
 
         self.init(counts: counts)

--- a/Tests/ScoutUITests/Analytics/Activity/ActivityProviderTests.swift
+++ b/Tests/ScoutUITests/Analytics/Activity/ActivityProviderTests.swift
@@ -31,9 +31,9 @@ struct ActivityProviderTests {
         let monthly = series.points(on: .monthly).sorted()
 
         // Zero-activity days never become points.
-        #expect(daily.map(\.count) == [2, 1])
-        #expect(weekly.map(\.count) == [2, 3])
-        #expect(monthly.map(\.count) == [2, 2, 5])
+        #expect(daily.map(\.value) == [2, 1])
+        #expect(weekly.map(\.value) == [2, 3])
+        #expect(monthly.map(\.value) == [2, 2, 5])
 
         // Millisecond timestamps resolve back to the original dates.
         #expect(daily.first?.date == date(2026, 6, 10))

--- a/Tests/ScoutUITests/Home/Section/Log/SeriesSpanTests.swift
+++ b/Tests/ScoutUITests/Home/Section/Log/SeriesSpanTests.swift
@@ -91,7 +91,7 @@ struct SeriesSpanTests {
 
         let points = span.points { $0 != CrashEntry.recordType }
 
-        #expect(points.map(\.count) == [3])
+        #expect(points.map(\.value) == [3])
     }
 
     @Test("Points by category keep the telemetry series filed under it")
@@ -105,7 +105,7 @@ struct SeriesSpanTests {
 
         let points = span.points(inCategories: Set(StatusBuckets.categories))
 
-        #expect(points.map(\.count).sorted() == [1, 5])
+        #expect(points.map(\.value).sorted() == [1, 5])
         #expect(points.total == 6)
     }
 

--- a/Tests/ScoutUITests/Monitoring/Alerts/Metric/MetricReadingChartPointsTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Alerts/Metric/MetricReadingChartPointsTests.swift
@@ -19,8 +19,8 @@ struct MetricReadingChartPointsTests {
     func recentOrder() {
         let reading = MetricReading(
             points: [
-                makePoint(day: 7, hour: 0, count: 5),
-                makePoint(day: 7, hour: 23, count: 9),
+                makePoint(day: 7, hour: 0, value: 5),
+                makePoint(day: 7, hour: 23, value: 9),
             ],
             period: scale
         )
@@ -34,8 +34,8 @@ struct MetricReadingChartPointsTests {
     func sameHour() {
         let reading = MetricReading(
             points: [
-                makePoint(day: 7, hour: 3, count: 2),
-                makePoint(day: 7, hour: 3, count: 3),
+                makePoint(day: 7, hour: 3, value: 2),
+                makePoint(day: 7, hour: 3, value: 3),
             ],
             period: scale
         )
@@ -45,7 +45,7 @@ struct MetricReadingChartPointsTests {
 
     @Test("Baseline is the median hourly bucket of the previous window")
     func baseline() {
-        let points = (0..<24).map { makePoint(day: 6, hour: $0, count: 4) }
+        let points = (0..<24).map { makePoint(day: 6, hour: $0, value: 4) }
         let reading = MetricReading(points: points, period: scale)
 
         #expect(reading.baseline == 4)
@@ -53,7 +53,7 @@ struct MetricReadingChartPointsTests {
 
     @Test("An empty previous window carries no baseline to compare against")
     func emptyPrevious() {
-        let reading = MetricReading(points: [makePoint(day: 7, hour: 1, count: 8)], period: scale)
+        let reading = MetricReading(points: [makePoint(day: 7, hour: 1, value: 8)], period: scale)
 
         #expect(reading.baseline == 0)
         #expect(reading.reference(for: .baselineFactor(2)) == nil)
@@ -61,10 +61,10 @@ struct MetricReadingChartPointsTests {
 
     @Test("Crash-free stability is computed per hour")
     func stability() {
-        let sessions = (0..<24).map { makePoint(day: 7, hour: $0, count: 10) }
+        let sessions = (0..<24).map { makePoint(day: 7, hour: $0, value: 10) }
         let reading = MetricReading(
             sessions: sessions,
-            crashes: [makePoint(day: 7, hour: 5, count: 1)],
+            crashes: [makePoint(day: 7, hour: 5, value: 1)],
             period: scale
         )
 
@@ -84,14 +84,14 @@ struct MetricReadingChartPointsTests {
     func crashesWithoutSessions() {
         let reading = MetricReading(
             sessions: [],
-            crashes: [makePoint(day: 7, hour: 3, count: 2)],
+            crashes: [makePoint(day: 7, hour: 3, value: 2)],
             period: scale
         )
 
         #expect(reading.recent[3] == 0)
     }
 
-    private func makePoint(day: Int, hour: Int, count: Int) -> ChartPoint<Int> {
-        ChartPoint(date: Date(year: 2026, month: 6, day: day, hour: hour), count: count)
+    private func makePoint(day: Int, hour: Int, value: Int) -> ChartPoint<Int> {
+        ChartPoint(date: Date(year: 2026, month: 6, day: day, hour: hour), value: value)
     }
 }

--- a/Tests/ScoutUITests/Monitoring/Metrics/MetricsProviderTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Metrics/MetricsProviderTests.swift
@@ -44,13 +44,13 @@ struct MetricsProviderTests {
 
         let calls = try #require(groups.first { $0.name == "api_calls" })
         // Points span two weeks but flatten under the one name.
-        #expect(calls.points.map(\.count).sorted() == [1, 2, 3])
+        #expect(calls.points.map(\.value).sorted() == [1, 2, 3])
         // The cell position round-trips back to the original hour.
         #expect(calls.points.contains { $0.date == date(2026, 6, 10, 9) })
         #expect(calls.points.contains { $0.date == date(2026, 6, 17, 9) })
 
         let errors = try #require(groups.first { $0.name == "errors" })
-        #expect(errors.points.map(\.count) == [4])
+        #expect(errors.points.map(\.value) == [4])
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int) -> Date {

--- a/Tests/ScoutUITests/Monitoring/Metrics/Series/RankedSeriesTests.swift
+++ b/Tests/ScoutUITests/Monitoring/Metrics/Series/RankedSeriesTests.swift
@@ -20,7 +20,7 @@ struct RankedSeriesTests {
     private func group(_ name: String, _ values: [Double]) -> PointGroup<Double> {
         let start = period.initialRange.lowerBound
         let points = values.enumerated().map { hour, value in
-            ChartPoint(date: start.addingTimeInterval(TimeInterval(hour) * .hour), count: value)
+            ChartPoint(date: start.addingTimeInterval(TimeInterval(hour) * .hour), value: value)
         }
         return PointGroup(name: name, points: points)
     }

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Comparison/ChartComparisonTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Comparison/ChartComparisonTests.swift
@@ -22,21 +22,21 @@ struct ChartComparisonTests {
 
     @Test("Reference segment aligns previous counts to current buckets") func testReferenceSegment() {
         let extent = ChartExtent(period: Period.week)
-        let points = makePoints(in: extent.domain, count: 2) + makePoints(in: extent.previousDomain, count: 5)
+        let points = makePoints(in: extent.domain, value: 2) + makePoints(in: extent.previousDomain, value: 5)
 
         let segment = extent.segment(from: points)
         let reference = extent.referenceSegment(from: points, alignedTo: segment)
 
         #expect(reference.count == segment.count)
         #expect(reference.map(\.date) == segment.map(\.date))
-        #expect(reference.allSatisfy { $0.count == 5 })
-        #expect(segment.allSatisfy { $0.count == 2 })
+        #expect(reference.allSatisfy { $0.value == 5 })
+        #expect(segment.allSatisfy { $0.value == 2 })
     }
 
     @Test("Reference segment pairs buckets by offset across month lengths") func testMonthLengthMismatch() {
         let domain = Date(year: 2026, month: 5, day: 10)..<Date(year: 2026, month: 6, day: 10)
         let extent = ChartExtent(period: Period.month, domain: domain)
-        let points = makePoints(in: extent.domain, count: 2) + makePoints(in: extent.previousDomain, count: 5)
+        let points = makePoints(in: extent.domain, value: 2) + makePoints(in: extent.previousDomain, value: 5)
 
         let segment = extent.segment(from: points)
         let reference = extent.referenceSegment(from: points, alignedTo: segment)
@@ -44,26 +44,26 @@ struct ChartComparisonTests {
         #expect(segment.count == 31)
         #expect(reference.count == 30)
         #expect(reference.map(\.date) == segment.prefix(30).map(\.date))
-        #expect(reference.allSatisfy { $0.count == 5 })
+        #expect(reference.allSatisfy { $0.value == 5 })
     }
 
     @Test("Reference segment is zero without previous data") func testEmptyReference() {
         let extent = ChartExtent(period: Period.week)
-        let points = makePoints(in: extent.domain, count: 3)
+        let points = makePoints(in: extent.domain, value: 3)
 
         let segment = extent.segment(from: points)
         let reference = extent.referenceSegment(from: points, alignedTo: segment)
 
         #expect(reference.count == segment.count)
-        #expect(reference.allSatisfy { $0.count == 0 })
+        #expect(reference.allSatisfy { $0.value == 0 })
     }
 
-    func makePoints(in range: Range<Date>, count: Int) -> [ChartPoint<Int>] {
+    func makePoints(in range: Range<Date>, value: Int) -> [ChartPoint<Int>] {
         var points: [ChartPoint<Int>] = []
         var date = range.lowerBound
 
         while date < range.upperBound {
-            points.append(ChartPoint(date: date, count: count))
+            points.append(ChartPoint(date: date, value: value))
             date.addDay()
         }
 

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Comparison/ComparisonChartViewTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Comparison/ComparisonChartViewTests.swift
@@ -19,7 +19,7 @@ import Testing
 struct ComparisonChartViewTests {
     @Test("Renders bars with the reference overlay") @MainActor func testRender() {
         let extent = ChartExtent(period: Period.week)
-        let points = makePoints(in: extent.domain, count: 2) + makePoints(in: extent.previousDomain, count: 5)
+        let points = makePoints(in: extent.domain, value: 2) + makePoints(in: extent.previousDomain, value: 5)
         let segment = extent.segment(from: points)
 
         let renderer = ImageRenderer(
@@ -55,12 +55,12 @@ struct ComparisonChartViewTests {
         #endif
     }
 
-    func makePoints(in range: Range<Date>, count: Int) -> [ChartPoint<Int>] {
+    func makePoints(in range: Range<Date>, value: Int) -> [ChartPoint<Int>] {
         var points: [ChartPoint<Int>] = []
         var date = range.lowerBound
 
         while date < range.upperBound {
-            points.append(ChartPoint(date: date, count: count))
+            points.append(ChartPoint(date: date, value: value))
             date.addDay()
         }
 

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Comparison/ComparisonPairTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Comparison/ComparisonPairTests.swift
@@ -14,25 +14,25 @@ import Testing
 
 struct ComparisonPairTests {
     @Test("Pairing matches reference counts to segment dates") func testPairing() {
-        let segment = makeSegment(days: 3, count: 2)
+        let segment = makeSegment(days: 3, value: 2)
         let reference = [
-            ChartPoint(date: segment[0].date, count: 7),
-            ChartPoint(date: segment[1].date, count: 4),
+            ChartPoint(date: segment[0].date, value: 7),
+            ChartPoint(date: segment[1].date, value: 4),
         ]
 
         let pairs = segment.paired(with: reference, unit: .day)
 
         #expect(pairs.map(\.date) == segment.map(\.date))
-        #expect(pairs.map(\.count) == [2, 2, 2])
+        #expect(pairs.map(\.value) == [2, 2, 2])
         #expect(pairs.map(\.reference) == [7, 4, nil])
         #expect(pairs.allSatisfy { $0.bin.contains($0.date) })
     }
 
     @Test("Pairing sums reference points sharing a date") func testDuplicateReferenceDates() {
-        let segment = makeSegment(days: 1, count: 2)
+        let segment = makeSegment(days: 1, value: 2)
         let reference = [
-            ChartPoint(date: segment[0].date, count: 3),
-            ChartPoint(date: segment[0].date, count: 4),
+            ChartPoint(date: segment[0].date, value: 3),
+            ChartPoint(date: segment[0].date, value: 4),
         ]
 
         let pairs = segment.paired(with: reference, unit: .day)
@@ -41,7 +41,7 @@ struct ComparisonPairTests {
     }
 
     @Test("Domain spans the full bucket bands") func testXDomain() {
-        let pairs = makeSegment(days: 3, count: 1).paired(with: [], unit: .day)
+        let pairs = makeSegment(days: 3, value: 1).paired(with: [], unit: .day)
 
         let domain = pairs.xDomain()
 
@@ -56,7 +56,7 @@ struct ComparisonPairTests {
     }
 
     @Test("Bar edges split the bucket slot by the bar ratio") func testBarGeometry() {
-        let pair = makeSegment(days: 1, count: 1).paired(with: [], unit: .day)[0]
+        let pair = makeSegment(days: 1, value: 1).paired(with: [], unit: .day)[0]
         let length = pair.bin.upperBound.timeIntervalSince(pair.bin.lowerBound)
 
         #expect(abs(pair.barStart.timeIntervalSince(pair.bin.lowerBound) - length * ChartGeometry.barStart) < 0.001)
@@ -65,8 +65,8 @@ struct ComparisonPairTests {
         #expect(abs(pair.barEnd.timeIntervalSince(pair.barStart) - length * ChartGeometry.barRatio) < 0.001)
     }
 
-    func makeSegment(days: Int, count: Int) -> [ChartPoint<Int>] {
+    func makeSegment(days: Int, value: Int) -> [ChartPoint<Int>] {
         let base = Date(year: 2026, month: 6, day: 1, hour: 12)
-        return (0..<days).map { ChartPoint(date: base.addingDay($0), count: count) }
+        return (0..<days).map { ChartPoint(date: base.addingDay($0), value: value) }
     }
 }

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Comparison/ReferenceLevelTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Comparison/ReferenceLevelTests.swift
@@ -65,7 +65,7 @@ struct ReferenceLevelTests {
     func makeLevel(reference: CGFloat, isClamped: Bool = false) -> ReferenceLevel {
         ReferenceLevel(
             x: 10...30,
-            count: 80,
+            value: 80,
             reference: reference,
             isClamped: isClamped
         )

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Model/MiniChartSeriesTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Model/MiniChartSeriesTests.swift
@@ -16,8 +16,8 @@ struct MiniChartSeriesTests {
     /// Seven days, so each slice spans exactly one day.
     let range = Date(year: 2026, month: 6, day: 1)..<Date(year: 2026, month: 6, day: 8)
 
-    private func makePoint(day: Int, hour: Int = 0, count: Int) -> ChartPoint<Int> {
-        ChartPoint(date: Date(year: 2026, month: 6, day: day, hour: hour), count: count)
+    private func makePoint(day: Int, hour: Int = 0, value: Int) -> ChartPoint<Int> {
+        ChartPoint(date: Date(year: 2026, month: 6, day: day, hour: hour), value: value)
     }
 
     @Test("Empty points produce sliceCount zeros")
@@ -28,7 +28,7 @@ struct MiniChartSeriesTests {
 
     @Test("Points land in their slice, oldest first")
     func slicing() {
-        let points = [makePoint(day: 1, count: 1), makePoint(day: 4, count: 5)]
+        let points = [makePoint(day: 1, value: 1), makePoint(day: 4, value: 5)]
         let series = MiniChartSeries(points: points, range: range, aggregation: .total)
 
         #expect(series.values == [1, 0, 0, 5, 0, 0, 0])
@@ -36,16 +36,16 @@ struct MiniChartSeriesTests {
 
     @Test("A point on a slice boundary belongs to the later slice")
     func sliceBoundary() {
-        let series = MiniChartSeries(points: [makePoint(day: 2, count: 7)], range: range, aggregation: .total)
+        let series = MiniChartSeries(points: [makePoint(day: 2, value: 7)], range: range, aggregation: .total)
         #expect(series.values == [0, 7, 0, 0, 0, 0, 0])
     }
 
     @Test("Points outside the range are ignored")
     func outsideRange() {
         let points = [
-            ChartPoint(date: Date(year: 2026, month: 5, day: 31), count: 9),
-            ChartPoint(date: range.upperBound, count: 9),
-            makePoint(day: 1, count: 1),
+            ChartPoint(date: Date(year: 2026, month: 5, day: 31), value: 9),
+            ChartPoint(date: range.upperBound, value: 9),
+            makePoint(day: 1, value: 1),
         ]
         let series = MiniChartSeries(points: points, range: range, aggregation: .total)
 
@@ -56,8 +56,8 @@ struct MiniChartSeriesTests {
     func unevenRange() {
         let range = Date(year: 2026, month: 5, day: 9)..<Date(year: 2026, month: 6, day: 8)
         let points = [
-            ChartPoint(date: range.lowerBound, count: 1),
-            ChartPoint(date: range.upperBound.addingTimeInterval(-1), count: 2),
+            ChartPoint(date: range.lowerBound, value: 1),
+            ChartPoint(date: range.upperBound.addingTimeInterval(-1), value: 2),
         ]
         let series = MiniChartSeries(points: points, range: range, aggregation: .total)
 
@@ -67,14 +67,14 @@ struct MiniChartSeriesTests {
     @Test("An empty range produces zeros instead of crashing")
     func emptyRange() {
         let date = Date(year: 2026, month: 6, day: 1)
-        let series = MiniChartSeries(points: [makePoint(day: 1, count: 5)], range: date..<date, aggregation: .total)
+        let series = MiniChartSeries(points: [makePoint(day: 1, value: 5)], range: date..<date, aggregation: .total)
 
         #expect(series.values == Array(repeating: 0, count: MiniChartSeries.sliceCount))
     }
 
     @Test("Total sums all points in a slice")
     func totalAggregation() {
-        let points = [makePoint(day: 1, hour: 3, count: 1), makePoint(day: 1, hour: 12, count: 2)]
+        let points = [makePoint(day: 1, hour: 3, value: 1), makePoint(day: 1, hour: 12, value: 2)]
         let series = MiniChartSeries(points: points, range: range, aggregation: .total)
 
         #expect(series.values == [3, 0, 0, 0, 0, 0, 0])
@@ -82,7 +82,7 @@ struct MiniChartSeriesTests {
 
     @Test("Latest picks the newest point in a slice")
     func latestAggregation() {
-        let points = [makePoint(day: 1, hour: 3, count: 10), makePoint(day: 1, hour: 20, count: 4)]
+        let points = [makePoint(day: 1, hour: 3, value: 10), makePoint(day: 1, hour: 20, value: 4)]
         let series = MiniChartSeries(points: points, range: range, aggregation: .latest)
 
         #expect(series.values == [4, 0, 0, 0, 0, 0, 0])
@@ -91,9 +91,9 @@ struct MiniChartSeriesTests {
     @Test("Latest aggregates each slice independently")
     func latestPerSlice() {
         let points = [
-            makePoint(day: 1, hour: 3, count: 10),
-            makePoint(day: 1, hour: 20, count: 4),
-            makePoint(day: 5, count: 9),
+            makePoint(day: 1, hour: 3, value: 10),
+            makePoint(day: 1, hour: 20, value: 4),
+            makePoint(day: 5, value: 9),
         ]
         let series = MiniChartSeries(points: points, range: range, aggregation: .latest)
 
@@ -110,7 +110,7 @@ struct MiniChartSeriesTests {
 
     @Test("A series with any value is not empty")
     func nonZeroIsNotEmpty() {
-        let series = MiniChartSeries(points: [makePoint(day: 1, count: 1)], range: range, aggregation: .total)
+        let series = MiniChartSeries(points: [makePoint(day: 1, value: 1)], range: range, aggregation: .total)
 
         #expect(!series.isEmpty)
     }

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Model/TrendTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Model/TrendTests.swift
@@ -19,9 +19,9 @@ struct TrendTests {
     func additive() throws {
         let trend = Trend.total(
             points: [
-                makePoint(day: 7, hour: 1, count: 8),
-                makePoint(day: 7, hour: 2, count: 4),
-                makePoint(day: 6, hour: 1, count: 10),
+                makePoint(day: 7, hour: 1, value: 8),
+                makePoint(day: 7, hour: 2, value: 4),
+                makePoint(day: 6, hour: 1, value: 10),
             ],
             period: scale
         )
@@ -33,7 +33,7 @@ struct TrendTests {
 
     @Test("Additive points with an empty previous day carry no delta")
     func additiveWithoutPrevious() {
-        let trend = Trend.total(points: [makePoint(day: 7, hour: 1, count: 8)], period: scale)
+        let trend = Trend.total(points: [makePoint(day: 7, hour: 1, value: 8)], period: scale)
 
         #expect(trend.count == 8)
         #expect(trend.delta == nil)
@@ -87,8 +87,8 @@ struct TrendTests {
         #expect(Trend.loading.series == nil)
     }
 
-    private func makePoint(day: Int, hour: Int, count: Int) -> ChartPoint<Int> {
-        ChartPoint(date: Date(year: 2026, month: 6, day: day, hour: hour), count: count)
+    private func makePoint(day: Int, hour: Int, value: Int) -> ChartPoint<Int> {
+        ChartPoint(date: Date(year: 2026, month: 6, day: day, hour: hour), value: value)
     }
 
     private func makeActivity(day: Int, level: Int) -> ActivityPoint {

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Scale/ChartExtentSegmentTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Scale/ChartExtentSegmentTests.swift
@@ -21,8 +21,8 @@ struct ChartExtentSegmentTests {
         date = Date()
         range = date..<date.addingTimeInterval(3600)
 
-        let chartPoint1 = ChartPoint(date: date, count: 10)
-        let chartPoint2 = ChartPoint(date: date.addingTimeInterval(86400), count: 20)
+        let chartPoint1 = ChartPoint(date: date, value: 10)
+        let chartPoint2 = ChartPoint(date: date.addingTimeInterval(86400), value: 20)
 
         points = [chartPoint1, chartPoint2]
     }
@@ -31,6 +31,6 @@ struct ChartExtentSegmentTests {
         let extent = ChartExtent(period: Period.today, domain: range)
         let points = extent.segment(from: points)
 
-        #expect(points.map(\.count) == [10])
+        #expect(points.map(\.value) == [10])
     }
 }

--- a/Tests/ScoutUITests/Primitives/Visualization/Chart/Scale/ChartTimingTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Chart/Scale/ChartTimingTests.swift
@@ -35,7 +35,7 @@ struct ChartTimingTests {
     @Test("Day-unit ticks land on UTC midnights") func dayTicksAlignToUTC() {
         let base = Date(timeIntervalSince1970: 1_752_759_000)  // 2025-07-17 13:30 UTC
         let points = (0..<7).map { day in
-            ChartPoint(date: base.addingTimeInterval(Double(day) * 86400), count: day)
+            ChartPoint(date: base.addingTimeInterval(Double(day) * 86400), value: day)
         }
         let extent = ChartExtent(period: Period.week)
 

--- a/Tests/ScoutUITests/Primitives/Visualization/Heatmap/HeatmapGridTests.swift
+++ b/Tests/ScoutUITests/Primitives/Visualization/Heatmap/HeatmapGridTests.swift
@@ -18,8 +18,8 @@ struct HeatmapGridTests {
         let sunday = try makeDate(year: 2026, month: 7, day: 19, hour: 23)
         let grid = HeatmapGrid(
             points: [
-                ChartPoint(date: monday, count: 3),
-                ChartPoint(date: sunday, count: 5),
+                ChartPoint(date: monday, value: 3),
+                ChartPoint(date: sunday, value: 5),
             ],
             range: try weekRange(),
             calendar: .utc
@@ -37,8 +37,8 @@ struct HeatmapGridTests {
         let range = try makeDate(year: 2026, month: 7, day: 6)..<makeDate(year: 2026, month: 7, day: 20)
         let grid = HeatmapGrid(
             points: [
-                ChartPoint(date: first, count: 3),
-                ChartPoint(date: second, count: 4),
+                ChartPoint(date: first, value: 3),
+                ChartPoint(date: second, value: 4),
             ],
             range: range,
             calendar: .utc
@@ -54,9 +54,9 @@ struct HeatmapGridTests {
         let after = try makeDate(year: 2026, month: 7, day: 20, hour: 0)
         let grid = HeatmapGrid(
             points: [
-                ChartPoint(date: inside, count: 3),
-                ChartPoint(date: before, count: 10),
-                ChartPoint(date: after, count: 10),
+                ChartPoint(date: inside, value: 3),
+                ChartPoint(date: before, value: 10),
+                ChartPoint(date: after, value: 10),
             ],
             range: try weekRange(),
             calendar: .utc


### PR DESCRIPTION
Stacked on #1273, which fixes the Events row that read `segment.count` — the length of the bucket array — where it meant the sum. That mistake type-checked because `ChartPoint` spelled its measure `count`, so `.count` on a collection of points silently resolved to `Collection.count` and stayed valid on every array in the chart layer. Renaming the measure to `value` (and `HasCount` to `HasValue`, with its associated type and the `init(date:value:)` requirement following) turns the same slip into a compile error instead of a plausible number on screen. `ComparisonPair` and `ReferenceLevel` carried the same field name against the same hazard, so they move too — `ReferenceLevel.count` was in fact a y coordinate, never a count. `total` keeps its name and stays the aggregate.

Pure rename, no behaviour change: the type checker located every call site, and the whole test bundle passes.
