### PR TITLE
Bound the devices report's session and crash reads to the default range

### DIFF
--- a/Sources/Scout/Database/Query/Range+DateFilters.swift
+++ b/Sources/Scout/Database/Query/Range+DateFilters.swift
@@ -9,9 +9,13 @@ import Foundation
 
 extension Range<Date> {
     package var dateFilters: [RecordQuery.Filter] {
+        dateFilters(on: "date")
+    }
+
+    package func dateFilters(on field: String) -> [RecordQuery.Filter] {
         [
-            RecordQuery.Filter(field: "date", op: .greaterThanOrEquals, value: .date(lowerBound)),
-            RecordQuery.Filter(field: "date", op: .lessThan, value: .date(upperBound)),
+            RecordQuery.Filter(field: field, op: .greaterThanOrEquals, value: .date(lowerBound)),
+            RecordQuery.Filter(field: field, op: .lessThan, value: .date(upperBound)),
         ]
     }
 }

--- a/Sources/ScoutUI/Delivery/Devices/View/DevicesProvider.swift
+++ b/Sources/ScoutUI/Delivery/Devices/View/DevicesProvider.swift
@@ -17,18 +17,20 @@ final class DevicesProvider: ObservableObject, Provider {
     }
 
     func fetch(in database: DatabaseReader) async throws -> DevicesReport {
+        let range = Calendar.utc.defaultRange
+
         async let devices: [Record] = database.readAll(
             matching: RecordQuery(recordType: Device.self),
             fields: ["device_id", "model"]
         )
 
         async let sessions: [Record] = database.readAll(
-            matching: RecordQuery(recordType: Session.self),
+            matching: RecordQuery(recordType: Session.self, filters: range.dateFilters(on: "start_date")),
             fields: ["device_id", "os_version", "start_date"]
         )
 
         async let crashes: [Record] = database.readAll(
-            matching: RecordQuery(recordType: Crash.self),
+            matching: RecordQuery(recordType: Crash.self, filters: range.dateFilters),
             fields: ["device_id"]
         )
 

--- a/Tests/ScoutTests/Database/Query/RangeDateFiltersTests.swift
+++ b/Tests/ScoutTests/Database/Query/RangeDateFiltersTests.swift
@@ -24,4 +24,18 @@ struct RangeDateFiltersTests {
             ]
         )
     }
+
+    @Test("Date range bounds a named field") func dateFiltersOnField() {
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let end = Date(timeIntervalSinceReferenceDate: 86400)
+
+        let filters = (start..<end).dateFilters(on: "start_date")
+
+        #expect(
+            filters == [
+                RecordQuery.Filter(field: "start_date", op: .greaterThanOrEquals, value: .date(start)),
+                RecordQuery.Filter(field: "start_date", op: .lessThan, value: .date(end)),
+            ]
+        )
+    }
 }

--- a/Tests/ScoutUITests/Delivery/Devices/View/DevicesProviderTests.swift
+++ b/Tests/ScoutUITests/Delivery/Devices/View/DevicesProviderTests.swift
@@ -47,7 +47,7 @@ struct DevicesProviderTests {
     @Test("Keeps one visit per session so devices can be counted per period")
     func fetchKeepsSessionVisits() async throws {
         let deviceA = UUID()
-        let date = Date(year: 2026, month: 6, day: 3)
+        let date = Date(timeIntervalSinceNow: -.day)
 
         let database = DatabaseStub()
         database.add(
@@ -66,6 +66,37 @@ struct DevicesProviderTests {
 
         #expect(report.visits.count == 2)
         #expect(report.visits.allSatisfy { $0.deviceID == deviceA.uuidString })
+    }
+
+    @Test("Skips sessions and crashes older than the default range")
+    func fetchIgnoresRecordsOutsideDefaultRange() async throws {
+        let deviceA = UUID()
+        let recent = Date(timeIntervalSinceNow: -.day)
+        let stale = Calendar.utc.defaultRange.lowerBound.addingTimeInterval(-.day)
+
+        let database = DatabaseStub()
+        database.add(
+            .deviceStub(deviceID: deviceA, date: stale, model: "iPhone15,3"),
+            .sessionStub(
+                sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: recent, osVersion: "iOS 17.4",
+                deviceID: deviceA),
+            .sessionStub(
+                sessionID: UUID(), launchID: UUID(), installID: UUID(), startDate: stale, osVersion: "iOS 16.7",
+                deviceID: deviceA),
+            .crashStub(deviceID: deviceA, date: recent),
+            .crashStub(deviceID: deviceA, date: stale)
+        )
+
+        let provider = DevicesProvider()
+        await provider.fetchIfNeeded(in: database)
+        let report = try #require(provider.result).get()
+        let summary = try #require(report.summaries.first)
+
+        #expect(report.summaries.count == 1)
+        #expect(summary.model == "iPhone15,3")
+        #expect(summary.sessions == 1)
+        #expect(summary.crashes == 1)
+        #expect(report.visits.count == 1)
     }
 
     @Test("No devices yields no summaries")


### PR DESCRIPTION
`DevicesProvider` issued three `readAll` calls with no filters at all, while every other provider narrows to `Calendar.utc.defaultRange`. `readAll` walks a cursor 400 records at a time, so an app with 100k sessions paid 250 sequential HTTP round trips before the report could be built — on the Home screen, in the log section and behind global search, where the user just watched a spinner. Sessions and crashes are now bounded by the same default range.

The device query keeps its open filter on purpose: a device record's `date` is when the device was first seen and is never bumped afterwards, so filtering it would drop the model off long-lived devices that still have sessions in range, and the row would render as "Unknown" instead. Device records are also one per device, which is the size of the list being rendered anyway; sessions and crashes were the terms that grew without bound.

`Range<Date>.dateFilters` gains a `dateFilters(on:)` form because a session carries its date in `start_date` rather than `date`. Both fields are declared in the entity catalog and are already filtered elsewhere, so the wire contract is unchanged.

Worth knowing for review: the year period's `previousRange` reaches two years back, so its device trend comparison is now truncated by the window — that is the pre-existing behaviour of the rest of Home, where `StatProvider` and `ActivityProvider` also read only `defaultRange`. The existing visit test pinned a fixed 2026-06-03 date, which a rolling one-year window would have aged out of by mid-2027; it now uses an offset from now, and a new test covers the cutoff.