### PR TITLE
Close file-backed test stores before deleting them

### DIFF
--- a/Tests/ScoutTests/Persistence/MergePolicyTests.swift
+++ b/Tests/ScoutTests/Persistence/MergePolicyTests.swift
@@ -21,9 +21,9 @@ struct MergePolicyTests {
     ///
     @Test("A duplicate insert on the same natural key dedupes instead of throwing")
     func duplicateInsertDedupes() throws {
-        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let container = try makeContainer(in: directory)
+        let store = try TemporaryStore()
+        defer { store.tearDown() }
+        let container = try store.container()
 
         // The main-queue viewContext is off-limits here: Swift Testing runs on a
         // background thread, and mutating it there races the main run loop's own
@@ -56,9 +56,9 @@ struct MergePolicyTests {
     ///
     @Test("Concurrent writes touching one session merge instead of failing")
     func concurrentSessionWritesMerge() async throws {
-        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let container = try makeContainer(in: directory)
+        let store = try TemporaryStore()
+        defer { store.tearDown() }
+        let container = try store.container()
 
         let identity = Identity.stub.snapshot
         try await container.performBackgroundTask { @Sendable context in
@@ -123,9 +123,9 @@ struct MergePolicyTests {
     ///
     @Test("Racing linkedSession writes collapse to one row per lifecycle entity")
     func concurrentLinkedSessionDedupes() async throws {
-        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let container = try makeContainer(in: directory)
+        let store = try TemporaryStore()
+        defer { store.tearDown() }
+        let container = try store.container()
 
         let identity = Identity.stub.snapshot
         let failures = Protected<[String]>([])
@@ -166,9 +166,9 @@ struct MergePolicyTests {
     ///
     @Test("A bare duplicate insert keeps the filled session fields")
     func bareDuplicateKeepsFilledFields() throws {
-        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let container = try makeContainer(in: directory)
+        let store = try TemporaryStore()
+        defer { store.tearDown() }
+        let container = try store.container()
 
         let identity = Identity.stub.snapshot
 
@@ -200,21 +200,5 @@ struct MergePolicyTests {
             #expect(sessions.first?.appVersion == "1.2.3")
             #expect(sessions.first?.osVersion == "26.0")
         }
-    }
-
-    /// Uniqueness constraints and row versioning are only enforced by the SQLite
-    /// store, so every case here needs a real file-backed store — an in-memory
-    /// one silently allows the duplicate and never conflicts.
-    ///
-    private func makeContainer(in directory: URL) throws -> NSPersistentContainer {
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-
-        let container = NSPersistentContainer(named: "ScoutModel")
-        container.persistentStoreDescriptions = [
-            NSPersistentStoreDescription(url: directory.appendingPathComponent("ScoutModel.sqlite"))
-        ]
-        try container.loadStore()
-
-        return container
     }
 }

--- a/Tests/ScoutTests/Persistence/MigrationDedupeTests.swift
+++ b/Tests/ScoutTests/Persistence/MigrationDedupeTests.swift
@@ -22,10 +22,8 @@ struct MigrationDedupeTests {
     ///
     @Test("A store with duplicate lifecycle rows migrates into merged singles")
     func duplicatesMergeDuringMigration() throws {
-        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let storeURL = directory.appendingPathComponent("ScoutModel.sqlite")
+        let store = try TemporaryStore()
+        defer { store.tearDown() }
 
         let momdURL = try #require(Bundle.module.url(forResource: "ScoutModel", withExtension: "momd"))
         let oldURL = momdURL.appendingPathComponent("ScoutModel 3.mom")
@@ -39,7 +37,7 @@ struct MigrationDedupeTests {
         let lateDate = Date(timeIntervalSinceNow: -300)
 
         let coordinator = NSPersistentStoreCoordinator(managedObjectModel: old)
-        let store = try coordinator.addPersistentStore(type: .sqlite, at: storeURL)
+        let seeded = try coordinator.addPersistentStore(type: .sqlite, at: store.url)
         let seed = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         seed.persistentStoreCoordinator = coordinator
 
@@ -89,11 +87,9 @@ struct MigrationDedupeTests {
 
             try seed.save()
         }
-        try coordinator.remove(store)
+        try coordinator.remove(seeded)
 
-        let container = NSPersistentContainer(named: "ScoutModel")
-        container.persistentStoreDescriptions = [NSPersistentStoreDescription(url: storeURL)]
-        try container.loadStore()
+        let container = try store.container()
 
         let context = container.newBackgroundContext()
         try context.performAndWait {

--- a/Tests/ScoutTests/Persistence/MigrationTests.swift
+++ b/Tests/ScoutTests/Persistence/MigrationTests.swift
@@ -55,6 +55,7 @@ struct MigrationTests {
                 )
                 let metadata = coordinator.metadata(for: store)
                 #expect(current.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata))
+                try coordinator.remove(store)
             } catch {
                 Issue.record("Store created by \(versionURL.lastPathComponent) failed to migrate: \(error)")
             }

--- a/Tests/ScoutTests/Persistence/TemporaryStore.swift
+++ b/Tests/ScoutTests/Persistence/TemporaryStore.swift
@@ -9,16 +9,6 @@ import CoreData
 
 @testable import Scout
 
-// Uniqueness constraints and row versioning are only enforced by the SQLite
-// store, so the persistence suites need a real file on disk — an in-memory
-// store silently allows a duplicate and never conflicts.
-//
-// SQLite tracks an open file once per (device, inode) for the whole process,
-// so deleting a store the coordinator still holds open leaves that entry
-// pointing at an unlinked vnode — "BUG IN CLIENT OF libsqlite3.dylib: vnode
-// unlinked while in use" — and the next store the file system hands the
-// recycled inode inherits it and fails to open. Every store here is closed
-// before its directory goes away.
 final class TemporaryStore {
     let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 

--- a/Tests/ScoutTests/Persistence/TemporaryStore.swift
+++ b/Tests/ScoutTests/Persistence/TemporaryStore.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import CoreData
+
+@testable import Scout
+
+// Uniqueness constraints and row versioning are only enforced by the SQLite
+// store, so the persistence suites need a real file on disk — an in-memory
+// store silently allows a duplicate and never conflicts.
+//
+// SQLite tracks an open file once per (device, inode) for the whole process,
+// so deleting a store the coordinator still holds open leaves that entry
+// pointing at an unlinked vnode — "BUG IN CLIENT OF libsqlite3.dylib: vnode
+// unlinked while in use" — and the next store the file system hands the
+// recycled inode inherits it and fails to open. Every store here is closed
+// before its directory goes away.
+final class TemporaryStore {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+    private var containers: [NSPersistentContainer] = []
+
+    var url: URL {
+        directory.appendingPathComponent("ScoutModel.sqlite")
+    }
+
+    init() throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    func container() throws -> NSPersistentContainer {
+        let container = NSPersistentContainer(named: "ScoutModel")
+        container.persistentStoreDescriptions = [NSPersistentStoreDescription(url: url)]
+        try container.loadStore()
+        containers.append(container)
+        return container
+    }
+
+    func tearDown() {
+        for container in containers {
+            let coordinator = container.persistentStoreCoordinator
+            for store in coordinator.persistentStores {
+                try? coordinator.remove(store)
+            }
+        }
+        containers.removeAll()
+        try? FileManager.default.removeItem(at: directory)
+    }
+}


### PR DESCRIPTION
The persistence suites built a SQLite store in a temporary directory and removed that directory in a `defer` while the coordinator still held the store open. SQLite tracks an open file once per (device, inode) for the whole process, so the unlinked vnode stayed in that registry and the next store the file system handed the recycled inode inherited it and failed to open. That is the `BUG IN CLIENT OF libsqlite3.dylib: vnode unlinked while in use` storm in the test logs, and behind it the two red pushes to main on the iOS 17 leg: a migration that could not stat its own store file (run 33907968124) and a container that could not open one with `SQLITE_CANTOPEN` (run 33558819435).

A new `TemporaryStore` helper owns the temporary directory and every container built on it; its `tearDown` removes the stores from the coordinator before the directory goes away. `MergePolicyTests` and `MigrationDedupeTests` go through it, which also retires the duplicated `makeContainer(in:)`, and `MigrationTests` drops its store before destroying it.

Locally on iPhone 17 Pro the run went from 13 `vnode unlinked while in use` messages to none, with all 268 `ScoutTests` and the other bundles green. The iOS 17 runtime is not available here, so the flake itself cannot be reproduced one-to-one — the fix removes its cause and the symptom it left in the logs.